### PR TITLE
stacking: Kabsch refinement + drizzle + SPCC + diagnostics omnibus

### DIFF
--- a/src/TianWen.Cli/StackSubCommand.cs
+++ b/src/TianWen.Cli/StackSubCommand.cs
@@ -105,6 +105,10 @@ internal sealed class StackSubCommand(
         {
             Description = "Enable per-frame quality filtering at this sigma threshold: a frame is dropped from integration when its median HFD or ellipticity exceeds median + sigma * 1.4826 * MAD of the session. An 80% keep floor caps rejection at the worst 20% by severity. 3.0 is a conservative starting value -- catches clear outliers (bloated low-altitude frames, wind-trailed frames) without biting into the body of the distribution. Off by default.",
         };
+        var referenceFrameHintOpt = new Option<string?>("--reference-frame")
+        {
+            Description = "Debug knob: pin the reference frame to the first candidate whose path contains this case-insensitive substring (e.g. '_0233' to pin to that filename). Falls back to the composite-quality score picker when unset or no match. Use to isolate per-frame artifacts that correlate with reference choice -- a frame near the session's temporal middle keeps per-frame rotation residuals symmetric, which balances per-channel drizzle coverage.",
+        };
 
         var stackCommand = new Command("stack", "Stack a folder of FITS lights into a master frame.")
         {
@@ -117,7 +121,7 @@ internal sealed class StackSubCommand(
                 noPngOpt, noPlateSolveOpt,
                 drizzlePixfracOpt, drizzleMinFramesOpt,
                 splitByPierSideOpt, hotPixelSigmaOpt,
-                qualityRejectSigmaOpt,
+                qualityRejectSigmaOpt, referenceFrameHintOpt,
             },
         };
         stackCommand.SetAction(async (parseResult, ct) =>
@@ -157,7 +161,8 @@ internal sealed class StackSubCommand(
                 DrizzleOptions: drizzleOptions,
                 SplitByPierSide: parseResult.GetValue(splitByPierSideOpt),
                 HotPixelSigma: parseResult.GetValue(hotPixelSigmaOpt),
-                QualityRejectSigma: parseResult.GetValue(qualityRejectSigmaOpt));
+                QualityRejectSigma: parseResult.GetValue(qualityRejectSigmaOpt),
+                ReferenceFrameHint: parseResult.GetValue(referenceFrameHintOpt));
 
             var noPng = parseResult.GetValue(noPngOpt);
             var skipPlateSolve = parseResult.GetValue(noPlateSolveOpt);

--- a/src/TianWen.Cli/StackSubCommand.cs
+++ b/src/TianWen.Cli/StackSubCommand.cs
@@ -101,6 +101,10 @@ internal sealed class StackSubCommand(
             Description = "Threshold (Gaussian sigmas above dark master median) for hot-pixel masking. Flagged pixels are NaN'd in calibrated lights so integration ignores them. Default 8 (hot pixels typically score 100+). Pass 0 to disable masking.",
             DefaultValueFactory = _ => 8.0f,
         };
+        var qualityRejectSigmaOpt = new Option<float?>("--quality-reject-sigma")
+        {
+            Description = "Enable per-frame quality filtering at this sigma threshold: a frame is dropped from integration when its median HFD or ellipticity exceeds median + sigma * 1.4826 * MAD of the session. An 80% keep floor caps rejection at the worst 20% by severity. 3.0 is a conservative starting value -- catches clear outliers (bloated low-altitude frames, wind-trailed frames) without biting into the body of the distribution. Off by default.",
+        };
 
         var stackCommand = new Command("stack", "Stack a folder of FITS lights into a master frame.")
         {
@@ -113,6 +117,7 @@ internal sealed class StackSubCommand(
                 noPngOpt, noPlateSolveOpt,
                 drizzlePixfracOpt, drizzleMinFramesOpt,
                 splitByPierSideOpt, hotPixelSigmaOpt,
+                qualityRejectSigmaOpt,
             },
         };
         stackCommand.SetAction(async (parseResult, ct) =>
@@ -151,7 +156,8 @@ internal sealed class StackSubCommand(
                 QuadStars: parseResult.GetValue(quadStarsOpt),
                 DrizzleOptions: drizzleOptions,
                 SplitByPierSide: parseResult.GetValue(splitByPierSideOpt),
-                HotPixelSigma: parseResult.GetValue(hotPixelSigmaOpt));
+                HotPixelSigma: parseResult.GetValue(hotPixelSigmaOpt),
+                QualityRejectSigma: parseResult.GetValue(qualityRejectSigmaOpt));
 
             var noPng = parseResult.GetValue(noPngOpt);
             var skipPlateSolve = parseResult.GetValue(noPlateSolveOpt);

--- a/src/TianWen.Cli/StackSubCommand.cs
+++ b/src/TianWen.Cli/StackSubCommand.cs
@@ -109,6 +109,10 @@ internal sealed class StackSubCommand(
         {
             Description = "Debug knob: pin the reference frame to the first candidate whose path contains this case-insensitive substring (e.g. '_0233' to pin to that filename). Falls back to the composite-quality score picker when unset or no match. Use to isolate per-frame artifacts that correlate with reference choice -- a frame near the session's temporal middle keeps per-frame rotation residuals symmetric, which balances per-channel drizzle coverage.",
         };
+        var noBayerDrizzleOpt = new Option<bool>("--no-bayer-drizzle")
+        {
+            Description = "Opt out of drizzle auto-selection. On RGGB sensors with >= 60 matched frames the selector picks BayerDrizzle / TilePipelinedDrizzle by default (3-5x faster than the standard AHD-debayer path on big-N sessions); this flag forces the standard path instead. Useful for A/B against a reference master, or when you specifically want kappa-sigma rejection rather than drizzle's per-cell coverage map. --strategy overrides still win -- forcing BayerDrizzle bypasses this flag.",
+        };
 
         var stackCommand = new Command("stack", "Stack a folder of FITS lights into a master frame.")
         {
@@ -122,6 +126,7 @@ internal sealed class StackSubCommand(
                 drizzlePixfracOpt, drizzleMinFramesOpt,
                 splitByPierSideOpt, hotPixelSigmaOpt,
                 qualityRejectSigmaOpt, referenceFrameHintOpt,
+                noBayerDrizzleOpt,
             },
         };
         stackCommand.SetAction(async (parseResult, ct) =>
@@ -137,15 +142,25 @@ internal sealed class StackSubCommand(
             var forcedStrategy = parseResult.GetValue(strategyOpt);
             var pixfrac = parseResult.GetValue(drizzlePixfracOpt);
             var drizzleMinFrames = parseResult.GetValue(drizzleMinFramesOpt);
+            var disableBayerDrizzle = parseResult.GetValue(noBayerDrizzleOpt);
+            // Drizzle options now apply for both forced drizzle AND auto-
+            // picked drizzle, so build them whenever drizzle could be
+            // selected (anything except a non-drizzle forced strategy).
+            // The pixfrac / min-frames flags stay no-ops only when the
+            // user has BOTH forced a non-drizzle strategy AND set them
+            // -- the previous warning fired too eagerly under auto-pick.
             DrizzleOptions? drizzleOptions = null;
-            if (forcedStrategy is IntegrationStrategyKind.BayerDrizzle)
+            var forcedNonDrizzle = forcedStrategy is { } fs
+                && fs != IntegrationStrategyKind.BayerDrizzle
+                && fs != IntegrationStrategyKind.TilePipelinedDrizzle;
+            if (!forcedNonDrizzle)
             {
                 drizzleOptions = new DrizzleOptions(Pixfrac: pixfrac, MinFrameCount: drizzleMinFrames);
             }
             else if (pixfrac != 1.0f || drizzleMinFrames != 60)
             {
                 consoleHost.WriteScrollable(
-                    "[stack] warning: --drizzle-* options ignored when --strategy != BayerDrizzle");
+                    $"[stack] warning: --drizzle-* options ignored when --strategy={forcedStrategy} (non-drizzle)");
             }
             var options = new StackingOptions(
                 DataRoot: dataRoot,
@@ -162,7 +177,8 @@ internal sealed class StackSubCommand(
                 SplitByPierSide: parseResult.GetValue(splitByPierSideOpt),
                 HotPixelSigma: parseResult.GetValue(hotPixelSigmaOpt),
                 QualityRejectSigma: parseResult.GetValue(qualityRejectSigmaOpt),
-                ReferenceFrameHint: parseResult.GetValue(referenceFrameHintOpt));
+                ReferenceFrameHint: parseResult.GetValue(referenceFrameHintOpt),
+                DisableBayerDrizzle: disableBayerDrizzle);
 
             var noPng = parseResult.GetValue(noPngOpt);
             var skipPlateSolve = parseResult.GetValue(noPlateSolveOpt);

--- a/src/TianWen.Cli/StackSubCommand.cs
+++ b/src/TianWen.Cli/StackSubCommand.cs
@@ -113,6 +113,10 @@ internal sealed class StackSubCommand(
         {
             Description = "Opt out of drizzle auto-selection. On RGGB sensors with >= 60 matched frames the selector picks BayerDrizzle / TilePipelinedDrizzle by default (3-5x faster than the standard AHD-debayer path on big-N sessions); this flag forces the standard path instead. Useful for A/B against a reference master, or when you specifically want kappa-sigma rejection rather than drizzle's per-cell coverage map. --strategy overrides still win -- forcing BayerDrizzle bypasses this flag.",
         };
+        var includeStackProductsOpt = new Option<bool>("--include-stack-products")
+        {
+            Description = "Keep frames with a non-zero FITS STACK_N header (i.e. masters from a previous run) as scan inputs. Default behaviour is to drop them since stale masters in adjacent output-*/ dirs otherwise pollute the next session's grouping. Pass this flag for two-stage mosaic stacking: integrate each panel separately, then re-run with --include-stack-products against the panel masters to produce the final mosaic. .rejection.fits sidecars are ALWAYS dropped regardless of this flag.",
+        };
 
         var stackCommand = new Command("stack", "Stack a folder of FITS lights into a master frame.")
         {
@@ -126,7 +130,7 @@ internal sealed class StackSubCommand(
                 drizzlePixfracOpt, drizzleMinFramesOpt,
                 splitByPierSideOpt, hotPixelSigmaOpt,
                 qualityRejectSigmaOpt, referenceFrameHintOpt,
-                noBayerDrizzleOpt,
+                noBayerDrizzleOpt, includeStackProductsOpt,
             },
         };
         stackCommand.SetAction(async (parseResult, ct) =>
@@ -178,7 +182,8 @@ internal sealed class StackSubCommand(
                 HotPixelSigma: parseResult.GetValue(hotPixelSigmaOpt),
                 QualityRejectSigma: parseResult.GetValue(qualityRejectSigmaOpt),
                 ReferenceFrameHint: parseResult.GetValue(referenceFrameHintOpt),
-                DisableBayerDrizzle: disableBayerDrizzle);
+                DisableBayerDrizzle: disableBayerDrizzle,
+                IncludeStackProducts: parseResult.GetValue(includeStackProductsOpt));
 
             var noPng = parseResult.GetValue(noPngOpt);
             var skipPlateSolve = parseResult.GetValue(noPlateSolveOpt);

--- a/src/TianWen.Lib.Tests/FrameQualityFilterTests.cs
+++ b/src/TianWen.Lib.Tests/FrameQualityFilterTests.cs
@@ -1,0 +1,229 @@
+using System.Linq;
+using Shouldly;
+using TianWen.Lib.Imaging.Stacking;
+using Xunit;
+
+namespace TianWen.Lib.Tests;
+
+/// <summary>
+/// Coverage for <see cref="FrameQualityFilter"/>: MAD-based outlier
+/// rejection on HFD + ellipticity with a hard 80% keep floor. Tests are
+/// pure-function and run in &lt; 5 ms each (no images, no I/O).
+/// </summary>
+[Collection("Imaging")]
+public class FrameQualityFilterTests
+{
+    /// <summary>
+    /// Shared helper -- repeats a baseline metric N times and optionally
+    /// appends a list of outliers. Cleaner than literal arrays for the
+    /// "20 normal frames + 4 outliers" patterns used below.
+    /// </summary>
+    private static FrameMetrics[] Frames(int normalCount, float baseHfd, float baseEcc, params (float Hfd, float Ecc)[] outliers)
+    {
+        var arr = new FrameMetrics[normalCount + outliers.Length];
+        for (var i = 0; i < normalCount; i++)
+        {
+            arr[i] = new FrameMetrics(baseHfd, baseHfd, baseEcc, StarCount: 1000);
+        }
+        for (var i = 0; i < outliers.Length; i++)
+        {
+            arr[normalCount + i] = new FrameMetrics(outliers[i].Hfd, outliers[i].Hfd, outliers[i].Ecc, StarCount: 1000);
+        }
+        return arr;
+    }
+
+    [Fact]
+    public void Filter_Empty_KeepsAll()
+    {
+        var result = FrameQualityFilter.Filter(System.ReadOnlySpan<FrameMetrics>.Empty, sigma: 3f);
+        result.KeptCount.ShouldBe(0);
+        result.FloorTriggered.ShouldBeFalse();
+        result.Reasons.Length.ShouldBe(0);
+    }
+
+    [Fact]
+    public void Filter_FewerThan4_KeepsAllEvenWithObviousOutlier()
+    {
+        // MAD on 3 samples is statistical noise; the documented minimum
+        // is 4. A 3-frame "session" with one obvious bloated frame still
+        // returns all kept rather than gambling on a tiny-sample MAD.
+        var metrics = Frames(2, baseHfd: 2.5f, baseEcc: 0.4f, (Hfd: 10f, Ecc: 0.9f));
+        var result = FrameQualityFilter.Filter(metrics, sigma: 3f);
+        result.KeptCount.ShouldBe(3);
+        result.FloorTriggered.ShouldBeFalse();
+        result.Reasons.ShouldAllBe(r => r == FrameRejectReason.Kept);
+    }
+
+    [Fact]
+    public void Filter_AllIdentical_KeepsAll()
+    {
+        // MAD = 0 -> threshold = median + 0; no frame exceeds the
+        // median (strict >), so nothing is rejected. Correct behaviour.
+        var metrics = Frames(10, baseHfd: 2.8f, baseEcc: 0.45f);
+        var result = FrameQualityFilter.Filter(metrics, sigma: 3f);
+        result.KeptCount.ShouldBe(10);
+        result.FloorTriggered.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Filter_OneHfdOutlier_DropsIt()
+    {
+        // 10 frames at HFD 2.5 (ecc 0.5) plus one bloated at HFD 5.0.
+        // The bloated frame is the only one above the threshold.
+        var metrics = Frames(10, baseHfd: 2.5f, baseEcc: 0.5f, (Hfd: 5f, Ecc: 0.5f));
+        var result = FrameQualityFilter.Filter(metrics, sigma: 3f);
+
+        result.KeptCount.ShouldBe(10);
+        result.FloorTriggered.ShouldBeFalse();
+        result.Reasons[10].ShouldBe(FrameRejectReason.HfdTooBroad);
+        // First 10 frames remain Kept.
+        for (var i = 0; i < 10; i++)
+        {
+            result.Reasons[i].ShouldBe(FrameRejectReason.Kept);
+        }
+    }
+
+    [Fact]
+    public void Filter_OneEccOutlier_DropsIt()
+    {
+        // 10 frames at HFD 2.5, ecc 0.45; one outlier with HFD identical
+        // but ecc 0.85 (badly elongated). HfdTooBroad must NOT fire --
+        // HFD is fine; only EllipticityTooHigh is the right reason.
+        var metrics = Frames(10, baseHfd: 2.5f, baseEcc: 0.45f, (Hfd: 2.5f, Ecc: 0.85f));
+        var result = FrameQualityFilter.Filter(metrics, sigma: 3f);
+
+        result.KeptCount.ShouldBe(10);
+        result.FloorTriggered.ShouldBeFalse();
+        result.Reasons[10].ShouldBe(FrameRejectReason.EllipticityTooHigh);
+    }
+
+    [Fact]
+    public void Filter_BothHfdAndEccOutOfBounds_ReportsBothFlags()
+    {
+        // Single outlier fails HFD and ecc simultaneously. With flags
+        // both bits are set; the enum literal `HfdTooBroad |
+        // EllipticityTooHigh` is the combined reason.
+        var metrics = Frames(10, baseHfd: 2.5f, baseEcc: 0.45f, (Hfd: 5f, Ecc: 0.85f));
+        var result = FrameQualityFilter.Filter(metrics, sigma: 3f);
+
+        result.KeptCount.ShouldBe(10);
+        result.Reasons[10].ShouldBe(FrameRejectReason.HfdTooBroad | FrameRejectReason.EllipticityTooHigh);
+    }
+
+    [Fact]
+    public void Filter_StarCountOutlier_DropsIt()
+    {
+        // 10 frames at ~1000 stars (small jitter so MAD > 0), one at
+        // 100 stars (cloud / haze). Triggers StarCountTooLow.
+        var arr = new FrameMetrics[11];
+        for (var i = 0; i < 10; i++)
+        {
+            arr[i] = new FrameMetrics(MedianHfd: 2.5f, MedianFwhm: 2.5f,
+                MedianEllipticity: 0.45f, StarCount: 1000 + i);
+        }
+        arr[10] = new FrameMetrics(MedianHfd: 2.5f, MedianFwhm: 2.5f,
+            MedianEllipticity: 0.45f, StarCount: 100);
+
+        var result = FrameQualityFilter.Filter(arr, sigma: 3f);
+
+        result.KeptCount.ShouldBe(10);
+        result.Reasons[10].ShouldBe(FrameRejectReason.StarCountTooLow);
+    }
+
+    [Fact]
+    public void Filter_WouldReject25Pct_CapsAt20PctBySeverity()
+    {
+        // 20 frames where 5 are clear HFD outliers (25% of N, above the
+        // 20% floor). The MAD threshold flags all 5; the 80% keep floor
+        // caps rejection at floor(0.20 * 20) = 4 by severity, so the
+        // 5th (least-severe) outlier gets a reprieve.
+        //
+        // Baseline body has small HFD jitter (0.01 px) so MAD > 0 --
+        // a degenerate MAD = 0 distribution can't rank rejects by
+        // severity. Outliers are graduated 4.5, 4.8, 5.0, 5.2, 5.5 so
+        // the floor reprieves the 4.5 one (smallest deviation from
+        // median) and rejects the other four.
+        //
+        // Note: when >50% of frames are "outliers", the median itself
+        // moves into the outliers and the MAD-based detector flips its
+        // notion of "what's normal". That's a known limitation of
+        // median-based filters and not what this test exercises -- the
+        // 20% floor is a guard rail for sessions with a long right
+        // tail (typical drift case), not for sessions where the
+        // majority of frames are bad.
+        var baseline = Enumerable.Range(0, 15)
+            .Select(i => (Hfd: 2.50f + 0.005f * (i - 7), Ecc: 0.45f))
+            .ToArray();
+        var outliers = new[]
+        {
+            (Hfd: 4.5f, Ecc: 0.45f), (Hfd: 5.0f, Ecc: 0.45f),
+            (Hfd: 5.5f, Ecc: 0.45f), (Hfd: 4.8f, Ecc: 0.45f),
+            (Hfd: 5.2f, Ecc: 0.45f),
+        };
+        var metrics = baseline.Concat(outliers)
+            .Select(t => new FrameMetrics(t.Hfd, t.Hfd, t.Ecc, 1000))
+            .ToArray();
+        var result = FrameQualityFilter.Filter(metrics, sigma: 3f);
+
+        result.KeptCount.ShouldBe(16); // 20 - floor(0.20 * 20) = 16
+        result.FloorTriggered.ShouldBeTrue();
+
+        // 4 of the 5 outliers should be rejected, baselines all kept.
+        for (var i = 0; i < 15; i++)
+        {
+            result.Reasons[i].ShouldBe(FrameRejectReason.Kept);
+        }
+        var outlierReasons = result.Reasons.Skip(15).ToArray();
+        outlierReasons.Count(r => r != FrameRejectReason.Kept).ShouldBe(4);
+        // The reprieved frame must be the lowest-HFD outlier (4.5).
+        outlierReasons[0].ShouldBe(FrameRejectReason.Kept);
+    }
+
+    [Fact]
+    public void Filter_SigmaZero_NoOp()
+    {
+        // sigma=0 is the documented "off" path for the field-level
+        // option. The filter should keep everything regardless of how
+        // bad the outlier looks.
+        var metrics = Frames(10, baseHfd: 2.5f, baseEcc: 0.45f, (Hfd: 50f, Ecc: 0.99f));
+        var result = FrameQualityFilter.Filter(metrics, sigma: 0f);
+
+        result.KeptCount.ShouldBe(11);
+        result.FloorTriggered.ShouldBeFalse();
+        result.Reasons.ShouldAllBe(r => r == FrameRejectReason.Kept);
+    }
+
+    [Fact]
+    public void Filter_SoLPierWLikeDistribution_DropsEarlyBloatedFrames()
+    {
+        // Mimic the SoL pierW observation: 28 frames at "good" PSF
+        // quality (HFD 2.85, ecc 0.55 -- matches the per-frame medians
+        // we logged for late pierW), plus 4 "early bloated" frames at
+        // HFD ~3.7 (early pierW). Sigma=3.0 should catch all 4 as
+        // outliers without triggering the 80% floor (4/32 = 12.5% which
+        // is below the 20% cap).
+        var bloated = new[]
+        {
+            (Hfd: 3.67f, Ecc: 0.527f),
+            (Hfd: 3.71f, Ecc: 0.522f),
+            (Hfd: 3.73f, Ecc: 0.520f),
+            (Hfd: 3.65f, Ecc: 0.530f),
+        };
+        var metrics = Frames(28, baseHfd: 2.85f, baseEcc: 0.55f, bloated);
+        var result = FrameQualityFilter.Filter(metrics, sigma: 3f);
+
+        result.KeptCount.ShouldBe(28); // 4 bloated rejected
+        result.FloorTriggered.ShouldBeFalse();
+
+        // The 4 bloated frames (indices 28..31) are the rejects. The
+        // 28 good frames stay.
+        for (var i = 0; i < 28; i++)
+        {
+            result.Reasons[i].ShouldBe(FrameRejectReason.Kept);
+        }
+        for (var i = 28; i < 32; i++)
+        {
+            result.Reasons[i].ShouldBe(FrameRejectReason.HfdTooBroad);
+        }
+    }
+}

--- a/src/TianWen.Lib.Tests/IntegrationStrategySelectorTests.cs
+++ b/src/TianWen.Lib.Tests/IntegrationStrategySelectorTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using Shouldly;
+using TianWen.Lib.Imaging;
 using TianWen.Lib.Imaging.Calibration;
 using TianWen.Lib.Imaging.Stacking;
 using Xunit;
@@ -13,22 +14,24 @@ public class IntegrationStrategySelectorTests
     // Hand-crafted probes that target each branch of the picker. Bytes/RAM
     // are chosen so the *ranking*, not just CanRun, exercises the right path.
 
-    private static IntegrationProbe SmallGroup(long ramBytes = 32L * 1024 * 1024 * 1024) => new(
+    private static IntegrationProbe SmallGroup(long ramBytes = 32L * 1024 * 1024 * 1024, SensorType sensor = SensorType.Monochrome) => new(
         FrameCount: 13,
         FrameWidth: 3008, FrameHeight: 3008, ChannelCount: 3,
         CanvasWidth: 3024, CanvasHeight: 3015,
         AvailableRamBytes: ramBytes,
         AvailableDiskBytes: 500L * 1024 * 1024 * 1024,
         StagingDir: "C:/tmp",
+        SensorType: sensor,
         StagingDiskKind: DiskKind.Ssd);
 
-    private static IntegrationProbe BigGroup(long ramBytes = 8L * 1024 * 1024 * 1024, long diskBytes = 500L * 1024 * 1024 * 1024, DiskKind disk = DiskKind.Ssd) => new(
+    private static IntegrationProbe BigGroup(long ramBytes = 8L * 1024 * 1024 * 1024, long diskBytes = 500L * 1024 * 1024 * 1024, DiskKind disk = DiskKind.Ssd, SensorType sensor = SensorType.Monochrome) => new(
         FrameCount: 244,
         FrameWidth: 3008, FrameHeight: 3008, ChannelCount: 3,
         CanvasWidth: 3024, CanvasHeight: 3015,
         AvailableRamBytes: ramBytes,
         AvailableDiskBytes: diskBytes,
         StagingDir: "C:/tmp",
+        SensorType: sensor,
         StagingDiskKind: disk);
 
     [Fact]
@@ -55,6 +58,113 @@ public class IntegrationStrategySelectorTests
         var inRam = selection.Considered.Single(c => c.Strategy.Kind == IntegrationStrategyKind.InRamAllFrames);
         inRam.Fit.CanRun.ShouldBeFalse();
         inRam.Fit.Rationale.ShouldContain("RAM");
+    }
+
+    [Fact]
+    public void BigGroup_RGGB_PicksBayerDrizzle()
+    {
+        // RGGB sensor + 244 frames (above the 60-frame coverage gate) +
+        // 16 GB host: drizzle should auto-win. The standard path's per-
+        // frame AHD + warp + reject-combine cost (~1000 ms / frame) is
+        // ~3-5x what drizzle's load+calibrate + forward-project (~300 ms /
+        // frame) needs; under Balanced policy that speed advantage wins
+        // over the 0.92-vs-0.98 fidelity discount.
+        var probe = BigGroup(ramBytes: 16L * 1024 * 1024 * 1024, sensor: SensorType.RGGB);
+
+        var selection = IntegrationStrategySelector.Pick(probe);
+
+        selection.Chosen.Kind.ShouldBeOneOf(
+            IntegrationStrategyKind.BayerDrizzle,
+            IntegrationStrategyKind.TilePipelinedDrizzle);
+        var drizzleCandidates = selection.Considered
+            .Where(c => c.Strategy.Kind is IntegrationStrategyKind.BayerDrizzle
+                or IntegrationStrategyKind.TilePipelinedDrizzle)
+            .ToArray();
+        drizzleCandidates.Length.ShouldBe(2,
+            "both drizzle variants should appear in the considered list on RGGB+N>=60");
+        drizzleCandidates.ShouldAllBe(c => c.Fit.CanRun);
+    }
+
+    [Fact]
+    public void SmallGroup_RGGB_GatesOutBayerDrizzleByFrameCount()
+    {
+        // RGGB sensor BUT only 13 frames -- below the 60-frame coverage
+        // gate. The per-Bayer-position coverage (~25% per channel) leaves
+        // big NaN gaps in R and B at this N, so drizzle stays gated even
+        // though the sensor type matches.
+        var probe = SmallGroup(sensor: SensorType.RGGB);
+
+        var selection = IntegrationStrategySelector.Pick(probe);
+
+        selection.Chosen.Kind.ShouldBe(IntegrationStrategyKind.InRamAllFrames);
+        var drizzle = selection.Considered.Single(c => c.Strategy.Kind == IntegrationStrategyKind.BayerDrizzle);
+        drizzle.Fit.CanRun.ShouldBeFalse();
+        drizzle.Fit.Rationale.ShouldContain("matched frames");
+    }
+
+    [Fact]
+    public void BigGroup_Monochrome_GatesOutBayerDrizzleBySensorType()
+    {
+        // 244 frames but mono sensor -- no Bayer matrix to dispatch from,
+        // so drizzle is meaningless. The selector falls back to the
+        // standard path (TilePipelined / FootprintStaged / etc.)
+        // depending on memory budget.
+        var probe = BigGroup(ramBytes: 16L * 1024 * 1024 * 1024, sensor: SensorType.Monochrome);
+
+        var selection = IntegrationStrategySelector.Pick(probe);
+
+        selection.Chosen.Kind.ShouldNotBe(IntegrationStrategyKind.BayerDrizzle);
+        selection.Chosen.Kind.ShouldNotBe(IntegrationStrategyKind.TilePipelinedDrizzle);
+        var drizzle = selection.Considered.Single(c => c.Strategy.Kind == IntegrationStrategyKind.BayerDrizzle);
+        drizzle.Fit.CanRun.ShouldBeFalse();
+        drizzle.Fit.Rationale.ShouldContain("RGGB");
+    }
+
+    [Fact]
+    public void RGGB_BelowDefaultMinFrames_AutoPicksDrizzleWhenMinFramesLowered()
+    {
+        // 50 frames, RGGB sensor. Default DrizzleStrategy uses
+        // AutoSelectMinFrameCount = 60, so the stock pool gates drizzle
+        // out. When the pipeline constructs a custom pool with
+        // minFrameCount=50 (as it would under --drizzle-min-frames 50),
+        // drizzle becomes auto-pickable. This proves the override
+        // threads through to the auto-pick path, not just the pre-gate.
+        var probe = new IntegrationProbe(
+            FrameCount: 50,
+            FrameWidth: 3008, FrameHeight: 3008, ChannelCount: 3,
+            CanvasWidth: 3024, CanvasHeight: 3015,
+            AvailableRamBytes: 16L * 1024 * 1024 * 1024,
+            AvailableDiskBytes: 500L * 1024 * 1024 * 1024,
+            StagingDir: "C:/tmp",
+            SensorType: SensorType.RGGB,
+            StagingDiskKind: DiskKind.Ssd);
+
+        // Default pool: drizzle gated by 60-frame minimum.
+        var defaultPick = IntegrationStrategySelector.Pick(probe);
+        var defaultDrizzle = defaultPick.Considered.Single(c => c.Strategy.Kind == IntegrationStrategyKind.BayerDrizzle);
+        defaultDrizzle.Fit.CanRun.ShouldBeFalse(
+            "default pool with minFrameCount=60 should gate out drizzle at N=50");
+        defaultDrizzle.Fit.Rationale.ShouldContain("matched frames");
+
+        // Custom pool: drizzle constructed with minFrameCount=50, matching
+        // what the pipeline would build when --drizzle-min-frames 50 is
+        // set. Both drizzle variants now accept N=50; selector picks one
+        // of them under Balanced policy.
+        var customPool = IntegrationStrategySelector.DefaultStrategies()
+            .Select(s => s.Kind switch
+            {
+                IntegrationStrategyKind.BayerDrizzle => (IIntegrationStrategy)new DrizzleStrategy(minFrameCount: 50),
+                IntegrationStrategyKind.TilePipelinedDrizzle => new TilePipelinedDrizzleStrategy(minFrameCount: 50),
+                _ => s,
+            })
+            .ToArray();
+        var customPick = IntegrationStrategySelector.Pick(probe, pool: customPool);
+        var customDrizzle = customPick.Considered.Single(c => c.Strategy.Kind == IntegrationStrategyKind.BayerDrizzle);
+        customDrizzle.Fit.CanRun.ShouldBeTrue(
+            $"custom pool with minFrameCount=50 should accept N=50 (rationale: {customDrizzle.Fit.Rationale})");
+        customPick.Chosen.Kind.ShouldBeOneOf(
+            IntegrationStrategyKind.BayerDrizzle,
+            IntegrationStrategyKind.TilePipelinedDrizzle);
     }
 
     [Fact]

--- a/src/TianWen.Lib.Tests/RegistrationRefinerTests.cs
+++ b/src/TianWen.Lib.Tests/RegistrationRefinerTests.cs
@@ -34,7 +34,7 @@ public class RegistrationRefinerTests
         foreach (var p in points)
         {
             bag.Add(new ImagedStar(HFD: 2f, StarFWHM: 2f, SNR: 100f, Flux: 1000f,
-                XCentroid: p.X, YCentroid: p.Y));
+                XCentroid: p.X, YCentroid: p.Y, Ellipticity: 0f));
         }
         return new SortedStarList(new StarList(bag));
     }

--- a/src/TianWen.Lib.Tests/RegistrationRefinerTests.cs
+++ b/src/TianWen.Lib.Tests/RegistrationRefinerTests.cs
@@ -1,0 +1,274 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Numerics;
+using Shouldly;
+using TianWen.Lib.Imaging;
+using TianWen.Lib.Imaging.Stacking;
+using Xunit;
+
+namespace TianWen.Lib.Tests;
+
+/// <summary>
+/// Coverage for both registration-refinement variants in
+/// <see cref="RegistrationRefiner"/>: the legacy translation-only
+/// <c>RefineTranslation</c> and the full 2D Procrustes <c>RefineRigid</c>
+/// (rotation + isotropic scale + translation). All tests build
+/// <see cref="SortedStarList"/> instances directly via the public
+/// <c>SortedStarList(new StarList(new ConcurrentBag&lt;ImagedStar&gt;(...)))</c>
+/// chain -- no FITS I/O needed, so the cases run in &lt; 10 ms each.
+/// </summary>
+[Collection("Imaging")]
+public class RegistrationRefinerTests
+{
+    /// <summary>
+    /// Build a <see cref="SortedStarList"/> from a sequence of 2D points.
+    /// Star photometry fields (HFD / FWHM / SNR / Flux) are filled with
+    /// plausible non-zero values so any future per-star quality filter
+    /// inside the refiner doesn't accidentally reject the synthetic data.
+    /// </summary>
+    private static SortedStarList Stars(IEnumerable<Vector2> points)
+    {
+        var bag = new ConcurrentBag<ImagedStar>();
+        foreach (var p in points)
+        {
+            bag.Add(new ImagedStar(HFD: 2f, StarFWHM: 2f, SNR: 100f, Flux: 1000f,
+                XCentroid: p.X, YCentroid: p.Y));
+        }
+        return new SortedStarList(new StarList(bag));
+    }
+
+    /// <summary>
+    /// Seeded star field laid out on a coarse grid with small per-point
+    /// jitter. The grid stride is 80 px so the typical inter-point
+    /// distance is much larger than the 5 px nearest-neighbour matching
+    /// tolerance — that prevents the synthetic test cases from
+    /// accidentally pairing a light star to a non-partner ref star
+    /// (which would inject phantom rotation/scale into the fit). Wide
+    /// enough overall extent ([50..530]² nominal) that the cross-
+    /// covariance accumulators have meaningful spread.
+    /// </summary>
+    private static Vector2[] SeededStarField(int count, int seed = 1234)
+    {
+        const float gridStride = 80f;
+        const float jitter = 15f;
+        const int cols = 6;
+        var rng = new Random(seed);
+        var points = new List<Vector2>(count);
+        for (var row = 0; points.Count < count; row++)
+        {
+            for (var col = 0; col < cols && points.Count < count; col++)
+            {
+                var cx = 50f + (col + 0.5f) * gridStride + (float)(jitter * (rng.NextDouble() - 0.5));
+                var cy = 50f + (row + 0.5f) * gridStride + (float)(jitter * (rng.NextDouble() - 0.5));
+                points.Add(new Vector2(cx, cy));
+            }
+        }
+        return points.ToArray();
+    }
+
+    [Fact]
+    public void RefineRigid_PureTranslation_RecoversOffset()
+    {
+        // Ground truth: reference = light shifted by (3, -2) px. bulk = identity.
+        var light = SeededStarField(30);
+        var refPoints = light.Select(p => p + new Vector2(3f, -2f));
+
+        var result = RegistrationRefiner.RefineRigid(
+            Stars(light), Stars(refPoints), Matrix3x2.Identity);
+
+        result.MatchedCount.ShouldBe(30);
+        result.RotationDeg.ShouldBe(0f, tolerance: 1e-3f);
+        result.Scale.ShouldBe(1f, tolerance: 1e-5f);
+        result.Tx.ShouldBe(3f, tolerance: 1e-3f);
+        result.Ty.ShouldBe(-2f, tolerance: 1e-3f);
+        result.RmsResidualPx.ShouldBeLessThan(0.01f);
+        result.Refined.M31.ShouldBe(3f, tolerance: 1e-3f);
+        result.Refined.M32.ShouldBe(-2f, tolerance: 1e-3f);
+    }
+
+    [Fact]
+    public void RefineRigid_PureRotation_RecoversAngle()
+    {
+        // 0.5° rotation about (200, 200). Bulk = identity.
+        var light = SeededStarField(30);
+        var rot = Matrix3x2.CreateRotation(0.5f * MathF.PI / 180f, new Vector2(200f, 200f));
+        var refPoints = light.Select(p => Vector2.Transform(p, rot));
+
+        var result = RegistrationRefiner.RefineRigid(
+            Stars(light), Stars(refPoints), Matrix3x2.Identity);
+
+        result.MatchedCount.ShouldBe(30);
+        result.RotationDeg.ShouldBe(0.5f, tolerance: 1e-3f);
+        result.Scale.ShouldBe(1f, tolerance: 1e-5f);
+        result.RmsResidualPx.ShouldBeLessThan(0.01f);
+    }
+
+    [Fact]
+    public void RefineRigid_RotationPlusScale_RecoversBoth()
+    {
+        // Realistic per-frame residual: 0.3° rotation + 1.0015× scale
+        // around the field centroid. Combined into a single Matrix3x2
+        // around the centre of the seeded field.
+        var light = SeededStarField(30);
+        var centroid = new Vector2(
+            light.Average(p => p.X),
+            light.Average(p => p.Y));
+        var rot = Matrix3x2.CreateRotation(0.3f * MathF.PI / 180f, centroid);
+        var scaleAround = Matrix3x2.CreateScale(1.0015f, centroid);
+        var truth = rot * scaleAround;
+        var refPoints = light.Select(p => Vector2.Transform(p, truth));
+
+        var result = RegistrationRefiner.RefineRigid(
+            Stars(light), Stars(refPoints), Matrix3x2.Identity);
+
+        result.MatchedCount.ShouldBe(30);
+        result.RotationDeg.ShouldBe(0.3f, tolerance: 1e-3f);
+        result.Scale.ShouldBe(1.0015f, tolerance: 1e-5f);
+        result.RmsResidualPx.ShouldBeLessThan(0.01f);
+    }
+
+    [Fact]
+    public void RefineRigid_OnTopOfBulkAffine_ComposesCorrectly()
+    {
+        // bulkAffine carries a non-identity translation; ground-truth
+        // adds a small rotation residual. The refined composed transform
+        // should reproduce the full ground truth at the test points.
+        var light = SeededStarField(30);
+        var bulkAffine = Matrix3x2.CreateTranslation(10f, 5f);
+        var residualRot = Matrix3x2.CreateRotation(0.2f * MathF.PI / 180f, new Vector2(210f, 205f));
+        var residualTx = Matrix3x2.CreateTranslation(1f, 0.5f);
+        var truthDelta = residualRot * residualTx;
+        var truth = bulkAffine * truthDelta;
+        var refPoints = light.Select(p => Vector2.Transform(p, truth));
+
+        var result = RegistrationRefiner.RefineRigid(
+            Stars(light), Stars(refPoints), bulkAffine);
+
+        result.MatchedCount.ShouldBe(30);
+
+        // Composed transform should map every test point to its ground-
+        // truth position within 0.05 px (tighter than the matching
+        // tolerance of 5 px so we know it's a real refit, not the
+        // unrefined bulk affine).
+        foreach (var p in light)
+        {
+            var refinedPos = Vector2.Transform(p, result.Refined);
+            var truthPos = Vector2.Transform(p, truth);
+            (refinedPos - truthPos).Length().ShouldBeLessThan(0.05f);
+        }
+    }
+
+    [Fact]
+    public void RefineRigid_FewerThanMinMatched_FallsBackToTranslation()
+    {
+        // 5 matched pairs (< minMatchedStars=8). Should fall back to
+        // RefineTranslation -- still computes median (dx, dy) but reports
+        // scale=1, rot=0, and rms=0 (translation-only fallback signature).
+        var light = SeededStarField(5);
+        var refPoints = light.Select(p => p + new Vector2(2f, 1f));
+
+        var result = RegistrationRefiner.RefineRigid(
+            Stars(light), Stars(refPoints), Matrix3x2.Identity);
+
+        result.MatchedCount.ShouldBe(5);
+        result.Scale.ShouldBe(1f);
+        result.RotationDeg.ShouldBe(0f);
+        // Translation-only fallback applies the median (dx, dy) directly
+        // to M31/M32. The fallback path doesn't compute RMS so it stays
+        // zero -- that's a deliberate marker that the rigid branch
+        // didn't run.
+        result.RmsResidualPx.ShouldBe(0f);
+        result.Refined.M31.ShouldBe(2f, tolerance: 1e-3f);
+        result.Refined.M32.ShouldBe(1f, tolerance: 1e-3f);
+    }
+
+    [Fact]
+    public void RefineRigid_CollinearPoints_FallsBackGracefully()
+    {
+        // 20 stars on a horizontal line, perfect identity alignment.
+        // sumPSq has y-variance ≈ 0 but x-variance > 0, so the algorithm
+        // doesn't hit the degeneracy guard (norm is finite). What we
+        // really want to assert: no NaN in any output field, and the
+        // recovered rotation is essentially zero (perfectly aligned
+        // colinear pairs CAN'T be rotated; the only meaningful answer
+        // is identity).
+        var light = Enumerable.Range(0, 20).Select(i => new Vector2(50f + i * 20f, 200f)).ToArray();
+        var refPoints = light.ToArray();
+
+        var result = RegistrationRefiner.RefineRigid(
+            Stars(light), Stars(refPoints), Matrix3x2.Identity);
+
+        result.MatchedCount.ShouldBe(20);
+        float.IsNaN(result.RotationDeg).ShouldBeFalse();
+        float.IsNaN(result.Scale).ShouldBeFalse();
+        float.IsNaN(result.Tx).ShouldBeFalse();
+        float.IsNaN(result.Ty).ShouldBeFalse();
+        float.IsNaN(result.RmsResidualPx).ShouldBeFalse();
+        result.RotationDeg.ShouldBe(0f, tolerance: 1e-3f);
+        result.Scale.ShouldBe(1f, tolerance: 1e-4f);
+    }
+
+    [Fact]
+    public void RefineRigid_With03PxIsotropicNoise_StaysBounded()
+    {
+        // 50 stars under identity mapping plus ±0.3 px isotropic
+        // Gaussian noise. The fit must not amplify the noise into a
+        // fictitious rotation or scale.
+        var rng = new Random(5678);
+        var light = SeededStarField(50, seed: 9999);
+        var refPoints = light.Select(p =>
+        {
+            var noise = NextGaussian(rng, 0.3f);
+            return new Vector2(p.X + noise.X, p.Y + noise.Y);
+        }).ToArray();
+
+        var result = RegistrationRefiner.RefineRigid(
+            Stars(light), Stars(refPoints), Matrix3x2.Identity);
+
+        result.MatchedCount.ShouldBe(50);
+        // RMS should be on the order of the per-sample noise (with N=50
+        // samples the centroid+fit absorbs some of it; 0.5 px is a
+        // generous ceiling that still catches a runaway fit).
+        result.RmsResidualPx.ShouldBeLessThan(0.5f);
+        // Rotation and scale should stay near identity -- noise alone
+        // mustn't drive a spurious rotation.
+        MathF.Abs(result.RotationDeg).ShouldBeLessThan(0.05f);
+        MathF.Abs(result.Scale - 1f).ShouldBeLessThan(5e-4f);
+    }
+
+    [Fact]
+    public void RefineTranslation_PureTranslation_StillWorks()
+    {
+        // Control test: confirms the legacy RefineTranslation behaviour
+        // is unchanged by the addition of RefineRigid. Same setup as
+        // RefineRigid_PureTranslation_RecoversOffset.
+        var light = SeededStarField(30);
+        var refPoints = light.Select(p => p + new Vector2(3f, -2f));
+
+        var (refined, dx, dy, matched) = RegistrationRefiner.RefineTranslation(
+            Stars(light), Stars(refPoints), Matrix3x2.Identity);
+
+        matched.ShouldBe(30);
+        dx.ShouldBe(3f, tolerance: 1e-3f);
+        dy.ShouldBe(-2f, tolerance: 1e-3f);
+        refined.M31.ShouldBe(3f, tolerance: 1e-3f);
+        refined.M32.ShouldBe(-2f, tolerance: 1e-3f);
+    }
+
+    /// <summary>
+    /// Box-Muller transform: returns a 2D vector of zero-mean Gaussian
+    /// samples with the requested standard deviation.
+    /// </summary>
+    private static Vector2 NextGaussian(Random rng, float stdDev)
+    {
+        var u1 = 1.0 - rng.NextDouble();  // avoid log(0)
+        var u2 = 1.0 - rng.NextDouble();
+        var r = Math.Sqrt(-2.0 * Math.Log(u1));
+        var theta = 2.0 * Math.PI * u2;
+        return new Vector2(
+            (float)(stdDev * r * Math.Cos(theta)),
+            (float)(stdDev * r * Math.Sin(theta)));
+    }
+}

--- a/src/TianWen.Lib.Tests/StackingPipelineRgbBayerDrizzleTest.cs
+++ b/src/TianWen.Lib.Tests/StackingPipelineRgbBayerDrizzleTest.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
@@ -142,6 +143,162 @@ public class StackingPipelineRgbBayerDrizzleTest(ITestOutputHelper output)
         //    coverage.
         result.Result.RejectionMap.ChannelCount.ShouldBe(3,
             "drizzle's RejectionMap is the per-channel coverage buffer");
+    }
+
+    [Fact]
+    public async Task Stack_TilePipelinedDrizzle_MatchesBayerDrizzleByteForByte()
+    {
+        // Both drizzle variants share DrizzleKernel for forward-projection
+        // and FinaliseDivide for the flux/weight pass. The only difference
+        // is the accumulator shape: full-canvas (BayerDrizzle) vs strip-
+        // local (TilePipelinedDrizzle). Addition order per cell is the
+        // same in both paths (same frame order, same source-pixel order,
+        // same Bayer dispatch), so the master pixels must match
+        // bit-exactly. A drift here would indicate the strip-deposit
+        // codepath is silently truncating or double-counting at strip
+        // boundaries.
+        var ct = TestContext.Current.CancellationToken;
+
+        // Share ONE workspace + ONE synthesised fixture across both runs.
+        // Each strategy gets its own output sub-dir so the master FITS
+        // files don't collide, but the input FITS files (light + dark)
+        // are byte-identical and present in the same on-disk order. That
+        // makes the directory-scan order in the pipeline reproducibly the
+        // same across both runs; with separate workspaces, file
+        // timestamps drift and the resulting frame iteration order can
+        // diverge enough to perturb per-cell drizzle sums by 1 ULP.
+        using var workspace = new TempStackingWorkspace();
+        var darksDir = Path.Combine(workspace.RootDir, "DARK");
+        Directory.CreateDirectory(darksDir);
+        RgbBayerSyntheticFixture.WriteSyntheticLights(workspace.LightsDir);
+        RgbBayerSyntheticFixture.WriteSyntheticDarks(darksDir);
+
+        async Task<float[][]> RunAndExtract(IntegrationStrategyKind kind)
+        {
+            var options = new StackingOptions(
+                DataRoot: workspace.RootDir,
+                OutputDir: workspace.OutputDir,
+                ForcedStrategy: kind,
+                DrizzleOptions: new DrizzleOptions(MinFrameCount: 6));
+            var logger = new XunitLogger(output);
+            var pipeline = new StackingPipeline(options, logger, catalogDb: null);
+
+            var results = new List<GroupResult>();
+            await foreach (var r in pipeline.RunAsync(ct))
+            {
+                results.Add(r);
+            }
+            results.Count.ShouldBe(1);
+            var masterPath = results[0].MasterFitsPath;
+            masterPath.ShouldNotBeNull();
+            Image.TryReadFitsFile(masterPath, out var master).ShouldBeTrue();
+            master.ShouldNotBeNull();
+            master.ChannelCount.ShouldBe(3);
+
+            // Flatten each channel into a row-major float[] for cmp.
+            var perChannel = new float[master.ChannelCount][];
+            for (var c = 0; c < master.ChannelCount; c++)
+            {
+                var span = master.GetChannelSpan(c);
+                perChannel[c] = span.ToArray();
+            }
+            return perChannel;
+        }
+
+        // First strategy writes its master into workspace.OutputDir. The
+        // pipeline filter excludes anything under that dir from the
+        // light-scan, so the second strategy's run won't see the first
+        // run's master FITS as a stray light frame. Both strategies emit
+        // master_<slug>_drizzle.fits (same _drizzle suffix), so move the
+        // first run's outputs aside before the second runs to avoid the
+        // overwrite-then-re-read collision and to preserve the master
+        // for the comparison.
+        var streaming = await RunAndExtract(IntegrationStrategyKind.BayerDrizzle);
+        // Archive the first run's master OUTSIDE workspace.RootDir entirely:
+        // anything left under workspace would get rescanned as a light by
+        // the second run unless it's under OutputDir (which is going to be
+        // recreated by the second run with conflicting filenames). System
+        // temp is the simplest "definitely not part of the second run's
+        // data root" location; the file gets cleaned up with the rest of
+        // the workspace via TempStackingWorkspace's IDisposable. We don't
+        // actually need the archived bytes -- the in-memory `streaming`
+        // float arrays are what we compare against -- so the move is just
+        // about getting the files out of the second run's scan path.
+        var trashDir = Path.Combine(Path.GetTempPath(), "tianwen-parity-trash-" + System.Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(trashDir);
+        try
+        {
+            foreach (var file in Directory.GetFiles(workspace.OutputDir))
+            {
+                File.Move(file, Path.Combine(trashDir, Path.GetFileName(file)));
+            }
+            var tiled = await RunAndExtract(IntegrationStrategyKind.TilePipelinedDrizzle);
+            CompareChannels(streaming, tiled);
+        }
+        finally
+        {
+            try { Directory.Delete(trashDir, recursive: true); } catch { /* hygiene */ }
+        }
+        return;
+
+        static void CompareChannels(float[][] streaming, float[][] tiled)
+        {
+            // Tolerance: 0.01% relative error. The two paths share the
+            // DrizzleKernel and the FinaliseDivide pass, so the deposit
+            // math + final divide are bit-equivalent for identical
+            // inputs. What CAN drift by a few ULPs is the calibrated
+            // input itself: streaming consumes Image instances from the
+            // pipeline's pre-populated `calibratedCache` (registered
+            // during the matching pass), while tiled re-reads + re-
+            // calibrates via DecodeCalibrate. Both follow the same
+            // FITS reader + Calibrator.Apply code paths, but SIMD-vs-
+            // scalar dispatch in Calibrator (ArrayPool reuse + thread-
+            // local intrinsics) can yield 1-2 ULP differences in
+            // calibrated samples when invoked under different call-site
+            // contexts. Those propagate as a handful of ULPs through
+            // the drizzle accumulator. The 1e-4 bound is wide enough to
+            // tolerate that drift across thread/SIMD scheduling
+            // variation, yet tight enough to flag a real algorithmic
+            // divergence (R/B swap, halo too tight, strip boundary
+            // off-by-one -- all of which produce > 1% local deltas).
+            const double RelativeTolerance = 1e-4;
+            streaming.Length.ShouldBe(tiled.Length);
+            var maxAbsDelta = 0.0;
+            var maxRelDelta = 0.0;
+            for (var c = 0; c < streaming.Length; c++)
+            {
+                streaming[c].Length.ShouldBe(tiled[c].Length,
+                    $"channel {c} length mismatch: {streaming[c].Length} vs {tiled[c].Length}");
+                var streamCh = streaming[c];
+                var tiledCh = tiled[c];
+                for (var i = 0; i < streamCh.Length; i++)
+                {
+                    var s = streamCh[i];
+                    var t = tiledCh[i];
+                    // NaN cells: both paths emit NaN where coverage is
+                    // zero -- they must agree on the NaN pattern (any cell
+                    // that's NaN in one path but a finite value in the
+                    // other is a real bug, not a precision artifact).
+                    if (float.IsNaN(s) || float.IsNaN(t))
+                    {
+                        float.IsNaN(s).ShouldBe(float.IsNaN(t),
+                            $"channel {c} cell {i}: NaN pattern mismatch (BayerDrizzle={s}, TilePipelinedDrizzle={t}). " +
+                            "The two paths must agree on which cells are uncovered.");
+                        continue;
+                    }
+                    var abs = (double)Math.Abs(s - t);
+                    if (abs > maxAbsDelta) maxAbsDelta = abs;
+                    var rel = abs / Math.Max(Math.Abs((double)s), 1e-10);
+                    if (rel > maxRelDelta) maxRelDelta = rel;
+                    rel.ShouldBeLessThan(RelativeTolerance,
+                        $"channel {c} cell {i}: BayerDrizzle={s:R} vs TilePipelinedDrizzle={t:R} " +
+                        $"(absolute delta {abs:G3}, relative {rel:G3}); tolerance {RelativeTolerance:G3}. " +
+                        "Above this threshold indicates a real algorithmic divergence, not a " +
+                        "floating-point summation-order artifact.");
+                }
+            }
+        }
+
     }
 
     [Fact]

--- a/src/TianWen.Lib.Tests/Tycho2FovExploratoryTests.cs
+++ b/src/TianWen.Lib.Tests/Tycho2FovExploratoryTests.cs
@@ -1,0 +1,148 @@
+using Shouldly;
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using TianWen.Lib.Astrometry.Catalogs;
+using TianWen.Lib.Imaging;
+using Xunit;
+
+namespace TianWen.Lib.Tests;
+
+/// <summary>
+/// Local-only exploratory diagnostic: count how many Tycho-2 stars actually
+/// fall inside a specific master FITS's field of view, broken down by gate
+/// (in-FOV, has B-V photometry, has V_Mag). Used to diagnose the SPCC
+/// match-count funnel without having to instrument production code.
+///
+/// <para>Parses the embedded <c>tyc2.bin.lz</c> binary directly rather than
+/// going through <see cref="CelestialObjectDB"/> -- a fresh DB instance in
+/// the test context doesn't populate <c>_tycho2Data</c> after
+/// <c>InitDBAsync(waitForTycho2BulkLoad: true)</c> (separate bug to investigate),
+/// so the diagnostic does its own binary walk.</para>
+///
+/// <para>Skipped silently in CI -- needs a local master FITS at a hard-coded
+/// path (the SoL drizzle output sitting in <c>C:\temp\stack\output\</c>). To
+/// run manually after a stack:</para>
+/// <code>
+/// dotnet test TianWen.Lib.Tests --filter FullyQualifiedName~Tycho2FovExploratory
+/// </code>
+/// </summary>
+public class Tycho2FovExploratoryTests(ITestOutputHelper output)
+{
+    [Fact]
+    public async Task Diagnose_Tycho2_BulkLoad_State()
+    {
+        // Probe the CelestialObjectDB internals after a full init with
+        // waitForTycho2BulkLoad: true. If the bulk task ran but _tycho2Data
+        // is still null, the early-exit in ReadTycho2Bulk fired -- print the
+        // task status + manifest names so we can see why.
+        var db = new CelestialObjectDB();
+        await db.InitDBAsync(waitForTycho2BulkLoad: true, cancellationToken: System.Threading.CancellationToken.None);
+        await db.EnsureTycho2DataLoadedAsync(System.Threading.CancellationToken.None);
+
+        var state = db.Tycho2BulkLoadState;
+        output.WriteLine($"DataLoaded={state.DataLoaded} StreamCount={state.StreamCount} IndexBuilt={state.IndexBuilt} BulkTaskRan={state.BulkTaskRan} TaskStatus={state.BulkTaskStatus}");
+        output.WriteLine($"Tycho2StarCount={db.Tycho2StarCount}");
+
+        // Also dump the manifest names that include "tyc2" to confirm the
+        // assembly the DB is looking at actually contains the resource.
+        var asm = typeof(CelestialObjectDB).Assembly;
+        var names = asm.GetManifestResourceNames();
+        foreach (var n in names.Where(n => n.Contains("tyc2", StringComparison.OrdinalIgnoreCase)))
+        {
+            output.WriteLine($"  manifest: {n}");
+        }
+        // And confirm the EndsWith predicate that ReadTycho2Bulk uses matches.
+        var match = names.FirstOrDefault(p => p.EndsWith(".tyc2.bin.lz", StringComparison.Ordinal));
+        output.WriteLine($"  FirstOrDefault(.tyc2.bin.lz): {match ?? "(null)"}");
+    }
+
+    [Fact]
+    public async Task SoL_60s_Drizzle_TychoFovCount()
+    {
+        const string masterPath = @"C:\temp\stack\output\master_StatueofLibertyNebula_light_60s_-5C_g120_drizzle.fits";
+        if (!File.Exists(masterPath))
+        {
+            output.WriteLine($"SKIP: master not found at {masterPath}");
+            return;
+        }
+
+        // Read master + WCS from the FITS file produced by the stacking pipeline.
+        Image.TryReadFitsFile(masterPath, out var master, out var wcs).ShouldBeTrue();
+        master.ShouldNotBeNull();
+        wcs.ShouldNotBeNull();
+        var (w, h) = (master.Width, master.Height);
+        output.WriteLine($"master: {w}x{h}, WCS present");
+
+        // Production DB path now that the Tycho2StarCount lazy bug is fixed.
+        var db = await SharedCatalogDB.InitAsync(TestContext.Current.CancellationToken);
+        await db.EnsureTycho2DataLoadedAsync(TestContext.Current.CancellationToken);
+        var catalogTotal = db.Tycho2StarCount;
+        var stars = new Tycho2StarLite[catalogTotal];
+        var copied = db.CopyTycho2Stars(stars);
+        copied.ShouldBe(catalogTotal);
+
+        // Funnel counters.
+        int inFovTotal = 0;
+        int inFovWithBV = 0;
+        int inFovWithVMag = 0;
+        int inFovWithBoth = 0;
+        Span<int> magBins = stackalloc int[16];
+        Span<int> magBinsWithBV = stackalloc int[16];
+
+        for (var i = 0; i < copied; i++)
+        {
+            var star = stars[i];
+            // Production code path: CopyTycho2Stars fills BMinusV=0.65 (solar
+            // fallback) when BT is missing -- it never returns NaN for BV.
+            // To match the SPCC pipeline's "real BV" gate, we treat 0.65f
+            // EXACTLY as the synthesised default and bucket separately. In
+            // practice few stars hit this branch (Tycho-2 has BT for most),
+            // so the histogram is dominated by real measurements.
+            var raDeg = star.RaHours * 15.0;
+            var pixel = wcs.Value.SkyToPixel(raDeg, (double)star.DecDeg);
+            if (pixel is not { } p) continue;
+            var x0 = p.X - 1.0;
+            var y0 = p.Y - 1.0;
+            if (x0 < 0 || x0 >= w || y0 < 0 || y0 >= h) continue;
+
+            inFovTotal++;
+            var hasVMag = !float.IsNaN(star.VMag);
+            // 0.65f is the synthetic solar-type default; treat anything else
+            // as a real measurement.
+            var hasBV = star.BMinusV != 0.65f && !float.IsNaN(star.BMinusV);
+            if (hasBV) inFovWithBV++;
+            if (hasVMag) inFovWithVMag++;
+            if (hasBV && hasVMag) inFovWithBoth++;
+
+            if (hasVMag)
+            {
+                var bin = (int)((star.VMag - 5.5f) * 2f);
+                bin = Math.Clamp(bin, 0, magBins.Length - 1);
+                magBins[bin]++;
+                if (hasBV) magBinsWithBV[bin]++;
+            }
+        }
+
+        output.WriteLine($"Tycho-2 catalog total: {catalogTotal}");
+        output.WriteLine($"");
+        output.WriteLine($"SoL FOV Tycho-2 funnel:");
+        output.WriteLine($"  in-FOV total       : {inFovTotal}");
+        output.WriteLine($"  in-FOV w/ V_Mag    : {inFovWithVMag}");
+        output.WriteLine($"  in-FOV w/ B-V      : {inFovWithBV}  ({(100.0 * inFovWithBV / Math.Max(1, inFovTotal)):F1} % of in-FOV)");
+        output.WriteLine($"  in-FOV w/ both     : {inFovWithBoth}  ({(100.0 * inFovWithBoth / Math.Max(1, inFovTotal)):F1} % of in-FOV)");
+        output.WriteLine($"");
+        output.WriteLine($"V-mag histogram of in-FOV stars (with B-V coverage):");
+        for (var b = 0; b < magBins.Length; b++)
+        {
+            if (magBins[b] == 0) continue;
+            var magLo = 5.5f + b * 0.5f;
+            var magHi = magLo + 0.5f;
+            var bvPct = 100.0 * magBinsWithBV[b] / magBins[b];
+            output.WriteLine($"  [{magLo:F1} .. {magHi:F1}]  total={magBins[b],4}  withBV={magBinsWithBV[b],4}  ({bvPct,5:F1} %)");
+        }
+
+        inFovTotal.ShouldBeGreaterThan(0);
+    }
+}

--- a/src/TianWen.Lib/Astrometry/Catalogs/CelestialObjectDB.cs
+++ b/src/TianWen.Lib/Astrometry/Catalogs/CelestialObjectDB.cs
@@ -116,6 +116,19 @@ internal sealed partial class CelestialObjectDB : ICelestialObjectDB
 
     public IRaDecIndex DeepSkyCoordinateGrid => _raDecIndex;
 
+    /// <summary>
+    /// Internal diagnostic: surfaces the inner state of the Tycho-2 bulk load
+    /// so a test (or precompute tool) can verify the binary was decoded
+    /// successfully. Production code should never need this -- use
+    /// <see cref="Tycho2StarCount"/> + <see cref="CopyTycho2Stars"/> instead.
+    /// </summary>
+    internal (bool DataLoaded, int StreamCount, bool IndexBuilt, bool BulkTaskRan, TaskStatus? BulkTaskStatus) Tycho2BulkLoadState =>
+        (_tycho2Data is not null,
+         _tycho2StreamCount,
+         _tycho2RaDecIndex is not null,
+         _tycho2BulkLoadTask is not null,
+         _tycho2BulkLoadTask?.Status);
+
     /// <inheritdoc/>
     public bool TryResolveCommonName(string name, out IReadOnlyList<CatalogIndex> matches) => _objectsByCommonName.TryGetLookupEntries(name, out matches);
 
@@ -1433,11 +1446,24 @@ internal sealed partial class CelestialObjectDB : ICelestialObjectDB
     public int HipStarCount => _hipToTyc?.Length ?? 0;
 
     /// <inheritdoc/>
-    public int Tycho2StarCount => _tycho2StarCount;
+    public int Tycho2StarCount
+    {
+        get
+        {
+            // The lazy is populated by CopyTycho2Stars on its first call; if a
+            // caller queries the count BEFORE iterating, the cached field is
+            // still 0 even though _tycho2Data is fully loaded. Trigger the
+            // count walk on read so the property doc ("populated lazily on
+            // first access") is true regardless of call order.
+            EnsureTycho2StarCount();
+            return _tycho2StarCount;
+        }
+    }
 
     /// <summary>
     /// Cached total star count across all Tycho-2 streams. Populated lazily on
-    /// first access and after the binary data is loaded.
+    /// first access (via <see cref="Tycho2StarCount"/> or
+    /// <see cref="CopyTycho2Stars"/>) once the binary data is loaded.
     /// </summary>
     private int _tycho2StarCount;
 

--- a/src/TianWen.Lib/Astrometry/PlateSolve/CatalogPlateSolver.cs
+++ b/src/TianWen.Lib/Astrometry/PlateSolve/CatalogPlateSolver.cs
@@ -683,7 +683,7 @@ internal sealed class CatalogPlateSolver(ICelestialObjectDB db, ILogger? logger 
             if (xPix >= -marginX && xPix <= dim.Width + marginX &&
                 yPix >= -marginY && yPix <= dim.Height + marginY)
             {
-                projected.Add(new ImagedStar(2f, 2f, 100f, 1000f, xPix, yPix));
+                projected.Add(new ImagedStar(2f, 2f, 100f, 1000f, xPix, yPix, 0f));
             }
         }
 

--- a/src/TianWen.Lib/Imaging/Calibration/BadPixelDetection.cs
+++ b/src/TianWen.Lib/Imaging/Calibration/BadPixelDetection.cs
@@ -208,16 +208,38 @@ public static class BadPixelDetection
             Array.Sort(workBuf, 0, liveCount);
             var mad = workBuf[liveCount / 2];
 
-            // MAD = 0 can happen when the inlier subset is uniform (rare
-            // but possible on a clipped / over-corrected dark). The
-            // threshold would collapse to median + 0, which is the median
-            // itself; counting "pixels exceeding the median" would mark
-            // ~half the channel. Bail with whatever mask we already have.
+            // MAD = 0 on cooled-CMOS bias-dominated darks: at -5C on an
+            // IMX571, 60s of dark current is sub-ADU, so the master dark
+            // is essentially uniform bias with a long hot-pixel tail.
+            // 50%+ of pixels collapse to a single quantized value, the
+            // median absolute deviation is 0 by construction, and the
+            // textbook threshold (median + sigma * MAD) degenerates to
+            // the median itself -- which would mark half the channel as
+            // "hot". Fall back to the median of the NON-ZERO absolute
+            // deviations: this anchors the noise scale to the typical
+            // step between the bias floor and the next-quantized level
+            // (a few ADU on this sensor), ignoring the degenerate
+            // delta-function at exactly the bias level.
             if (mad <= 0f)
             {
-                logger?.LogDebug("  hot-pixel ch={Ch} iter={Iter}: MAD=0 (inlier subset uniform); stopping",
-                    channelIndex, iter);
-                break;
+                // Find the first non-zero deviation. workBuf is sorted
+                // ascending, so a linear scan from the start lands on the
+                // first non-zero entry quickly (most zeros are clustered
+                // at the bottom).
+                var firstNonZero = 0;
+                while (firstNonZero < liveCount && workBuf[firstNonZero] <= 0f) firstNonZero++;
+                if (firstNonZero >= liveCount)
+                {
+                    // Truly uniform channel (every strided sample
+                    // identical). Can't recover a noise scale; bail.
+                    logger?.LogDebug("  hot-pixel ch={Ch} iter={Iter}: every strided sample identical to median; stopping",
+                        channelIndex, iter);
+                    break;
+                }
+                // Median of the non-zero deviation tail.
+                mad = workBuf[firstNonZero + (liveCount - firstNonZero) / 2];
+                logger?.LogDebug("  hot-pixel ch={Ch} iter={Iter}: MAD=0 (bias-dominated dark); using non-zero-tail MAD={Mad:F4}",
+                    channelIndex, iter, mad);
             }
 
             var threshold = median + sigmaThreshold * GaussianFactor * mad;

--- a/src/TianWen.Lib/Imaging/Calibration/BadPixelDetection.cs
+++ b/src/TianWen.Lib/Imaging/Calibration/BadPixelDetection.cs
@@ -1,4 +1,5 @@
 using System;
+using Microsoft.Extensions.Logging;
 
 namespace TianWen.Lib.Imaging.Calibration;
 
@@ -13,35 +14,83 @@ namespace TianWen.Lib.Imaging.Calibration;
 public static class BadPixelDetection
 {
     /// <summary>Subsample stride used when computing the per-channel median +
-    /// MAD of the dark master. A 6224x4168 IMX455 dark at stride=32 yields
-    /// ~25k samples per channel -- enough for a stable median estimate, ~10ms
-    /// per channel. The dark master changes rarely (one build per session),
-    /// so over-investing in precision here doesn't pay back.</summary>
-    private const int StatStride = 32;
+    /// MAD of the dark master. Denser than the original stride=32 because the
+    /// iterative loop (<see cref="BuildMaskFromDark"/>) leans on the sample
+    /// containing actual hot pixels: each iteration excludes the flagged
+    /// strided positions and re-estimates noise stats from the inlier
+    /// remainder, which only helps if a meaningful fraction of the sample
+    /// IS contaminated. At stride=8 a 6224x4168 IMX455 dark yields ~405k
+    /// samples per channel -- big enough to contain dozens of hot pixels at
+    /// typical 0.01-0.1 % hot-pixel rates, so excluding them measurably
+    /// tightens the MAD between iterations. Sort cost stays under 10 ms per
+    /// channel per iteration.</summary>
+    private const int StatStride = 8;
 
     /// <summary>Conventional MAD-to-Gaussian-sigma factor. Median +
     /// <see cref="GaussianFactor"/> * MAD approximates median + 1*sigma
     /// for a Gaussian distribution, which is what the
-    /// <paramref name="sigmaThreshold"/> in <see cref="BuildMaskFromDark"/>
-    /// effectively maps to.</summary>
+    /// <c>sigmaThreshold</c> parameter effectively maps to.</summary>
     private const float GaussianFactor = 1.4826f;
 
+    /// <summary>Default iteration cap for kappa-sigma convergence in
+    /// <see cref="BuildMaskFromDark"/>. Typical real-data convergence
+    /// happens in 2-4 iterations; the cap is a runaway guard for
+    /// pathological inputs (uniform dark, single-bin distribution, etc.).</summary>
+    private const int DefaultMaxIterations = 10;
+
+    /// <summary>Default convergence floor: stop iterating when an iteration
+    /// adds fewer than this fraction of the channel's total pixel count to
+    /// the mask. 0.0001 = 0.01 % (~2600 pixels on a 26 MP frame) -- small
+    /// enough that "we've found nearly everything" but big enough that we
+    /// don't iterate forever chasing noise-floor flicker.</summary>
+    private const float DefaultConvergenceFraction = 0.0001f;
+
     /// <summary>
-    /// Per-channel hot-pixel mask: <c>true</c> bit = pixel is hotter than
-    /// <paramref name="sigmaThreshold"/> Gaussian-sigma above the channel
-    /// median, masked from downstream integration. One <see cref="BitMatrix"/>
-    /// per channel keeps the memory footprint at 1 bit/pixel (8x denser
-    /// than <c>bool[,]</c> -- ~3 MB per 6k frame channel vs 26 MB).
+    /// Per-channel hot-pixel mask: <c>true</c> bit = pixel exceeds the
+    /// converged threshold (median + sigma * 1.4826 * MAD), masked from
+    /// downstream integration. One <see cref="BitMatrix"/> per channel keeps
+    /// the memory footprint at 1 bit/pixel (8x denser than <c>bool[,]</c>
+    /// -- ~3 MB per 6k frame channel vs 26 MB).
+    ///
+    /// <para>The kappa-sigma loop iterates until convergence: each pass
+    /// recomputes the median + MAD over the strided sample positions that
+    /// are NOT YET masked. Outliers (hot pixels) in the sample inflate the
+    /// initial MAD; excluding them on the next iteration tightens MAD,
+    /// drops the threshold (in absolute ADU), and catches more borderline
+    /// pixels. The mask grows monotonically -- never un-mask -- and the
+    /// loop terminates when an iteration adds fewer than
+    /// <paramref name="convergenceFraction"/> of total pixels, or after
+    /// <paramref name="maxIterations"/> as a safety cap. This is the
+    /// standard astro pipeline approach (PixInsight CosmeticCorrection,
+    /// Astro Pixel Processor, DeepSkyStacker bad-pixel rejection all do
+    /// equivalent iterative kappa-sigma) and catches the warm-borderline
+    /// pixels a one-shot threshold misses.</para>
     /// </summary>
     /// <param name="darkMaster">Master dark frame.</param>
     /// <param name="sigmaThreshold">Threshold in Gaussian sigmas. Typical
-    /// good value is 8 -- hot pixels usually score 100+ sigma above the
-    /// channel median, so 8 is comfortably above the legitimate dark
-    /// current spread without flagging warm-but-usable pixels. Pass 0 or
-    /// negative to return <c>null</c> (disable masking).</param>
+    /// good value is 8 -- once the iterative loop has converged, anything
+    /// 8 sigma above the noise floor is a hot pixel by definition (no
+    /// legitimate dark current spread reaches 8 sigma above the cleaned
+    /// median). Pass 0 or negative to return <c>null</c> (disable masking).</param>
+    /// <param name="logger">Optional logger -- receives one
+    /// <c>Information</c> line per channel summarising the converged mask
+    /// (count + iterations + final threshold) and per-iteration
+    /// <c>Debug</c> lines for forensics.</param>
+    /// <param name="maxIterations">Hard cap on iterations. Defaults to
+    /// <see cref="DefaultMaxIterations"/>; tighter values (3-5) for
+    /// runtime-sensitive paths.</param>
+    /// <param name="convergenceFraction">Stop when newly-masked pixels in
+    /// one iteration drop below <c>fraction * totalChannelPx</c>. Defaults
+    /// to <see cref="DefaultConvergenceFraction"/> (0.01 % of channel
+    /// pixels).</param>
     /// <returns>A per-channel mask <c>BitMatrix[ChannelCount]</c> or
     /// <c>null</c> when masking is disabled.</returns>
-    public static BitMatrix[]? BuildMaskFromDark(Image darkMaster, float sigmaThreshold)
+    public static BitMatrix[]? BuildMaskFromDark(
+        Image darkMaster,
+        float sigmaThreshold,
+        ILogger? logger = null,
+        int maxIterations = DefaultMaxIterations,
+        float convergenceFraction = DefaultConvergenceFraction)
     {
         if (sigmaThreshold <= 0f)
         {
@@ -51,32 +100,18 @@ public static class BadPixelDetection
         var masks = new BitMatrix[channelCount];
         for (var c = 0; c < channelCount; c++)
         {
-            var data = darkMaster.GetChannelArray(c);
-            var (median, mad) = ComputeMedianAndMad(data);
-            var threshold = median + sigmaThreshold * GaussianFactor * mad;
-            var h = data.GetLength(0);
-            var w = data.GetLength(1);
-            var mask = new BitMatrix(h, w);
-            for (var y = 0; y < h; y++)
-            {
-                for (var x = 0; x < w; x++)
-                {
-                    if (data[y, x] > threshold)
-                    {
-                        mask[y, x] = true;
-                    }
-                }
-            }
-            masks[c] = mask;
+            masks[c] = BuildMaskForChannel(darkMaster.GetChannelArray(c), c,
+                sigmaThreshold, maxIterations, convergenceFraction, logger);
         }
         return masks;
     }
 
     /// <summary>
     /// Counts the masked pixels (true bits) across all channels. Useful
-    /// for the pipeline log -- a typical CMOS sensor reports 50-5000 hot
-    /// pixels at sigma=8, larger or smaller counts hint at a bad sigma
-    /// choice or a corrupted dark.
+    /// for the pipeline log -- a typical CMOS sensor reports a few hundred
+    /// to several thousand hot pixels after iterative convergence; very
+    /// different orders of magnitude hint at a bad sigma choice or a
+    /// corrupted dark.
     /// </summary>
     public static int CountMaskedPixels(BitMatrix[]? mask, int width, int height)
     {
@@ -96,30 +131,136 @@ public static class BadPixelDetection
         return total;
     }
 
-    private static (float Median, float Mad) ComputeMedianAndMad(float[,] data)
+    /// <summary>
+    /// Run the iterative kappa-sigma loop for one channel of the dark master.
+    /// Strided positions + values are captured once; each iteration filters
+    /// the sample to currently un-masked positions, recomputes median + MAD,
+    /// applies the new threshold to the FULL channel, and grows the mask.
+    /// </summary>
+    private static BitMatrix BuildMaskForChannel(
+        float[,] data, int channelIndex,
+        float sigmaThreshold, int maxIterations, float convergenceFraction,
+        ILogger? logger)
     {
         var h = data.GetLength(0);
         var w = data.GetLength(1);
+        var totalPx = (long)h * w;
+        var convergenceFloor = (long)(totalPx * convergenceFraction);
+
+        // Strided sample collected once; reused (with position-aware
+        // mask filtering) across iterations.
         var sampleCount = ((h + StatStride - 1) / StatStride) * ((w + StatStride - 1) / StatStride);
-        var samples = new float[sampleCount];
+        var sampleValues = new float[sampleCount];
+        var sampleY = new int[sampleCount];
+        var sampleX = new int[sampleCount];
         var idx = 0;
         for (var y = 0; y < h; y += StatStride)
         {
             for (var x = 0; x < w; x += StatStride)
             {
-                samples[idx++] = data[y, x];
+                sampleValues[idx] = data[y, x];
+                sampleY[idx] = y;
+                sampleX[idx] = x;
+                idx++;
             }
         }
-        Array.Sort(samples, 0, idx);
-        var median = samples[idx / 2];
-        // Reuse the samples buffer for the deviation array -- we've already
-        // consumed the sorted samples to read the median.
-        for (var i = 0; i < idx; i++)
+        var totalSample = idx;
+
+        var mask = new BitMatrix(h, w);
+        var workBuf = new float[totalSample];
+        long maskedTotal = 0;
+        var lastThreshold = 0f;
+        var iterRan = 0;
+
+        for (var iter = 0; iter < maxIterations; iter++)
         {
-            samples[i] = MathF.Abs(samples[i] - median);
+            iterRan = iter + 1;
+
+            // Filter the strided sample to positions NOT in the current
+            // mask. After iter 0 these are guaranteed non-hot (we just
+            // flagged the hot ones), so the median + MAD anchor to the
+            // inlier distribution.
+            var liveCount = 0;
+            for (var i = 0; i < totalSample; i++)
+            {
+                if (!mask[sampleY[i], sampleX[i]])
+                {
+                    workBuf[liveCount++] = sampleValues[i];
+                }
+            }
+            // Degenerate: every strided sample has been masked. Stop --
+            // the channel's distribution is so contaminated that one more
+            // iteration would have no signal to anchor against.
+            if (liveCount == 0)
+            {
+                break;
+            }
+
+            Array.Sort(workBuf, 0, liveCount);
+            var median = workBuf[liveCount / 2];
+
+            // Reuse the buffer for the absolute-deviation array. We've
+            // already consumed the sorted samples to read the median.
+            for (var i = 0; i < liveCount; i++)
+            {
+                workBuf[i] = MathF.Abs(workBuf[i] - median);
+            }
+            Array.Sort(workBuf, 0, liveCount);
+            var mad = workBuf[liveCount / 2];
+
+            // MAD = 0 can happen when the inlier subset is uniform (rare
+            // but possible on a clipped / over-corrected dark). The
+            // threshold would collapse to median + 0, which is the median
+            // itself; counting "pixels exceeding the median" would mark
+            // ~half the channel. Bail with whatever mask we already have.
+            if (mad <= 0f)
+            {
+                logger?.LogDebug("  hot-pixel ch={Ch} iter={Iter}: MAD=0 (inlier subset uniform); stopping",
+                    channelIndex, iter);
+                break;
+            }
+
+            var threshold = median + sigmaThreshold * GaussianFactor * mad;
+            lastThreshold = threshold;
+
+            // Walk the FULL channel; flag any un-masked pixel exceeding
+            // threshold. Mask grows monotonically -- a pixel marked in
+            // iter K stays marked through convergence even if a later
+            // iteration's threshold would un-mark it. This is correct:
+            // once we've identified a hot pixel using cleaner statistics,
+            // re-introducing it would contaminate the very loop that just
+            // excluded it.
+            long newlyMasked = 0;
+            for (var y = 0; y < h; y++)
+            {
+                for (var x = 0; x < w; x++)
+                {
+                    if (!mask[y, x] && data[y, x] > threshold)
+                    {
+                        mask[y, x] = true;
+                        newlyMasked++;
+                    }
+                }
+            }
+            maskedTotal += newlyMasked;
+
+            logger?.LogDebug(
+                "  hot-pixel ch={Ch} iter={Iter}: median={Med:F4} mad={Mad:F4} threshold={T:F4} added={Added} total={Total}",
+                channelIndex, iter, median, mad, threshold, newlyMasked, maskedTotal);
+
+            // Convergence criterion: newly-added below the absolute floor,
+            // OR exactly zero (full convergence). Iter 0 always has
+            // newlyMasked > 0 in practice; subsequent iters tail off.
+            if (newlyMasked == 0 || newlyMasked < convergenceFloor)
+            {
+                break;
+            }
         }
-        Array.Sort(samples, 0, idx);
-        var mad = samples[idx / 2];
-        return (median, mad);
+
+        logger?.LogInformation(
+            "  hot-pixel ch={Ch}: {Count} px in {Iters} iter(s) (final threshold={T:F4})",
+            channelIndex, maskedTotal, iterRan, lastThreshold);
+
+        return mask;
     }
 }

--- a/src/TianWen.Lib/Imaging/Calibration/FrameInfo.cs
+++ b/src/TianWen.Lib/Imaging/Calibration/FrameInfo.cs
@@ -18,13 +18,19 @@ namespace TianWen.Lib.Imaging.Calibration;
 /// <param name="Meta">Parsed <see cref="ImageMeta"/> — frame type, exposure,
 /// filter, sensor type, temperature, etc. All FITS header reads needed by the
 /// stacking pipeline are routed through this field.</param>
+/// <param name="StackedFrameCount">Value of the FITS <c>STACK_N</c> header, or 0
+/// when the keyword is absent. Non-zero marks the file as a stacking product
+/// (master integrated by <c>IntegrationFitsWriter</c>) — these must be filtered
+/// out at scan time when they sit alongside lights, otherwise they get treated
+/// as fresh frames and pollute the next run's groups.</param>
 public sealed record FrameInfo(
     string Path,
     int Width,
     int Height,
     int ChannelCount,
     BitDepth BitDepth,
-    ImageMeta Meta)
+    ImageMeta Meta,
+    int StackedFrameCount = 0)
 {
     /// <summary>Convenience accessor — <c>Meta.FrameType</c>.</summary>
     public FrameType FrameType => Meta.FrameType;

--- a/src/TianWen.Lib/Imaging/ColorCalibration/Tycho2ColorCalibration.cs
+++ b/src/TianWen.Lib/Imaging/ColorCalibration/Tycho2ColorCalibration.cs
@@ -22,6 +22,37 @@ public static class Tycho2ColorCalibration
         double ExpectedR, double ExpectedG, double ExpectedB,
         double Magnitude);
 
+    /// <summary>Outcome of the white-balance fit. Carries both the converged
+    /// multipliers and the iteration trail (initial-vs-final match count +
+    /// iteration count) so the caller can log "started with 127 candidates,
+    /// 119 survived 3-iter kappa-sigma" without re-deriving the numbers.</summary>
+    public readonly record struct SpccWhiteBalanceResult(
+        float R, float G, float B,
+        int InitialMatches,
+        int FinalMatches,
+        int Iterations)
+    {
+        /// <summary>Back-compat shim: callers that only want the survivor
+        /// count read this; equivalent to <see cref="FinalMatches"/>.</summary>
+        public int MatchCount => FinalMatches;
+    }
+
+    /// <summary>Default kappa for iterative SPCC rejection. 3.0 keeps ~99 %
+    /// of a clean Gaussian sample while dropping the photometric outliers
+    /// that bias the median (close-pair contamination, faint-star aperture
+    /// noise, mismatched Tycho-2 catalog rows that passed the 5" coord
+    /// gate). Looser than the hot-pixel sigma=8 because the WB fit's signal
+    /// IS noisy by nature -- we want to drop only the obvious mismatches.</summary>
+    private const float DefaultKappaSigma = 3.0f;
+
+    /// <summary>Iteration cap; real data converges in 2-4 iters.</summary>
+    private const int DefaultMaxIterations = 8;
+
+    /// <summary>Minimum survivors before the iteration aborts. Below this,
+    /// the kappa-sigma cut is on shaky statistical footing -- we'd rather
+    /// keep an outlier than under-fit a 4-star sample.</summary>
+    private const int MinSurvivors = 5;
+
     // Delegate type for computing expected RGB from a stellar B-V colour index.
     // Used by ExtractPhotometry to support both blackbody and SED-based approaches.
     private delegate (double R, double G, double B) ExpectedColorFunc(double bv);
@@ -30,7 +61,7 @@ public static class Tycho2ColorCalibration
     /// Computes per-channel white balance multipliers by matching detected stars to
     /// Tycho-2 and comparing observed photometry to B-V predicted colors.
     /// </summary>
-    public static (float R, float G, float B, int MatchCount)? ComputeWhiteBalance(
+    public static SpccWhiteBalanceResult? ComputeWhiteBalance(
         Image image,
         StarList stars,
         WCS wcs,
@@ -49,8 +80,7 @@ public static class Tycho2ColorCalibration
             bv => SyntheticStarFieldRenderer.BMinusVToRGB(bv));
         if (photometry.Count < minStars) return null;
 
-        var (wbR, wbG, wbB) = ComputeMultipliers(photometry);
-        return (wbR, wbG, wbB, photometry.Count);
+        return ComputeMultipliers(photometry);
     }
 
     /// <summary>
@@ -68,7 +98,7 @@ public static class Tycho2ColorCalibration
     /// <param name="tsysG">System throughput for the green channel.</param>
     /// <param name="tsysB">System throughput for the blue channel.</param>
     /// <returns>White balance (R, G, B) multipliers, or null if insufficient matches.</returns>
-    public static (float R, float G, float B, int MatchCount)? ComputeSpectrophotometricWhiteBalance(
+    public static SpccWhiteBalanceResult? ComputeSpectrophotometricWhiteBalance(
         Image image,
         StarList stars,
         WCS wcs,
@@ -91,8 +121,7 @@ public static class Tycho2ColorCalibration
             bv => ComputeExpectedRgbFromSed(bv, tsysR, tsysG, tsysB));
         if (photometry.Count < minStars) return null;
 
-        var (wbR, wbG, wbB) = ComputeMultipliers(photometry);
-        return (wbR, wbG, wbB, photometry.Count);
+        return ComputeMultipliers(photometry);
     }
 
     /// <summary>
@@ -299,7 +328,10 @@ public static class Tycho2ColorCalibration
 
     /// <summary>
     /// Computes per-channel white balance multipliers from observed and expected channel values.
-    /// Exposed for testing. wbR = median((expectedR/observedR) / (expectedG/observedG)), etc.
+    /// Exposed for testing. Internally runs iterative kappa-sigma rejection on the
+    /// per-channel ratios; the returned wbR / wbB are the converged medians clamped
+    /// to [0.5, 2.0] (values outside that range indicate sensor/model mismatch
+    /// rather than correctable color cast).
     /// </summary>
     internal static (float R, float G, float B) ComputeMultipliers(
         ReadOnlySpan<float> obsR, ReadOnlySpan<float> obsG, ReadOnlySpan<float> obsB,
@@ -309,53 +341,181 @@ public static class Tycho2ColorCalibration
         var rRatios = new float[n];
         var bRatios = new float[n];
 
+        var k = 0;
         for (var i = 0; i < n; i++)
         {
-            if (obsG[i] <= 0 || expG[i] <= 0) continue;
+            if (obsG[i] <= 0 || expG[i] <= 0 || obsR[i] <= 0 || obsB[i] <= 0) continue;
             var norm = obsG[i] / expG[i];
-            rRatios[i] = expR[i] / obsR[i] * norm;
-            bRatios[i] = expB[i] / obsB[i] * norm;
+            rRatios[k] = expR[i] / obsR[i] * norm;
+            bRatios[k] = expB[i] / obsB[i] * norm;
+            k++;
         }
 
-        Array.Sort(rRatios);
-        Array.Sort(bRatios);
-
-        // Trim top/bottom 20% to reject outliers before taking median
-        var trim = n / 5;
-        var wbR = Math.Clamp(rRatios[n / 2], rRatios[trim], rRatios[n - 1 - trim]);
-        var wbB = Math.Clamp(bRatios[n / 2], bRatios[trim], bRatios[n - 1 - trim]);
-        // Clamp to reasonable range — values outside [0.5, 2.0] indicate sensor/model
-        // mismatch rather than correctable color cast
-        wbR = Math.Clamp(wbR, 0.5f, 2.0f);
-        wbB = Math.Clamp(wbB, 0.5f, 2.0f);
+        var result = FitIterativeKappaSigma(rRatios.AsSpan(0, k), bRatios.AsSpan(0, k));
+        var wbR = Math.Clamp(result.R, 0.5f, 2.0f);
+        var wbB = Math.Clamp(result.B, 0.5f, 2.0f);
         return (wbR, 1f, wbB);
     }
 
     /// <summary>
-    /// Computes per-channel white balance multipliers via robust median of observed/expected ratios.
+    /// Computes per-channel white balance multipliers via iterative kappa-sigma
+    /// fit on the observed/expected ratios. Same algorithm as the public
+    /// span overload, but returns the iteration outcome (initial vs. final
+    /// match counts + iteration count) so the caller can log the funnel.
     /// </summary>
-    private static (float R, float G, float B) ComputeMultipliers(List<StarMatch> photometry)
+    private static SpccWhiteBalanceResult ComputeMultipliers(List<StarMatch> photometry)
     {
         var rRatios = new float[photometry.Count];
-        var gRatios = new float[photometry.Count];
         var bRatios = new float[photometry.Count];
 
+        // Same valid-input filter as the span overload -- skip rows that
+        // would produce a divide-by-zero or NaN in the ratio. Pack the
+        // surviving rows into the front of the array so the iteration
+        // works on a contiguous span.
+        var k = 0;
         for (var i = 0; i < photometry.Count; i++)
         {
             var m = photometry[i];
-            // WB multiplier = expected / observed, normalised so green = 1
-            // wR = (expectedR / observedR) * (observedG / expectedG)
+            if (m.ObservedG <= 0 || m.ExpectedG <= 0 || m.ObservedR <= 0 || m.ObservedB <= 0) continue;
             var norm = (float)(m.ObservedG / m.ExpectedG);
-            rRatios[i] = (float)(m.ExpectedR / m.ObservedR * norm);
-            gRatios[i] = 1f;
-            bRatios[i] = (float)(m.ExpectedB / m.ObservedB * norm);
+            rRatios[k] = (float)(m.ExpectedR / m.ObservedR * norm);
+            bRatios[k] = (float)(m.ExpectedB / m.ObservedB * norm);
+            k++;
         }
 
-        Array.Sort(rRatios);
-        Array.Sort(bRatios);
+        var fit = FitIterativeKappaSigma(rRatios.AsSpan(0, k), bRatios.AsSpan(0, k));
+        return new SpccWhiteBalanceResult(
+            R: Math.Clamp(fit.R, 0.1f, 10f),
+            G: 1f,
+            B: Math.Clamp(fit.B, 0.1f, 10f),
+            InitialMatches: photometry.Count,
+            FinalMatches: fit.FinalCount,
+            Iterations: fit.Iterations);
+    }
 
-        var wbR = Math.Clamp(rRatios[photometry.Count / 2], 0.1f, 10f);
-        var wbB = Math.Clamp(bRatios[photometry.Count / 2], 0.1f, 10f);
-        return (wbR, 1f, wbB);
+    /// <summary>
+    /// Iterative kappa-sigma fit on two correlated ratio streams (one per
+    /// non-reference channel). Each iteration:
+    /// <list type="number">
+    ///   <item>Compute median of currently-live R / B ratios.</item>
+    ///   <item>Compute MAD of (ratio - median) over those same live entries.</item>
+    ///   <item>Reject rows where either channel exceeds
+    ///   <c>kappa * 1.4826 * MAD</c> from the channel median.</item>
+    ///   <item>Stop when no new rejections, or survivors would dip below
+    ///   <see cref="MinSurvivors"/>, or max iterations hit.</item>
+    /// </list>
+    /// Rejection is OR-combined across channels (a star with bad R ratio
+    /// AND good B ratio still drops -- it's likely a contaminated photometry
+    /// entry overall, not just one channel). When MAD is 0 on a channel
+    /// (uniform inlier subset) that channel contributes no rejection
+    /// signal -- the loop continues on the other channel until convergence.
+    /// </summary>
+    private static (float R, float B, int FinalCount, int Iterations) FitIterativeKappaSigma(
+        Span<float> rRatios, Span<float> bRatios,
+        float kappa = DefaultKappaSigma, int maxIterations = DefaultMaxIterations)
+    {
+        var n = rRatios.Length;
+        if (n == 0) return (1f, 1f, 0, 0);
+        if (n < MinSurvivors)
+        {
+            // Sample too small for kappa-sigma to be statistically meaningful;
+            // fall back to plain median. Tests with n=1 / n=5 hit this path.
+            var rSorted = rRatios.ToArray(); Array.Sort(rSorted);
+            var bSorted = bRatios.ToArray(); Array.Sort(bSorted);
+            return (rSorted[n / 2], bSorted[n / 2], n, 0);
+        }
+
+        // Track survival via a parallel alive[] flag so we don't need to
+        // physically compact the arrays on each iteration. Allocating once
+        // up front is cheaper than per-iter compaction for the typical
+        // 100-300 star photometry list.
+        Span<bool> alive = stackalloc bool[n];
+        alive.Fill(true);
+        var liveCount = n;
+        var medianR = 0f;
+        var medianB = 0f;
+        var iter = 0;
+
+        // Work buffer reused per iteration to read out live values, sort,
+        // and compute median/MAD.
+        Span<float> workR = stackalloc float[n];
+        Span<float> workB = stackalloc float[n];
+
+        for (iter = 0; iter < maxIterations; iter++)
+        {
+            // Collect live values into the contiguous prefix of the work buf.
+            var liveIdx = 0;
+            for (var i = 0; i < n; i++)
+            {
+                if (alive[i])
+                {
+                    workR[liveIdx] = rRatios[i];
+                    workB[liveIdx] = bRatios[i];
+                    liveIdx++;
+                }
+            }
+            workR[..liveIdx].Sort();
+            workB[..liveIdx].Sort();
+            medianR = workR[liveIdx / 2];
+            medianB = workB[liveIdx / 2];
+
+            // Compute MAD per channel against its own median. We can reuse
+            // the work buffers because we've already consumed the sorted
+            // values to read the medians.
+            for (var i = 0; i < liveIdx; i++)
+            {
+                workR[i] = MathF.Abs(workR[i] - medianR);
+                workB[i] = MathF.Abs(workB[i] - medianB);
+            }
+            workR[..liveIdx].Sort();
+            workB[..liveIdx].Sort();
+            var madR = workR[liveIdx / 2];
+            var madB = workB[liveIdx / 2];
+
+            // Kappa-sigma threshold; MAD * 1.4826 ≈ stddev for a Gaussian.
+            // A zero MAD means the inlier subset is uniform on that channel,
+            // which signals "no spread to threshold against" -- skip
+            // rejection on that channel rather than rejecting everything
+            // (threshold=0 would).
+            var thresholdR = madR > 0f ? kappa * 1.4826f * madR : float.PositiveInfinity;
+            var thresholdB = madB > 0f ? kappa * 1.4826f * madB : float.PositiveInfinity;
+
+            // First pass: count the rejections this iteration would make.
+            // We need this up front so the floor check (MinSurvivors) can
+            // decide whether to commit them -- a single iteration that
+            // would drop us below the floor would otherwise leave us in
+            // an under-fit state.
+            var wouldReject = 0;
+            for (var i = 0; i < n; i++)
+            {
+                if (!alive[i]) continue;
+                if (MathF.Abs(rRatios[i] - medianR) > thresholdR ||
+                    MathF.Abs(bRatios[i] - medianB) > thresholdB)
+                {
+                    wouldReject++;
+                }
+            }
+            if (wouldReject == 0) break;
+            if (liveCount - wouldReject < MinSurvivors)
+            {
+                // Don't commit; we'd be fitting too thin a remainder.
+                // Keep the current medians as the converged answer.
+                break;
+            }
+
+            // Commit rejections.
+            for (var i = 0; i < n; i++)
+            {
+                if (!alive[i]) continue;
+                if (MathF.Abs(rRatios[i] - medianR) > thresholdR ||
+                    MathF.Abs(bRatios[i] - medianB) > thresholdB)
+                {
+                    alive[i] = false;
+                    liveCount--;
+                }
+            }
+        }
+
+        return (medianR, medianB, liveCount, iter);
     }
 }

--- a/src/TianWen.Lib/Imaging/Image.Fits.cs
+++ b/src/TianWen.Lib/Imaging/Image.Fits.cs
@@ -72,7 +72,12 @@ public partial class Image
         }
 
         var imageMeta = ParseImageMetaFromHeader(hdu, channelCount);
-        frameInfo = new Calibration.FrameInfo(fileName, width, height, channelCount, bitDepth, imageMeta);
+        // STACK_N is stamped by IntegrationFitsWriter on every stacking product
+        // (masters + rejection maps). Carrying it on FrameInfo lets the
+        // pipeline drop these at scan time when a stale output-*/ dir sits
+        // alongside the lights, otherwise they get treated as fresh frames.
+        var stackedFrameCount = hdu.Header.GetIntValue("STACK_N", 0);
+        frameInfo = new Calibration.FrameInfo(fileName, width, height, channelCount, bitDepth, imageMeta, stackedFrameCount);
         return true;
     }
 

--- a/src/TianWen.Lib/Imaging/Image.StarDetection.cs
+++ b/src/TianWen.Lib/Imaging/Image.StarDetection.cs
@@ -541,10 +541,14 @@ public partial class Image
             return false;
         }
 
-        // Get HFD
+        // Get HFD + second-order moments (for ellipticity).
         var pixel_counter = 0;
         sumVal = 0.0f; // reset
         var sumValR = 0.0f;
+        // Second moments accumulate only positive-flux pixels around
+        // the centroid. Doubles because i*i*val products on a bright
+        // star can overflow float precision before normalisation.
+        double sumPosFlux = 0, sumMxx = 0, sumMyy = 0, sumMxy = 0;
 
         // Get HFD using the aproximation routine assuming that HFD line divides the star in equal portions of gravity:
         for (var i = -r_aperture; i <= r_aperture; i++) /*Make steps of one pixel*/
@@ -560,12 +564,45 @@ public partial class Image
                     // How many pixels are above half maximum
                     pixel_counter++;
                 }
+                if (val > 0f)
+                {
+                    // SubpixelValue takes (channel, x, y), so i = dx, j = dy.
+                    sumPosFlux += val;
+                    sumMxx += (double)val * i * i;
+                    sumMyy += (double)val * j * j;
+                    sumMxy += (double)val * i * j;
+                }
             }
         }
 
         var flux = MathF.Max(sumVal, 0.00001f); /* prevent dividing by zero or negative values */
         var hfd = MathF.Max(0.7f, 2 * sumValR / flux);
         var star_fwhm = 2 * MathF.Sqrt(pixel_counter / MathF.PI);/*calculate from surface (by counting pixels above half max) the diameter equals FWHM */
+
+        // Moment-based ellipticity from the 2x2 flux-weighted second-
+        // moment matrix [[Mxx, Mxy], [Mxy, Myy]] (each normalised by
+        // total positive flux). Eigenvalues a², b² are the variances
+        // along major/minor axes; ellipticity e = sqrt(1 - b²/a²) gives
+        // 0 for a round star, ~0.866 for 2:1 elongation, → 1 for a line.
+        // Clamped to [0, 1] to absorb rounding artefacts on near-circular
+        // fits where b² can land slightly negative.
+        var ellipticity = 0f;
+        if (sumPosFlux > 0)
+        {
+            var mxx = sumMxx / sumPosFlux;
+            var myy = sumMyy / sumPosFlux;
+            var mxy = sumMxy / sumPosFlux;
+            var halfTrace = (mxx + myy) * 0.5;
+            var halfDiff = (mxx - myy) * 0.5;
+            var disc = Math.Sqrt(halfDiff * halfDiff + mxy * mxy);
+            var a2 = halfTrace + disc;
+            var b2 = halfTrace - disc;
+            if (a2 > 1e-10)
+            {
+                var ratio = Math.Max(0.0, b2 / a2);
+                ellipticity = (float)Math.Sqrt(Math.Max(0.0, 1.0 - ratio));
+            }
+        }
 
         // SNR formula assumes Poisson statistics on ADU counts (gain=1).
         // For normalized [0,1] images, scale flux and sd back to ADU range so shot noise is correct.
@@ -574,7 +611,7 @@ public partial class Image
         var aduSdBg = sd_bg * aduScale;
         var snr = aduFlux / MathF.Sqrt(aduFlux + r_aperture * r_aperture * MathF.PI * aduSdBg * aduSdBg);
 
-        star = new ImagedStar(hfd, star_fwhm, snr, flux, xc, yc);
+        star = new ImagedStar(hfd, star_fwhm, snr, flux, xc, yc, ellipticity);
         return true;
         /*For both bright stars (shot-noise limited) or skybackground limited situations
         snr := signal/noise

--- a/src/TianWen.Lib/Imaging/Image.Transform.cs
+++ b/src/TianWen.Lib/Imaging/Image.Transform.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Drawing;
 using System.Numerics;
+using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -90,6 +91,19 @@ public partial class Image
     /// <exception cref="ArgumentException"><paramref name="transform"/> is not invertible.</exception>
     public async Task<Image> WarpToReferenceGridAsync(Matrix3x2 transform, int refWidth, int refHeight, CancellationToken cancellationToken = default)
     {
+        // Identity-skip fast path. The reference frame in StackingPipeline
+        // is registered against itself with transform = Matrix3x2.Identity
+        // and the canvas grid is sized to the reference dims, so this
+        // branch fires once per group and avoids the per-pixel bilinear
+        // sample + NaN-bounds check that otherwise runs over the full
+        // canvas. Matches the precedent in TransformAsync (line 53) where
+        // identity already short-circuits.
+        if (transform.IsIdentity && refWidth == Width && refHeight == Height)
+        {
+            await Task.CompletedTask;
+            return this;
+        }
+
         if (!Matrix3x2.Invert(transform, out var inverseTransform))
         {
             throw new ArgumentException("Transform is not invertible", nameof(transform));
@@ -166,10 +180,6 @@ public partial class Image
             throw new ArgumentOutOfRangeException(nameof(canvasRegion),
                 $"Region {canvasRegion} out of canvas bounds [0,0)-({canvasWidth},{canvasHeight}).");
         }
-        if (!Matrix3x2.Invert(transform, out var inverseTransform))
-        {
-            throw new ArgumentException("Transform is not invertible", nameof(transform));
-        }
 
         var channelCount = ChannelCount;
         var srcW = Width;
@@ -178,6 +188,61 @@ public partial class Image
         var regionH = canvasRegion.Height;
         var x0 = canvasRegion.X;
         var y0 = canvasRegion.Y;
+
+        // Identity-skip fast path. Under identity, source coords equal
+        // canvas coords; sampling collapses to a strided copy of the
+        // source's [x0..x0+regionW, y0..y0+regionH] sub-rect into the
+        // region-sized output. Pixels whose canvas position falls
+        // outside the source remain NaN. The TilePipelined strategy
+        // calls WarpRegionAsync once per strip per frame; under
+        // identity (the reference frame's strips) that's `stripsTotal`
+        // calls saved from the bilinear sampler.
+        if (transform.IsIdentity)
+        {
+            var copied = CreateChannelData(channelCount, regionH, regionW);
+            // Intersect canvas region with source bounds. The reference
+            // frame's source dims equal canvas dims, so fullyInside is
+            // the common case and we can skip the NaN pre-fill pass.
+            var copyX0 = Math.Max(0, x0);
+            var copyY0 = Math.Max(0, y0);
+            var copyX1 = Math.Min(srcW, x0 + regionW);
+            var copyY1 = Math.Min(srcH, y0 + regionH);
+            var fullyInside = copyX0 == x0 && copyY0 == y0
+                && copyX1 == x0 + regionW && copyY1 == y0 + regionH;
+            for (var c = 0; c < channelCount; c++)
+            {
+                var dst = copied[c];
+                if (!fullyInside)
+                {
+                    // Vectorized fill -- Span<float>.Fill uses SIMD where
+                    // available; a per-pixel loop here would dominate the
+                    // fast path on big strips. CreateSpan over a float[,]
+                    // is the in-house idiom (Image.Arithmetic.cs et al.).
+                    MemoryMarshal.CreateSpan(ref dst[0, 0], dst.Length).Fill(float.NaN);
+                }
+                if (copyX1 > copyX0 && copyY1 > copyY0)
+                {
+                    var srcCh = GetChannelArray(c);
+                    var rowLen = copyX1 - copyX0;
+                    for (var sy = copyY0; sy < copyY1; sy++)
+                    {
+                        // Row-wise BlockCopy is faster than the scalar
+                        // copy loop when rowLen is non-trivial.
+                        var dstRow = MemoryMarshal.CreateSpan(ref dst[sy - y0, copyX0 - x0], rowLen);
+                        var srcRow = MemoryMarshal.CreateSpan(ref srcCh[sy, copyX0], rowLen);
+                        srcRow.CopyTo(dstRow);
+                    }
+                }
+            }
+            await Task.CompletedTask;
+            return new Image(copied, BitDepth.Float32, maxValue, minValue, pedestal, imageMeta);
+        }
+
+        if (!Matrix3x2.Invert(transform, out var inverseTransform))
+        {
+            throw new ArgumentException("Transform is not invertible", nameof(transform));
+        }
+
         var output = CreateChannelData(channelCount, regionH, regionW);
 
         var parallelOptions = new ParallelOptions

--- a/src/TianWen.Lib/Imaging/ImagedStar.cs
+++ b/src/TianWen.Lib/Imaging/ImagedStar.cs
@@ -1,3 +1,11 @@
 ﻿namespace TianWen.Lib.Imaging;
 
-public readonly record struct ImagedStar(float HFD, float StarFWHM, float SNR, float Flux, float XCentroid, float YCentroid);
+/// <summary>
+/// One detected star. <c>Ellipticity</c> is the moment-based elongation
+/// of the aperture pixel cloud (0 = circular, → 1 = highly elongated).
+/// Derived from the eigenvalues a², b² of the flux-weighted second-moment
+/// matrix as <c>e = sqrt(1 - b²/a²)</c>. Useful for spotting tracking
+/// drift or collimation issues per frame, and for grading the stacked
+/// master.
+/// </summary>
+public readonly record struct ImagedStar(float HFD, float StarFWHM, float SNR, float Flux, float XCentroid, float YCentroid, float Ellipticity);

--- a/src/TianWen.Lib/Imaging/SampleKind.cs
+++ b/src/TianWen.Lib/Imaging/SampleKind.cs
@@ -4,5 +4,7 @@ public enum SampleKind : byte
 {
     None = 0,
     HFD = 1,
-    FWHM = 2
+    FWHM = 2,
+    /// <summary>Moment-based ellipticity (0 = circular, → 1 = elongated).</summary>
+    Ellipticity = 3,
 }

--- a/src/TianWen.Lib/Imaging/Stacking/CanvasGeometry.cs
+++ b/src/TianWen.Lib/Imaging/Stacking/CanvasGeometry.cs
@@ -219,4 +219,52 @@ internal static class CanvasGeometry
         var t = ((a.X - p1.X) * ey - (a.Y - p1.Y) * ex) / denom;
         return new Vector2(p1.X + t * dx, p1.Y + t * dy);
     }
+
+    /// <summary>
+    /// Inverse-transform a canvas rectangle to its bounding box in source-frame
+    /// coordinates, then expand by <paramref name="halo"/> pixels (sampler /
+    /// numerical cushion) and clamp to source bounds. Used by tile-pipelined
+    /// strategies to figure out how much of the source frame needs to be
+    /// touched for a given canvas strip -- only those pixels can project into
+    /// the strip, the rest can be skipped entirely.
+    /// </summary>
+    /// <param name="canvasRect">Strip rectangle on the output canvas.</param>
+    /// <param name="transformToCanvas">Frame's source -> canvas affine.</param>
+    /// <param name="srcW">Source frame width.</param>
+    /// <param name="srcH">Source frame height.</param>
+    /// <param name="halo">Pixels to expand on each side for sampler safety
+    /// (bilinear: 1 px; AHD: 5 px; drizzle forward-project: 1 px is sufficient
+    /// since the drop covers a unit cell at most).</param>
+    public static Rectangle ProjectCanvasRectToSourceRect(
+        Rectangle canvasRect, Matrix3x2 transformToCanvas, int srcW, int srcH, int halo)
+    {
+        if (!Matrix3x2.Invert(transformToCanvas, out var inverse))
+        {
+            // Non-invertible transform shouldn't happen for affine fits we
+            // ship -- fall back to the whole source so the caller still gets
+            // a non-empty result rather than dropping the frame silently.
+            return new Rectangle(0, 0, srcW, srcH);
+        }
+
+        Span<Vector2> corners = stackalloc Vector2[4];
+        corners[0] = new Vector2(canvasRect.X, canvasRect.Y);
+        corners[1] = new Vector2(canvasRect.Right, canvasRect.Y);
+        corners[2] = new Vector2(canvasRect.X, canvasRect.Bottom);
+        corners[3] = new Vector2(canvasRect.Right, canvasRect.Bottom);
+
+        var min = new Vector2(float.PositiveInfinity, float.PositiveInfinity);
+        var max = new Vector2(float.NegativeInfinity, float.NegativeInfinity);
+        for (var i = 0; i < 4; i++)
+        {
+            var srcPos = Vector2.Transform(corners[i], inverse);
+            min = Vector2.Min(min, srcPos);
+            max = Vector2.Max(max, srcPos);
+        }
+
+        var x0 = Math.Max(0, (int)Math.Floor(min.X) - halo);
+        var y0 = Math.Max(0, (int)Math.Floor(min.Y) - halo);
+        var x1 = Math.Min(srcW, (int)Math.Ceiling(max.X) + halo);
+        var y1 = Math.Min(srcH, (int)Math.Ceiling(max.Y) + halo);
+        return new Rectangle(x0, y0, Math.Max(0, x1 - x0), Math.Max(0, y1 - y0));
+    }
 }

--- a/src/TianWen.Lib/Imaging/Stacking/DrizzleKernel.cs
+++ b/src/TianWen.Lib/Imaging/Stacking/DrizzleKernel.cs
@@ -1,0 +1,223 @@
+using System;
+using System.Drawing;
+using System.Numerics;
+using System.Runtime.CompilerServices;
+
+namespace TianWen.Lib.Imaging.Stacking;
+
+/// <summary>
+/// Shared forward-projection kernel for the drizzle family of strategies
+/// (<see cref="DrizzleStrategy"/>, <see cref="TilePipelinedDrizzleStrategy"/>).
+/// Per-frame, iterates a source-pixel rectangle and deposits each valid CFA
+/// sample as a <c>pixfrac</c>-sized "drop" onto the per-channel
+/// <c>flux</c> / <c>weight</c> planes the caller owns. The accumulator
+/// arrays are not necessarily canvas-sized: the caller passes
+/// <paramref name="xStart"/>/<paramref name="xEnd"/>/<paramref name="yStart"/>/<paramref name="yEnd"/>
+/// to declare the canvas coordinate range the arrays cover. Drops landing
+/// outside that range are clipped. This is the single mechanism that lets
+/// <see cref="DrizzleStrategy"/> deposit into a full-canvas accumulator
+/// and <see cref="TilePipelinedDrizzleStrategy"/> deposit into a strip-
+/// local one without the kernel needing to know the difference.
+/// </summary>
+internal static class DrizzleKernel
+{
+    /// <summary>
+    /// Iterate the <paramref name="sourceRect"/> sub-region of
+    /// <paramref name="raw"/> (a 1-channel calibrated Bayer plane) and
+    /// forward-project each valid sample onto <paramref name="flux"/> /
+    /// <paramref name="weight"/>. Honours <paramref name="badPixelMask"/> via
+    /// a per-64-pixel-chunk word fast-path: when the mask word is zero (which
+    /// is the common case -- typical sensor hot-pixel rates are 0.02% so
+    /// 99.98% of chunks are clean) the per-pixel mask check is skipped
+    /// entirely.
+    /// </summary>
+    /// <param name="raw">Calibrated 1-channel Bayer source frame.</param>
+    /// <param name="transform">Source -> canvas affine for this frame.</param>
+    /// <param name="pattern">2x2 Bayer pattern in sensor coordinates;
+    /// <c>pattern[ySrc &amp; 1, xSrc &amp; 1]</c> selects which output channel
+    /// the source pixel feeds.</param>
+    /// <param name="halfP">Half the pixfrac drop extent (i.e. <c>pixfrac/2</c>).
+    /// At pixfrac=1.0 each drop is a unit cell; smaller pixfrac sharpens
+    /// the output at the cost of needing more frames for coverage.</param>
+    /// <param name="flux">Per-channel flux accumulator, indexed as
+    /// <c>flux[ch][yCanvas - yStart, xCanvas - xStart]</c>. Must be sized
+    /// at least <c>(yEnd - yStart) x (xEnd - xStart)</c> per channel.</param>
+    /// <param name="weight">Per-channel coverage-weight accumulator, same
+    /// shape as <paramref name="flux"/>.</param>
+    /// <param name="xStart">Canvas X coordinate the first column of the
+    /// accumulators corresponds to.</param>
+    /// <param name="xEnd">Canvas X coordinate one past the last column of
+    /// the accumulators (exclusive).</param>
+    /// <param name="yStart">Canvas Y coordinate the first row of the
+    /// accumulators corresponds to.</param>
+    /// <param name="yEnd">Canvas Y coordinate one past the last row of the
+    /// accumulators (exclusive).</param>
+    /// <param name="sourceRect">Sub-rectangle of <paramref name="raw"/> to
+    /// iterate. Pre-clamped to source bounds. Pass the whole frame for the
+    /// full-canvas drizzle path.</param>
+    /// <param name="badPixelMask">Optional hot-pixel mask. Default value
+    /// (<c>!hasBadPixelMask</c>) skips the mask check entirely.</param>
+    /// <param name="hasBadPixelMask">True iff <paramref name="badPixelMask"/>
+    /// is populated. Hoisted out of the inner loop.</param>
+    public static void IterateAndDeposit(
+        Image raw,
+        Matrix3x2 transform,
+        int[,] pattern,
+        float halfP,
+        float[][,] flux,
+        float[][,] weight,
+        int xStart,
+        int xEnd,
+        int yStart,
+        int yEnd,
+        Rectangle sourceRect,
+        BitMatrix badPixelMask,
+        bool hasBadPixelMask)
+    {
+        var srcX0 = sourceRect.X;
+        var srcX1 = sourceRect.X + sourceRect.Width;
+        var srcY0 = sourceRect.Y;
+        var srcY1 = sourceRect.Y + sourceRect.Height;
+
+        for (var ySrc = srcY0; ySrc < srcY1; ySrc++)
+        {
+            var xSrc = srcX0;
+            while (xSrc < srcX1)
+            {
+                // 64-wide horizontal chunk -- aligned to word boundary so a
+                // single GetWord covers all 64 mask bits at once. ChunkEnd
+                // is the next word boundary or the end of the rect,
+                // whichever comes first.
+                var chunkEnd = Math.Min(((xSrc >> 6) + 1) << 6, srcX1);
+                var maskWord = hasBadPixelMask ? badPixelMask.GetWord(ySrc, xSrc >> 6) : 0UL;
+                if (maskWord == 0UL)
+                {
+                    // Fast path: no per-pixel mask check needed.
+                    for (; xSrc < chunkEnd; xSrc++)
+                    {
+                        DepositOne(xSrc, ySrc, raw, transform, pattern, halfP, flux, weight, xStart, xEnd, yStart, yEnd);
+                    }
+                }
+                else
+                {
+                    // Slow path: bit-test each pixel against the already-
+                    // loaded mask word.
+                    for (; xSrc < chunkEnd; xSrc++)
+                    {
+                        if ((maskWord & (1UL << (xSrc & 63))) != 0UL) continue;
+                        DepositOne(xSrc, ySrc, raw, transform, pattern, halfP, flux, weight, xStart, xEnd, yStart, yEnd);
+                    }
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Forward-project a single source pixel and deposit its area-weighted
+    /// share into each canvas cell its drop covers. Coordinate convention
+    /// matches <c>Image.SubpixelValue</c> / <c>WarpToReferenceGridAsync</c>:
+    /// canvas cell at index <c>(xc, yc)</c> is centered on position
+    /// <c>(xc, yc)</c> and occupies <c>[xc-0.5, xc+0.5] x [yc-0.5, yc+0.5]</c>.
+    /// A previous version of this kernel mixed half-pixel-shift conventions
+    /// and produced dumbbell-shaped stars in combined meridian-flip drizzle
+    /// output -- keep this path strictly consistent with the warp path or
+    /// the per-frame rotation residuals will reappear as visible artifacts.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void DepositOne(
+        int xSrc, int ySrc,
+        Image raw, Matrix3x2 transform, int[,] pattern, float halfP,
+        float[][,] flux, float[][,] weight,
+        int xStart, int xEnd, int yStart, int yEnd)
+    {
+        var v = raw[0, ySrc, xSrc];
+        if (float.IsNaN(v)) return;
+
+        var p = Vector2.Transform(new Vector2(xSrc, ySrc), transform);
+        var xLo = p.X - halfP;
+        var xHi = p.X + halfP;
+        var yLo = p.Y - halfP;
+        var yHi = p.Y + halfP;
+
+        // Loop bounds: cell index i overlaps the drop iff
+        //   i - 0.5 < xHi and i + 0.5 > xLo,
+        // i.e. floor(xLo + 0.5) <= i <= ceil(xHi - 0.5).
+        // Clamp to the [xStart, xEnd) x [yStart, yEnd) accumulator range
+        // (full canvas for the streaming drizzle, strip-local for tiled).
+        var x0 = Math.Max(xStart, (int)MathF.Floor(xLo + 0.5f));
+        var x1 = Math.Min(xEnd - 1, (int)MathF.Ceiling(xHi - 0.5f));
+        var y0 = Math.Max(yStart, (int)MathF.Floor(yLo + 0.5f));
+        var y1 = Math.Min(yEnd - 1, (int)MathF.Ceiling(yHi - 0.5f));
+        if (x1 < x0 || y1 < y0) return;
+
+        var ch = pattern[ySrc & 1, xSrc & 1];
+        var fluxCh = flux[ch];
+        var weightCh = weight[ch];
+
+        for (var yc = y0; yc <= y1; yc++)
+        {
+            var localY = yc - yStart;
+            var cellYLo = yc - 0.5f;
+            var cellYHi = yc + 0.5f;
+            var dy = MathF.Min(yHi, cellYHi) - MathF.Max(yLo, cellYLo);
+            if (dy <= 0f) continue;
+            for (var xc = x0; xc <= x1; xc++)
+            {
+                var localX = xc - xStart;
+                var cellXLo = xc - 0.5f;
+                var cellXHi = xc + 0.5f;
+                var dx = MathF.Min(xHi, cellXHi) - MathF.Max(xLo, cellXLo);
+                if (dx <= 0f) continue;
+                var area = dx * dy;
+                fluxCh[localY, localX] += v * area;
+                weightCh[localY, localX] += area;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Final pass: <c>master = (flux / weight) * invMaxValue</c>, with NaN
+    /// where coverage is zero. Mutates <paramref name="flux"/> in place
+    /// (the caller hands the buffer over and treats the result as the
+    /// master). <paramref name="weight"/> stays as the coverage map.
+    /// Returns the number of cells that had non-zero coverage so the
+    /// caller can build the rejection-rate diagnostic.
+    /// </summary>
+    /// <param name="flux">Per-channel flux accumulator -- on return, holds
+    /// the normalised master pixels.</param>
+    /// <param name="weight">Per-channel coverage weight accumulator. Read-
+    /// only here.</param>
+    /// <param name="invMaxValue"><c>1 / sourceMaxValue</c> so the master
+    /// lands in <c>[0, 1]</c> -- matches the Integrator's per-frame
+    /// normalization output so <c>MasterPostProcessor</c>'s MaxValue=1.0
+    /// fix-up and <c>Image.Histogram</c>'s MaxValue&lt;=1.0 branch both see
+    /// a self-consistent (range, label) pair.</param>
+    /// <param name="height">Accumulator rows.</param>
+    /// <param name="width">Accumulator columns.</param>
+    public static long FinaliseDivide(float[][,] flux, float[][,] weight, float invMaxValue, int height, int width)
+    {
+        long coveredCells = 0;
+        for (var c = 0; c < flux.Length; c++)
+        {
+            var f = flux[c];
+            var w = weight[c];
+            for (var y = 0; y < height; y++)
+            {
+                for (var x = 0; x < width; x++)
+                {
+                    var wv = w[y, x];
+                    if (wv > 0f)
+                    {
+                        f[y, x] = f[y, x] / wv * invMaxValue;
+                        coveredCells++;
+                    }
+                    else
+                    {
+                        f[y, x] = float.NaN;
+                    }
+                }
+            }
+        }
+        return coveredCells;
+    }
+}

--- a/src/TianWen.Lib/Imaging/Stacking/DrizzleStrategy.cs
+++ b/src/TianWen.Lib/Imaging/Stacking/DrizzleStrategy.cs
@@ -1,6 +1,6 @@
 using System;
+using System.Drawing;
 using System.Numerics;
-using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -43,6 +43,26 @@ namespace TianWen.Lib.Imaging.Stacking;
 /// </summary>
 public sealed class DrizzleStrategy : IIntegrationStrategy
 {
+    /// <summary>Default minimum matched-frame count for drizzle auto-select.
+    /// Below this the per-channel coverage (~25% per Bayer position) is too
+    /// sparse to fill R/B reliably under sub-pixel dither, producing NaN-
+    /// riddled R/B planes. Matches <see cref="DrizzleOptions.MinFrameCount"/>'s
+    /// default; the pipeline can override this per-run by constructing
+    /// the strategy with a custom <c>minFrameCount</c> so
+    /// <c>--drizzle-min-frames N</c> drives both the auto-pick gate here
+    /// and the pre-strategy gate in <see cref="StackingPipeline"/>
+    /// uniformly.</summary>
+    public const int AutoSelectMinFrameCount = 60;
+
+    private readonly IntegrationCostModel _costs;
+    private readonly int _minFrameCount;
+
+    public DrizzleStrategy(IntegrationCostModel? costs = null, int minFrameCount = AutoSelectMinFrameCount)
+    {
+        _costs = costs ?? new IntegrationCostModel();
+        _minFrameCount = minFrameCount;
+    }
+
     public IntegrationStrategyKind Kind => IntegrationStrategyKind.BayerDrizzle;
 
     /// <summary>Phase-1 drizzle at scale=10 is roughly forward-bilinear --
@@ -56,14 +76,63 @@ public sealed class DrizzleStrategy : IIntegrationStrategy
 
     public StrategyFit Evaluate(IntegrationProbe probe, ResourceBudget budget)
     {
-        // Opt-in only. The selector still routes here when the user passes
-        // --strategy BayerDrizzle (preferred-override bypasses CanRun).
+        // RAM profile: flux + weight planes are both canvas-sized at 3
+        // channels (drizzle ignores ChannelCount and always emits RGB), plus
+        // one in-flight calibrated 1-channel raw frame. No N-scaling on the
+        // accumulators -- streaming drizzle holds everything full-canvas.
+        var fluxWeightBytes = (long)probe.CanvasWidth * probe.CanvasHeight * 3 * sizeof(float) * 2;
+        var inFlightRam = (long)probe.FrameWidth * probe.FrameHeight * sizeof(float); // 1-channel calibrated bayer
+        var ram = fluxWeightBytes + inFlightRam;
+
+        // CanRun gate: drizzle dispatches Bayer samples by physical filter
+        // position, so it's RGGB-only. Below MinFrameCount the per-Bayer-
+        // position coverage (~25% per channel) leaves swathes of R/B
+        // uncovered -- worse than just running the standard path with AHD
+        // interpolation. Selector gates this off rather than producing a
+        // NaN-riddled master and surfacing the problem post-hoc.
+        if (probe.SensorType != SensorType.RGGB)
+        {
+            return new StrategyFit(
+                CanRun: false,
+                EstimatedRamBytes: ram,
+                EstimatedDiskBytes: 0,
+                EstimatedDuration: TimeSpan.Zero,
+                Rationale: $"BayerDrizzle requires SensorType.RGGB (got {probe.SensorType})");
+        }
+        if (probe.FrameCount < _minFrameCount)
+        {
+            return new StrategyFit(
+                CanRun: false,
+                EstimatedRamBytes: ram,
+                EstimatedDiskBytes: 0,
+                EstimatedDuration: TimeSpan.Zero,
+                Rationale: $"BayerDrizzle needs >= {_minFrameCount} matched frames for robust R/B coverage (got {probe.FrameCount})");
+        }
+        if (ram > budget.AllowedRam(probe))
+        {
+            return new StrategyFit(
+                CanRun: false,
+                EstimatedRamBytes: ram,
+                EstimatedDiskBytes: 0,
+                EstimatedDuration: TimeSpan.Zero,
+                Rationale: $"BayerDrizzle flux+weight planes ({Format.GB(ram)}) exceed budget ({Format.GB(budget.AllowedRam(probe))})");
+        }
+
+        // Wall-time = load+calibrate (every frame, full source) + forward-
+        // project (every frame, full source, ~4 cells per pixel). No
+        // debayer, no warp, no reject-combine -- those phases are
+        // replaced by the drizzle deposit + final divide. Typical net is
+        // 3-5x faster than the standard path on RGGB inputs.
+        var loadCalibrate = _costs.LoadAndCalibrateAllFrames(probe);
+        var projectMs = (double)probe.FrameWidth * probe.FrameHeight * probe.FrameCount * _costs.CpuNsPerDrizzleProjectPixel / 1e6;
+        var eta = loadCalibrate + TimeSpan.FromMilliseconds(projectMs);
+
         return new StrategyFit(
-            CanRun: false,
-            EstimatedRamBytes: probe.OutputRamBytes * 2, // flux + weight planes
+            CanRun: true,
+            EstimatedRamBytes: ram,
             EstimatedDiskBytes: 0,
-            EstimatedDuration: TimeSpan.Zero,
-            Rationale: "BayerDrizzle is opt-in only (--strategy BayerDrizzle)");
+            EstimatedDuration: eta,
+            Rationale: $"drizzle forward-project (no debayer; flux+weight {Format.GB(ram)})");
     }
 
     public async ValueTask<IntegrationResult> RunAsync(IntegrationJob job, CancellationToken ct)
@@ -153,115 +222,20 @@ public sealed class DrizzleStrategy : IIntegrationStrategy
             var srcW = raw.Width;
             var srcH = raw.Height;
 
-            // Chunked walk over the source pixels in 64-wide horizontal
-            // strips so we can use BitMatrix.GetWord to skip the per-pixel
-            // mask check entirely on the common case (word == 0 = no hot
-            // pixels in this 64-pixel chunk). A typical CMOS sensor at
-            // sigma=8 has ~5000 hot pixels in 26 M -- 99.98% of words
-            // are zero, so the fast path runs almost always.
-            for (var ySrc = 0; ySrc < srcH; ySrc++)
-            {
-                var xSrc = 0;
-                while (xSrc < srcW)
-                {
-                    var chunkEnd = Math.Min(((xSrc >> 6) + 1) << 6, srcW);
-                    var maskWord = hasBadPixelMask ? badPixelMask.GetWord(ySrc, xSrc >> 6) : 0UL;
-                    if (maskWord == 0UL)
-                    {
-                        // Fast path: no per-pixel mask check needed.
-                        for (; xSrc < chunkEnd; xSrc++)
-                        {
-                            DepositOne(xSrc, ySrc);
-                        }
-                    }
-                    else
-                    {
-                        // Slow path: bit-test each pixel against the
-                        // already-loaded mask word.
-                        for (; xSrc < chunkEnd; xSrc++)
-                        {
-                            if ((maskWord & (1UL << (xSrc & 63))) != 0UL) continue;
-                            DepositOne(xSrc, ySrc);
-                        }
-                    }
-                }
-            }
-
-            // Per-pixel drop projection. Local function so the fast/slow
-            // mask branches above don't duplicate the body. Closes over
-            // the per-frame locals (transform, pattern, flux, weight,
-            // halfP, canvasW, canvasH, raw, srcH/srcW) -- C# hoists
-            // those into a struct displayclass, no GC pressure per call.
-            // AggressiveInlining nudges the JIT to fold this into both
-            // call sites.
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            void DepositOne(int xSrc, int ySrc)
-            {
-                var v = raw[0, ySrc, xSrc];
-                if (float.IsNaN(v)) return;
-
-                // Forward-warp using the same coordinate convention as
-                // WarpToReferenceGridAsync (Image.Transform.cs): pixel
-                // index *is* position -- no +0.5 / -0.5 center-offset
-                // dance. The registrator's affine was computed from star
-                // centroids reported in this convention; applying it to
-                // raw integer pixel indices keeps everything consistent.
-                //
-                // (Previously this method added +0.5 on source and
-                // subtracted 0.5 on canvas, mixing it with a [i, i+1]
-                // cell-extent convention on the output. Those two
-                // half-pixel shifts cancel under pure translation but
-                // *not* under rotation: a 180-degree-rotated source
-                // pixel ended up shifted by an extra (-1, -1) on the
-                // canvas vs the standard path, which manifested as the
-                // dumbbell stretch on every star in the combined
-                // meridian-flip drizzle output. Translation-only
-                // per-frame refinement narrowed each frame's residual
-                // but couldn't fix the underlying convention mismatch.)
-                var p = Vector2.Transform(new Vector2(xSrc, ySrc), transform);
-                var xW = p.X;
-                var yW = p.Y;
-
-                // Square drop on the output grid. Canvas cell at index
-                // (xc, yc) is at position (xc, yc) and occupies
-                // [xc - 0.5, xc + 0.5] x [yc - 0.5, yc + 0.5] -- same
-                // convention as SubpixelValue / WarpToReferenceGridAsync.
-                var xLo = xW - halfP;
-                var xHi = xW + halfP;
-                var yLo = yW - halfP;
-                var yHi = yW + halfP;
-
-                // Loop bounds: cell index i overlaps the drop iff
-                // i - 0.5 < xHi and i + 0.5 > xLo, i.e.
-                // floor(xLo + 0.5) <= i <= ceil(xHi - 0.5).
-                var x0 = Math.Max(0, (int)MathF.Floor(xLo + 0.5f));
-                var x1 = Math.Min(canvasW - 1, (int)MathF.Ceiling(xHi - 0.5f));
-                var y0 = Math.Max(0, (int)MathF.Floor(yLo + 0.5f));
-                var y1 = Math.Min(canvasH - 1, (int)MathF.Ceiling(yHi - 0.5f));
-                if (x1 < x0 || y1 < y0) return;
-
-                var ch = pattern[ySrc & 1, xSrc & 1];
-                var fluxCh = flux[ch];
-                var weightCh = weight[ch];
-
-                for (var yc = y0; yc <= y1; yc++)
-                {
-                    var cellYLo = yc - 0.5f;
-                    var cellYHi = yc + 0.5f;
-                    var dy = MathF.Min(yHi, cellYHi) - MathF.Max(yLo, cellYLo);
-                    if (dy <= 0f) continue;
-                    for (var xc = x0; xc <= x1; xc++)
-                    {
-                        var cellXLo = xc - 0.5f;
-                        var cellXHi = xc + 0.5f;
-                        var dx = MathF.Min(xHi, cellXHi) - MathF.Max(xLo, cellXLo);
-                        if (dx <= 0f) continue;
-                        var area = dx * dy;
-                        fluxCh[yc, xc] += v * area;
-                        weightCh[yc, xc] += area;
-                    }
-                }
-            }
+            // Full-canvas deposit: iterate the entire source frame, accumulate
+            // into the full-canvas flux/weight planes. The kernel handles the
+            // chunked hot-pixel-mask fast path internally so the streaming
+            // drizzle and the tile-pipelined variant share one deposit
+            // implementation -- a previous version inlined the loop here and
+            // diverged subtly from the half-pixel convention in the warp path,
+            // producing dumbbell stars in combined-pier-flip output.
+            DrizzleKernel.IterateAndDeposit(
+                raw, transform, pattern, halfP,
+                flux, weight,
+                xStart: 0, xEnd: canvasW,
+                yStart: 0, yEnd: canvasH,
+                new Rectangle(0, 0, srcW, srcH),
+                badPixelMask, hasBadPixelMask);
 
             frameCount++;
         }
@@ -272,37 +246,13 @@ public sealed class DrizzleStrategy : IIntegrationStrategy
         }
 
         // Final divide -- master[c, y, x] = (flux / weight) / sourceMaxValue;
-        // NaN where weight is zero. Dividing by sourceMaxValue puts the
-        // master into [0, 1] (matching the Integrator's per-frame
-        // normalization output), so MasterPostProcessor's MaxValue=1.0
-        // relabel pass and Image.Histogram's MaxValue<=1.0 branch both
-        // see a self-consistent (range, label) pair. We reuse the flux
-        // buffer in-place for the master since it's allocated at the
-        // right shape; weight stays as the coverage map.
+        // NaN where weight is zero. The kernel helper mutates flux in place
+        // and returns the covered-cell count for the coverage-rate stat.
+        // Shared with TilePipelinedDrizzleStrategy so the post-processing
+        // path is identical regardless of memory layout.
         var invMax = sourceMaxValue > 0f ? 1f / sourceMaxValue : 1f;
-        long coveredCells = 0;
         var totalCells = (long)canvasH * canvasW * 3;
-        for (var c = 0; c < 3; c++)
-        {
-            var f = flux[c];
-            var w = weight[c];
-            for (var y = 0; y < canvasH; y++)
-            {
-                for (var x = 0; x < canvasW; x++)
-                {
-                    var wv = w[y, x];
-                    if (wv > 0f)
-                    {
-                        f[y, x] = f[y, x] / wv * invMax;
-                        coveredCells++;
-                    }
-                    else
-                    {
-                        f[y, x] = float.NaN;
-                    }
-                }
-            }
-        }
+        var coveredCells = DrizzleKernel.FinaliseDivide(flux, weight, invMax, canvasH, canvasW);
 
         var master = new Image(
             data: flux,

--- a/src/TianWen.Lib/Imaging/Stacking/FrameQualityFilter.cs
+++ b/src/TianWen.Lib/Imaging/Stacking/FrameQualityFilter.cs
@@ -1,0 +1,216 @@
+using System;
+
+namespace TianWen.Lib.Imaging.Stacking;
+
+/// <summary>
+/// Per-frame PSF metrics extracted during registration. Median over the
+/// stars detected on the frame, computed once and carried through the
+/// pipeline so the post-registration quality filter has session-wide
+/// statistics without re-running star detection.
+/// </summary>
+/// <param name="MedianHfd">Median half-flux diameter, pixels.</param>
+/// <param name="MedianFwhm">Median full-width-half-maximum, pixels.</param>
+/// <param name="MedianEllipticity">Median moment-based ellipticity, in
+/// [0, 1]. 0 = round, → 1 = elongated.</param>
+/// <param name="StarCount">Number of stars the detector found on the
+/// frame. Useful for diagnostics but not used by <see cref="FrameQualityFilter"/>
+/// since <c>MinStarsForMatch</c> already gates this at registration time.</param>
+public readonly record struct FrameMetrics(
+    float MedianHfd,
+    float MedianFwhm,
+    float MedianEllipticity,
+    int StarCount);
+
+/// <summary>
+/// Reason(s) a frame was kept or dropped by <see cref="FrameQualityFilter"/>.
+/// Flags so a frame can fail multiple criteria simultaneously (HFD broad
+/// AND star count low, for instance) without losing detail.
+/// </summary>
+[System.Flags]
+public enum FrameRejectReason : byte
+{
+    Kept = 0,
+    /// <summary>Median HFD above session-wide threshold (right tail).</summary>
+    HfdTooBroad = 1 << 0,
+    /// <summary>Median ellipticity above session-wide threshold (right tail).</summary>
+    EllipticityTooHigh = 1 << 1,
+    /// <summary>Star count below session-wide threshold (left tail).
+    /// Catches haze / clouds / dew which reduce transparency without
+    /// necessarily widening HFD on the few stars that do detect.</summary>
+    StarCountTooLow = 1 << 2,
+}
+
+/// <summary>
+/// Outcome of one filter pass over a session's matched frames.
+/// </summary>
+/// <param name="Reasons">Per-frame keep/drop decision, indexed the same
+/// as the input metrics. <see cref="FrameRejectReason.Kept"/> means the
+/// frame contributes to the integration; anything else means rejected.</param>
+/// <param name="KeptCount">Number of kept frames -- redundant with
+/// counting <see cref="FrameRejectReason.Kept"/> in <see cref="Reasons"/>
+/// but cheaper than re-scanning at log time.</param>
+/// <param name="FloorTriggered">True when the MAD threshold flagged
+/// more than the 20% keep-floor would allow and the filter degraded to
+/// severity-ranked quantile rejection. Surfaced so callers can log
+/// "threshold mis-calibrated for this session" rather than the simpler
+/// per-frame line.</param>
+public readonly record struct FrameQualityFilterResult(
+    FrameRejectReason[] Reasons,
+    int KeptCount,
+    bool FloorTriggered);
+
+/// <summary>
+/// Per-frame quality filter: MAD-based outlier rejection on HFD +
+/// ellipticity, with an 80% keep floor (the worst 20% by severity get
+/// dropped at most, even when the MAD threshold would cut more).
+///
+/// <para>The filter is pure: in metrics + sigma, out keep/drop array. No
+/// I/O, no image access. The pipeline computes <see cref="FrameMetrics"/>
+/// once per frame during registration and passes the full session to
+/// this filter after the loop completes, so the threshold is anchored
+/// to session-wide median + MAD rather than any single frame.</para>
+/// </summary>
+internal static class FrameQualityFilter
+{
+    /// <summary>
+    /// MAD → standard-deviation scale factor (so the sigma knob reads
+    /// like "N standard deviations" for users familiar with kappa-sigma
+    /// rejection literature). Exact for Gaussian noise; the right rule
+    /// of thumb for real PSF distributions which are right-skewed.
+    /// </summary>
+    private const float MadToStdDev = 1.4826f;
+
+    /// <summary>
+    /// Maximum fraction of frames we will mark as rejected in one filter
+    /// pass. If the MAD threshold flags more than this, we fall back to
+    /// severity-ranked quantile rejection.
+    /// </summary>
+    private const float MaxRejectFraction = 0.20f;
+
+    /// <summary>
+    /// Minimum input length where MAD-based thresholding is statistically
+    /// meaningful. Below this we skip the filter entirely and keep all
+    /// frames -- a 3-frame session's "outlier" is just noise on a noise
+    /// distribution.
+    /// </summary>
+    private const int MinFramesForFilter = 4;
+
+    /// <summary>
+    /// Filter the input <paramref name="metrics"/> at the given
+    /// <paramref name="sigma"/> threshold. See class doc for the
+    /// algorithm.
+    /// </summary>
+    public static FrameQualityFilterResult Filter(ReadOnlySpan<FrameMetrics> metrics, float sigma)
+    {
+        var n = metrics.Length;
+        var reasons = new FrameRejectReason[n];
+
+        if (n < MinFramesForFilter || sigma <= 0f)
+        {
+            // Below 4 frames the MAD estimate is dominated by noise;
+            // sigma=0 is the documented "off" path. Either way: keep all.
+            return new FrameQualityFilterResult(reasons, n, FloorTriggered: false);
+        }
+
+        // Robust median + MAD on each metric. We sort copies (n is
+        // typically <= a few hundred so the allocation cost is
+        // negligible compared to the registration pass that produced
+        // these). Three metrics: HFD + ellipticity are right-tail
+        // (high is bad), star count is left-tail (low is bad: haze /
+        // clouds / dew reduce transparency).
+        var hfdSorted = new float[n];
+        var eccSorted = new float[n];
+        var starSorted = new float[n];
+        for (var i = 0; i < n; i++)
+        {
+            hfdSorted[i] = metrics[i].MedianHfd;
+            eccSorted[i] = metrics[i].MedianEllipticity;
+            starSorted[i] = metrics[i].StarCount;
+        }
+        Array.Sort(hfdSorted);
+        Array.Sort(eccSorted);
+        Array.Sort(starSorted);
+        var hfdMedian = hfdSorted[n / 2];
+        var eccMedian = eccSorted[n / 2];
+        var starMedian = starSorted[n / 2];
+
+        // MAD = median absolute deviation from the median.
+        for (var i = 0; i < n; i++)
+        {
+            hfdSorted[i] = MathF.Abs(metrics[i].MedianHfd - hfdMedian);
+            eccSorted[i] = MathF.Abs(metrics[i].MedianEllipticity - eccMedian);
+            starSorted[i] = MathF.Abs(metrics[i].StarCount - starMedian);
+        }
+        Array.Sort(hfdSorted);
+        Array.Sort(eccSorted);
+        Array.Sort(starSorted);
+        var hfdMad = hfdSorted[n / 2];
+        var eccMad = eccSorted[n / 2];
+        var starMad = starSorted[n / 2];
+
+        // Per-metric reject threshold. MadToStdDev makes sigma read
+        // like a standard-deviation cutoff. HFD and ecc are right-tail
+        // (reject when metric exceeds threshold); star count is
+        // left-tail (reject when metric falls below).
+        var hfdThreshold = hfdMedian + sigma * MadToStdDev * hfdMad;
+        var eccThreshold = eccMedian + sigma * MadToStdDev * eccMad;
+        var starThreshold = starMedian - sigma * MadToStdDev * starMad;
+
+        // First pass: mark all frames that fail any metric. severity[i]
+        // is the worst per-metric breach in σ units so the floor
+        // fallback can rank without a second pass.
+        var severity = new float[n];
+        var flaggedCount = 0;
+        for (var i = 0; i < n; i++)
+        {
+            var reason = FrameRejectReason.Kept;
+            if (metrics[i].MedianHfd > hfdThreshold) reason |= FrameRejectReason.HfdTooBroad;
+            if (metrics[i].MedianEllipticity > eccThreshold) reason |= FrameRejectReason.EllipticityTooHigh;
+            if (metrics[i].StarCount < starThreshold) reason |= FrameRejectReason.StarCountTooLow;
+            reasons[i] = reason;
+            if (reason != FrameRejectReason.Kept) flaggedCount++;
+
+            // Severity = worst per-metric breach in σ units. MAD = 0
+            // (all frames identical on that metric) → severity 0; the
+            // metric won't trip the threshold anyway so the floor
+            // ranking can ignore it.
+            var hfdSigma = hfdMad > 1e-6f ? (metrics[i].MedianHfd - hfdMedian) / (MadToStdDev * hfdMad) : 0f;
+            var eccSigma = eccMad > 1e-6f ? (metrics[i].MedianEllipticity - eccMedian) / (MadToStdDev * eccMad) : 0f;
+            // Star count breach is in the OTHER direction: severity is
+            // how many σ BELOW the median we are.
+            var starSigma = starMad > 1e-6f ? (starMedian - metrics[i].StarCount) / (MadToStdDev * starMad) : 0f;
+            severity[i] = MathF.Max(MathF.Max(hfdSigma, eccSigma), starSigma);
+        }
+
+        // Apply the 80% keep floor: at most 20% of frames may end up
+        // rejected. If the MAD threshold flagged more, rank the flagged
+        // frames by severity and keep only the worst N as rejected.
+        var maxReject = (int)MathF.Floor(MaxRejectFraction * n);
+        var floorTriggered = false;
+        if (flaggedCount > maxReject)
+        {
+            floorTriggered = true;
+            // Threshold for "is this severity in the worst maxReject?":
+            // find the (n - maxReject)-th smallest severity, anything
+            // above it stays rejected. Simple sort; n is small.
+            var sevSorted = (float[])severity.Clone();
+            Array.Sort(sevSorted);
+            // The maxReject-th-from-the-top severity value.
+            var cutoff = sevSorted[n - maxReject];
+            for (var i = 0; i < n; i++)
+            {
+                if (reasons[i] != FrameRejectReason.Kept && severity[i] < cutoff)
+                {
+                    reasons[i] = FrameRejectReason.Kept; // floor reprieve
+                }
+            }
+        }
+
+        var keptCount = 0;
+        for (var i = 0; i < n; i++)
+        {
+            if (reasons[i] == FrameRejectReason.Kept) keptCount++;
+        }
+        return new FrameQualityFilterResult(reasons, keptCount, floorTriggered);
+    }
+}

--- a/src/TianWen.Lib/Imaging/Stacking/FrameQualityFilter.cs
+++ b/src/TianWen.Lib/Imaging/Stacking/FrameQualityFilter.cs
@@ -13,8 +13,12 @@ namespace TianWen.Lib.Imaging.Stacking;
 /// <param name="MedianEllipticity">Median moment-based ellipticity, in
 /// [0, 1]. 0 = round, → 1 = elongated.</param>
 /// <param name="StarCount">Number of stars the detector found on the
-/// frame. Useful for diagnostics but not used by <see cref="FrameQualityFilter"/>
-/// since <c>MinStarsForMatch</c> already gates this at registration time.</param>
+/// frame. Used by <see cref="FrameQualityFilter"/> as a left-tail
+/// reject metric: a session-wide drop in star count catches haze,
+/// clouds, or dew which reduce transparency without necessarily
+/// widening HFD on the few stars that do detect. Independent of the
+/// <c>MinStarsForMatch</c> registration gate (that's an absolute
+/// floor; this is a relative-to-session-median outlier check).</param>
 public readonly record struct FrameMetrics(
     float MedianHfd,
     float MedianFwhm,

--- a/src/TianWen.Lib/Imaging/Stacking/HostSnapshot.cs
+++ b/src/TianWen.Lib/Imaging/Stacking/HostSnapshot.cs
@@ -1,0 +1,115 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using Microsoft.Extensions.Logging;
+
+namespace TianWen.Lib.Imaging.Stacking;
+
+/// <summary>
+/// Point-in-time host resource snapshot: process working-set + managed
+/// heap size, free RAM the GC believes the process can still grow into,
+/// and free disk on a caller-supplied drive. Cheap to take -- one
+/// <see cref="Process.GetCurrentProcess"/>, one
+/// <see cref="GC.GetGCMemoryInfo()"/>, one <see cref="DriveInfo"/>.
+/// </summary>
+internal readonly record struct HostSnapshot(
+    long ProcessWorkingSetBytes,
+    long ManagedHeapBytes,
+    long FreeRamBytes,
+    long FreeDiskBytes,
+    long ElapsedMs)
+{
+    public static HostSnapshot Take(string diskPath, Stopwatch sw)
+    {
+        using var p = Process.GetCurrentProcess();
+        var gc = GC.GetGCMemoryInfo();
+        long freeDisk = 0;
+        if (!string.IsNullOrEmpty(diskPath))
+        {
+            // DriveInfo throws on a vanished drive / share permission denial;
+            // a missing free-disk reading should not abort the run.
+            try
+            {
+                var root = Path.GetPathRoot(Path.GetFullPath(diskPath));
+                if (!string.IsNullOrEmpty(root)) freeDisk = new DriveInfo(root).AvailableFreeSpace;
+            }
+            catch { /* best-effort: log 0 rather than crashing the run */ }
+        }
+        return new HostSnapshot(
+            ProcessWorkingSetBytes: p.WorkingSet64,
+            ManagedHeapBytes: GC.GetTotalMemory(forceFullCollection: false),
+            // TotalAvailableMemoryBytes - MemoryLoadBytes: "what the process
+            // can still grow into without paging". MemoryLoadBytes includes
+            // the process itself plus everything else on the host.
+            FreeRamBytes: Math.Max(0, gc.TotalAvailableMemoryBytes - gc.MemoryLoadBytes),
+            FreeDiskBytes: freeDisk,
+            ElapsedMs: sw.ElapsedMilliseconds);
+    }
+}
+
+/// <summary>
+/// Holds the run's baseline <see cref="HostSnapshot"/> + a single
+/// <see cref="Stopwatch"/> and emits structured <c>[host]</c> log lines
+/// with deltas vs. baseline at each milestone. One tracker per
+/// <c>RunAsync</c> invocation; threaded through the per-group helpers so
+/// every stage's line uses the same baseline + clock.
+/// </summary>
+internal sealed class HostSnapshotTracker
+{
+    private readonly Stopwatch _sw;
+    private readonly HostSnapshot _baseline;
+    private readonly string _diskPath;
+
+    public HostSnapshotTracker(string diskPath)
+    {
+        _diskPath = diskPath;
+        _sw = Stopwatch.StartNew();
+        _baseline = HostSnapshot.Take(diskPath, _sw);
+    }
+
+    /// <summary>
+    /// Emit one <c>[host]</c> line tagged with <paramref name="stage"/>.
+    /// Format: <c>[host/stage] rss=1.2GB(+340MB) heap=820MB(+220MB)
+    /// freeRam=8.4GB(-2.1GB) freeDisk=412GB(-1.2GB) @ +245s</c>.
+    /// Deltas are computed against the tracker's construction-time
+    /// baseline, not the previous log call, so the +/- numbers always
+    /// answer "how much has the run consumed so far?".
+    /// </summary>
+    public void Log(ILogger logger, string stage)
+    {
+        var current = HostSnapshot.Take(_diskPath, _sw);
+        logger.LogInformation(
+            "[host/{Stage}] rss={Rss}({RssD}) heap={Heap}({HeapD}) freeRam={FreeRam}({FreeRamD}) freeDisk={FreeDisk}({FreeDiskD}) @ +{Seconds}s",
+            stage,
+            FormatBytes(current.ProcessWorkingSetBytes),
+            FormatDelta(current.ProcessWorkingSetBytes - _baseline.ProcessWorkingSetBytes),
+            FormatBytes(current.ManagedHeapBytes),
+            FormatDelta(current.ManagedHeapBytes - _baseline.ManagedHeapBytes),
+            FormatBytes(current.FreeRamBytes),
+            FormatDelta(current.FreeRamBytes - _baseline.FreeRamBytes),
+            FormatBytes(current.FreeDiskBytes),
+            FormatDelta(current.FreeDiskBytes - _baseline.FreeDiskBytes),
+            current.ElapsedMs / 1000);
+    }
+
+    /// <summary>
+    /// Format an absolute byte count as a short human-readable string:
+    /// <c>1.2GB</c>, <c>340MB</c>, <c>820KB</c>, <c>42B</c>. Picks the
+    /// biggest unit where the magnitude is >= 1.
+    /// </summary>
+    internal static string FormatBytes(long bytes)
+    {
+        var abs = Math.Abs(bytes);
+        if (abs >= 1L << 30) return $"{bytes / (double)(1L << 30):F1}GB";
+        if (abs >= 1L << 20) return $"{bytes / (1L << 20)}MB";
+        if (abs >= 1L << 10) return $"{bytes / (1L << 10)}KB";
+        return $"{bytes}B";
+    }
+
+    /// <summary>Same as <see cref="FormatBytes"/> but always carries an explicit
+    /// sign (<c>+</c> for non-negative, <c>-</c> for negative) so a delta is
+    /// instantly distinguishable from an absolute number in the log line.</summary>
+    internal static string FormatDelta(long bytes) => bytes >= 0
+        ? "+" + FormatBytes(bytes)
+        : "-" + FormatBytes(-bytes);
+}

--- a/src/TianWen.Lib/Imaging/Stacking/IIntegrationStrategy.cs
+++ b/src/TianWen.Lib/Imaging/Stacking/IIntegrationStrategy.cs
@@ -54,6 +54,21 @@ public enum IntegrationStrategyKind
     /// explicit <c>--strategy BayerDrizzle</c> override. See
     /// <see cref="DrizzleOptions"/>.</summary>
     BayerDrizzle,
+
+    /// <summary>Tile-pipelined Bayer drizzle: same forward-projection
+    /// kernel as <see cref="BayerDrizzle"/> but the flux/weight
+    /// accumulators are sized per canvas strip rather than full-canvas.
+    /// Caches calibrated 1-channel Bayer frames; per strip, inverse-
+    /// projects the canvas strip rect back to a source rect per frame
+    /// and iterates only those source pixels (the rest can't reach the
+    /// strip). Memory profile is bounded by strip working set +
+    /// calibrated-frame cache rather than (3 ch x 2 planes x full
+    /// canvas) -- ~25 MB strip vs ~400 MB full canvas on a 4032 RGB
+    /// output, scaling 4x harder under Phase 2 (2.0x output scale).
+    /// Drizzle kernel + post-processing are shared with
+    /// <see cref="BayerDrizzle"/> via <see cref="DrizzleKernel"/>; only
+    /// memory layout differs.</summary>
+    TilePipelinedDrizzle,
 }
 
 /// <summary>

--- a/src/TianWen.Lib/Imaging/Stacking/IntegrationProbe.cs
+++ b/src/TianWen.Lib/Imaging/Stacking/IntegrationProbe.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using TianWen.Lib.Imaging;
 
 namespace TianWen.Lib.Imaging.Stacking;
 
@@ -87,6 +88,18 @@ public sealed record IntegrationProbe(
     long AvailableRamBytes,
     long AvailableDiskBytes,
     string StagingDir,
+    // Sensor type of the reference frame, authoritatively the group's
+    // <see cref="LightGroupKey.CalibrationKey"/>.SensorType. The scanner
+    // pins this at scan-time from per-frame FITS headers; it's invariant
+    // within a group (frames with different SensorType end up in
+    // different groups by construction). Required (no default) so a
+    // caller that doesn't know the sensor type has to make an explicit
+    // choice -- <see cref="Imaging.SensorType.Monochrome"/> for the safe
+    // "no Bayer matrix" assumption, matching the Image / ImageMeta
+    // convention. Drizzle strategies key CanRun off this; only
+    // <see cref="Imaging.SensorType.RGGB"/> exposes the Bayer-encoded
+    // source plane the forward-projection kernel dispatches from.
+    SensorType SensorType,
     DiskKind StagingDiskKind = DiskKind.Unknown,
     bool EmitRejectionMap = true,
     bool LiveStacking = false,
@@ -127,6 +140,7 @@ public sealed record IntegrationProbe(
         int canvasWidth,
         int canvasHeight,
         string stagingDir,
+        SensorType sensorType,
         DiskKind stagingDiskKind = DiskKind.Unknown,
         bool emitRejectionMap = true,
         bool liveStacking = false)
@@ -151,7 +165,8 @@ public sealed record IntegrationProbe(
             StagingDiskKind: stagingDiskKind,
             EmitRejectionMap: emitRejectionMap,
             LiveStacking: liveStacking,
-            FreeRamBytes: currentlyFree);
+            FreeRamBytes: currentlyFree,
+            SensorType: sensorType);
     }
 }
 
@@ -210,6 +225,17 @@ public sealed record IntegrationCostModel
     /// factor of ~10 -- this constant is the single biggest determinant of
     /// pipeline wall time on raw FITS lights.</summary>
     public double CpuNsPerDebayerPixel { get; init; } = 60.0;
+
+    /// <summary>Per-source-pixel CPU cost of drizzle forward-projection (ns).
+    /// Each Bayer sample touches up to 4 output cells at pixfrac=1; the inner
+    /// loop is 4 multiplies + 4 adds + 4 stores per cell, ~30 ns per source
+    /// pixel measured empirically from earlier SoL drizzle runs. This is
+    /// what the drizzle family pays instead of <see cref="CpuNsPerDebayerPixel"/>
+    /// + <see cref="CpuNsPerWarpPixel"/> + <see cref="CpuNsPerStackPixelPerFrame"/>;
+    /// the net is ~3-5x speedup vs the standard path on RGGB inputs, which
+    /// is what makes drizzle competitive enough to auto-select on big-N
+    /// sessions despite its 0.92 vs 0.98 fidelity discount.</summary>
+    public double CpuNsPerDrizzleProjectPixel { get; init; } = 30.0;
 
     /// <summary>Float16 unpack overhead per pixel on read (ns). Cheap thanks to
     /// hardware f16->f32 paths, but not zero.</summary>

--- a/src/TianWen.Lib/Imaging/Stacking/IntegrationStrategySelector.cs
+++ b/src/TianWen.Lib/Imaging/Stacking/IntegrationStrategySelector.cs
@@ -253,5 +253,6 @@ public static class IntegrationStrategySelector
         new ChunkedTwoPassStrategy(),
         new LiveAccumulatorStrategy(),
         new DrizzleStrategy(),
+        new TilePipelinedDrizzleStrategy(),
     };
 }

--- a/src/TianWen.Lib/Imaging/Stacking/RegistrationRefiner.cs
+++ b/src/TianWen.Lib/Imaging/Stacking/RegistrationRefiner.cs
@@ -4,28 +4,30 @@ using System.Numerics;
 namespace TianWen.Lib.Imaging.Stacking;
 
 /// <summary>
-/// Translation-only refinement for the bulk affine produced by
+/// Per-frame refinement of the bulk affine produced by
 /// <see cref="SortedStarList.FindOffsetAndRotationWithRmsAsync"/>. The
 /// quad-fingerprint match minimises RMS residual across the brightest
-/// N stars but leaves a small per-frame translation bias when the
-/// session crosses a meridian flip (pre- and post-flip frames have
-/// slightly different mount + atmosphere offsets that fit the bulk
-/// average instead of zero). In bilinear-warp strategies that bias is
-/// invisible because the warp kernel smooths over a 1-2 px shift; in
-/// <see cref="DrizzleStrategy"/> the bias is preserved as a "dumbbell"
-/// stretch on every star -- pre-flip stack centroid at one position,
-/// post-flip centroid at another.
+/// N stars but leaves small per-frame residuals (sub-pixel translation
+/// bias from a meridian flip, plus slow rotation/scale drift from
+/// atmospheric refraction + mount imperfection over multi-hour stacks)
+/// that the bulk fit averages away. In bilinear-warp strategies those
+/// residuals are invisible because the warp kernel smooths over 1-2 px
+/// of misregistration; in <see cref="DrizzleStrategy"/> they show up
+/// directly as broader stars or, in the meridian-flip case, dumbbells.
 ///
-/// <para>This refiner shifts each frame's source-to-reference affine by
-/// the median residual of its detected stars against the reference
-/// frame's detected stars, after applying the bulk affine. Rotation
-/// and scale stay at whatever the bulk fit produced; this is strictly
-/// a translation correction. Empirically sufficient for typical
-/// meridian-flip dumbbells (verified against SoL data: 244-frame
-/// dataset, dumbbells visible pre-refinement, round stars after).
-/// Rotation refinement would be a Kabsch-based extension; not needed
-/// for the meridian-flip case but kept as a follow-up for future
-/// non-rigid distortions.</para>
+/// <para>Two variants live here:</para>
+/// <list type="bullet">
+///   <item><see cref="RefineTranslation"/> -- median (dx, dy) residual
+///   only. Cheap, robust on a handful of matches, fixes meridian-flip
+///   dumbbells. Kept as the low-match-count fallback.</item>
+///   <item><see cref="RefineRigid"/> -- full 2D Procrustes (rotation +
+///   isotropic scale + translation) via the closed-form 2D solution.
+///   Closes the residual that <see cref="RefineTranslation"/> can't
+///   touch, which empirically helps long-span pier-side subsets (e.g.
+///   SoL pierW: 152 frames over 3 hours saw <c>matched=509/879</c> +
+///   23 Tycho-2 SPCC matches vs. pierE's 1019/1165 + 177 -- rotation
+///   drift the bulk fit couldn't capture).</item>
+/// </list>
 /// </summary>
 internal static class RegistrationRefiner
 {
@@ -122,5 +124,192 @@ internal static class RegistrationRefiner
         refined.M31 += medianDx;
         refined.M32 += medianDy;
         return (refined, medianDx, medianDy, matched);
+    }
+
+    /// <summary>
+    /// Returns <paramref name="bulkAffine"/> composed with the closed-form
+    /// 2D Procrustes refinement (rotation + isotropic scale + translation)
+    /// that best maps the bulk-warped light-frame stars onto
+    /// <paramref name="referenceStars"/>. Falls back to
+    /// <see cref="RefineTranslation"/> when fewer than
+    /// <paramref name="minMatchedStars"/> pairs are found (rigid refit
+    /// needs ~6+ for a stable rotation estimate; translation only needs 1)
+    /// or when the predicted points are collinear / coincident (norm
+    /// guard) so a rotation can't be fit.
+    /// </summary>
+    /// <param name="lightStars">Detected stars on the light frame, in
+    /// SOURCE pixel coordinates.</param>
+    /// <param name="referenceStars">Detected stars on the reference
+    /// frame, in REFERENCE pixel coordinates.</param>
+    /// <param name="bulkAffine">Source-to-reference affine from the
+    /// quad-fingerprint match.</param>
+    /// <param name="matchToleranceRefPx">Maximum nearest-neighbour
+    /// distance in reference space to accept a match.</param>
+    /// <param name="minMatchedStars">Minimum matched pairs required to
+    /// run the full rigid fit. Below this, falls back to
+    /// <see cref="RefineTranslation"/> (which needs only 1 pair).</param>
+    /// <returns>Refined affine plus diagnostics (scale factor, rotation
+    /// in degrees, centroid-shift translation, RMS residual in reference
+    /// pixels, matched-pair count). All scalars are reported for the
+    /// DELTA refinement applied on top of <paramref name="bulkAffine"/>,
+    /// not the absolute composed transform.</returns>
+    public static (Matrix3x2 Refined, float Scale, float RotationDeg, float Tx, float Ty, float RmsResidualPx, int MatchedCount)
+        RefineRigid(
+            SortedStarList lightStars,
+            SortedStarList referenceStars,
+            Matrix3x2 bulkAffine,
+            float matchToleranceRefPx = 5.0f,
+            int minMatchedStars = 8)
+    {
+        // Step 1: snapshot reference positions for nearest-neighbour scan.
+        var refCount = referenceStars.Count;
+        var refX = new float[refCount];
+        var refY = new float[refCount];
+        var i = 0;
+        foreach (var s in referenceStars)
+        {
+            refX[i] = s.XCentroid;
+            refY[i] = s.YCentroid;
+            i++;
+        }
+
+        // Step 2: pair each light star with its nearest ref star (in
+        // reference space, after bulk warp). Brute-force O(N*M) -- same
+        // complexity as RefineTranslation.
+        var tolSq = matchToleranceRefPx * matchToleranceRefPx;
+        var predX = new float[lightStars.Count];
+        var predY = new float[lightStars.Count];
+        var matchedRefX = new float[lightStars.Count];
+        var matchedRefY = new float[lightStars.Count];
+        var matched = 0;
+        foreach (var ls in lightStars)
+        {
+            var predicted = Vector2.Transform(new Vector2(ls.XCentroid, ls.YCentroid), bulkAffine);
+            var bestSq = float.MaxValue;
+            float bestRefX = 0f, bestRefY = 0f;
+            for (var j = 0; j < refCount; j++)
+            {
+                var dx = refX[j] - predicted.X;
+                var dy = refY[j] - predicted.Y;
+                var sq = dx * dx + dy * dy;
+                if (sq < bestSq && sq <= tolSq)
+                {
+                    bestSq = sq;
+                    bestRefX = refX[j];
+                    bestRefY = refY[j];
+                }
+            }
+            if (bestSq < float.MaxValue)
+            {
+                predX[matched] = predicted.X;
+                predY[matched] = predicted.Y;
+                matchedRefX[matched] = bestRefX;
+                matchedRefY[matched] = bestRefY;
+                matched++;
+            }
+        }
+
+        // Translation-only fallback for low-match cases. Rotation
+        // estimation needs ~6+ pairs to escape sample noise; below that
+        // the translation median is the more honest correction.
+        if (matched < minMatchedStars)
+        {
+            var (translatedFallback, dx, dy, _) = RefineTranslation(
+                lightStars, referenceStars, bulkAffine,
+                matchToleranceRefPx, minMatchedStars: 1);
+            return (translatedFallback, 1f, 0f, dx, dy, 0f, matched);
+        }
+
+        // Step 3: centroids in double precision -- the cross-covariance
+        // accumulators below sum N products of ~1k-px values, so single-
+        // precision would lose a couple of ulps in the rotation angle on
+        // dense star fields.
+        double sumPX = 0, sumPY = 0, sumRX = 0, sumRY = 0;
+        for (var k = 0; k < matched; k++)
+        {
+            sumPX += predX[k]; sumPY += predY[k];
+            sumRX += matchedRefX[k]; sumRY += matchedRefY[k];
+        }
+        var cpx = sumPX / matched;
+        var cpy = sumPY / matched;
+        var crx = sumRX / matched;
+        var cry = sumRY / matched;
+
+        // Step 4: cross-covariance over centred points.
+        double Hxx = 0, Hxy = 0, Hyx = 0, Hyy = 0, sumPSq = 0;
+        for (var k = 0; k < matched; k++)
+        {
+            var px = predX[k] - cpx;
+            var py = predY[k] - cpy;
+            var rx = matchedRefX[k] - crx;
+            var ry = matchedRefY[k] - cry;
+            Hxx += px * rx;
+            Hxy += px * ry;
+            Hyx += py * rx;
+            Hyy += py * ry;
+            sumPSq += px * px + py * py;
+        }
+
+        // Step 5: closed-form 2D Procrustes.
+        //   tan θ = (Hxy - Hyx) / (Hxx + Hyy)
+        //   s = ((Hxx + Hyy) cos θ + (Hxy - Hyx) sin θ) / Σ |p'|²
+        //     = sqrt((Hxy-Hyx)² + (Hxx+Hyy)²) / Σ |p'|²
+        // Derivation: minimise Σ |s R p'_i - r'_i|² over (s, θ).
+        // Reference: standard "2D rigid Procrustes" (no SVD needed for 2D).
+        var num = Hxy - Hyx;
+        var den = Hxx + Hyy;
+        var norm = Math.Sqrt(num * num + den * den);
+        if (norm < 1e-12 || sumPSq < 1e-12)
+        {
+            // Degenerate: predicted points are coincident (sumPSq=0) or
+            // produce a zero cross-covariance for some pathological
+            // arrangement (norm=0). Either way we can't fit a rotation;
+            // fall back to translation refinement on the existing pairs.
+            var (translatedFallback, dx, dy, _) = RefineTranslation(
+                lightStars, referenceStars, bulkAffine,
+                matchToleranceRefPx, minMatchedStars: 1);
+            return (translatedFallback, 1f, 0f, dx, dy, 0f, matched);
+        }
+
+        var cosT = den / norm;
+        var sinT = num / norm;
+        var scale = norm / sumPSq;
+
+        // Step 6: delta in System.Numerics row-vec convention. For a
+        // rotation θ + isotropic scale s applied to a row-vector p:
+        //   p_after = p * [[s cos θ,  s sin θ],
+        //                  [-s sin θ, s cos θ]] + translation
+        // The translation is centroid_ref - delta_2x2(centroid_pred), so
+        // delta(centroid_pred) == centroid_ref exactly.
+        var m11 = (float)(scale * cosT);
+        var m12 = (float)(scale * sinT);
+        var m21 = (float)(-scale * sinT);
+        var m22 = (float)(scale * cosT);
+        var m31 = (float)(crx - (cpx * m11 + cpy * m21));
+        var m32 = (float)(cry - (cpx * m12 + cpy * m22));
+        var delta = new Matrix3x2(m11, m12, m21, m22, m31, m32);
+
+        // Step 7: compose with bulk affine. In System.Numerics row-vec,
+        // `A * B` is "apply A, then B", so `bulkAffine * delta` means
+        // source -> bulk-warp -> delta-refine -> reference.
+        var refined = bulkAffine * delta;
+
+        // Diagnostics: post-refinement RMS in reference pixels + rotation
+        // angle in degrees + centroid translation (matches the dx/dy
+        // semantic of RefineTranslation for caller continuity).
+        double sumResSq = 0;
+        for (var k = 0; k < matched; k++)
+        {
+            var pAfter = Vector2.Transform(new Vector2(predX[k], predY[k]), delta);
+            var ddx = matchedRefX[k] - pAfter.X;
+            var ddy = matchedRefY[k] - pAfter.Y;
+            sumResSq += ddx * ddx + ddy * ddy;
+        }
+        var rms = (float)Math.Sqrt(sumResSq / matched);
+        var rotationDeg = (float)(Math.Atan2(num, den) * 180.0 / Math.PI);
+        var txCentroid = (float)(crx - cpx);
+        var tyCentroid = (float)(cry - cpy);
+
+        return (refined, (float)scale, rotationDeg, txCentroid, tyCentroid, rms, matched);
     }
 }

--- a/src/TianWen.Lib/Imaging/Stacking/StackingOptions.cs
+++ b/src/TianWen.Lib/Imaging/Stacking/StackingOptions.cs
@@ -77,6 +77,19 @@ namespace TianWen.Lib.Imaging.Stacking;
 /// temporal MIDDLE of a session makes per-frame rotation residuals
 /// symmetric around zero, balancing per-channel drizzle coverage. Off
 /// by default.</param>
+/// <param name="DisableBayerDrizzle">Opt out of drizzle auto-selection.
+/// Drizzle (both <see cref="IntegrationStrategyKind.BayerDrizzle"/> and
+/// <see cref="IntegrationStrategyKind.TilePipelinedDrizzle"/>) is
+/// auto-pickable when the sensor is RGGB and the matched-frame count
+/// meets the minimum coverage threshold (default 60). The 3-5x wall-
+/// time advantage usually beats the standard path under the Balanced
+/// ranking policy on RGGB input. Set this when you want the AHD-
+/// debayered + warp-rejected master instead -- e.g. for SPCC
+/// validation against a reference master, or when you specifically
+/// want the standard rejection kernel's outlier handling rather than
+/// drizzle's per-cell coverage map. <see cref="ForcedStrategy"/>
+/// overrides this either way (forcing BayerDrizzle still routes to
+/// the drizzle path even when this flag is true).</param>
 public sealed record StackingOptions(
     string DataRoot,
     string OutputDir,
@@ -92,4 +105,5 @@ public sealed record StackingOptions(
     bool SplitByPierSide = false,
     float HotPixelSigma = 8.0f,
     float? QualityRejectSigma = null,
-    string? ReferenceFrameHint = null);
+    string? ReferenceFrameHint = null,
+    bool DisableBayerDrizzle = false);

--- a/src/TianWen.Lib/Imaging/Stacking/StackingOptions.cs
+++ b/src/TianWen.Lib/Imaging/Stacking/StackingOptions.cs
@@ -58,6 +58,16 @@ namespace TianWen.Lib.Imaging.Stacking;
 /// per-cell averaging). Default 8 is conservative; hot pixels typically
 /// score 100+ sigma. Pass 0 to disable masking (legacy behaviour).
 /// Ignored when no dark master is matched to the light group.</param>
+/// <param name="QualityRejectSigma">When set, runs the post-registration
+/// frame quality filter at this sigma threshold: a frame is dropped from
+/// integration if its median HFD or ellipticity exceeds
+/// <c>median + sigma · 1.4826 · MAD</c> of the session's matched-frame
+/// distribution. An 80% keep floor caps rejection at the worst 20% by
+/// severity when the MAD threshold would over-cut. Null disables the
+/// filter (default; preserves the pre-this-feature behaviour). 3.0 is the
+/// recommended starting value -- conservative, catches clear outliers
+/// (low-altitude bloated frames, wind-trailed frames) without biting
+/// into the body of the distribution. See <see cref="FrameQualityFilter"/>.</param>
 public sealed record StackingOptions(
     string DataRoot,
     string OutputDir,
@@ -71,4 +81,5 @@ public sealed record StackingOptions(
     int QuadStars = 500,
     DrizzleOptions? DrizzleOptions = null,
     bool SplitByPierSide = false,
-    float HotPixelSigma = 8.0f);
+    float HotPixelSigma = 8.0f,
+    float? QualityRejectSigma = null);

--- a/src/TianWen.Lib/Imaging/Stacking/StackingOptions.cs
+++ b/src/TianWen.Lib/Imaging/Stacking/StackingOptions.cs
@@ -68,6 +68,15 @@ namespace TianWen.Lib.Imaging.Stacking;
 /// recommended starting value -- conservative, catches clear outliers
 /// (low-altitude bloated frames, wind-trailed frames) without biting
 /// into the body of the distribution. See <see cref="FrameQualityFilter"/>.</param>
+/// <param name="ReferenceFrameHint">Debug knob: when set, pins the
+/// reference frame for each light group to the first candidate whose
+/// path contains this case-insensitive substring. Null falls back to
+/// the composite-quality score reference picker (the production
+/// default). Use to isolate per-frame Bayer-drizzle artifacts that
+/// correlate with reference choice -- pinning to a frame near the
+/// temporal MIDDLE of a session makes per-frame rotation residuals
+/// symmetric around zero, balancing per-channel drizzle coverage. Off
+/// by default.</param>
 public sealed record StackingOptions(
     string DataRoot,
     string OutputDir,
@@ -82,4 +91,5 @@ public sealed record StackingOptions(
     DrizzleOptions? DrizzleOptions = null,
     bool SplitByPierSide = false,
     float HotPixelSigma = 8.0f,
-    float? QualityRejectSigma = null);
+    float? QualityRejectSigma = null,
+    string? ReferenceFrameHint = null);

--- a/src/TianWen.Lib/Imaging/Stacking/StackingOptions.cs
+++ b/src/TianWen.Lib/Imaging/Stacking/StackingOptions.cs
@@ -77,6 +77,16 @@ namespace TianWen.Lib.Imaging.Stacking;
 /// temporal MIDDLE of a session makes per-frame rotation residuals
 /// symmetric around zero, balancing per-channel drizzle coverage. Off
 /// by default.</param>
+/// <param name="IncludeStackProducts">When true, the scan keeps frames with a
+/// non-zero FITS <c>STACK_N</c> header (i.e. masters integrated by a previous
+/// run) and feeds them into the next-stage grouping. Two-stage mosaic
+/// stacking is the canonical use case: each panel is integrated separately,
+/// then the resulting masters are re-stacked as the panel-aligned final
+/// mosaic. Off by default -- stale masters in adjacent <c>output-*/</c> dirs
+/// from prior runs would otherwise pollute the next session's lights. The
+/// <c>.rejection.fits</c> sidecar is ALWAYS dropped regardless of this flag:
+/// it's a per-pixel rejection-fraction map, not an image suitable for
+/// further integration.</param>
 /// <param name="DisableBayerDrizzle">Opt out of drizzle auto-selection.
 /// Drizzle (both <see cref="IntegrationStrategyKind.BayerDrizzle"/> and
 /// <see cref="IntegrationStrategyKind.TilePipelinedDrizzle"/>) is
@@ -106,4 +116,5 @@ public sealed record StackingOptions(
     float HotPixelSigma = 8.0f,
     float? QualityRejectSigma = null,
     string? ReferenceFrameHint = null,
-    bool DisableBayerDrizzle = false);
+    bool DisableBayerDrizzle = false,
+    bool IncludeStackProducts = false);

--- a/src/TianWen.Lib/Imaging/Stacking/StackingPipeline.cs
+++ b/src/TianWen.Lib/Imaging/Stacking/StackingPipeline.cs
@@ -530,11 +530,28 @@ public sealed class StackingPipeline(
                         qSigma, matched.Count - filterResult.KeptCount, matched.Count);
                 }
                 var filtered = new List<(FrameInfo Light, Matrix3x2 Transform, FrameMetrics Metrics)>(filterResult.KeptCount);
+                // Rebuild the calibratedCache alongside matched so the
+                // integrator's index-based lookup stays consistent. The
+                // cache is keyed by integer frame index = matched[i]
+                // position; when we drop frame K from matched, every
+                // subsequent index in the cache becomes off-by-one
+                // relative to the new matched list. Without this
+                // rebuild, the integrator pairs new matched[K+] with
+                // OLD cache[K+]'s calibrated image -- it uses the
+                // wrong calibrated frame with the right transform,
+                // producing systematic misregistration on every frame
+                // after the drop. That looked like chromatic speckle on
+                // SoL pier-side drizzle masters.
+                var newCache = new FrameCache(filterResult.KeptCount, FrameCache.DecideCacheCap(filterResult.KeptCount, calibratedFrameBytes));
                 for (var i = 0; i < matched.Count; i++)
                 {
                     var reason = filterResult.Reasons[i];
                     if (reason == FrameRejectReason.Kept)
                     {
+                        if (calibratedCache.TryGet(i, out var cachedImg))
+                        {
+                            newCache.Set(filtered.Count, cachedImg);
+                        }
                         filtered.Add(matched[i]);
                     }
                     else
@@ -547,6 +564,7 @@ public sealed class StackingPipeline(
                     }
                 }
                 matched = filtered;
+                calibratedCache = newCache;
             }
             else
             {

--- a/src/TianWen.Lib/Imaging/Stacking/StackingPipeline.cs
+++ b/src/TianWen.Lib/Imaging/Stacking/StackingPipeline.cs
@@ -12,6 +12,7 @@ using Microsoft.Extensions.Logging;
 using TianWen.Lib.Astrometry;
 using TianWen.Lib.Astrometry.Catalogs;
 using TianWen.Lib.Imaging.Calibration;
+using TianWen.Lib.Stat;
 
 namespace TianWen.Lib.Imaging.Stacking;
 
@@ -416,9 +417,17 @@ public sealed class StackingPipeline(
                         var (refined, refScale, refRotDeg, refTx, refTy, refRms, refMatched) =
                             RegistrationRefiner.RefineRigid(lightSorted, referenceSorted, transform.Value);
                         transform = refined;
+                        // Per-frame PSF medians from the detected stars. Cheap
+                        // (single pass over the existing StarList) so always
+                        // logged -- spotting an outlier frame's HFD or
+                        // ellipticity spike is exactly what we need when a
+                        // long-span stack ends up with poor SPCC matches.
+                        var medHfd = stars.MapReduceStarProperty(SampleKind.HFD, AggregationMethod.Median);
+                        var medFwhm = stars.MapReduceStarProperty(SampleKind.FWHM, AggregationMethod.Median);
+                        var medEcc = stars.MapReduceStarProperty(SampleKind.Ellipticity, AggregationMethod.Median);
                         logger.LogInformation(
-                            "  [{Name}] stars={Stars} -> MATCH qt={Tol:F3} refine: rot={Rot:F3}° s={Scale:F5} t=({Tx:F2},{Ty:F2}) rms={Rms:F2}px from {RefMatched} pairs",
-                            name, stars.Count, tolUsed, refRotDeg, refScale, refTx, refTy, refRms, refMatched);
+                            "  [{Name}] stars={Stars} hfd={Hfd:F2} fwhm={Fwhm:F2} ecc={Ecc:F3} -> MATCH qt={Tol:F3} refine: rot={Rot:F3}° s={Scale:F5} t=({Tx:F2},{Ty:F2}) rms={Rms:F2}px from {RefMatched} pairs",
+                            name, stars.Count, medHfd, medFwhm, medEcc, tolUsed, refRotDeg, refScale, refTx, refTy, refRms, refMatched);
                     }
                 }
             }

--- a/src/TianWen.Lib/Imaging/Stacking/StackingPipeline.cs
+++ b/src/TianWen.Lib/Imaging/Stacking/StackingPipeline.cs
@@ -133,7 +133,15 @@ public sealed class StackingPipeline(
             catch { /* best-effort cleanup; per-group code surfaces if it still fails */ }
         }
 
+        // Construct the tracker AFTER the wipe + staging cleanup so the
+        // baseline disk reading reflects the run's actual starting point
+        // (not the pre-cleanup state including stale outputs that we just
+        // deleted). RAM baseline is "right before we open any FITS files",
+        // which is the most useful reference for "how much did the pipeline
+        // consume" questions.
+        var hostTracker = new HostSnapshotTracker(outputDir);
         logger.LogInformation("[start] data={DataRoot} out={OutputDir}", options.DataRoot, outputDir);
+        hostTracker.Log(logger, "start");
 
         // -----------------------------------------------------------------
         // 1) Enumerate ALL FITS recursively + group by frame type
@@ -205,6 +213,7 @@ public sealed class StackingPipeline(
                 stackProductKept);
         }
         logger.LogInformation("[scan] {Count} frames in {ElapsedMs} ms", allFrames.Count, sw.ElapsedMilliseconds);
+        hostTracker.Log(logger, "scan");
 
         var byType = allFrames.GroupBy(f => f.FrameType).ToDictionary(g => g.Key, g => g.ToList());
         foreach (var (type, frames) in byType)
@@ -222,6 +231,7 @@ public sealed class StackingPipeline(
         var flatMasters = await BuildMastersAsync(byType.GetValueOrDefault(FrameType.Flat), MasterFrameBuilder.BuildFlatMasterAsync, mastersDir, ct);
         logger.LogInformation("[masters] {Bias} bias, {Dark} dark, {Flat} flat ready in {ElapsedMs} ms",
             biasMasters.Count, darkMasters.Count, flatMasters.Count, sw.ElapsedMilliseconds);
+        hostTracker.Log(logger, "masters");
 
         // -----------------------------------------------------------------
         // 3) For each lights group, run the integration pipeline
@@ -335,10 +345,11 @@ public sealed class StackingPipeline(
         {
             ct.ThrowIfCancellationRequested();
             var result = await ProcessLightGroupAsync(
-                key, slug, frames, darkMasters, flatMasters, outputDir, ct);
+                key, slug, frames, darkMasters, flatMasters, outputDir, hostTracker, ct);
             yield return result;
         }
 
+        hostTracker.Log(logger, "end");
         logger.LogInformation("[end]");
     }
 
@@ -353,6 +364,7 @@ public sealed class StackingPipeline(
         List<(MasterGroupKey Key, Image Master)> darkMasters,
         List<(MasterGroupKey Key, Image Master)> flatMasters,
         string outputDir,
+        HostSnapshotTracker hostTracker,
         CancellationToken ct)
     {
         // slug carries any pier-side / future sub-group suffix on top of
@@ -591,6 +603,7 @@ public sealed class StackingPipeline(
         }
         logger.LogInformation("  registered {Matched}/{Attempted} frames (skipped {Skipped}) in {ElapsedMs} ms",
             matched.Count, lightList.Count, skipCount, sw.ElapsedMilliseconds);
+        hostTracker.Log(logger, $"register/{slug}");
 
         // Post-registration quality filter. Off by default; enable via
         // StackingOptions.QualityRejectSigma. Drops frames whose median
@@ -884,6 +897,7 @@ public sealed class StackingPipeline(
         }
         logger.LogInformation("  integrated in {ElapsedMs} ms (frames={Frames}, rejections={Rej}, rate={Rate:P2})",
             sw.ElapsedMilliseconds, intResult.FrameCount, intResult.TotalRejections, intResult.MeanRejectionRate);
+        hostTracker.Log(logger, $"integrate/{slug}");
 
         // 3c. Plate-solve the master + write FITS (+ autocrop). No
         // SPCC / bg-neut / PNG render: those are display-side, handled

--- a/src/TianWen.Lib/Imaging/Stacking/StackingPipeline.cs
+++ b/src/TianWen.Lib/Imaging/Stacking/StackingPipeline.cs
@@ -562,6 +562,41 @@ public sealed class StackingPipeline(
                 PreviewPngPath: null, Elapsed: groupSw.Elapsed, SkipReason: "fewer than 2 matched frames");
         }
 
+        // Re-center per-frame rotations around zero. Subtracts the mean
+        // rotation across kept frames from each frame's transform; the
+        // master canvas ends up rotated by -mean from the original
+        // reference orientation, but per-frame Kabsch residuals are now
+        // symmetric. This breaks Bayer drizzle's per-channel coverage
+        // bias when the reference frame happens to sit at one temporal
+        // extreme of the session -- per-frame rotation residuals
+        // otherwise all point the same way, the same canvas position
+        // ends up sampling the same Bayer color across many frames, and
+        // chromatic speckle appears around bright stars. Confirmed
+        // empirically on SoL pierE: ref 0249 (late-pierE) + Kabsch
+        // produced visible speckle; same data with mean-rotation
+        // subtracted is clean.
+        //
+        // Plate-solving the master after integration discovers the new
+        // orientation naturally; no special WCS handling needed.
+        double sumTheta = 0;
+        foreach (var (_, t, _) in matched)
+        {
+            sumTheta += Math.Atan2(t.M12, t.M11);
+        }
+        var meanThetaRad = (float)(sumTheta / matched.Count);
+        if (Math.Abs(meanThetaRad) > 1e-6f)
+        {
+            var invMean = Matrix3x2.CreateRotation(-meanThetaRad);
+            for (var i = 0; i < matched.Count; i++)
+            {
+                var (light, t, metricsT) = matched[i];
+                matched[i] = (light, t * invMean, metricsT);
+            }
+            logger.LogInformation(
+                "  [rotDebias] mean per-frame rotation = {DegMean:F4}° across {N} frames; subtracted from each transform",
+                meanThetaRad * 180.0 / Math.PI, matched.Count);
+        }
+
         // BayerDrizzle is opt-in only (--strategy BayerDrizzle). Gate up
         // front so we fail fast with a clear reason rather than producing
         // a NaN-riddled master at low frame count or on a Mono / Color

--- a/src/TianWen.Lib/Imaging/Stacking/StackingPipeline.cs
+++ b/src/TianWen.Lib/Imaging/Stacking/StackingPipeline.cs
@@ -323,8 +323,6 @@ public sealed class StackingPipeline(
         progress?.Report(new StackingProgress(StackingPhase.Registering, slug, 0, lightList.Count));
         var sw = Stopwatch.StartNew();
         var frameCandidates = new List<(FrameInfo Frame, FrameMetrics Metrics, float Score)>(lightList.Count);
-        FrameInfo? reference = null;
-        var bestScore = float.NegativeInfinity;
         foreach (var lf in lightList)
         {
             ct.ThrowIfCancellationRequested();
@@ -339,10 +337,38 @@ public sealed class StackingPipeline(
                 StarCount: stars.Count);
             var score = stars.Count / (MathF.Max(metrics.MedianHfd, 1f) * (1f + 4f * metrics.MedianEllipticity));
             frameCandidates.Add((lf, metrics, score));
-            if (score > bestScore)
+        }
+
+        // Reference selection: explicit ReferenceFrameHint wins (substring
+        // match on path, first hit), otherwise composite-quality score.
+        // The hint is a debug knob for isolating Bayer-drizzle artifacts
+        // that correlate with reference choice -- pinning to a frame near
+        // the temporal MIDDLE of the session keeps per-frame rotation
+        // residuals symmetric around zero so per-channel drizzle coverage
+        // stays balanced.
+        FrameInfo? reference = null;
+        if (!string.IsNullOrEmpty(options.ReferenceFrameHint))
+        {
+            var hint = options.ReferenceFrameHint;
+            var match = frameCandidates.FirstOrDefault(c =>
+                c.Frame.Path.Contains(hint, StringComparison.OrdinalIgnoreCase));
+            if (match.Frame is not null)
             {
-                bestScore = score;
-                reference = lf;
+                reference = match.Frame;
+                logger.LogInformation("  [refHint] pinning reference to {File} (hint=\"{Hint}\")",
+                    Path.GetFileName(reference.Path), hint);
+            }
+            else
+            {
+                logger.LogWarning("  [refHint] no candidate path matches \"{Hint}\"; falling back to score-based pick", hint);
+            }
+        }
+        if (reference is null)
+        {
+            var bestScore = float.NegativeInfinity;
+            foreach (var c in frameCandidates)
+            {
+                if (c.Score > bestScore) { bestScore = c.Score; reference = c.Frame; }
             }
         }
         if (reference is null)

--- a/src/TianWen.Lib/Imaging/Stacking/StackingPipeline.cs
+++ b/src/TianWen.Lib/Imaging/Stacking/StackingPipeline.cs
@@ -305,14 +305,26 @@ public sealed class StackingPipeline(
                 maskedCount, options.HotPixelSigma);
         }
 
-        // 3a. Pick reference (highest star count). We bypass
+        // 3a. Pick reference by composite PSF quality. We bypass
         // Registrator.PickReferenceAsync because it operates on the raw
         // FrameInfo without debayer awareness.
+        //
+        // Score = StarCount / (max(HFD, 1) * (1 + 4 * Ellipticity)).
+        // Picks the frame with the most stars, weighted down by broad
+        // PSF (HFD) and elongation (ecc). Rewards sharp-round-many-stars
+        // simultaneously. A bloated frame with 10000 stars loses to a
+        // sharp frame with 5000 stars whenever the HFD difference is
+        // >2x; an elongated frame is penalised regardless of count
+        // (factor 5 at ecc=1, factor 3 at ecc=0.5). Pre-refactor logic
+        // picked by star count alone, which let low-altitude bloated
+        // early frames win on dense fields even when their PSF was 30%
+        // broader -- bad reference for the rest of the session to
+        // register against.
         progress?.Report(new StackingProgress(StackingPhase.Registering, slug, 0, lightList.Count));
         var sw = Stopwatch.StartNew();
-        var frameStarCounts = new List<(FrameInfo Frame, int StarCount)>(lightList.Count);
+        var frameCandidates = new List<(FrameInfo Frame, FrameMetrics Metrics, float Score)>(lightList.Count);
         FrameInfo? reference = null;
-        var bestCount = -1;
+        var bestScore = float.NegativeInfinity;
         foreach (var lf in lightList)
         {
             ct.ThrowIfCancellationRequested();
@@ -320,10 +332,16 @@ public sealed class StackingPipeline(
             var calibrated = calibrator.Apply(raw);
             var debayered = await calibrated.DebayerAsync(options.CentroidDebayerAlg, cancellationToken: ct);
             var stars = await debayered.FindStarsAsync(channel: 0, snrMin: options.SnrMin, minStars: options.MinStars, cancellationToken: ct);
-            frameStarCounts.Add((lf, stars.Count));
-            if (stars.Count > bestCount)
+            var metrics = new FrameMetrics(
+                MedianHfd: stars.MapReduceStarProperty(SampleKind.HFD, AggregationMethod.Median),
+                MedianFwhm: stars.MapReduceStarProperty(SampleKind.FWHM, AggregationMethod.Median),
+                MedianEllipticity: stars.MapReduceStarProperty(SampleKind.Ellipticity, AggregationMethod.Median),
+                StarCount: stars.Count);
+            var score = stars.Count / (MathF.Max(metrics.MedianHfd, 1f) * (1f + 4f * metrics.MedianEllipticity));
+            frameCandidates.Add((lf, metrics, score));
+            if (score > bestScore)
             {
-                bestCount = stars.Count;
+                bestScore = score;
                 reference = lf;
             }
         }
@@ -333,9 +351,13 @@ public sealed class StackingPipeline(
             return new GroupResult(slug, lightList.Count, 0, Result: null, MasterFitsPath: null,
                 PreviewPngPath: null, Elapsed: groupSw.Elapsed, SkipReason: "no reference frame could be picked");
         }
-        logger.LogInformation("  reference: {File} ({Stars} stars, {ElapsedMs} ms)",
+        var refCandidate = frameCandidates.First(s => s.Frame.Path == reference.Path);
+        logger.LogInformation("  reference: {File} (stars={Stars} hfd={Hfd:F2} ecc={Ecc:F3} score={Score:F1}, {ElapsedMs} ms)",
             Path.GetFileName(reference.Path),
-            frameStarCounts.First(s => s.Frame.Path == reference.Path).StarCount,
+            refCandidate.Metrics.StarCount,
+            refCandidate.Metrics.MedianHfd,
+            refCandidate.Metrics.MedianEllipticity,
+            refCandidate.Score,
             sw.ElapsedMilliseconds);
 
         // Pre-load + calibrate + debayer reference once; detect ref stars
@@ -354,6 +376,16 @@ public sealed class StackingPipeline(
         var referenceStars = await referenceDebayered.FindStarsAsync(channel: 0, snrMin: options.SnrMin, minStars: options.MinStars, cancellationToken: ct);
         var referenceSorted = new SortedStarList(referenceStars);
         var referenceQuads = await referenceSorted.FindQuadsAsync(maxStars: options.QuadStars, ct);
+        // Reference-frame metrics so the matched tuple gets a real
+        // FrameMetrics even for the reference (which skips the register
+        // loop's star-detection path). Used by the post-registration
+        // quality filter -- without it the reference would be a (0,0,0)
+        // outlier and always survive even if it's actually the worst.
+        var referenceMetrics = new FrameMetrics(
+            MedianHfd: referenceStars.MapReduceStarProperty(SampleKind.HFD, AggregationMethod.Median),
+            MedianFwhm: referenceStars.MapReduceStarProperty(SampleKind.FWHM, AggregationMethod.Median),
+            MedianEllipticity: referenceStars.MapReduceStarProperty(SampleKind.Ellipticity, AggregationMethod.Median),
+            StarCount: referenceStars.Count);
 
         // Per-group staging dir. Cleaned up by the chosen strategy.
         var stagingDir = Path.Combine(outputDir, "_staging", slug);
@@ -366,7 +398,7 @@ public sealed class StackingPipeline(
         var calibratedCache = new FrameCache(
             lightList.Count,
             FrameCache.DecideCacheCap(lightList.Count, calibratedFrameBytes));
-        var matched = new List<(FrameInfo Light, Matrix3x2 Transform)>();
+        var matched = new List<(FrameInfo Light, Matrix3x2 Transform, FrameMetrics Metrics)>();
         var skipCount = 0;
         sw.Restart();
         foreach (var lightInfo in lightList)
@@ -378,9 +410,11 @@ public sealed class StackingPipeline(
             var name = Path.GetFileNameWithoutExtension(lightInfo.Path);
 
             Matrix3x2? transform;
+            FrameMetrics frameMetrics = default;
             if (string.Equals(lightInfo.Path, reference.Path, StringComparison.OrdinalIgnoreCase))
             {
                 transform = Matrix3x2.Identity;
+                frameMetrics = referenceMetrics;
             }
             else
             {
@@ -422,9 +456,13 @@ public sealed class StackingPipeline(
                         // logged -- spotting an outlier frame's HFD or
                         // ellipticity spike is exactly what we need when a
                         // long-span stack ends up with poor SPCC matches.
+                        // Stashed on the matched tuple so the post-loop
+                        // quality filter has session-wide statistics without
+                        // re-running star detection.
                         var medHfd = stars.MapReduceStarProperty(SampleKind.HFD, AggregationMethod.Median);
                         var medFwhm = stars.MapReduceStarProperty(SampleKind.FWHM, AggregationMethod.Median);
                         var medEcc = stars.MapReduceStarProperty(SampleKind.Ellipticity, AggregationMethod.Median);
+                        frameMetrics = new FrameMetrics(medHfd, medFwhm, medEcc, stars.Count);
                         logger.LogInformation(
                             "  [{Name}] stars={Stars} hfd={Hfd:F2} fwhm={Fwhm:F2} ecc={Ecc:F3} -> MATCH qt={Tol:F3} refine: rot={Rot:F3}° s={Scale:F5} t=({Tx:F2},{Ty:F2}) rms={Rms:F2}px from {RefMatched} pairs",
                             name, stars.Count, medHfd, medFwhm, medEcc, tolUsed, refRotDeg, refScale, refTx, refTy, refRms, refMatched);
@@ -434,11 +472,61 @@ public sealed class StackingPipeline(
             if (transform is null) { skipCount++; continue; }
 
             calibratedCache.Set(matched.Count, calibrated);
-            matched.Add((lightInfo, transform.Value));
+            matched.Add((lightInfo, transform.Value, frameMetrics));
             progress?.Report(new StackingProgress(StackingPhase.Registering, slug, matched.Count + skipCount, lightList.Count));
         }
         logger.LogInformation("  registered {Matched}/{Attempted} frames (skipped {Skipped}) in {ElapsedMs} ms",
             matched.Count, lightList.Count, skipCount, sw.ElapsedMilliseconds);
+
+        // Post-registration quality filter. Off by default; enable via
+        // StackingOptions.QualityRejectSigma. Drops frames whose median
+        // HFD or ellipticity exceeds the session's median + sigma * MAD
+        // threshold, capped at the worst 20% by severity (the 80% keep
+        // floor in FrameQualityFilter). One log line per dropped frame
+        // so the audit is per-frame, not just a count.
+        if (options.QualityRejectSigma is { } qSigma && qSigma > 0f && matched.Count >= 4)
+        {
+            var metricsArr = new FrameMetrics[matched.Count];
+            for (var i = 0; i < matched.Count; i++) metricsArr[i] = matched[i].Metrics;
+            var filterResult = FrameQualityFilter.Filter(metricsArr, qSigma);
+            if (filterResult.KeptCount < matched.Count)
+            {
+                if (filterResult.FloorTriggered)
+                {
+                    logger.LogInformation(
+                        "  [quality] sigma={Sigma:F2} -- FLOOR triggered: MAD threshold would over-cut, capped to worst {N}/{Total} by severity",
+                        qSigma, matched.Count - filterResult.KeptCount, matched.Count);
+                }
+                else
+                {
+                    logger.LogInformation(
+                        "  [quality] sigma={Sigma:F2}: rejecting {N}/{Total} frames",
+                        qSigma, matched.Count - filterResult.KeptCount, matched.Count);
+                }
+                var filtered = new List<(FrameInfo Light, Matrix3x2 Transform, FrameMetrics Metrics)>(filterResult.KeptCount);
+                for (var i = 0; i < matched.Count; i++)
+                {
+                    var reason = filterResult.Reasons[i];
+                    if (reason == FrameRejectReason.Kept)
+                    {
+                        filtered.Add(matched[i]);
+                    }
+                    else
+                    {
+                        var m = matched[i].Metrics;
+                        var rejName = Path.GetFileNameWithoutExtension(matched[i].Light.Path);
+                        logger.LogInformation(
+                            "  [quality] reject {Name} reason={Reason} hfd={Hfd:F2} ecc={Ecc:F3} stars={Stars}",
+                            rejName, reason, m.MedianHfd, m.MedianEllipticity, m.StarCount);
+                    }
+                }
+                matched = filtered;
+            }
+            else
+            {
+                logger.LogInformation("  [quality] sigma={Sigma:F2}: no frames rejected", qSigma);
+            }
+        }
 
         if (matched.Count < 2)
         {
@@ -498,7 +586,7 @@ public sealed class StackingPipeline(
         {
             for (var i = 0; i < matched.Count; i++)
             {
-                var (lightInfo, transformOrig) = matched[i];
+                var (lightInfo, transformOrig, _) = matched[i];
                 token.ThrowIfCancellationRequested();
                 Image calibrated;
                 if (calibratedCache.TryGet(i, out var cached))
@@ -527,7 +615,7 @@ public sealed class StackingPipeline(
         {
             for (var i = 0; i < matched.Count; i++)
             {
-                var (lightInfo, transformOrig) = matched[i];
+                var (lightInfo, transformOrig, _) = matched[i];
                 token.ThrowIfCancellationRequested();
                 Image calibrated;
                 if (calibratedCache.TryGet(i, out var cached))
@@ -564,7 +652,7 @@ public sealed class StackingPipeline(
         logger.LogInformation("  rejector: {Rejector}", rejector?.GetType().Name ?? "<none>");
 
         var rawSources = new List<RawLightSource>(matched.Count);
-        foreach (var (lightInfo, transformOrig) in matched)
+        foreach (var (lightInfo, transformOrig, _) in matched)
         {
             rawSources.Add(new RawLightSource(Path: lightInfo.Path, TransformToCanvas: transformOrig * canvasShift));
         }

--- a/src/TianWen.Lib/Imaging/Stacking/StackingPipeline.cs
+++ b/src/TianWen.Lib/Imaging/Stacking/StackingPipeline.cs
@@ -395,13 +395,23 @@ public sealed class StackingPipeline(
         // MeanCombiner sigma-clips hot-pixel outliers across N frames
         // already, so the mask is a net loss there. One-time cost per
         // group; ~tens of ms even on full-frame.
+        // Build the per-channel hot-pixel mask whenever a dark + sigma are
+        // available. Strategy selection happens later and an auto-picked
+        // drizzle would otherwise miss the mask entirely (the previous
+        // ForcedStrategy==BayerDrizzle gate was a bug: TilePipelinedDrizzle
+        // and auto-picked drizzle both consume the mask but neither path
+        // satisfied the gate, so they ran with NO hot-pixel rejection and
+        // visible hot-pixel clusters survived into the master). Non-drizzle
+        // strategies ignore IntegrationJob.BadPixelMask anyway -- their
+        // MeanCombiner sigma-clip handles outliers across N frames -- so
+        // unconditional construction costs ~tens of ms and is free for
+        // them.
         BitMatrix[]? badPixelMask = null;
-        if (dark is not null && options.HotPixelSigma > 0f &&
-            options.ForcedStrategy is IntegrationStrategyKind.BayerDrizzle)
+        if (dark is not null && options.HotPixelSigma > 0f)
         {
-            badPixelMask = BadPixelDetection.BuildMaskFromDark(dark, options.HotPixelSigma);
+            badPixelMask = BadPixelDetection.BuildMaskFromDark(dark, options.HotPixelSigma, logger);
             var maskedCount = BadPixelDetection.CountMaskedPixels(badPixelMask, dark.Width, dark.Height);
-            logger.LogInformation("  hot-pixel mask: {Count} px flagged at {Sigma:F1} sigma",
+            logger.LogInformation("  hot-pixel mask: {Count} px flagged at sigma={Sigma:F1}",
                 maskedCount, options.HotPixelSigma);
         }
 

--- a/src/TianWen.Lib/Imaging/Stacking/StackingPipeline.cs
+++ b/src/TianWen.Lib/Imaging/Stacking/StackingPipeline.cs
@@ -144,6 +144,8 @@ public sealed class StackingPipeline(
         var allFrames = new List<FrameInfo>();
         var outputDirNormalised = Path.GetFullPath(outputDir);
         var stackProductSkipped = 0;
+        var rejectionMapSkipped = 0;
+        var stackProductKept = 0;
         await foreach (var frame in source.EnumerateAsync(ct))
         {
             // Skip anything under outputDir -- masters and previous-run
@@ -154,23 +156,53 @@ public sealed class StackingPipeline(
             {
                 continue;
             }
-            // STACK_N is stamped on every stacking product (master + rejection
-            // map). When the data root contains adjacent output-*/ dirs from
-            // prior runs -- which the outputDir-startsWith check above doesn't
-            // cover because they don't sit under the current output dir --
-            // those masters look like ordinary 1-frame FITS to the scan and
-            // partition the lights into ghost MasterGroupKey buckets. Header
-            // check is authoritative regardless of where the file lives.
+            // Rejection maps carry STACK_N too but are per-pixel
+            // rejection-fraction images, not sky data -- always drop them
+            // regardless of IncludeStackProducts. Filename suffix is the
+            // canonical IntegrationFitsWriter marker; check both bare and
+            // .gz variants since FitsFolderFrameSource accepts both.
+            if (frame.Path.EndsWith(IntegrationFitsWriter.RejectionMapSuffix, StringComparison.OrdinalIgnoreCase) ||
+                frame.Path.EndsWith(IntegrationFitsWriter.RejectionMapSuffix + ".gz", StringComparison.OrdinalIgnoreCase))
+            {
+                rejectionMapSkipped++;
+                continue;
+            }
+            // STACK_N marks any stacking product (master or rejection map);
+            // the rejection branch above has already filtered the latter,
+            // so reaching here with STACK_N>0 means an integrated master.
+            // Default policy is to drop them -- stale masters in adjacent
+            // output-*/ dirs from prior runs would otherwise look like
+            // ordinary 1-frame FITS to the scan and partition the lights
+            // into ghost MasterGroupKey buckets. IncludeStackProducts opts
+            // in for two-stage mosaic stacking where each panel is integrated
+            // separately, then the panel masters are re-stacked.
             if (frame.StackedFrameCount > 0)
             {
-                stackProductSkipped++;
-                continue;
+                if (options.IncludeStackProducts)
+                {
+                    stackProductKept++;
+                }
+                else
+                {
+                    stackProductSkipped++;
+                    continue;
+                }
             }
             allFrames.Add(frame);
         }
+        if (rejectionMapSkipped > 0)
+        {
+            logger.LogInformation("[scan] ignored {Count} rejection map(s)", rejectionMapSkipped);
+        }
         if (stackProductSkipped > 0)
         {
-            logger.LogInformation("[scan] ignored {Count} stack product(s) (STACK_N set)", stackProductSkipped);
+            logger.LogInformation("[scan] ignored {Count} stack product(s) (STACK_N set); pass --include-stack-products to keep them",
+                stackProductSkipped);
+        }
+        if (stackProductKept > 0)
+        {
+            logger.LogInformation("[scan] keeping {Count} stack product(s) as input (IncludeStackProducts=true)",
+                stackProductKept);
         }
         logger.LogInformation("[scan] {Count} frames in {ElapsedMs} ms", allFrames.Count, sw.ElapsedMilliseconds);
 

--- a/src/TianWen.Lib/Imaging/Stacking/StackingPipeline.cs
+++ b/src/TianWen.Lib/Imaging/Stacking/StackingPipeline.cs
@@ -143,6 +143,7 @@ public sealed class StackingPipeline(
         var source = new FitsFolderFrameSource(options.DataRoot, recursive: true);
         var allFrames = new List<FrameInfo>();
         var outputDirNormalised = Path.GetFullPath(outputDir);
+        var stackProductSkipped = 0;
         await foreach (var frame in source.EnumerateAsync(ct))
         {
             // Skip anything under outputDir -- masters and previous-run
@@ -153,7 +154,23 @@ public sealed class StackingPipeline(
             {
                 continue;
             }
+            // STACK_N is stamped on every stacking product (master + rejection
+            // map). When the data root contains adjacent output-*/ dirs from
+            // prior runs -- which the outputDir-startsWith check above doesn't
+            // cover because they don't sit under the current output dir --
+            // those masters look like ordinary 1-frame FITS to the scan and
+            // partition the lights into ghost MasterGroupKey buckets. Header
+            // check is authoritative regardless of where the file lives.
+            if (frame.StackedFrameCount > 0)
+            {
+                stackProductSkipped++;
+                continue;
+            }
             allFrames.Add(frame);
+        }
+        if (stackProductSkipped > 0)
+        {
+            logger.LogInformation("[scan] ignored {Count} stack product(s) (STACK_N set)", stackProductSkipped);
         }
         logger.LogInformation("[scan] {Count} frames in {ElapsedMs} ms", allFrames.Count, sw.ElapsedMilliseconds);
 
@@ -241,6 +258,45 @@ public sealed class StackingPipeline(
         {
             logger.LogInformation("[lights] pier-side split: {Groups} -> {SubGroups} sub-group(s)",
                 lightGroups.Count, subGroups.Count);
+        }
+
+        // Drop tiny sub-groups silently. These are almost always ghosts from
+        // MasterGroupKey drift -- a single frame's CCDTemperature rounding
+        // to -4C instead of -5C, or an offset value that drifted mid-session,
+        // partitions an otherwise-uniform observation into a "real" group
+        // (most of the frames) plus a handful of 1-2 frame stragglers. Each
+        // straggler then trickles through registration, fails the "matched
+        // >= 2" check, and emits a SKIPPED warning per group -- pure log
+        // noise. Pre-filtering at scan time means one summary instead of
+        // N warnings. Threshold of 4 lines up with the smallest viable
+        // integration count; below it kappa-sigma rejection has nothing
+        // to clip against and the result is statistically meaningless
+        // anyway. Real 4+ frame sub-groups still process normally.
+        const int MinSubGroupFramesToProcess = 4;
+        var tinySubGroups = subGroups.Where(g => g.Frames.Count < MinSubGroupFramesToProcess).ToList();
+        if (tinySubGroups.Count > 0)
+        {
+            var totalDropped = tinySubGroups.Sum(g => g.Frames.Count);
+            logger.LogInformation(
+                "[lights] dropped {Count} ghost sub-group(s) below MinSubGroupFrames={Min} ({Frames} frames total, likely header-drift artifacts)",
+                tinySubGroups.Count, MinSubGroupFramesToProcess, totalDropped);
+            // Per-ghost diagnostic: surface every field of the
+            // MasterGroupKey since the slug strips the ones that usually
+            // drift (Offset, FilterName, exact TemperatureC, dimensions).
+            // One Debug-level line per ghost so the file logger captures it
+            // for post-mortem but the console (Warning min) stays quiet.
+            foreach (var ghost in tinySubGroups)
+            {
+                var k = ghost.Key.CalibrationKey;
+                var sample = ghost.Frames[0];
+                logger.LogDebug(
+                    "[lights/ghost] {Slug} ({Frames} fr): temp={Temp}C filter={Filter}/{Band} offset={Offset} gain={Gain} dim={W}x{H}x{Ch} sensor={Sensor} sample={Path}",
+                    ghost.Slug, ghost.Frames.Count,
+                    k.TemperatureC?.ToString() ?? "n/a", k.FilterName.Length > 0 ? k.FilterName : "(empty)", k.FilterBandpass,
+                    k.Offset, k.Gain, k.Width, k.Height, k.ChannelCount, k.SensorType,
+                    System.IO.Path.GetFileName(sample.Path));
+            }
+            subGroups = subGroups.Where(g => g.Frames.Count >= MinSubGroupFramesToProcess).ToList();
         }
 
         foreach (var (key, slug, frames) in subGroups)

--- a/src/TianWen.Lib/Imaging/Stacking/StackingPipeline.cs
+++ b/src/TianWen.Lib/Imaging/Stacking/StackingPipeline.cs
@@ -413,12 +413,12 @@ public sealed class StackingPipeline(
                         // brute-force NN over ~100 stars) so we always
                         // apply it; non-drizzle strategies get a marginal
                         // accuracy improvement at zero cost.
-                        var (refined, refDx, refDy, refMatched) = RegistrationRefiner.RefineTranslation(
-                            lightSorted, referenceSorted, transform.Value);
+                        var (refined, refScale, refRotDeg, refTx, refTy, refRms, refMatched) =
+                            RegistrationRefiner.RefineRigid(lightSorted, referenceSorted, transform.Value);
                         transform = refined;
                         logger.LogInformation(
-                            "  [{Name}] stars={Stars} -> MATCH qt={Tol:F3} refine=({Dx:F2},{Dy:F2})px from {RefMatched} pairs",
-                            name, stars.Count, tolUsed, refDx, refDy, refMatched);
+                            "  [{Name}] stars={Stars} -> MATCH qt={Tol:F3} refine: rot={Rot:F3}° s={Scale:F5} t=({Tx:F2},{Ty:F2}) rms={Rms:F2}px from {RefMatched} pairs",
+                            name, stars.Count, tolUsed, refRotDeg, refScale, refTx, refTy, refRms, refMatched);
                     }
                 }
             }

--- a/src/TianWen.Lib/Imaging/Stacking/StackingPipeline.cs
+++ b/src/TianWen.Lib/Imaging/Stacking/StackingPipeline.cs
@@ -587,26 +587,32 @@ public sealed class StackingPipeline(
         // checks would otherwise sneak through into RunAsync and produce
         // either a useless master (low N) or a wrong-channel-assignment
         // master (non-RGGB).
-        if (options.ForcedStrategy is IntegrationStrategyKind.BayerDrizzle)
+        // Both drizzle variants share the same algorithmic preconditions
+        // (RGGB sensor for Bayer dispatch + enough matched frames for
+        // robust R/B coverage); only memory layout differs. Gate them
+        // identically.
+        if (options.ForcedStrategy is IntegrationStrategyKind.BayerDrizzle
+            or IntegrationStrategyKind.TilePipelinedDrizzle)
         {
             var drizzleOpts = options.DrizzleOptions ?? new DrizzleOptions();
+            var kindName = options.ForcedStrategy.Value;
             if (referenceRaw.ImageMeta.SensorType != SensorType.RGGB)
             {
-                logger.LogWarning("  [skip] BayerDrizzle requires SensorType.RGGB (got {Sensor})",
-                    referenceRaw.ImageMeta.SensorType);
+                logger.LogWarning("  [skip] {Kind} requires SensorType.RGGB (got {Sensor})",
+                    kindName, referenceRaw.ImageMeta.SensorType);
                 try { Directory.Delete(stagingDir, recursive: true); } catch { /* hygiene */ }
                 return new GroupResult(slug, lightList.Count, matched.Count, Result: null, MasterFitsPath: null,
                     PreviewPngPath: null, Elapsed: groupSw.Elapsed,
-                    SkipReason: $"BayerDrizzle requires SensorType.RGGB (got {referenceRaw.ImageMeta.SensorType})");
+                    SkipReason: $"{kindName} requires SensorType.RGGB (got {referenceRaw.ImageMeta.SensorType})");
             }
             if (matched.Count < drizzleOpts.MinFrameCount)
             {
-                logger.LogWarning("  [skip] BayerDrizzle needs >= {Min} matched frames (got {Got}); drizzle coverage would be too sparse",
-                    drizzleOpts.MinFrameCount, matched.Count);
+                logger.LogWarning("  [skip] {Kind} needs >= {Min} matched frames (got {Got}); drizzle coverage would be too sparse",
+                    kindName, drizzleOpts.MinFrameCount, matched.Count);
                 try { Directory.Delete(stagingDir, recursive: true); } catch { /* hygiene */ }
                 return new GroupResult(slug, lightList.Count, matched.Count, Result: null, MasterFitsPath: null,
                     PreviewPngPath: null, Elapsed: groupSw.Elapsed,
-                    SkipReason: $"BayerDrizzle requires >= {drizzleOpts.MinFrameCount} matched frames (got {matched.Count})");
+                    SkipReason: $"{kindName} requires >= {drizzleOpts.MinFrameCount} matched frames (got {matched.Count})");
             }
         }
 
@@ -678,6 +684,11 @@ public sealed class StackingPipeline(
 
         // Snapshot host + pick strategy. Snapshot factory probes free
         // RAM + disk; the selector wants those for its budget gate.
+        // SensorType is pulled from the group key (the canonical scan-time
+        // value), not from the reference frame's meta -- they agree by
+        // construction since grouping keys on SensorType, but the group
+        // key is the source of truth for the whole group's invariants.
+        // Drizzle strategies key CanRun off this in their Evaluate.
         var probe = IntegrationProbe.Snapshot(
             frameCount: matched.Count,
             frameWidth: referenceDebayered.Width,
@@ -686,8 +697,42 @@ public sealed class StackingPipeline(
             canvasWidth: outWidth,
             canvasHeight: outHeight,
             stagingDir: stagingDir,
+            sensorType: key.CalibrationKey.SensorType,
             stagingDiskKind: DiskKind.Ssd);
-        var selection = IntegrationStrategySelector.Pick(probe, preferred: options.ForcedStrategy);
+        // Build the strategy pool. Two reasons to deviate from the default:
+        //   1) --no-bayer-drizzle: filter both drizzle variants out so
+        //      auto-pick falls back to the standard path.
+        //   2) --drizzle-min-frames N (N != 60): replace the default
+        //      drizzle instances with ones constructed against the
+        //      user-overridden minimum, so the auto-pick gate matches
+        //      what the user asked for. Without this, --drizzle-min-frames
+        //      would only affect the pre-strategy gate (which fires
+        //      ONLY on --strategy=BayerDrizzle/TilePipelinedDrizzle),
+        //      leaving the auto-pick path still using the hardcoded 60.
+        // ForcedStrategy still wins either way (the override bypasses
+        // CanRun and the pool entirely), so a user who passes both
+        // --no-bayer-drizzle and --strategy=BayerDrizzle gets drizzle.
+        IEnumerable<IIntegrationStrategy>? pool = null;
+        var drizzleMinFrames = options.DrizzleOptions?.MinFrameCount ?? DrizzleStrategy.AutoSelectMinFrameCount;
+        if (options.DisableBayerDrizzle)
+        {
+            pool = IntegrationStrategySelector.DefaultStrategies()
+                .Where(s => s.Kind is not IntegrationStrategyKind.BayerDrizzle
+                        and not IntegrationStrategyKind.TilePipelinedDrizzle)
+                .ToArray();
+        }
+        else if (drizzleMinFrames != DrizzleStrategy.AutoSelectMinFrameCount)
+        {
+            pool = IntegrationStrategySelector.DefaultStrategies()
+                .Select(s => s.Kind switch
+                {
+                    IntegrationStrategyKind.BayerDrizzle => (IIntegrationStrategy)new DrizzleStrategy(minFrameCount: drizzleMinFrames),
+                    IntegrationStrategyKind.TilePipelinedDrizzle => new TilePipelinedDrizzleStrategy(minFrameCount: drizzleMinFrames),
+                    _ => s,
+                })
+                .ToArray();
+        }
+        var selection = IntegrationStrategySelector.Pick(probe, preferred: options.ForcedStrategy, pool: pool);
         logger.LogInformation("  [strategy] picked {Kind} -- {Notes}", selection.Chosen.Kind, selection.Notes);
         logger.LogInformation("  [sink] {Sink} (canvas {GB:F2} GB)", selection.Sink, probe.CanvasBytes / 1e9);
         var sinkFactory = SinkFactories.Create(selection.Sink, stagingDir);
@@ -707,7 +752,17 @@ public sealed class StackingPipeline(
             : new Progress<IntegrationProgress>(p => progress.Report(
                 new StackingProgress(StackingPhase.Integrating, slug, p.CompletedItems, p.TotalItems, p)));
 
-        var isDrizzle = selection.Chosen.Kind == IntegrationStrategyKind.BayerDrizzle;
+        // Drizzle dispatch: BayerDrizzle (streaming, full-canvas accumulator)
+        // and TilePipelinedDrizzle (strip-pipelined accumulator) both run
+        // the drizzle algorithm and need DrizzleOptions + the bad-pixel
+        // mask. They differ in producer plumbing: streaming uses
+        // RawBayerFrames (one-shot, frame-at-a-time), tile-pipelined uses
+        // RawLightSources (multi-pass per strip from cached calibrated
+        // bayer). The bool `isDrizzle` gates BOTH; the producer pick
+        // happens inside that branch.
+        var isStreamingDrizzle = selection.Chosen.Kind == IntegrationStrategyKind.BayerDrizzle;
+        var isTiledDrizzle = selection.Chosen.Kind == IntegrationStrategyKind.TilePipelinedDrizzle;
+        var isDrizzle = isStreamingDrizzle || isTiledDrizzle;
         var job = new IntegrationJob(
             WarpedFrames: WarpedFramesProducer,
             ExpectedFrameCount: matched.Count,
@@ -722,7 +777,7 @@ public sealed class StackingPipeline(
             CanvasHeight: outHeight,
             Progress: integrationProgress,
             MasterSinkFactory: sinkFactory,
-            RawBayerFrames: isDrizzle ? RawBayerFramesProducer : null,
+            RawBayerFrames: isStreamingDrizzle ? RawBayerFramesProducer : null,
             DrizzleOptions: isDrizzle ? (options.DrizzleOptions ?? new DrizzleOptions()) : null,
             BadPixelMask: isDrizzle ? badPixelMask : null);
 
@@ -754,7 +809,13 @@ public sealed class StackingPipeline(
         // data itself, so a strategy-per-filename split would just add
         // noise. The strategy IS recorded in the SWCREATE+STRATEGY
         // headers regardless of strategy, so provenance stays queryable.
-        var strategySuffix = selection.Chosen.Kind == IntegrationStrategyKind.BayerDrizzle
+        // Both drizzle variants emit byte-equivalent output (same kernel,
+        // same final divide), so they share the _drizzle infix. Other
+        // strategies share the canonical master_<slug>.fits name -- their
+        // differences in memory layout / staging / rejection kernel are
+        // invisible in the output FITS bytes.
+        var strategySuffix = selection.Chosen.Kind is IntegrationStrategyKind.BayerDrizzle
+            or IntegrationStrategyKind.TilePipelinedDrizzle
             ? "_drizzle"
             : "";
         var masterPath = Path.Combine(outputDir, $"master_{slug}{strategySuffix}.fits");

--- a/src/TianWen.Lib/Imaging/Stacking/StackingPipeline.cs
+++ b/src/TianWen.Lib/Imaging/Stacking/StackingPipeline.cs
@@ -562,41 +562,6 @@ public sealed class StackingPipeline(
                 PreviewPngPath: null, Elapsed: groupSw.Elapsed, SkipReason: "fewer than 2 matched frames");
         }
 
-        // Re-center per-frame rotations around zero. Subtracts the mean
-        // rotation across kept frames from each frame's transform; the
-        // master canvas ends up rotated by -mean from the original
-        // reference orientation, but per-frame Kabsch residuals are now
-        // symmetric. This breaks Bayer drizzle's per-channel coverage
-        // bias when the reference frame happens to sit at one temporal
-        // extreme of the session -- per-frame rotation residuals
-        // otherwise all point the same way, the same canvas position
-        // ends up sampling the same Bayer color across many frames, and
-        // chromatic speckle appears around bright stars. Confirmed
-        // empirically on SoL pierE: ref 0249 (late-pierE) + Kabsch
-        // produced visible speckle; same data with mean-rotation
-        // subtracted is clean.
-        //
-        // Plate-solving the master after integration discovers the new
-        // orientation naturally; no special WCS handling needed.
-        double sumTheta = 0;
-        foreach (var (_, t, _) in matched)
-        {
-            sumTheta += Math.Atan2(t.M12, t.M11);
-        }
-        var meanThetaRad = (float)(sumTheta / matched.Count);
-        if (Math.Abs(meanThetaRad) > 1e-6f)
-        {
-            var invMean = Matrix3x2.CreateRotation(-meanThetaRad);
-            for (var i = 0; i < matched.Count; i++)
-            {
-                var (light, t, metricsT) = matched[i];
-                matched[i] = (light, t * invMean, metricsT);
-            }
-            logger.LogInformation(
-                "  [rotDebias] mean per-frame rotation = {DegMean:F4}° across {N} frames; subtracted from each transform",
-                meanThetaRad * 180.0 / Math.PI, matched.Count);
-        }
-
         // BayerDrizzle is opt-in only (--strategy BayerDrizzle). Gate up
         // front so we fail fast with a clear reason rather than producing
         // a NaN-riddled master at low frame count or on a Mono / Color

--- a/src/TianWen.Lib/Imaging/Stacking/TilePipelinedDrizzleStrategy.cs
+++ b/src/TianWen.Lib/Imaging/Stacking/TilePipelinedDrizzleStrategy.cs
@@ -1,0 +1,369 @@
+using System;
+using System.Drawing;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using TianWen.Lib.Imaging.Calibration;
+
+namespace TianWen.Lib.Imaging.Stacking;
+
+/// <summary>
+/// Tile-pipelined Bayer drizzle: combines <see cref="DrizzleStrategy"/>'s
+/// forward-projection algorithm (no debayer, no warp, no reject-combine)
+/// with <see cref="TilePipelinedStrategy"/>'s strip-pipelined memory
+/// layout (one strip's worth of flux/weight planes live at a time,
+/// rather than the full canvas).
+///
+/// <para>Algorithm × memory-strategy is an orthogonal product:
+/// <list type="bullet">
+///   <item>Algorithm = Standard (debayer + warp + reject-combine) vs
+///   Drizzle (forward-project Bayer samples).</item>
+///   <item>Memory strategy = in-RAM canvas vs strip-pipelined vs
+///   footprint-staged vs ...</item>
+/// </list>
+/// <see cref="DrizzleStrategy"/> sits at (Drizzle, in-RAM canvas) and
+/// this strategy sits at (Drizzle, strip-pipelined). The kernel is
+/// identical, just deposited into a strip-sized accumulator instead of
+/// a canvas-sized one.</para>
+///
+/// <para><b>Memory profile</b>: peak = (calibrated-frame cache) +
+/// (strip working set: 2 planes × 3 channels × <see cref="StripHeight"/> ×
+/// canvasW × float) + (master flux + coverage maps, canvas-sized,
+/// unavoidable since that's the output). The strip working set is
+/// ~25 MB at 4032 wide × 256 rows × 24 B/cell vs ~400 MB for
+/// full-canvas drizzle, scaling 4x harder at Phase 2 (2.0x output
+/// scale).</para>
+///
+/// <para><b>Per-strip kernel</b>: each frame's contribution to a strip
+/// is bounded by the source-pixel rect that inverse-projects to the
+/// strip rect (via <see cref="CanvasGeometry.ProjectCanvasRectToSourceRect"/>).
+/// Frames whose entire source projection misses the strip are skipped
+/// entirely; for the rest we only iterate the relevant source sub-rect.
+/// This trades a constant factor (re-iterating frame data per strip)
+/// for the strip-size memory bound, which lets the strategy run on
+/// memory-constrained hosts that can't afford full-canvas drizzle at
+/// Phase 2 scales.</para>
+/// </summary>
+public sealed class TilePipelinedDrizzleStrategy : IIntegrationStrategy
+{
+    /// <summary>Output strip height in canvas rows. Matches
+    /// <see cref="TilePipelinedStrategy.StripHeight"/> so the cost-model
+    /// strip working-set comparison is apples-to-apples between the two
+    /// tile-pipelined strategies.</summary>
+    public const int StripHeight = 256;
+
+    private readonly IntegrationCostModel _costs;
+    private readonly int _minFrameCount;
+
+    public TilePipelinedDrizzleStrategy(IntegrationCostModel? costs = null, int minFrameCount = DrizzleStrategy.AutoSelectMinFrameCount)
+    {
+        _costs = costs ?? new IntegrationCostModel();
+        _minFrameCount = minFrameCount;
+    }
+
+    public IntegrationStrategyKind Kind => IntegrationStrategyKind.TilePipelinedDrizzle;
+
+    /// <summary>Same drizzle-fidelity discount as <see cref="DrizzleStrategy"/>
+    /// (0.92): the algorithm is identical, only the memory layout differs,
+    /// so per-pixel output values must agree byte-for-byte between the two
+    /// at the same pixfrac.</summary>
+    public double FidelityScore => 0.92;
+
+    public bool SupportsLiveStacking => false;
+
+    public StrategyFit Evaluate(IntegrationProbe probe, ResourceBudget budget)
+    {
+        // RAM profile: calibrated-frame cache (1-channel raw, sized to N)
+        // plus one strip's flux/weight working set plus the canvas-sized
+        // master + coverage planes plus an in-flight calibrated raw.
+        // Floor (when cache is empty under memory pressure) drops to just
+        // the strip + master + in-flight; the cache evict + re-decode
+        // path keeps the strategy running on hosts where the optimistic
+        // target would otherwise bust.
+        var calibratedFrameBytes = (long)probe.FrameWidth * probe.FrameHeight * sizeof(float);
+        var cacheRam = calibratedFrameBytes * probe.FrameCount;
+        var stripBytes = (long)probe.CanvasWidth * StripHeight * 3 * sizeof(float) * 2; // flux + weight, 3 channels
+        var masterRam = (long)probe.CanvasWidth * probe.CanvasHeight * 3 * sizeof(float) * 2; // master + coverage canvases
+        var inFlightRam = calibratedFrameBytes;
+        var ram = cacheRam + stripBytes + masterRam + inFlightRam;
+        var floor = stripBytes + masterRam + inFlightRam;
+
+        // Same gating as DrizzleStrategy: RGGB-only + min frame count.
+        // See DrizzleStrategy.Evaluate for the rationale on both gates.
+        if (probe.SensorType != SensorType.RGGB)
+        {
+            return new StrategyFit(
+                CanRun: false,
+                EstimatedRamBytes: ram,
+                EstimatedDiskBytes: 0,
+                EstimatedDuration: TimeSpan.Zero,
+                Rationale: $"TilePipelinedDrizzle requires SensorType.RGGB (got {probe.SensorType})")
+            { FloorRamBytes = floor };
+        }
+        if (probe.FrameCount < _minFrameCount)
+        {
+            return new StrategyFit(
+                CanRun: false,
+                EstimatedRamBytes: ram,
+                EstimatedDiskBytes: 0,
+                EstimatedDuration: TimeSpan.Zero,
+                Rationale: $"TilePipelinedDrizzle needs >= {_minFrameCount} matched frames for robust R/B coverage (got {probe.FrameCount})")
+            { FloorRamBytes = floor };
+        }
+        if (floor > budget.AllowedRam(probe))
+        {
+            return new StrategyFit(
+                CanRun: false,
+                EstimatedRamBytes: ram,
+                EstimatedDiskBytes: 0,
+                EstimatedDuration: TimeSpan.Zero,
+                Rationale: $"TilePipelinedDrizzle floor ({Format.GB(floor)}) exceeds budget ({Format.GB(budget.AllowedRam(probe))})")
+            { FloorRamBytes = floor };
+        }
+
+        // Wall-time: same components as DrizzleStrategy (no debayer / no
+        // warp / no reject-combine). The strip iteration adds a small
+        // overhead for inverse-projection bounds + strip allocation;
+        // covered by the same forward-project per-pixel constant. With
+        // full cache the per-frame work is touched exactly once
+        // regardless of strip count.
+        var loadCalibrate = _costs.LoadAndCalibrateAllFrames(probe);
+        var projectMs = (double)probe.FrameWidth * probe.FrameHeight * probe.FrameCount * _costs.CpuNsPerDrizzleProjectPixel / 1e6;
+        var eta = loadCalibrate + TimeSpan.FromMilliseconds(projectMs);
+
+        return new StrategyFit(
+            CanRun: true,
+            EstimatedRamBytes: ram,
+            EstimatedDiskBytes: 0,
+            EstimatedDuration: eta,
+            Rationale: $"strip-pipelined drizzle (target {Format.GB(ram)}, floor {Format.GB(floor)})")
+        {
+            FloorRamBytes = floor,
+        };
+    }
+
+    public async ValueTask<IntegrationResult> RunAsync(IntegrationJob job, CancellationToken ct)
+    {
+        if (job.RawLightSources is null || job.Calibrator is null)
+        {
+            throw new InvalidOperationException(
+                "TilePipelinedDrizzleStrategy requires job.RawLightSources + job.Calibrator. " +
+                "The pipeline wires these when --strategy TilePipelinedDrizzle is selected.");
+        }
+
+        var sources = job.RawLightSources;
+        var calibrator = job.Calibrator;
+        var n = sources.Count;
+        if (n == 0)
+        {
+            throw new InvalidOperationException("TilePipelinedDrizzleStrategy: RawLightSources is empty.");
+        }
+
+        var options = job.DrizzleOptions ?? new DrizzleOptions();
+        if (options.OutputScale != DrizzleOptions.OutputScalePhase1)
+        {
+            throw new NotSupportedException(
+                $"DrizzleOptions.OutputScale={options.OutputScale} is Phase 2; " +
+                $"Phase 1 only supports OutputScale={DrizzleOptions.OutputScalePhase1} (1.0x grid).");
+        }
+
+        var canvasW = job.CanvasWidth;
+        var canvasH = job.CanvasHeight;
+        if (canvasW <= 0 || canvasH <= 0)
+        {
+            throw new InvalidOperationException(
+                $"TilePipelinedDrizzleStrategy needs CanvasWidth/Height on the job (got {canvasW}x{canvasH}); " +
+                "the pipeline computes these from the union-BB transform set.");
+        }
+
+        var pixfrac = options.Pixfrac;
+        var halfP = pixfrac * 0.5f;
+        var swStrat = System.Diagnostics.Stopwatch.StartNew();
+
+        // Same bad-pixel-mask plumbing as DrizzleStrategy -- single-channel
+        // raw Bayer plane, mask 0 is the right read.
+        var badPixelMask = job.BadPixelMask is { Length: > 0 } m ? m[0] : default;
+        var hasBadPixelMask = job.BadPixelMask is { Length: > 0 };
+
+        // ---------------- Pass 1: load + calibrate every frame, cache ----------------
+        // Cache calibrated 1-channel Bayer (~36 MB / frame at 3008^2) so
+        // pass 2 can re-iterate per strip without re-reading FITS. Same
+        // FrameCache + cap policy as TilePipelinedStrategy: roomy hosts
+        // hold all N; tight hosts evict and re-decode on miss in pass 2.
+        ct.ThrowIfCancellationRequested();
+        var firstCalibrated = DecodeCalibrate(sources[0], calibrator);
+        var calibratedBytes = (long)firstCalibrated.Width * firstCalibrated.Height * firstCalibrated.ChannelCount * sizeof(float);
+        var cache = new FrameCache(n, FrameCache.DecideCacheCap(n, calibratedBytes));
+        var refMeta = firstCalibrated.ImageMeta;
+        var sourceMaxValue = firstCalibrated.MaxValue;
+        // Cache the first frame BEFORE the loop so pass-2 can refer to it
+        // through the cache uniformly with the other frames -- no special
+        // "is this the first one?" branch.
+        cache.Set(0, firstCalibrated);
+        job.Progress?.Report(new IntegrationProgress(IntegrationPhase.LoadingFrames, 1, n, swStrat.Elapsed));
+
+        for (var f = 1; f < n; f++)
+        {
+            ct.ThrowIfCancellationRequested();
+            var calibrated = DecodeCalibrate(sources[f], calibrator);
+            cache.Set(f, calibrated);
+            job.Progress?.Report(new IntegrationProgress(IntegrationPhase.LoadingFrames, f + 1, n, swStrat.Elapsed));
+        }
+
+        // Bayer pattern is sensor geometry, not per-frame -- a meridian
+        // flip changes the transform, not which physical filter sits over
+        // each sensor pixel. If frames within a group reported different
+        // BayerOffsetX/Y, they'd belong to different LightGroupKeys
+        // upstream; mixing patterns within a group is a grouping bug, not
+        // a runtime hazard. Cache once.
+        var pattern = refMeta.SensorType.GetBayerPatternMatrix(refMeta.BayerOffsetX, refMeta.BayerOffsetY);
+        var rawW = firstCalibrated.Width;
+        var rawH = firstCalibrated.Height;
+
+        // ---------------- Master + coverage canvases ----------------
+        // Full-canvas accumulators for the FINAL output. Strip-local
+        // flux/weight (below) fill these one strip at a time.
+        var masterFlux = new float[3][,];
+        var masterWeight = new float[3][,];
+        for (var c = 0; c < 3; c++)
+        {
+            masterFlux[c] = new float[canvasH, canvasW];
+            masterWeight[c] = new float[canvasH, canvasW];
+        }
+
+        // ---------------- Pass 2: strip-by-strip drizzle ----------------
+        // Halo on projected source rect: drizzle's drop covers a unit cell
+        // at most (pixfrac <= 1) plus rotation can land a source pixel's
+        // drop on a strip cell up to ~sqrt(2)/2 + 0.5 ≈ 1.2 px outside the
+        // axis-aligned inverse projection. 2 px of cushion handles that
+        // plus floating-point rounding without iterating an unbounded
+        // halo.
+        const int projectionHalo = 2;
+        var stripsTotal = (canvasH + StripHeight - 1) / StripHeight;
+        var stripIdx = 0;
+
+        for (var stripY0 = 0; stripY0 < canvasH; stripY0 += StripHeight)
+        {
+            ct.ThrowIfCancellationRequested();
+            var stripH = Math.Min(StripHeight, canvasH - stripY0);
+            var stripRect = new Rectangle(0, stripY0, canvasW, stripH);
+
+            // Allocate strip-local flux/weight. Zero-initialised by .NET so
+            // uncovered cells stay 0 -- the FinaliseDivide pass converts
+            // those to NaN. We deliberately do NOT pool these: a 256x4032x3
+            // pair (~24 MB) is fast to allocate vs the wallclock of an N-
+            // frame deposit pass over the strip, and pooling would couple
+            // the two strategies more tightly than it's worth.
+            var stripFlux = new float[3][,];
+            var stripWeight = new float[3][,];
+            for (var c = 0; c < 3; c++)
+            {
+                stripFlux[c] = new float[stripH, canvasW];
+                stripWeight[c] = new float[stripH, canvasW];
+            }
+
+            // Strip-local accumulators address [stripH x canvasW]. The
+            // kernel takes the accumulator's canvas-coord origin via
+            // (xStart, yStart) -- (0, stripY0) for this strip -- so
+            // canvas cell (yc, xc) lands at stripFlux[c][yc - stripY0, xc].
+            for (var f = 0; f < n; f++)
+            {
+                ct.ThrowIfCancellationRequested();
+                if (!cache.TryGet(f, out var calibrated))
+                {
+                    // Tier miss: re-decode + recalibrate. Re-add to cache;
+                    // the cache may evict another frame to make room.
+                    calibrated = DecodeCalibrate(sources[f], calibrator);
+                    cache.Set(f, calibrated);
+                }
+
+                var transform = sources[f].TransformToCanvas;
+                var sourceRect = CanvasGeometry.ProjectCanvasRectToSourceRect(stripRect, transform, rawW, rawH, projectionHalo);
+                if (sourceRect.Width <= 0 || sourceRect.Height <= 0)
+                {
+                    // Frame's source pixels can't reach this strip -- skip
+                    // entirely.
+                    continue;
+                }
+
+                DrizzleKernel.IterateAndDeposit(
+                    calibrated, transform, pattern, halfP,
+                    stripFlux, stripWeight,
+                    xStart: 0, xEnd: canvasW,
+                    yStart: stripY0, yEnd: stripY0 + stripH,
+                    sourceRect, badPixelMask, hasBadPixelMask);
+            }
+
+            // Copy strip-local accumulators into the canvas-sized master
+            // and coverage planes. Row-wise memcpy via BlockCopy: faster
+            // than nested-for on float[,] and keeps the strip life short.
+            for (var c = 0; c < 3; c++)
+            {
+                var srcF = stripFlux[c];
+                var srcW2 = stripWeight[c];
+                var dstF = masterFlux[c];
+                var dstW = masterWeight[c];
+                for (var dy = 0; dy < stripH; dy++)
+                {
+                    Buffer.BlockCopy(srcF, dy * canvasW * sizeof(float),
+                        dstF, (stripY0 + dy) * canvasW * sizeof(float),
+                        canvasW * sizeof(float));
+                    Buffer.BlockCopy(srcW2, dy * canvasW * sizeof(float),
+                        dstW, (stripY0 + dy) * canvasW * sizeof(float),
+                        canvasW * sizeof(float));
+                }
+            }
+
+            stripIdx++;
+            job.Progress?.Report(new IntegrationProgress(IntegrationPhase.Integrating, stripIdx, stripsTotal, swStrat.Elapsed));
+        }
+
+        // ---------------- Finalise: flux/weight, NaN where uncovered ----------------
+        // Same post-processing as DrizzleStrategy via the shared helper.
+        // Master and coverage map carry the FITS contract DrizzleStrategy
+        // established (master in [0, 1], coverage as the rejection-map
+        // sidecar, uncovered cells reported as "rejections" for the
+        // existing writer gate).
+        var invMax = sourceMaxValue > 0f ? 1f / sourceMaxValue : 1f;
+        var totalCells = (long)canvasH * canvasW * 3;
+        var coveredCells = DrizzleKernel.FinaliseDivide(masterFlux, masterWeight, invMax, canvasH, canvasW);
+
+        var master = new Image(
+            data: masterFlux,
+            bitDepth: BitDepth.Float32,
+            maxValue: 1.0f,
+            minValue: 0f,
+            pedestal: 0f,
+            imageMeta: refMeta);
+        var coverageMap = new Image(
+            data: masterWeight,
+            bitDepth: BitDepth.Float32,
+            maxValue: 1.0f,
+            minValue: 0f,
+            pedestal: 0f,
+            imageMeta: refMeta);
+
+        var uncovered = totalCells - coveredCells;
+        return new IntegrationResult(
+            Master: master,
+            RejectionMap: coverageMap,
+            FrameCount: n,
+            TotalRejections: uncovered,
+            MeanRejectionRate: (double)uncovered / totalCells);
+    }
+
+    /// <summary>Load + calibrate, no debayer. Same contract as
+    /// <see cref="TilePipelinedStrategy"/>'s private helper -- duplicated
+    /// rather than promoted to a shared internal because it's a trivial
+    /// 5-line wrapper around <see cref="Image.TryReadFitsFile"/> + the
+    /// calibrator and DRYing it would couple the two strategies through
+    /// a third file purely on convenience grounds.</summary>
+    private static Image DecodeCalibrate(RawLightSource source, Calibrator calibrator)
+    {
+        if (!Image.TryReadFitsFile(source.Path, out var raw))
+        {
+            throw new InvalidDataException($"TilePipelinedDrizzleStrategy: failed to read raw FITS at {source.Path}");
+        }
+        return calibrator.Apply(raw);
+    }
+}

--- a/src/TianWen.Lib/Imaging/Stacking/TilePipelinedStrategy.cs
+++ b/src/TianWen.Lib/Imaging/Stacking/TilePipelinedStrategy.cs
@@ -277,7 +277,7 @@ public sealed class TilePipelinedStrategy : IIntegrationStrategy
                 }
 
                 var transform = sources[f].TransformToCanvas;
-                var sourceRect = ProjectCanvasRectToSourceRect(stripRect, transform, rawW, rawH, projectionHalo);
+                var sourceRect = CanvasGeometry.ProjectCanvasRectToSourceRect(stripRect, transform, rawW, rawH, projectionHalo);
 
                 // Sub-region debayer of the strip's source footprint (plus
                 // halo) into the pre-allocated full-canvas dest. Only the
@@ -337,43 +337,6 @@ public sealed class TilePipelinedStrategy : IIntegrationStrategy
             throw new InvalidDataException($"TilePipelinedStrategy: failed to read raw FITS at {source.Path}");
         }
         return calibrator.Apply(raw);
-    }
-
-    /// <summary>Inverse-transform a canvas rectangle to its bounding box in
-    /// source-frame coordinates, then expand by <paramref name="halo"/> pixels
-    /// (for bilinear sampling + numerical cushion) and clamp to source bounds.
-    /// Used by pass 2 to figure out how much of the calibrated raw needs to be
-    /// debayered for a given canvas strip.</summary>
-    private static Rectangle ProjectCanvasRectToSourceRect(
-        Rectangle canvasRect, System.Numerics.Matrix3x2 transformToCanvas, int srcW, int srcH, int halo)
-    {
-        if (!System.Numerics.Matrix3x2.Invert(transformToCanvas, out var inverse))
-        {
-            // Non-invertible transform shouldn't happen for the affine fits
-            // we ship -- fall back to full source.
-            return new Rectangle(0, 0, srcW, srcH);
-        }
-
-        Span<System.Numerics.Vector2> corners = stackalloc System.Numerics.Vector2[4];
-        corners[0] = new System.Numerics.Vector2(canvasRect.X, canvasRect.Y);
-        corners[1] = new System.Numerics.Vector2(canvasRect.Right, canvasRect.Y);
-        corners[2] = new System.Numerics.Vector2(canvasRect.X, canvasRect.Bottom);
-        corners[3] = new System.Numerics.Vector2(canvasRect.Right, canvasRect.Bottom);
-
-        var min = new System.Numerics.Vector2(float.PositiveInfinity, float.PositiveInfinity);
-        var max = new System.Numerics.Vector2(float.NegativeInfinity, float.NegativeInfinity);
-        for (var i = 0; i < 4; i++)
-        {
-            var srcPos = System.Numerics.Vector2.Transform(corners[i], inverse);
-            min = System.Numerics.Vector2.Min(min, srcPos);
-            max = System.Numerics.Vector2.Max(max, srcPos);
-        }
-
-        var x0 = Math.Max(0, (int)Math.Floor(min.X) - halo);
-        var y0 = Math.Max(0, (int)Math.Floor(min.Y) - halo);
-        var x1 = Math.Min(srcW, (int)Math.Ceiling(max.X) + halo);
-        var y1 = Math.Min(srcH, (int)Math.Ceiling(max.Y) + halo);
-        return new Rectangle(x0, y0, Math.Max(0, x1 - x0), Math.Max(0, y1 - y0));
     }
 
     private static void CopyStripIntoMaster(Image stripImage, float[][,] masterData, int stripY0, int channelCount)

--- a/src/TianWen.Lib/Imaging/StarList.cs
+++ b/src/TianWen.Lib/Imaging/StarList.cs
@@ -32,6 +32,7 @@ public class StarList(ConcurrentBag<ImagedStar> stars, BitMatrix? starMask = nul
             {
                 SampleKind.HFD => star.HFD,
                 SampleKind.FWHM => star.StarFWHM,
+                SampleKind.Ellipticity => star.Ellipticity,
                 _ => throw new ArgumentException($"Cannot find sample value for {kind}", nameof(kind))
             };
         }

--- a/src/TianWen.Lib/Sequencing/Session.Imaging.cs
+++ b/src/TianWen.Lib/Sequencing/Session.Imaging.cs
@@ -1316,10 +1316,10 @@ internal partial record Session
 
             if (result.HasValue)
             {
-                var (wbR, wbG, wbB, matchCount) = result.Value;
+                var r = result.Value;
                 _logger.LogInformation(
-                    "SPCC: {MatchCount} stars, WB=(R:{R:F3} G:{G:F3} B:{B:F3}) for {Instrument} sensor={Sensor} filter={Filter}",
-                    matchCount, wbR, wbG, wbB,
+                    "SPCC: {Final}/{Initial} stars in {Iters} iter(s), WB=(R:{R:F3} G:{G:F3} B:{B:F3}) for {Instrument} sensor={Sensor} filter={Filter}",
+                    r.FinalMatches, r.InitialMatches, r.Iterations, r.R, r.G, r.B,
                     meta.Instrument,
                     meta.SensorModel is { Length: > 0 } s ? s : "?",
                     meta.Filter.FilterNameForFits);

--- a/src/TianWen.Lib/TianWen.Lib.csproj
+++ b/src/TianWen.Lib/TianWen.Lib.csproj
@@ -33,7 +33,21 @@
     <None Remove="Astrometry/Catalogs/tmp-data/**" />
     <EmbeddedResource Remove="Astrometry/Catalogs/*.json" />
     <EmbeddedResource Include="Astrometry/Catalogs/*.lz" WithCulture="false" />
-    <EmbeddedResource Include="Astrometry/Catalogs/*.gz" WithCulture="false" />
+    <!-- Tracked .gz/.bin.gz catalog files: committed in git (filter_curves,
+         hd_hip_cross, pickles_sed, sensor_qe, simbad_merge), so they exist at
+         project-evaluation time. Listed explicitly because the previous
+         "Astrometry/Catalogs/*.gz" wildcard races against PreprocessCatalogs
+         on a fresh worktree: the glob expands at project-load time before
+         the target generates Barnard.gs.gz / NGC.gs.gz / etc., so first-build
+         DLLs silently shipped without 15 of the 30 catalogs embedded. The
+         generated outputs of PreprocessCatalogs are now injected by the
+         EmbedCatalogOutputs target below so they get picked up deterministically
+         regardless of disk state at evaluation time. -->
+    <EmbeddedResource Include="Astrometry/Catalogs/filter_curves.gs.gz" WithCulture="false" />
+    <EmbeddedResource Include="Astrometry/Catalogs/hd_hip_cross.bin.gz" WithCulture="false" />
+    <EmbeddedResource Include="Astrometry/Catalogs/pickles_sed.gs.gz" WithCulture="false" />
+    <EmbeddedResource Include="Astrometry/Catalogs/sensor_qe.gs.gz" WithCulture="false" />
+    <EmbeddedResource Include="Astrometry/Catalogs/simbad_merge.bin.gz" WithCulture="false" />
     <!-- Catalogs migrated to the ASCII-separated .gs.gz format: keep the .json.lz on
          disk as preprocessor input but exclude it from the assembly so only the
          faster path ships. See PLAN-catalog-binary-format.md. -->
@@ -110,6 +124,19 @@
           Inputs="@(CatalogPreprocess)"
           Outputs="@(CatalogPreprocess->'%(OutputPath)')">
     <Exec Command="pwsh -NoProfile -File &quot;$(MSBuildThisFileDirectory)..\..\tools\preprocess-catalog.ps1&quot; -Input &quot;%(CatalogPreprocess.FullPath)&quot; -Output &quot;$(MSBuildThisFileDirectory)%(CatalogPreprocess.OutputPath)&quot;" />
+  </Target>
+
+  <!-- Register the generated .gs.gz outputs as EmbeddedResource items.
+       Separate target with no Inputs/Outputs gate so it runs on every build
+       (incremental and clean), making the embed set deterministic. The
+       DependsOnTargets ensures PreprocessCatalogs has generated the files
+       before this target collects them. -->
+  <Target Name="EmbedCatalogOutputs"
+          BeforeTargets="AssignTargetPaths"
+          DependsOnTargets="PreprocessCatalogs">
+    <ItemGroup>
+      <EmbeddedResource Include="@(CatalogPreprocess->'%(OutputPath)')" WithCulture="false" />
+    </ItemGroup>
   </Target>
 
   <ItemGroup>

--- a/src/TianWen.UI.Abstractions/MasterPreviewRenderer.cs
+++ b/src/TianWen.UI.Abstractions/MasterPreviewRenderer.cs
@@ -143,8 +143,11 @@ public sealed class MasterPreviewRenderer(ICelestialObjectDB? catalogDb, ILogger
                         if (spcc is { } gains)
                         {
                             wbGains = (gains.R, gains.G, gains.B);
-                            logger.LogInformation("  [SPCC] WB=({R:F3}, {G:F3}, {B:F3}) from {Matches} Tycho-2 matches ({Ms} ms)",
-                                gains.R, gains.G, gains.B, gains.MatchCount, spccSw.ElapsedMilliseconds);
+                            logger.LogInformation(
+                                "  [SPCC] WB=({R:F3}, {G:F3}, {B:F3}) from {Final}/{Initial} Tycho-2 matches in {Iters} kappa-sigma iter(s) ({Ms} ms)",
+                                gains.R, gains.G, gains.B,
+                                gains.FinalMatches, gains.InitialMatches, gains.Iterations,
+                                spccSw.ElapsedMilliseconds);
                         }
                         else
                         {

--- a/src/TianWen.UI.Abstractions/MasterPreviewRenderer.cs
+++ b/src/TianWen.UI.Abstractions/MasterPreviewRenderer.cs
@@ -10,6 +10,7 @@ using TianWen.Lib.Astrometry;
 using TianWen.Lib.Astrometry.Catalogs;
 using TianWen.Lib.Imaging;
 using TianWen.Lib.Imaging.ColorCalibration;
+using TianWen.Lib.Stat;
 
 namespace TianWen.UI.Abstractions;
 
@@ -108,6 +109,21 @@ public sealed class MasterPreviewRenderer(ICelestialObjectDB? catalogDb, ILogger
             catch (Exception ex)
             {
                 logger.LogWarning("  [WB] star detection failed: {Type}: {Msg}", ex.GetType().Name, ex.Message);
+            }
+
+            // Post-stack PSF summary on the master. Lets us spot when a
+            // stacked output ends up with broader / more elongated stars
+            // than the per-frame medians would suggest -- a tell for
+            // residual registration drift or aggressive rejection cutting
+            // into the best frames.
+            if (statsStars is { Count: > 0 } detected)
+            {
+                var masterHfd = detected.MapReduceStarProperty(SampleKind.HFD, AggregationMethod.Median);
+                var masterFwhm = detected.MapReduceStarProperty(SampleKind.FWHM, AggregationMethod.Median);
+                var masterEcc = detected.MapReduceStarProperty(SampleKind.Ellipticity, AggregationMethod.Median);
+                logger.LogInformation(
+                    "  [masterStats] N={N} hfd={Hfd:F2} fwhm={Fwhm:F2} ecc={Ecc:F3}",
+                    detected.Count, masterHfd, masterFwhm, masterEcc);
             }
 
             if (effectiveWcs is { } w && statsStars is { Count: >= 3 } && catalogDb is { } db)


### PR DESCRIPTION
## Summary

Branch started as a focused Kabsch (translation→rotation+scale) refinement on per-frame registration and grew into a broader stacking-pipeline improvement set. Each commit is independently scoped and tested; the bundle ships together because each piece reinforced the previous one through real-data feedback loops on the SoL 60s dataset (243 frames, IMX571, galactic plane).

## What's in here

**Registration**
- Kabsch rotation+scale refinement (`bbc2b01`) — closed-form 2D Procrustes on per-frame match pairs, falls back to translation-only when < 8 pairs. Drops the WB cross-pier-side B-divergence from 0.152 → 0.006 on the SoL dataset.
- Identity-skip fast path in `WarpToReferenceGridAsync` + `WarpRegionAsync` (`a900342`).
- Per-frame + per-stack PSF stats (HFD / FWHM / ellipticity) logged during registration (`1745a5f`).
- Per-frame quality filter (HFD / ecc / star count, MAD-based threshold with 80% keep floor) (`49ec877`).
- `--reference-frame <substring>` debug knob to pin the registration reference (`b0c843d`).
- Calibrated-frame cache rebuilds correctly when the quality filter drops frames (`ea3d2ad`).

**Integration strategies**
- `TilePipelinedDrizzle` integration strategy — strip-pipelined Bayer drizzle, byte-equivalent to the streaming variant within 1e-4 (`58c7787`).
- Drizzle auto-pick on RGGB inputs with N >= 60 matched frames — selector competes drizzle against the standard AHD path under the Balanced policy (`58c7787`).
- `--no-bayer-drizzle` CLI opt-out + `--drizzle-min-frames` plumbed through both forced and auto-pick gates (`58c7787`).
- `--include-stack-products` flag for two-stage mosaic stacking, with rejection-map sidecars always skipped (`51eeed5`).
- Ghost sub-group filter (MinSubGroupFrames=4 backstop) + STACK_N scan filter so stale masters from adjacent `output-*/` dirs don't pollute (`2b9ef6d`).

**Hot-pixel masking** (root-cause investigation triggered by surviving green/red pixel clusters)
- **Fix the strategy gate** — `BuildMaskFromDark` was only called for `ForcedStrategy==BayerDrizzle`. TilePipelinedDrizzle and auto-picked drizzle both consume the mask but skipped construction entirely, so visible hot pixels survived (`6b1d739`).
- **Iterative kappa-sigma** convergence on dark masters — each iteration excludes already-masked strided positions, recomputes median+MAD on the inlier remainder (tightening MAD), and grows the mask until convergence (typically 2–4 iters) (`6b1d739`).
- **MAD=0 fallback** for cooled-CMOS bias-dominated darks — at -5C dark current is sub-ADU, 56% of pixels collapse to a single quantized bias value, MAD degenerates. Falls back to median of non-zero deviations as the noise floor; flags 13,845 px on SoL where pre-fix flagged 0 (`2f22d4b`).

**Colour calibration (SPCC)**
- **Iterative kappa-sigma SPCC fit** — replaces the one-shot median over per-channel ratios with a multi-iteration kappa-sigma rejection. Same WB to 3 decimal places on clean data; tighter inlier set on contaminated. Returns `SpccWhiteBalanceResult(R, G, B, InitialMatches, FinalMatches, Iterations)` so the log line surfaces the full funnel (`0222d90`).

**Telemetry**
- `[host/<stage>]` snapshot log lines at each pipeline milestone (start / scan / masters / register / integrate / end) — RSS, managed heap, free RAM, free disk, all carrying delta-from-start (`b23a1d5`).

**Catalog bug fix**
- `Tycho2StarCount` returned 0 even after bulk load completed — getter read the lazy field directly without triggering `EnsureTycho2StarCount()`. Doc-comment promise "lazily on first access" now actually holds (`6873af8`).
- Adds internal `Tycho2BulkLoadState` diagnostic property for future regression checks.

**Build**
- Fix EmbeddedResource glob race with PreprocessCatalogs target (`2219f30`) — explicit `<EmbeddedResource Include=...>` list for tracked .gz files + `EmbedCatalogOutputs` target with `BeforeTargets="AssignTargetPaths"` to pick up generated `.gs.gz` outputs deterministically.

## Result on SoL 60s drizzle

| Metric | pre-branch | post-branch |
|---|---|---|
| WB cross-pier-side B-divergence | 0.152 | 0.006 |
| Unsplit master SPCC matches | n/a | 127 (111 inliers after iter-fit) |
| Visible hot-pixel clusters | yes (green + red) | none |
| Run wall time (243 frames, TilePipelinedDrizzle) | n/a | 7-9 min |
| Working disk delta during run | n/a | < 1 MB |
| Peak RAM (TilePipelinedDrizzle, FrameCache) | n/a | 4-7 GB (adaptive to host headroom) |

## Tests

- `RegistrationRefinerTests` — 8 tests covering pure translation, pure rotation, rotation+scale, composition, fallback paths, noise tolerance.
- `BadPixelDetectionTests` (existing) — kappa-sigma convergence stays green.
- `StackingPipelineRgbBayerDrizzleTest` — byte-equivalence between streaming and tile-pipelined drizzle at 1e-4 relative tolerance.
- `ColorCalibrationTests` — 5 SPCC fit cases (balanced, green/red/blue cast, clamping) green through the new iterative path.
- `Tycho2FovExploratoryTests` (new) — bulk-load state diagnostic + end-to-end FOV funnel against an SoL master (auto-skips when the local FITS isn't present).
- `IntegrationStrategySelectorTests` — drizzle auto-pick gates (RGGB + N>=60 + sensor type + min-frames threading).
- Full suite: 2256+ passed / 17 skipped / 0 failed locally.

## Out of scope (followups)

- Proper-motion-aware Tycho-2 match in SPCC `MatchStars` — the unsplit master has 773 in-FOV Tycho-2 stars and only 127 photometric matches; suspected cause is PM drift (26-35 years × 50 mas/yr = 1-2", up to 5"+ for high-PM stars) against the 5" match radius.
- Persistent per-sensor hot-pixel map at `Profiles/HotPixelMap/<sensorKey>.json` (converges across sessions).
- Sensor-temp-keyed master dark routing (fall back to nearest-temperature when an exact match isn't cached).
- `tianwen solve <fits> --export-stars` CLI verb for diagnostic round-trips.
- SIP optical-distortion support in WCS / catalogue projection.

## Test plan

- [x] CI green on this PR
- [x] `dotnet test TianWen.Lib.Tests` passes locally (2256+ tests)
- [x] End-to-end: SoL drizzle unsplit run completes cleanly with `[host]` telemetry, hot-pixel mask flagging 13,845 px, SPCC iter-fit converging in 2 iters at 111/127

🤖 Generated with [Claude Code](https://claude.com/claude-code)