### PR TITLE
fix(ai): linux-x64 ONNX uses .Gpu.Linux, dropping ~291 MB of Windows CUDA DLLs

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -40,7 +40,7 @@
          (gated by RuntimeIdentifier in TianWen.AI.csproj). Floats to track
          testwinai's transitive QNN version. -->
     <PackageVersion Include="Microsoft.ML.OnnxRuntime" Version="1.24.*" />
-    <PackageVersion Include="Microsoft.ML.OnnxRuntime.Gpu" Version="1.24.*" />
+    <PackageVersion Include="Microsoft.ML.OnnxRuntime.Gpu.Linux" Version="1.24.*" />
     <PackageVersion Include="Microsoft.ML.OnnxRuntime.DirectML" Version="1.24.*" />
     <PackageVersion Include="Microsoft.ML.OnnxRuntime.QNN" Version="1.24.*" />
     <!-- Benchmark packages -->

--- a/src/TianWen.AI/TianWen.AI.csproj
+++ b/src/TianWen.AI/TianWen.AI.csproj
@@ -38,8 +38,17 @@
         <!-- CUDA EP. Requires libcuda.so.1 + libcudart.so.X on the host;
              if absent the runtime silently falls back to CPU. Only fires
              when the user explicitly targets the CUDA RID; a no-RID
-             dev build on Linux falls through to the CPU baseline below. -->
-        <PackageReference Include="Microsoft.ML.OnnxRuntime.Gpu" />
+             dev build on Linux falls through to the CPU baseline below.
+             Reference the Linux-specific package, NOT the combined
+             Microsoft.ML.OnnxRuntime.Gpu meta-package: the latter depends
+             on BOTH .Gpu.Linux (the .so EPs) AND .Gpu.Windows (the .dll
+             EPs), and publish copies every native asset regardless of RID,
+             so the combined package dragged ~291 MB of unloadable Windows
+             CUDA DLLs (onnxruntime_providers_cuda.dll etc.) into the
+             linux-x64 artifact, roughly half the download. .Gpu.Linux
+             pulls the managed wrapper transitively (via .Managed) so the
+             TrimmerRootAssembly below stays valid. -->
+        <PackageReference Include="Microsoft.ML.OnnxRuntime.Gpu.Linux" />
       </ItemGroup>
     </When>
     <When Condition="'$(OS)' == 'Windows_NT'">


### PR DESCRIPTION
## Problem

The `tianwen-cli-linux-x64.tar.gz` release artifact is ~433 MB — ~7× every other RID's tarball. A tar listing of `v5.0.799` shows why:

| File | Size | Belongs on linux? |
|---|---|---|
| `libonnxruntime_providers_cuda.so` | 316 MB | ✅ linux CUDA EP (legit, inherently huge) |
| `onnxruntime_providers_cuda.dll` | 276 MB | ❌ **Windows DLL** |
| `onnxruntime.dll` | 14 MB | ❌ **Windows DLL** |
| `onnxruntime_providers_tensorrt.dll` / `_shared.dll` | ~0.85 MB | ❌ **Windows DLLs** |

~291 MB of **unloadable Windows CUDA DLLs** were riding in the linux-x64 artifact — roughly half the download.

## Cause

`TianWen.AI.csproj`'s linux-x64 branch referenced the **combined** `Microsoft.ML.OnnxRuntime.Gpu` meta-package, which depends on **both** `.Gpu.Linux` (the `.so` EPs) **and** `.Gpu.Windows` (the `.dll` EPs). AOT publish copies every native asset regardless of RID.

## Fix

Reference `Microsoft.ML.OnnxRuntime.Gpu.Linux` directly for linux-x64. It pulls the managed wrapper transitively via `.Managed` (so the `TrimmerRootAssembly` stays valid) and ships only the linux `.so` EPs. The legit 316 MB `libonnxruntime_providers_cuda.so` is unchanged.

## Verification

With the RID forced as a global property (the way CI's `publish -r linux-x64` sets it):

- linux-x64 → `.Gpu.Linux` + `.Managed`, **no `.Gpu.Windows`** ✅
- win-x64 → DirectML (unchanged) ✅
- host-default (win-arm64) build → DirectML (unchanged) ✅

Other RIDs untouched. Expected impact: linux-x64 tarball ~433 MB → ~260 MB; no functional change on any platform.

🤖 Generated with [Claude Code](https://claude.com/claude-code)