### PR TITLE
Code-quality sweep + planner handoff-slider UX fixes

### DIFF
--- a/src/TianWen.Cli/Plan/PlanSubCommand.cs
+++ b/src/TianWen.Cli/Plan/PlanSubCommand.cs
@@ -145,8 +145,8 @@ internal class PlanSubCommand(
             if (scored is { Target: not null })
             {
                 var start = i == 0 ? plannerState.AstroDark
-                    : i - 1 < plannerState.HandoffSliders.Count ? plannerState.HandoffSliders[i - 1] : scored.OptimalStart;
-                var end = i >= pinnedCount - 1 || i >= plannerState.HandoffSliders.Count
+                    : i - 1 < plannerState.HandoffSliders.Length ? plannerState.HandoffSliders[i - 1] : scored.OptimalStart;
+                var end = i >= pinnedCount - 1 || i >= plannerState.HandoffSliders.Length
                     ? plannerState.AstroTwilight : plannerState.HandoffSliders[i];
                 var duration = end - start;
                 var durationStr = duration.TotalHours >= 1.0
@@ -168,8 +168,8 @@ internal class PlanSubCommand(
         for (var i = 0; i < pinnedCount; i++)
         {
             var windowStart = i == 0 ? plannerState.AstroDark
-                : i - 1 < plannerState.HandoffSliders.Count ? plannerState.HandoffSliders[i - 1] : plannerState.AstroDark;
-            var windowEnd = i >= pinnedCount - 1 || i >= plannerState.HandoffSliders.Count
+                : i - 1 < plannerState.HandoffSliders.Length ? plannerState.HandoffSliders[i - 1] : plannerState.AstroDark;
+            var windowEnd = i >= pinnedCount - 1 || i >= plannerState.HandoffSliders.Length
                 ? plannerState.AstroTwilight : plannerState.HandoffSliders[i];
             var hours = (windowEnd - windowStart).TotalHours;
 

--- a/src/TianWen.Hosting/Api/NinaV2/NinaSequenceEndpoints.cs
+++ b/src/TianWen.Hosting/Api/NinaV2/NinaSequenceEndpoints.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Logging;
 using TianWen.Lib.Devices;
 using TianWen.Hosting.Dto;
 using TianWen.Hosting.Dto.NinaV2;
@@ -54,7 +55,7 @@ internal static class NinaSequenceEndpoints
         });
 
         // GET /v2/api/sequence/start — start session using active profile + pending targets
-        group.MapGet("/start", (IHostedSession hosted, ISessionFactory factory, CancellationToken ct) =>
+        group.MapGet("/start", (IHostedSession hosted, ISessionFactory factory, ILogger<HostedSession> logger, CancellationToken ct) =>
         {
             if (hosted.CurrentSession is not null)
             {
@@ -103,7 +104,8 @@ internal static class NinaSequenceEndpoints
             _ = Task.Run(async () =>
             {
                 try { await session.RunAsync(ct); }
-                catch (OperationCanceledException) { }
+                catch (OperationCanceledException) { logger.LogInformation("ninaAPI: session run cancelled"); }
+                catch (Exception ex) { logger.LogError(ex, "ninaAPI: session run faulted"); }
             }, ct);
 
             return Results.Json(

--- a/src/TianWen.Lib.Tests/PlannerHandoffWindowTests.cs
+++ b/src/TianWen.Lib.Tests/PlannerHandoffWindowTests.cs
@@ -82,7 +82,7 @@ public class PlannerHandoffWindowTests
         state.Proposals = proposalsBuilder.ToImmutable();
         if (sliders is not null)
         {
-            state.HandoffSliders.AddRange(sliders);
+            state.HandoffSliders = [.. sliders];
         }
         return state;
     }

--- a/src/TianWen.Lib/Astrometry/Catalogs/CelestialObjectDB.cs
+++ b/src/TianWen.Lib/Astrometry/Catalogs/CelestialObjectDB.cs
@@ -702,16 +702,17 @@ internal sealed partial class CelestialObjectDB : ICelestialObjectDB
     /// <summary>
     /// Overrides the default interface implementation in <see cref="ICelestialObjectDB"/>.
     /// Returns the result of the background bake started during init (see
-    /// <see cref="_autoCompleteListTask"/>), blocking only if the bake is still in flight.
-    /// Idempotent: subsequent calls return the same array reference.
+    /// <see cref="_autoCompleteListTask"/>) once it has completed; while the bake is still
+    /// in flight it builds the list synchronously on the calling thread rather than blocking
+    /// on the task. Once the bake has finished, subsequent calls return the same baked array.
     /// <para>
-    /// Pre-init or when the bake task was somehow not started (defensive only — init always
-    /// starts it), falls back to building synchronously here so unit tests that construct
-    /// a partially-populated db can still call this without depending on init internals.
+    /// Building inline is also the fallback for the pre-init / not-yet-started case (defensive
+    /// only — init always starts the bake) so unit tests that construct a partially-populated
+    /// db can still call this without depending on init internals.
     /// </para>
     /// </summary>
     public string[] CreateAutoCompleteList()
-        => _autoCompleteListTask is { } t ? t.GetAwaiter().GetResult() : BuildSortedAutoCompleteList();
+        => _autoCompleteListTask is { IsCompletedSuccessfully: true } t ? t.Result : BuildSortedAutoCompleteList();
 
     /// <summary>
     /// Pure CPU bake: enumerates <see cref="AllObjectIndices"/> + <see cref="CommonNames"/>

--- a/src/TianWen.Lib/Sequencing/Session.Focus.cs
+++ b/src/TianWen.Lib/Sequencing/Session.Focus.cs
@@ -509,7 +509,7 @@ internal partial record Session
         }
 
         var autoFocusExposure = TimeSpan.FromSeconds(2);
-        var currentGain = await camera.GetGainAsync(cancellationToken);
+        var currentGain = await ResilientInvokeAsync(camera, camera.GetGainAsync, ResilientCallOptions.IdempotentRead, cancellationToken);
 
         // Bootstrap per-focuser EWMA from disk on first encounter so the very first move
         // of the session uses last-night's overshoot estimate, not the URI seed.
@@ -541,14 +541,14 @@ internal partial record Session
             var targetPos = startPos + i * stepSize;
             _currentActivity = $"#{telescopeIndex + 1} V-curve {i + 1}/{stepCount} pos={targetPos}";
             // Move may have been started during previous iteration's download overlap
-            if (!await focuser.GetIsMovingAsync(cancellationToken))
+            if (!await ResilientInvokeAsync(focuser, focuser.GetIsMovingAsync, ResilientCallOptions.IdempotentRead, cancellationToken))
             {
                 await ResilientInvokeAsync(
                     focuser,
                     ct => focuser.BeginMoveAsync(targetPos, ct),
                     ResilientCallOptions.AbsoluteMove, cancellationToken);
             }
-            while (await focuser.GetIsMovingAsync(cancellationToken) && !cancellationToken.IsCancellationRequested)
+            while (await ResilientInvokeAsync(focuser, focuser.GetIsMovingAsync, ResilientCallOptions.IdempotentRead, cancellationToken) && !cancellationToken.IsCancellationRequested)
             {
                 await PollDeviceStatesAsync(cancellationToken);
                 await _timeProvider.SleepAsync(TimeSpan.FromMilliseconds(100), cancellationToken);

--- a/src/TianWen.Lib/Sequencing/Session.Imaging.Obstruction.cs
+++ b/src/TianWen.Lib/Sequencing/Session.Imaging.Obstruction.cs
@@ -404,15 +404,15 @@ internal partial record Session
         var camera = Setup.Telescopes[telescopeIndex].Camera.Driver;
 
         // Cancel any in-progress exposure left over from prior phases
-        if (await camera.GetCameraStateAsync(cancellationToken) is CameraState.Exposing)
+        if (await ResilientInvokeAsync(camera, camera.GetCameraStateAsync, ResilientCallOptions.IdempotentRead, cancellationToken) is CameraState.Exposing)
         {
             if (camera.CanAbortExposure)
             {
-                await camera.AbortExposureAsync(cancellationToken);
+                await ResilientInvokeAsync(camera, camera.AbortExposureAsync, ResilientCallOptions.NonIdempotentAction, cancellationToken);
             }
             else if (camera.CanStopExposure)
             {
-                await camera.StopExposureAsync(cancellationToken);
+                await ResilientInvokeAsync(camera, camera.StopExposureAsync, ResilientCallOptions.NonIdempotentAction, cancellationToken);
             }
             await _timeProvider.SleepAsync(TimeSpan.FromSeconds(1), cancellationToken);
         }
@@ -423,7 +423,7 @@ internal partial record Session
             ResilientCallOptions.NonIdempotentAction, cancellationToken);
         await _timeProvider.SleepAsync(scoutExposure + TimeSpan.FromSeconds(2), cancellationToken);
 
-        if (!await camera.GetImageReadyAsync(cancellationToken))
+        if (!await ResilientInvokeAsync(camera, camera.GetImageReadyAsync, ResilientCallOptions.IdempotentRead, cancellationToken))
         {
             return default;
         }
@@ -439,7 +439,7 @@ internal partial record Session
         try
         {
             var stars = await image.FindStarsAsync(0, snrMin: 10, maxStars: 200, cancellationToken: cancellationToken);
-            var gain = await camera.GetGainAsync(cancellationToken);
+            var gain = await ResilientInvokeAsync(camera, camera.GetGainAsync, ResilientCallOptions.IdempotentRead, cancellationToken);
 
             // Preserve exposure on 0-star results — see TakeScoutFrameAsync rationale.
             // FrameMetrics.FromStarList returns default(FrameMetrics) when stars.Count == 0,

--- a/src/TianWen.Lib/Sequencing/Session.Imaging.cs
+++ b/src/TianWen.Lib/Sequencing/Session.Imaging.cs
@@ -1217,9 +1217,9 @@ internal partial record Session
             var camera = Setup.Telescopes[telescopeIndex].Camera.Driver;
 
             // Abort any in-progress exposure before taking a short test exposure
-            if (await camera.GetCameraStateAsync(cancellationToken) is CameraState.Exposing)
+            if (await ResilientInvokeAsync(camera, camera.GetCameraStateAsync, ResilientCallOptions.IdempotentRead, cancellationToken) is CameraState.Exposing)
             {
-                await camera.AbortExposureAsync(cancellationToken);
+                await ResilientInvokeAsync(camera, camera.AbortExposureAsync, ResilientCallOptions.NonIdempotentAction, cancellationToken);
                 await _timeProvider.SleepAsync(TimeSpan.FromSeconds(1), cancellationToken);
             }
 
@@ -1230,7 +1230,7 @@ internal partial record Session
                 ResilientCallOptions.NonIdempotentAction, cancellationToken);
             await _timeProvider.SleepAsync(testExposure + TimeSpan.FromSeconds(2), cancellationToken);
 
-            if (!await camera.GetImageReadyAsync(cancellationToken))
+            if (!await ResilientInvokeAsync(camera, camera.GetImageReadyAsync, ResilientCallOptions.IdempotentRead, cancellationToken))
             {
                 continue;
             }
@@ -1247,7 +1247,7 @@ internal partial record Session
             var imgW = image.Width;
             var imgH = image.Height;
             image.Release();
-            var currentGain = await camera.GetGainAsync(cancellationToken);
+            var currentGain = await ResilientInvokeAsync(camera, camera.GetGainAsync, ResilientCallOptions.IdempotentRead, cancellationToken);
             var metrics = FrameMetrics.FromStarList(stars, testExposure, currentGain, imgW, imgH);
 
             if (!metrics.IsValid)

--- a/src/TianWen.UI.Abstractions/AltitudeChartRenderer.cs
+++ b/src/TianWen.UI.Abstractions/AltitudeChartRenderer.cs
@@ -420,7 +420,7 @@ public static class AltitudeChartRenderer
 
             // Determine this target's time window from sliders
             var windowStart = i == 0 ? state.AstroDark : state.HandoffSliders[i - 1];
-            var windowEnd = i >= pinnedCount - 1 || i >= state.HandoffSliders.Count
+            var windowEnd = i >= pinnedCount - 1 || i >= state.HandoffSliders.Length
                 ? state.AstroTwilight
                 : state.HandoffSliders[i];
 
@@ -456,7 +456,7 @@ public static class AltitudeChartRenderer
         }
 
         // Draw handoff slider lines
-        for (var i = 0; i < state.HandoffSliders.Count; i++)
+        for (var i = 0; i < state.HandoffSliders.Length; i++)
         {
             var sliderX = timeToX(state.HandoffSliders[i]);
             if (sliderX >= plotX && sliderX <= plotX + plotW)

--- a/src/TianWen.UI.Abstractions/EquipmentActions.cs
+++ b/src/TianWen.UI.Abstractions/EquipmentActions.cs
@@ -531,15 +531,13 @@ public static class EquipmentActions
                 break;
             }
 
-            try { await Task.Delay(stepInterval, cancellationToken); }
-            catch (OperationCanceledException) { throw; }
+            await Task.Delay(stepInterval, cancellationToken);
         }
 
         try { await camera.SetCoolerOnAsync(false, cancellationToken); }
         catch (Exception ex) { logger.LogWarning(ex, "SetCoolerOnAsync(false) failed for {Uri}", deviceUri); }
 
-        try { await Task.Delay(TimeSpan.FromSeconds(2), cancellationToken); }
-        catch (OperationCanceledException) { throw; }
+        await Task.Delay(TimeSpan.FromSeconds(2), cancellationToken);
 
         if (disconnectAfter)
         {

--- a/src/TianWen.UI.Abstractions/GuiEventHandlerBase.cs
+++ b/src/TianWen.UI.Abstractions/GuiEventHandlerBase.cs
@@ -120,7 +120,7 @@ namespace TianWen.UI.Abstractions
                 return true;
             }
 
-            // Slider drag start + selection
+            // Slider drag start + selection (clicked directly on a slider handle)
             if (hit is HitResult.SliderHit { SliderIndex: var sliderIdx })
             {
                 _plannerState.DraggingSliderIndex = sliderIdx;
@@ -128,7 +128,31 @@ namespace TianWen.UI.Abstractions
                 return true;
             }
 
-            // Clicking outside a slider → deselect
+            // Click-to-place: a click anywhere in the planner chart (but not directly on a
+            // slider handle) moves the nearest handoff slider to that time and begins a drag,
+            // so the same press can refine it. Selecting it also makes Left/Right step the
+            // slider (which trumps date-switching). Replaces the old click-empty-chart-to-deselect.
+            if (hit is null
+                && _appState.ActiveTab == GuiTab.Planner
+                && _plannerState.HandoffSliders.Length > 0)
+            {
+                var chartRect = _chrome.PlannerChartRect;
+                if (px >= chartRect.X && px <= chartRect.X + chartRect.Width
+                    && py >= chartRect.Y && py <= chartRect.Y + chartRect.Height)
+                {
+                    var (tStart, tEnd, plotX, plotW) = AltitudeChartRenderer.GetChartTimeLayout(
+                        _plannerState, (int)chartRect.X, (int)chartRect.Width);
+                    var clickedTime = AltitudeChartRenderer.XToTime(px, tStart, tEnd, plotX, plotW);
+                    if (PlannerActions.PlaceNearestSlider(_plannerState, clickedTime) is var moved && moved >= 0)
+                    {
+                        _plannerState.DraggingSliderIndex = moved;
+                        _appState.NeedsRedraw = true;
+                        return true;
+                    }
+                }
+            }
+
+            // Clicking outside a slider and outside the chart → deselect
             if (_plannerState.SelectedSliderIndex >= 0)
             {
                 PlannerActions.SelectSlider(_plannerState, -1);
@@ -185,7 +209,7 @@ namespace TianWen.UI.Abstractions
                 return _chrome.ActiveTab?.HandleInput(new InputEvent.MouseMove(px, py)) ?? false;
             }
 
-            if (idx >= _plannerState.HandoffSliders.Count)
+            if (idx >= _plannerState.HandoffSliders.Length)
             {
                 _plannerState.DraggingSliderIndex = -1;
                 return false;

--- a/src/TianWen.UI.Abstractions/PlannerActions.cs
+++ b/src/TianWen.UI.Abstractions/PlannerActions.cs
@@ -313,7 +313,7 @@ public static class PlannerActions
     public static bool StepSelectedSlider(PlannerState state, int minutesDelta)
     {
         var idx = state.SelectedSliderIndex;
-        if (idx < 0 || idx >= state.HandoffSliders.Count)
+        if (idx < 0 || idx >= state.HandoffSliders.Length)
         {
             return false;
         }
@@ -321,7 +321,7 @@ public static class PlannerActions
         var newTime = state.HandoffSliders[idx] + TimeSpan.FromMinutes(minutesDelta);
         ClampSlider(state, idx, ref newTime);
 
-        state.HandoffSliders[idx] = newTime;
+        state.HandoffSliders = state.HandoffSliders.SetItem(idx, newTime);
         state.IsDirty = true;
         state.NeedsRedraw = true;
         return true;
@@ -333,16 +333,46 @@ public static class PlannerActions
     /// </summary>
     public static void MoveSlider(PlannerState state, int idx, DateTimeOffset newTime)
     {
-        if (idx < 0 || idx >= state.HandoffSliders.Count)
+        if (idx < 0 || idx >= state.HandoffSliders.Length)
         {
             return;
         }
 
         ClampSlider(state, idx, ref newTime);
 
-        state.HandoffSliders[idx] = newTime;
+        state.HandoffSliders = state.HandoffSliders.SetItem(idx, newTime);
         state.IsDirty = true;
         state.NeedsRedraw = true;
+    }
+
+    /// <summary>
+    /// Click-to-place: moves the handoff slider nearest (in time) to <paramref name="time"/>
+    /// to that time (clamped to keep 15-minute gaps) and selects it so Left/Right stepping
+    /// works. Returns the moved slider's index, or -1 when there are no sliders. Used by the
+    /// chart's click-to-place + drag-start interaction.
+    /// </summary>
+    public static int PlaceNearestSlider(PlannerState state, DateTimeOffset time)
+    {
+        if (state.HandoffSliders.Length == 0)
+        {
+            return -1;
+        }
+
+        var nearest = 0;
+        var bestDelta = (state.HandoffSliders[0] - time).Duration();
+        for (var i = 1; i < state.HandoffSliders.Length; i++)
+        {
+            var delta = (state.HandoffSliders[i] - time).Duration();
+            if (delta < bestDelta)
+            {
+                bestDelta = delta;
+                nearest = i;
+            }
+        }
+
+        SelectSlider(state, nearest);
+        MoveSlider(state, nearest, time);
+        return nearest;
     }
 
     /// <summary>
@@ -351,7 +381,7 @@ public static class PlannerActions
     /// </summary>
     public static void SelectSlider(PlannerState state, int index)
     {
-        if (index >= 0 && index < state.HandoffSliders.Count)
+        if (index >= 0 && index < state.HandoffSliders.Length)
         {
             state.SelectedSliderOriginalTime = state.HandoffSliders[index];
         }
@@ -369,13 +399,13 @@ public static class PlannerActions
     /// </summary>
     public static bool CycleSelectedSlider(PlannerState state)
     {
-        if (state.HandoffSliders.Count == 0)
+        if (state.HandoffSliders.Length == 0)
         {
             return false;
         }
 
         state.SelectedSliderIndex =
-            state.SelectedSliderIndex < state.HandoffSliders.Count - 1
+            state.SelectedSliderIndex < state.HandoffSliders.Length - 1
                 ? state.SelectedSliderIndex + 1
                 : -1;
         state.NeedsRedraw = true;
@@ -410,9 +440,9 @@ public static class PlannerActions
                 if (state.SelectedSliderOriginalTime is { } originalTime)
                 {
                     var idx = state.SelectedSliderIndex;
-                    if (idx >= 0 && idx < state.HandoffSliders.Count)
+                    if (idx >= 0 && idx < state.HandoffSliders.Length)
                     {
-                        state.HandoffSliders[idx] = originalTime;
+                        state.HandoffSliders = state.HandoffSliders.SetItem(idx, originalTime);
                     }
                 }
                 state.SelectedSliderOriginalTime = null;
@@ -435,7 +465,7 @@ public static class PlannerActions
     /// </summary>
     public static int HitTestSlider(PlannerState state, float pixelX, float chartX, float chartW)
     {
-        if (state.HandoffSliders.Count == 0)
+        if (state.HandoffSliders.Length == 0)
         {
             return -1;
         }
@@ -451,7 +481,7 @@ public static class PlannerActions
         var bestIdx = -1;
         var bestDist = double.MaxValue;
 
-        for (var i = 0; i < state.HandoffSliders.Count; i++)
+        for (var i = 0; i < state.HandoffSliders.Length; i++)
         {
             var fraction = (state.HandoffSliders[i] - tStart).TotalSeconds / (tEnd - tStart).TotalSeconds;
             var sliderPixelX = plotX + fraction * plotW;
@@ -471,7 +501,7 @@ public static class PlannerActions
         var minSlot = TimeSpan.FromMinutes(15);
 
         var minTime = idx > 0 ? state.HandoffSliders[idx - 1] + minSlot : state.AstroDark + minSlot;
-        var maxTime = idx < state.HandoffSliders.Count - 1
+        var maxTime = idx < state.HandoffSliders.Length - 1
             ? state.HandoffSliders[idx + 1] - minSlot
             : state.AstroTwilight - minSlot;
 
@@ -1114,7 +1144,7 @@ public static class PlannerActions
         var filtered = GetFilteredTargets(state);
         var pinnedCount = state.PinnedCount;
 
-        state.HandoffSliders.Clear();
+        state.HandoffSliders = [];
         state.PinnedTargetConflicts = new bool[pinnedCount];
 
         if (pinnedCount < 2)
@@ -1124,6 +1154,11 @@ public static class PlannerActions
 
         var minSlot = TimeSpan.FromMinutes(15);
 
+        // Build into a local then publish atomically -- this runs on the background
+        // InitializePlannerAsync thread while the render thread reads HandoffSliders, so the
+        // collection must never be observed mid-mutation (see CLAUDE.md shared-UI-state rule).
+        var slidersBuilder = ImmutableArray.CreateBuilder<DateTimeOffset>(pinnedCount - 1);
+
         for (var i = 0; i < pinnedCount - 1; i++)
         {
             var targetA = filtered[i].Target;
@@ -1132,12 +1167,12 @@ public static class PlannerActions
             var slider = FindCurveIntersection(state, targetA, targetB);
 
             // Ensure sliders are monotonically increasing with minimum gap
-            var minTime = i > 0 ? state.HandoffSliders[i - 1] + minSlot : state.AstroDark + minSlot;
+            var minTime = i > 0 ? slidersBuilder[i - 1] + minSlot : state.AstroDark + minSlot;
             var maxTime = state.AstroTwilight - minSlot * (pinnedCount - 1 - i);
             if (slider < minTime) slider = minTime;
             if (slider > maxTime) slider = maxTime;
 
-            state.HandoffSliders.Add(slider);
+            slidersBuilder.Add(slider);
 
             // Conflict: check if actual peak altitude times are within 1 hour
             var peakTimeA = state.AltitudeProfiles.TryGetValue(filtered[i].Target, out var profA) && profA.Count > 0
@@ -1153,12 +1188,14 @@ public static class PlannerActions
             }
         }
 
+        state.HandoffSliders = slidersBuilder.ToImmutable();
+
         // Flag targets whose allocated window is very small (< 1.5 hours)
         for (var i = 0; i < pinnedCount; i++)
         {
             var windowStart = i == 0 ? state.AstroDark
-                : i - 1 < state.HandoffSliders.Count ? state.HandoffSliders[i - 1] : state.AstroDark;
-            var windowEnd = i >= pinnedCount - 1 || i >= state.HandoffSliders.Count
+                : i - 1 < state.HandoffSliders.Length ? state.HandoffSliders[i - 1] : state.AstroDark;
+            var windowEnd = i >= pinnedCount - 1 || i >= state.HandoffSliders.Length
                 ? state.AstroTwilight : state.HandoffSliders[i];
             var allocatedHours = (windowEnd - windowStart).TotalHours;
 
@@ -1257,8 +1294,8 @@ public static class PlannerActions
 
             var windowStart = i == 0
                 ? state.AstroDark
-                : i - 1 < state.HandoffSliders.Count ? state.HandoffSliders[i - 1] : state.AstroDark;
-            var windowEnd = i >= pinnedCount - 1 || i >= state.HandoffSliders.Count
+                : i - 1 < state.HandoffSliders.Length ? state.HandoffSliders[i - 1] : state.AstroDark;
+            var windowEnd = i >= pinnedCount - 1 || i >= state.HandoffSliders.Length
                 ? state.AstroTwilight
                 : state.HandoffSliders[i];
 

--- a/src/TianWen.UI.Abstractions/PlannerDetails.cs
+++ b/src/TianWen.UI.Abstractions/PlannerDetails.cs
@@ -47,8 +47,8 @@ public static class PlannerDetails
         if (isProposed && idx < pinnedCount)
         {
             var imgStart = idx == 0 ? state.AstroDark
-                : idx - 1 < state.HandoffSliders.Count ? state.HandoffSliders[idx - 1] : state.AstroDark;
-            var imgEnd = idx >= pinnedCount - 1 || idx >= state.HandoffSliders.Count
+                : idx - 1 < state.HandoffSliders.Length ? state.HandoffSliders[idx - 1] : state.AstroDark;
+            var imgEnd = idx >= pinnedCount - 1 || idx >= state.HandoffSliders.Length
                 ? state.AstroTwilight : state.HandoffSliders[idx];
 
             var effectiveStart = imgStart;

--- a/src/TianWen.UI.Abstractions/PlannerPersistence.cs
+++ b/src/TianWen.UI.Abstractions/PlannerPersistence.cs
@@ -157,13 +157,10 @@ public static class PlannerPersistence
             restoredProposals.Count, dto.Proposals.Length);
 
         // Restore saved slider positions if count matches and they fall within the current night window
-        if (dto.Sliders.Length == state.HandoffSliders.Count
+        if (dto.Sliders.Length == state.HandoffSliders.Length
             && dto.Sliders.All(s => s >= state.AstroDark && s <= state.AstroTwilight))
         {
-            for (var i = 0; i < dto.Sliders.Length; i++)
-            {
-                state.HandoffSliders[i] = dto.Sliders[i];
-            }
+            state.HandoffSliders = [.. dto.Sliders];
             logger.LogInformation("PlannerPersistence: restored {Count} slider positions", dto.Sliders.Length);
         }
         else if (dto.Sliders.Length > 0)

--- a/src/TianWen.UI.Abstractions/PlannerState.cs
+++ b/src/TianWen.UI.Abstractions/PlannerState.cs
@@ -85,8 +85,13 @@ public class PlannerState
     /// <summary>
     /// Handoff times between adjacent pinned targets (N-1 entries for N pinned targets).
     /// Slider[i] is the boundary between pinned target i and pinned target i+1.
+    /// <para>
+    /// <see cref="ImmutableArray{T}"/> with atomic replacement: <see cref="AppSignalHandler.InitializePlannerAsync"/>
+    /// recomputes these on a background task while the render thread reads them, so the
+    /// collection must never be observed mid-mutation (see CLAUDE.md shared-UI-state rule).
+    /// </para>
     /// </summary>
-    public List<DateTimeOffset> HandoffSliders { get; set; } = [];
+    public ImmutableArray<DateTimeOffset> HandoffSliders { get; set; } = [];
 
     /// <summary>
     /// Conflict flags parallel to the sorted pinned targets list.

--- a/src/TianWen.UI.Abstractions/PlannerTab.cs
+++ b/src/TianWen.UI.Abstractions/PlannerTab.cs
@@ -182,7 +182,7 @@ namespace TianWen.UI.Abstractions
 
         private void RegisterSliderHitRegions(PlannerState state, float dpiScale)
         {
-            if (state.HandoffSliders.Count == 0)
+            if (state.HandoffSliders.Length == 0)
             {
                 return;
             }
@@ -192,7 +192,7 @@ namespace TianWen.UI.Abstractions
             var tRange = (tEnd - tStart).TotalHours;
 
             var hitW = 10f * dpiScale;
-            for (var i = 0; i < state.HandoffSliders.Count; i++)
+            for (var i = 0; i < state.HandoffSliders.Length; i++)
             {
                 var fraction = (state.HandoffSliders[i] - tStart).TotalHours / tRange;
                 var sliderX = plotX + (float)(fraction * plotW);
@@ -364,9 +364,9 @@ namespace TianWen.UI.Abstractions
                 string infoStr;
                 if (isPinned)
                 {
-                    var startTime = i == 0 || state.HandoffSliders.Count == 0
+                    var startTime = i == 0 || state.HandoffSliders.Length == 0
                         ? state.AstroDark
-                        : i - 1 < state.HandoffSliders.Count
+                        : i - 1 < state.HandoffSliders.Length
                             ? state.HandoffSliders[i - 1]
                             : scored.OptimalStart;
                     infoStr = startTime.ToOffset(state.SiteTimeZone).ToString("HH:mm");

--- a/src/TianWen.UI.Abstractions/PlannerTargetList.cs
+++ b/src/TianWen.UI.Abstractions/PlannerTargetList.cs
@@ -47,9 +47,9 @@ public static class PlannerTargetList
             string info;
             if (isPinned)
             {
-                var startTime = i == 0 || state.HandoffSliders.Count == 0
+                var startTime = i == 0 || state.HandoffSliders.Length == 0
                     ? state.AstroDark
-                    : i - 1 < state.HandoffSliders.Count
+                    : i - 1 < state.HandoffSliders.Length
                         ? state.HandoffSliders[i - 1]
                         : scored.OptimalStart;
                 info = startTime.ToOffset(state.SiteTimeZone).ToString("HH:mm");

--- a/src/TianWen.UI.Abstractions/SessionContent.cs
+++ b/src/TianWen.UI.Abstractions/SessionContent.cs
@@ -105,8 +105,8 @@ namespace TianWen.UI.Abstractions
                 var proposal = proposals[i];
 
                 // Compute window, clipped to "now" for remaining time estimate
-                var windowStart = i > 0 && i - 1 < sliders.Count ? sliders[i - 1] : dark;
-                var windowEnd = i < sliders.Count ? sliders[i] : twilight;
+                var windowStart = i > 0 && i - 1 < sliders.Length ? sliders[i - 1] : dark;
+                var windowEnd = i < sliders.Length ? sliders[i] : twilight;
                 var effectiveStart = windowStart;
                 if (timeProvider is not null)
                 {

--- a/src/TianWen.UI.Abstractions/SessionTab.cs
+++ b/src/TianWen.UI.Abstractions/SessionTab.cs
@@ -517,8 +517,8 @@ namespace TianWen.UI.Abstractions
                 var bgColor = i % 2 == 0 ? PanelBg : RowAltBg;
 
                 // Compute remaining window (clipped to now)
-                var windowStart = i > 0 && i - 1 < sliders.Count ? sliders[i - 1] : dark;
-                var windowEnd = i < sliders.Count ? sliders[i] : twilight;
+                var windowStart = i > 0 && i - 1 < sliders.Length ? sliders[i - 1] : dark;
+                var windowEnd = i < sliders.Length ? sliders[i] : twilight;
                 var effectiveStart = windowStart;
                 var utcNow = (_timeProvider ?? SystemTimeProvider.Instance).GetUtcNow();
                 if (utcNow > windowStart && utcNow < windowEnd)

--- a/src/TianWen.UI.Abstractions/ViewerController.cs
+++ b/src/TianWen.UI.Abstractions/ViewerController.cs
@@ -113,7 +113,7 @@ public sealed class ViewerController(
                             newDoc.Stars?.Count ?? 0, newDoc.StarDetectionDuration.TotalSeconds, newDoc.AverageHFR, newDoc.AverageFWHM);
                         state.NeedsRedraw = true;
                     }
-                    catch (OperationCanceledException) { }
+                    catch (OperationCanceledException) { logger.LogDebug("Star detection cancelled"); }
                     catch (Exception ex)
                     {
                         logger.LogWarning(ex, "Star detection failed");
@@ -201,11 +201,11 @@ public sealed class ViewerController(
 
         if (_loadTask is not null)
         {
-            try { await _loadTask; } catch (OperationCanceledException) { }
+            try { await _loadTask; } catch (OperationCanceledException) { logger.LogDebug("Load task cancelled during shutdown"); }
         }
         if (_backgroundTask is not null)
         {
-            try { await _backgroundTask; } catch (OperationCanceledException) { }
+            try { await _backgroundTask; } catch (OperationCanceledException) { logger.LogDebug("Background task cancelled during shutdown"); }
         }
     }
 }

--- a/src/TianWen.UI.Gui/VkPlannerTab.cs
+++ b/src/TianWen.UI.Gui/VkPlannerTab.cs
@@ -106,17 +106,27 @@ public sealed class VkPlannerTab : PlannerTab<VulkanContext>, IDisposable
             return;
         }
 
+        // Slider positions must be part of the cache key: dragging or arrow-stepping a handoff
+        // slider changes its time (not the count or selected index), so without this the cached
+        // chart texture would not rebuild and the slider line would appear frozen mid-drag.
+        var slidersHash = new HashCode();
+        foreach (var sliderTime in state.HandoffSliders)
+        {
+            slidersHash.Add(sliderTime.UtcTicks);
+        }
+
         // Build cache key — excludes mouse and current time (drawn as overlays)
         var key = new ChartCacheKey(
             chartW, chartH,
             selectedIndex,
             state.PinnedCount,
-            state.HandoffSliders.Count,
+            state.HandoffSliders.Length,
             state.SelectedSliderIndex,
             state.DraggingSliderIndex,
             state.MinHeightAboveHorizon,
             state.WeatherForecast is { Count: > 0 } wf ? wf[0].Time.GetHashCode() : 0,
-            state.AstroDark.GetHashCode()
+            state.AstroDark.GetHashCode(),
+            slidersHash.ToHashCode()
         );
 
         // Re-render only on cache miss AND when no upload is already queued for
@@ -231,5 +241,6 @@ public sealed class VkPlannerTab : PlannerTab<VulkanContext>, IDisposable
         int DraggingSliderIndex,
         int MinAltitude,
         int WeatherForecastHash,
-        int AstroDarkHash);
+        int AstroDarkHash,
+        int SlidersHash);
 }


### PR DESCRIPTION
## Summary

Two strands from a code-quality sweep session.

### Quality sweep (CLAUDE.md anti-patterns)
- **Hot-path resilience:** wrapped raw `await driver.X()` status reads/actions in `Session.Imaging`, `Session.Imaging.Obstruction`, and `Session.Focus` (the AutoFocus move-wait poll loop) with the correct `ResilientCall` preset, so a transient driver fault retries+reconnects instead of aborting the operation.
- **OperationCanceledException:** log the swallowed OCE in `NinaSequenceEndpoints` (and catch the otherwise-unobserved fault in its fire-and-forget `Task.Run`) and `ViewerController`; removed dead `catch (OCE) { throw; }` no-ops in `EquipmentActions`.
- **`CelestialObjectDB.CreateAutoCompleteList`:** dropped the blocking `GetAwaiter().GetResult()` — returns the baked array once ready, builds inline otherwise.
- **`PlannerState.HandoffSliders`:** `List<T>` → `ImmutableArray<T>` with atomic build-and-swap. It was mutated (`Clear`/`Add`) on the background `InitializePlanner` thread while the render thread iterated it — a `Collection was modified` race.

### Planner handoff-slider UX
- **Click-to-place:** clicking anywhere in the chart moves the nearest slider to that time, selects it, and starts a drag (`PlannerActions.PlaceNearestSlider` + `GuiEventHandlerBase`). Replaces the old click-empty-chart → deselect.
- **Live drag/step feedback:** `VkPlannerTab.ChartCacheKey` now includes slider positions, so dragging or arrow-stepping re-renders the chart — the slider line was previously frozen mid-drag because only slider count/index were keyed.
- **Left/Right** now reliably steps the selected slider (trumping date-switching), because selection sticks.

## Investigated, not a bug
- `Transform.cs:678` `.Result` — false positive: it's `GeoTimeZone.TimeZoneResult.Result` (a string property), not `Task.Result`.
- ILogger DI null-trap — clean: the only non-generic-`ILogger` DI ctor (`OpenPHD2GuiderDriver`) resolves via `ILogger<T>` and chains; the rest are manually constructed.

## Testing
- Full suite: **2491 unit + 242 functional pass**, 0 failures (23 env-gated skips).
- Solution builds clean (0 warnings, 0 errors).
- GUI smoke-tested: launches, renders, slider interaction verified, clean exit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
