### PR TITLE
Fake-mount polar misalignment for imaging + live-session GUI fixes

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -21,7 +21,7 @@
 - [x] Weather overlay in planner — hourly forecast from Open-Meteo (free, no API key) with layered color emoji (rain/snow/thunder/fog/cloud/sun/moon), file-cached with 1h TTL + offline fallback. Weather as full device type (IWeatherDriver) with equipment/profile integration
 - [x] Planner: show Moon phase + position — altitude curve on the chart with phase emoji (hemisphere-aware). Uses Meeus lunar ephemeris via VSOP87a pipeline
 - [ ] Moon penalty in target scoring — penalise targets within ~30° of a bright Moon (illumination × proximity factor). Compute angular separation per target in ObservationScheduler.ScoreTarget
-- [ ] Live viewer: camera switching — allow selecting which OTA's camera to preview in both GUI MiniViewer and TUI Sixel preview (currently always shows first available)
+- [ ] Live viewer: camera switching — allow selecting which OTA's camera to preview in both GUI MiniViewer and TUI Sixel preview (currently always shows first available). PARTIAL (verified 2026-06-02): GUI DONE (`MiniViewerState.SelectedCameraIndex` + `#1`/`#2` toolbar toggles, `LiveSessionTab.cs:373`); TUI Sixel preview still always takes first available (`TuiLiveSessionTab.cs:644`).
 - [x] Guider graph: connect dots with lines (Bresenham or anti-aliased) instead of scatter dots — users expect smooth curves like PHD2
 - [x] Guider graph: scrolling window (last N samples) with dynamic Y scale and grid lines at integer arcsec
 - [x] Guider graph: reuse the existing LiveSessionTab guide graph widget — the guider tab should show a larger version of the same graph, not a separate implementation. Extract shared graph rendering
@@ -48,7 +48,7 @@
   - [x] `FakeGuider`: generate synthetic guide frames with star field
   - [x] GUI: guide camera Canvas + crosshair overlay + SNR + frame counter
   - [x] GUI: star profile panel with 1D H/V intensity cross-sections + Gaussian fits + FWHM
-  - [ ] PHD2: no image (show placeholder), SNR/mass from event stream only
+  - [ ] PHD2: no image (show placeholder), SNR/mass from event stream only. PARTIAL (verified 2026-06-02): placeholder DONE (`GuiderTabState.PlaceholderReason`); SNR/mass from PHD2 event stream still TODO (`OpenPHD2GuiderDriver` leaves `GuideStarSNR` null).
 - [x] Live session: show dither state — guider header shows `[Settling 0.42px]` with live distance, `[Paused (Slewing)]` during slews, correction arrows `[Guiding →142ms ↑38ms]`
 - [ ] Cooling graph: same scrolling window treatment
 - [ ] VSOP87 vectorization — convert 43K lines of hardcoded `amplitude * Cos(phase + frequency * t)` into coefficient arrays, evaluate with `Vector256<double>` (AVX2). Process 4 terms per iteration. Requires source generator or one-time conversion of all planet files (EarthX/Y/Z, MarsX/Y/Z, etc.)
@@ -56,11 +56,11 @@
 - [ ] Equipment tab: fully data-driven profile panel — replace hardcoded `RenderProfileSlot` calls (mount, guider, guider cam/foc) with a declarative slot model that includes special sections (site editing, focal length input, device settings) as metadata. Currently core slots are hardcoded and only "extra" slots (weather, future types) are rendered dynamically via `EquipmentContent.GetExtraProfileSlots`. Goal: single loop over all slots with pluggable section renderers.
 - [ ] Equipment tab: generic per-device settings pane — each device type (camera, mount, guider, etc.) should declare configurable properties via URI query params (like BuiltInGuiderDevice), and the equipment tab renders them automatically. FakeDevice should carry PE amplitude, period, guide rate etc. as URI params so FakeCameraDriver initializes from them instead of hardcoded defaults
 - [ ] Fake camera: shift/change star field during slews — currently renders the same fixed seed regardless of mount pointing
-- [ ] Fake camera: scale synthetic background noise with exposure duration in `SyntheticStarFieldRenderer` — long subs (≥60s) have unrealistically clean backgrounds, causing per-channel stretch to produce degenerate parameters. Real cameras accumulate sky glow + dark current + read noise over time.
+- [x] Fake camera: scale synthetic background noise with exposure duration in `SyntheticStarFieldRenderer` — long subs (≥60s) have unrealistically clean backgrounds, causing per-channel stretch to produce degenerate parameters. Real cameras accumulate sky glow + dark current + read noise over time. DONE (2026-06-02): sky background scales by exposure on all paths (`skyLevel = skyBackground * exposureSeconds`, `SyntheticStarFieldRenderer.cs:132,270,836`); star flux scales too, read noise stays fixed (correct).
 
 - [x] Fake filter wheels should have pre-installed filters (realistic filter sets per device ID)
 - [ ] Planner: disambiguate duplicate common names — when multiple catalog entries share the same display name (e.g. NGC 4038 and NGC 4039 both named "Antennae Galaxies"), append the catalog designation in brackets: "Antennae Galaxies (NGC 4038)"
-- [ ] Planner: full rescan when site coordinates change significantly (>1°) instead of fast-path recompute — currently changing lat from -37 to 50 keeps southern-hemisphere targets with 0° altitude
+- [x] Planner: full rescan when site coordinates change significantly (>1°) instead of fast-path recompute — currently changing lat from -37 to 50 keeps southern-hemisphere targets with 0° altitude. DONE (2026-06-02): `AppSignalHandler.cs:489-510` runs full `ComputeTonightsBestAsync` when |Δlat| or |Δlon| > 1°, else fast-path `RecomputeForDate`.
 - [ ] Extract VkImageRenderer UI layout to Abstractions — toolbar, file list, status bar, hit testing are renderer-agnostic; image rendering + texture upload stay Vulkan-specific in Shared
 - [ ] Viewer tab renders at (0,0) ignoring contentRect — refactor ImageRendererBase.Render to accept a contentRect like PlannerTab/SessionTab/EquipmentTab so it works correctly when embedded in the tabbed GUI
 - [x] Pinned items in planner should persist to disk — auto-save/load via `PlannerPersistence` keyed by profile+date, stored under `{OutputFolder}/Planner/{profileId}/{date}.json`
@@ -260,7 +260,7 @@
 
 - [ ] Free unmanaged resources and override finalizer in `External.Dispose` (`External.cs:85-91`)
 - [ ] Actually ensure that FITS library writes async (`IExternal.cs:226`)
-- [ ] Write an MCP server for TianWen (expose session status, device state, observation schedule)
+- [ ] Write an MCP server for TianWen (expose session status, device state, observation schedule). PARTIAL (verified 2026-06-02): `TianWen.AI.MCP` (`tianwen-mcp`) ships `FitsTools` (Header/Stats/FindStars/PlateSolve/Pixels), `CatalogTools` (Lookup), `LogTools` (Tail). Session-status / device-state / observation-schedule tools still TODO (planned `stack.*`/`profile.*`/`devices.*`/`app.*` categories are doc-only in `Program.cs`).
 
 ## Imaging
 
@@ -344,7 +344,7 @@ Learnings from PixInsight Statistical Stretch (SetiAstro, v2.3).
 ## FITS Viewer
 
 - [ ] Rename HDR button/label to "Compress Highlights"
-- [ ] Remove debug `Console.Error.WriteLine` WCS output from `Program.cs`
+- [x] Remove debug `Console.Error.WriteLine` WCS output from `Program.cs` DONE (2026-06-02): none present in `TianWen.UI.FitsViewer/Program.cs` (all logging via `ILogger`).
 - [x] Support rec601/rec2020 luminance weighting options in luma stretch (2026-05-11) — see Stretch / Image Processing section.
 - [ ] Grid label formatting: show arc-seconds for very narrow FOVs
 - [ ] Crosshair / reticle overlay at image center
@@ -385,7 +385,7 @@ Learnings from PixInsight Statistical Stretch (SetiAstro, v2.3).
 
 - [ ] `ObjectType.IsStar()` helper method
 - [ ] VDB has objects listed as `Be*`, but in HIP we only know stars (`*`) (`CelestialObjectDBTests.cs:73`)
-- [ ] Read WCS from FITS file in `FakePlateSolver` (`FakePlateSolver.cs:26`)
+- [x] Read WCS from FITS file in `FakePlateSolver` (`FakePlateSolver.cs:26`) DONE (2026-06-02): `SolveFileAsync` falls back to `Image.TryReadFitsFile(...)` WCS when no `CatalogPlateSolver` is injected (`FakePlateSolver.cs:50-54`).
 - [ ] See if fake mounts (`FakeMountDriver` and `FakeMeadeLX200ProtocolMountDriver`) can share a mount-specific base class
 
 ## Statistics
@@ -455,3 +455,70 @@ Dispatch order on CR2 import: try spectral matrix first (best — first-principl
 - [x] Touch input: pinch-to-zoom via `SDL_EVENT_FINGER_*` events — two-finger tracking + scale computation in `SdlEventLoop` (`OnPinch`/`OnPinchEnd`), consumed by `SkyMapTab` via `InputEvent.Pinch`/`PinchEnd` (2f0b484)
 
 Vulkan/SDL migration rationale moved to `../SdlVulkan.Renderer/README.md` ("Rationale: Why SDL3 + Vortice.Vulkan" section).
+
+## Inbox: consolidated from Slack self-notes (2026-06-02)
+
+New, still-actionable TianWen items lifted from the Slack "messages to self" brain-dump (Mar-May 2026),
+deduped against the rest of this file. Date in parens is when the note was written. Triage into the
+sections above when picked up. Notes that turned out to be already DONE or already tracked elsewhere are
+intentionally NOT repeated here.
+
+### Sky Map
+- [ ] Search box + click-to-goto (slew to clicked object) (2026-04-16)
+- [ ] Compass markers + horizon markers (2026-04-16)
+- [ ] "N" key jumps the sky to local midnight (2026-04-18) (pairs with the time-adjuster item above)
+- [ ] "Show in planner" action from the sky map (2026-04-18)
+- [ ] Compute edge crossings (clip constellation / grid lines at the viewport edge) (2026-04-04)
+- [ ] Load Gaia stars from Stellarium `.dat` files (the 3-vector unit-pos pipeline is already DONE; only the loader is missing) (2026-04-04, 2026-05-19)
+- [ ] Bake a nebulosity layer into the baked Milky Way background image (2026-04-18)
+- [ ] Share more rendering code between the Sky Map and the FITS viewer (2026-04-04)
+
+### Planner / Session GUI
+- [ ] Second planner view: all unique pinned objects plotted over their bounding visibility timespan (2026-04-18) (confirmed not implemented)
+- [ ] Indicate a "light" / coverage marker under targets that actually have scheduled exposure time (2026-03-25) (the Tonight tab already goes read-only with Start disabled during a running session; only the per-target coverage marker is missing)
+- [ ] Site change should unpin pinned targets when coordinates change, and must NOT invalidate cooler setpoint temps (2026-03-27) (unpin: confirmed not done)
+- [ ] Planner input bugs: Ctrl+V paste does nothing, input field too small, Enter does not commit the "Today" date edit (2026-04-07)
+- [ ] Replace the Live Session tab icon with a Milky Way image (2026-03-24) (currently the camera-flash emoji)
+- [ ] Make the Windows taskbar entry more dynamic (progress / session state) (2026-04-02)
+
+### Equipment / device UX
+- [ ] Gate "Connect All" on discovery completion (2026-04-30)
+- [ ] Clicking a device class should ensure all devices of that class are visible; vendor text is hard to read (2026-04-23)
+- [ ] Better feedback than logging "Expected Camera, got mount" on a type mismatch (2026-04-23)
+- [ ] "Hold Shift reveals extra options" pattern (e.g. Shift on discover; Shift = loop instead of single-click preview) (2026-04-16)
+- [ ] Manual device creator UI (host / port fields) (2026-04-20) (overlaps the "Add unseen device" OnStep follow-up above)
+
+### Sequencing / Session
+- [ ] Avoid auto-focus when approaching the meridian (2026-05-14)
+- [ ] Custom horizon file support (2026-03-17) (overlaps the deferred horizon-mask sub-plan)
+- [ ] Configurable parking position (2026-03-17)
+- [ ] Memoize pier side / polarity (2026-03-17)
+- [ ] Spares: compute from higher-priority list items that conflict with the accepted schedule, prefer same object type (2026-03-23) (refines the existing spare-target fallback)
+- [ ] Revisit imaging / guider / polar-align loop tick rate; see if it can be increased in real (non-fake) time (2026-05-01) (pairs with the GCD/6 faster-tick item above)
+
+### Drivers / hardware
+- [ ] Canon lens stepper as a special focuser: model manual vs automatic telephoto lenses as a special optical system so we know when auto-focus is usable; test that manual focus works during a session (2026-04-19)
+
+### Stacker (no section exists yet)
+- [ ] Support 3rd-party master frames (bias/dark/flat from other tools) (2026-05-19)
+- [ ] Auto-pick flats by matching object time + filter (2026-05-19)
+- [ ] Download Gaia SP stars (2026-05-19) (same source as the Sky Map Gaia loader)
+
+### Stretch / Astrometry
+- [ ] Auto-stretch ("MML") should use the object DB for grounding (object type + shape) (2026-05-07)
+- [ ] Debug why so few stars match in Tycho-2 SPCC (2026-05-19)
+- [ ] MCP: "best of tonight / this week / this month" tools (2026-05-21) (pairs with the MCP server + generalise-TonightsBest items above)
+
+### Build / infra / docs
+- [ ] Shrink git fetch size (~500 MB of `.zip` / `.gz` / `.lzip` data files) (2026-04-19)
+- [ ] Create a subset of the emoji font to cut size (2026-03-26) (pairs with fetch-size)
+- [ ] Mention FC.SDK in the skills docs (2026-04-19)
+- [ ] Investigate AOT trim warnings: LibUsbDotNet (IL2104 / IL3053), CSharpFITS (IL3053) (2026-04-19)
+- [ ] CI: ensure publish does not run while tests are still going; reduce server AOT publish warnings (2026-04-19)
+- [ ] App self-update detection (2026-04-26)
+
+### Code quality
+- [ ] Move `RGBAColor32Extensions.cs` to a base layer (DIR.Lib) (2026-04-26)
+- [ ] Use `Vector2` where we currently pass `PointF`-style pairs (2026-04-10)
+- [ ] Document / clarify how `ResilientCall` interacts with collision detection (2026-04-26)
+- [ ] Maybe support .NET Standard 2.0 for wider lib reuse (2026-05-02)

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -60,8 +60,11 @@
     <!-- SDL3 + Vulkan packages -->
     <!-- DIR.Lib 4.0 dropped its phantom codec dependencies (SharpAstro.Tiff/.Exif/.Color.Icc
          are not used by DIR.Lib source). BoxRasterizer.RenderToRgba now returns RgbaImage
-         instead of a (byte[], int, int) tuple. -->
-    <PackageVersion Include="DIR.Lib" Version="4.0.*" />
+         instead of a (byte[], int, int) tuple.
+         4.4 adds renderer clip hooks (PushClip/PopClip) + TabBar / FontFallbackResolver
+         widgets. Lockstep with SdlVulkan.Renderer 5.1, which implements the clip hooks
+         via Vulkan scissor, so the two must move together. -->
+    <PackageVersion Include="DIR.Lib" Version="4.4.*" />
     <!-- DIR.Lib 3.0 extracted its codec layer to these sibling packages, which
          ship as a lockstep family from the StbImageSharp repo. 3.0 brought a
          binary-breaking SharpAstro.Tiff change (TiffPageOptions.IccProfile is
@@ -87,8 +90,9 @@
     <PackageVersion Include="Console.Lib" Version="2.12.*" />
     <!-- SdlVulkan.Renderer 5.0 adds a multi-page SDF glyph atlas (no more grow
          stall / Adreno submit-wedge) on top of 4.1's SetSystemCursor + anisotropic
-         glyph xScale. Still DIR.Lib 4.0 transitive (the 5.0 bump is renderer-side only). -->
-    <PackageVersion Include="SdlVulkan.Renderer" Version="5.0.*" />
+         glyph xScale. 5.1 implements DIR.Lib 4.4's PushClip/PopClip via Vulkan
+         scissor, in lockstep with DIR.Lib 4.4 (see above). -->
+    <PackageVersion Include="SdlVulkan.Renderer" Version="5.1.*" />
     <PackageVersion Include="SDL3-CS" Version="3.5.0-preview.20260213-150035" />
     <PackageVersion Include="SDL3-CS.Native" Version="3.5.0-preview.20260205-174353" />
     <!-- Canon DSLR -->

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -87,7 +87,10 @@
          other SharpAstro codec siblings. -->
     <PackageVersion Include="SharpAstro.Jxr" Version="3.2.*" />
     <PackageVersion Include="SharpAstro.Exr" Version="3.2.*" />
-    <PackageVersion Include="Console.Lib" Version="2.12.*" />
+    <!-- Console.Lib 2.17 adds ScrollableList + TreeView opt-in auto wheel routing
+         (on top of 2.13-2.16 widget work). Built on DIR.Lib 4.4, same sibling
+         family as SdlVulkan.Renderer 5.1. -->
+    <PackageVersion Include="Console.Lib" Version="2.17.*" />
     <!-- SdlVulkan.Renderer 5.0 adds a multi-page SDF glyph atlas (no more grow
          stall / Adreno submit-wedge) on top of 4.1's SetSystemCursor + anisotropic
          glyph xScale. 5.1 implements DIR.Lib 4.4's PushClip/PopClip via Vulkan

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -85,10 +85,10 @@
     <PackageVersion Include="SharpAstro.Jxr" Version="3.2.*" />
     <PackageVersion Include="SharpAstro.Exr" Version="3.2.*" />
     <PackageVersion Include="Console.Lib" Version="2.12.*" />
-    <!-- SdlVulkan.Renderer 4.1 adds SdlVulkanWindow.SetSystemCursor (needed by the
-         FITS viewer hover cursors) + anisotropic glyph xScale. Still DIR.Lib 4.0
-         transitive (the 4.1 bump is renderer-side only). -->
-    <PackageVersion Include="SdlVulkan.Renderer" Version="4.1.*" />
+    <!-- SdlVulkan.Renderer 5.0 adds a multi-page SDF glyph atlas (no more grow
+         stall / Adreno submit-wedge) on top of 4.1's SetSystemCursor + anisotropic
+         glyph xScale. Still DIR.Lib 4.0 transitive (the 5.0 bump is renderer-side only). -->
+    <PackageVersion Include="SdlVulkan.Renderer" Version="5.0.*" />
     <PackageVersion Include="SDL3-CS" Version="3.5.0-preview.20260213-150035" />
     <PackageVersion Include="SDL3-CS.Native" Version="3.5.0-preview.20260205-174353" />
     <!-- Canon DSLR -->

--- a/src/TianWen.Lib.Tests.Functional/FakeCameraMountCouplingTests.cs
+++ b/src/TianWen.Lib.Tests.Functional/FakeCameraMountCouplingTests.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using TianWen.Lib.Devices;
 using TianWen.Lib.Devices.Fake;
+using TianWen.Lib.Devices.Guider;
 using TianWen.Lib.Imaging;
 using Xunit;
 
@@ -37,15 +38,16 @@ public class FakeCameraMountCouplingTests(ITestOutputHelper output)
             .AddSingleton<IDeviceHub, DeviceHub>()
             .BuildServiceProvider();
 
-    private static async Task<IMountDriver> ConnectMisalignedMountAsync(IDeviceHub hub, CancellationToken ct)
+    private static async Task<IMountDriver> ConnectMisalignedMountAsync(IDeviceHub hub, CancellationToken ct,
+        double azArcmin = TestAzMisalignArcmin, double altArcmin = TestAltMisalignArcmin)
     {
         var mountDevice = new FakeDevice(DeviceType.Mount, 1, new NameValueCollection
         {
             { "port", "SkyWatcher" },
             { "latitude", "48.2" },
             { "longitude", "16.3" },
-            { "polarMisalignmentAzArcmin", TestAzMisalignArcmin.ToString() },
-            { "polarMisalignmentAltArcmin", TestAltMisalignArcmin.ToString() }
+            { "polarMisalignmentAzArcmin", azArcmin.ToString() },
+            { "polarMisalignmentAltArcmin", altArcmin.ToString() }
         });
         var mount = (IMountDriver)await hub.ConnectAsync(mountDevice, ct);
         await mount.SetSiteLatitudeAsync(48.2, ct);
@@ -136,5 +138,114 @@ public class FakeCameraMountCouplingTests(ITestOutputHelper output)
         var drift = mainCam.CurrentMountDriftPixels;
         drift.X.ShouldBe(0.0, "the main imaging camera does not couple to the mount drift");
         drift.Y.ShouldBe(0.0);
+    }
+
+    /// <summary>
+    /// The end-to-end scenario the user hit in the GUI: the built-in guider calibrating
+    /// and guiding against the misaligned <see cref="FakeSkywatcherMountDriver"/> through
+    /// a coupled <see cref="FakeCameraDriver"/> guide camera, with ST-4 pulses routed to
+    /// the camera (<c>pulseGuideSource=Camera</c> -- the Test profile's setting). Asserts
+    /// the loop calibrates, reaches Guiding, and then STAYS locked with bounded RMS for
+    /// minutes while the mount keeps drifting -- the corrections null the misalignment drift.
+    /// <para>
+    /// Requires <see cref="FakeTimeProviderWrapper.ExternalTimePump"/> so this pump is the
+    /// SOLE clock: otherwise the guide loop's own <c>SleepAsync</c> calls advance fake time
+    /// too, and the two competing clocks scramble the exposure/correction cadence into a
+    /// spurious limit cycle (a test artifact, not a real guiding fault).
+    /// </para>
+    /// </summary>
+    [Fact(Timeout = 120_000)]
+    public async Task GivenBuiltInGuiderWithMisalignedSkywatcherAndCameraPulseWhenCalibrateAndGuideThenStaysLockedWhileMountDrifts()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var timeProvider = new FakeTimeProviderWrapper(new DateTimeOffset(2025, 6, 15, 22, 0, 0, TimeSpan.Zero));
+        var external = new FakeExternal(output, timeProvider);
+        await using var sp = BuildHubServiceProvider(external);
+        var hub = sp.GetRequiredService<IDeviceHub>();
+
+        // Misaligned SkyWatcher, tracking, centred away from the pole (alignment learned
+        // -> the residual polar-axis drift is now what the guider must chase).
+        var mount = await ConnectMisalignedMountAsync(hub, ct);
+        await mount.SetTrackingAsync(true, ct);
+        await mount.SyncRaDecAsync(6.0, 45.0, ct);
+
+        // Guide camera: URI names it GuideCam (couples to the mount drift); shrink the
+        // readout so the per-frame render stays cheap across the long calibrate+guide loop.
+        var guideCam = (FakeCameraDriver)await hub.ConnectAsync(
+            new FakeDevice(new Uri("camera://FakeDevice/FakeGuideCam1#Fake Guide Cam")), ct);
+        guideCam.FocalLength = 130;
+        guideCam.BinX = 1;
+        guideCam.NumX = 800;
+        guideCam.NumY = 600;
+
+        // Built-in guider with ST-4 routed to the camera -- exactly the Test profile.
+        var guiderDevice = new BuiltInGuiderDevice(
+            new Uri("guider://BuiltInGuiderDevice/builtin?pulseGuideSource=Camera#Built-in Guider"));
+        var guider = new BuiltInGuiderDriver(guiderDevice, sp);
+        await guider.ConnectAsync(ct);
+        guider.LinkDevices(mount, guideCam);
+
+        string? guidingError = null;
+        guider.GuidingErrorEvent += (_, e) => guidingError = e.Message;
+
+        // Drive time SOLELY from this pump now -- otherwise the guide loop's own
+        // SleepAsync calls would also advance fake time, racing the pump and
+        // scrambling the exposure<->correction timing.
+        timeProvider.ExternalTimePump = true;
+
+        // Kick off calibration + guiding (runs as a background task).
+        await guider.GuideAsync(settlePixels: 1.5, settleTime: 3.0, settleTimeout: 90.0, ct);
+
+        // Cooperative time pump: advance fake time so exposures complete and the loop
+        // iterates, yielding to the background task between steps. Never SleepAsync here.
+        var increment = TimeSpan.FromMilliseconds(250);
+        var pumped = TimeSpan.Zero;
+        var cap = TimeSpan.FromMinutes(10);
+        while (pumped < cap && guidingError is null && !await guider.IsGuidingAsync(ct))
+        {
+            timeProvider.Advance(increment);
+            pumped += increment;
+            await Task.Delay(1, ct);
+        }
+
+        // Calibration must have acquired a star, measured rates/angle, and settled --
+        // i.e. the built-in guider calibrates cleanly against the misaligned SkyWatcher
+        // + coupled guide cam with ST-4 on the camera (the exact Test-profile scenario).
+        guidingError.ShouldBeNull("calibration must not raise an error (acquire star + measure displacement)");
+        (await guider.IsGuidingAsync(ct)).ShouldBeTrue(
+            "the guider must reach the Guiding state after calibrating + settling against the misaligned mount");
+
+        // At settle the lifetime RMS is tiny -- both axes converged cleanly.
+        var settleStats = await guider.GetStatsAsync(ct);
+        settleStats.ShouldNotBeNull();
+        output.WriteLine(
+            $"At-settle: TotalRMS={settleStats.TotalRMS:F2}\" RaRMS={settleStats.RaRMS:F2}\" DecRMS={settleStats.DecRMS:F2}\"");
+        settleStats.TotalRMS.ShouldBeLessThan(3.0, "calibration + settle must converge cleanly (sub-3\" RMS)");
+
+        // Guide for ~2 more minutes of fake time: the misaligned mount keeps drifting
+        // (mostly Dec) the whole time, but the guider's camera ST-4 corrections null it,
+        // so guiding stays locked. (Earlier this looked unstable -- that was a test bug:
+        // without ExternalTimePump the guide loop's own SleepAsync calls advanced fake
+        // time AND so did the pump, two clocks racing. With a single clock the loop is
+        // rock-solid; the GuideLoop itself was never at fault.)
+        for (var i = 0; i < 700 && guidingError is null && !ct.IsCancellationRequested; i++)
+        {
+            timeProvider.Advance(increment);
+            await Task.Delay(1, ct);
+        }
+        guidingError.ShouldBeNull("guiding must stay healthy while the mount drifts");
+        (await guider.IsGuidingAsync(ct)).ShouldBeTrue("guiding must stay locked, not fall out");
+
+        var sustainedStats = await guider.GetStatsAsync(ct);
+        sustainedStats.ShouldNotBeNull();
+        output.WriteLine(
+            $"Sustained: TotalRMS={sustainedStats.TotalRMS:F2}\" RaRMS={sustainedStats.RaRMS:F2}\" " +
+            $"DecRMS={sustainedStats.DecRMS:F2}\" PeakRa={sustainedStats.PeakRa:F2}\" PeakDec={sustainedStats.PeakDec:F2}\"");
+        // The corrections track the drift -> bounded RMS, NOT the runaway we saw with the
+        // broken two-clock harness. Generous bound: the mount drift + PE residual + centroid
+        // noise should stay well under a few arcsec on this coarse (~3.8"/px) guide scope.
+        sustainedStats.TotalRMS.ShouldBeLessThan(5.0, "sustained guiding must stay locked against the drift");
+
+        await guider.StopCaptureAsync(TimeSpan.FromSeconds(5), ct);
     }
 }

--- a/src/TianWen.Lib.Tests.Functional/FakeCameraMountCouplingTests.cs
+++ b/src/TianWen.Lib.Tests.Functional/FakeCameraMountCouplingTests.cs
@@ -1,0 +1,140 @@
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using System;
+using System.Collections.Specialized;
+using System.Threading;
+using System.Threading.Tasks;
+using TianWen.Lib.Devices;
+using TianWen.Lib.Devices.Fake;
+using TianWen.Lib.Imaging;
+using Xunit;
+
+namespace TianWen.Lib.Tests.Functional;
+
+/// <summary>
+/// Part 2 of the fake-mount misalignment work: the guide camera couples its
+/// rendered star field to the connected mount's misalignment drift. The camera
+/// self-resolves the mount from the device hub (mirroring how it self-resolves
+/// the catalog DB), so the session / shared layer stays unaware of the coupling.
+/// These tests exercise the real <see cref="DeviceHub"/> resolution path.
+/// </summary>
+public class FakeCameraMountCouplingTests(ITestOutputHelper output)
+{
+    private const double TestAzMisalignArcmin = 30.0;
+    private const double TestAltMisalignArcmin = -10.0;
+
+    /// <summary>
+    /// Builds a service provider that registers a real <see cref="DeviceHub"/> so a
+    /// camera connected through it can self-resolve the connected mount. The hub is
+    /// constructed by DI with this same provider, so the camera's
+    /// <see cref="FakeDeviceDriverBase.ServiceProvider"/> resolves the very same hub.
+    /// </summary>
+    private static ServiceProvider BuildHubServiceProvider(FakeExternal external) =>
+        new ServiceCollection()
+            .AddSingleton<IExternal>(external)
+            .AddSingleton<ITimeProvider>(external.TimeProvider)
+            .AddLogging()
+            .AddSingleton<IDeviceHub, DeviceHub>()
+            .BuildServiceProvider();
+
+    private static async Task<IMountDriver> ConnectMisalignedMountAsync(IDeviceHub hub, CancellationToken ct)
+    {
+        var mountDevice = new FakeDevice(DeviceType.Mount, 1, new NameValueCollection
+        {
+            { "port", "SkyWatcher" },
+            { "latitude", "48.2" },
+            { "longitude", "16.3" },
+            { "polarMisalignmentAzArcmin", TestAzMisalignArcmin.ToString() },
+            { "polarMisalignmentAltArcmin", TestAltMisalignArcmin.ToString() }
+        });
+        var mount = (IMountDriver)await hub.ConnectAsync(mountDevice, ct);
+        await mount.SetSiteLatitudeAsync(48.2, ct);
+        await mount.SetSiteLongitudeAsync(16.3, ct);
+        return mount;
+    }
+
+    /// <summary>
+    /// Arm-and-abort an exposure: this triggers the async mount-pointing snapshot in
+    /// <see cref="FakeCameraDriver.StartExposureAsync"/> without paying for a rendered
+    /// frame (the drift offset is what we assert on, not the pixels).
+    /// </summary>
+    private static async Task SnapshotPointingAsync(FakeCameraDriver camera, CancellationToken ct)
+    {
+        await camera.StartExposureAsync(TimeSpan.FromSeconds(2), FrameType.Light, ct);
+        await camera.AbortExposureAsync(ct);
+    }
+
+    [Fact(Timeout = 60_000)]
+    public async Task GivenGuideCameraCoupledToMisalignedMountWhenTrackingThenStarFieldDriftsWithMount()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var external = new FakeExternal(output, now: new DateTimeOffset(2025, 6, 15, 22, 0, 0, TimeSpan.Zero));
+        await using var sp = BuildHubServiceProvider(external);
+        var hub = sp.GetRequiredService<IDeviceHub>();
+
+        var mount = await ConnectMisalignedMountAsync(hub, ct);
+
+        // Guide camera: the URI names it "GuideCam" so the driver both picks the
+        // IMX178M preset and couples to the mount. FL=130mm @ 2.4um -> ~3.8"/px.
+        var guideCamUri = new Uri("camera://FakeDevice/FakeGuideCam1#Fake Guide Cam");
+        var guideCam = (FakeCameraDriver)await hub.ConnectAsync(new FakeDevice(guideCamUri), ct);
+        guideCam.FocalLength = 130;
+
+        // Plate-solve sync away from the pole: static offset learned, drift armed.
+        await mount.SyncRaDecAsync(6.0, 45.0, ct);
+
+        // First guide exposure captures the zero-drift reference -> star centred.
+        await SnapshotPointingAsync(guideCam, ct);
+        var atRef = guideCam.CurrentMountDriftPixels;
+        Math.Abs(atRef.X).ShouldBeLessThan(0.05, "the guide star starts centred at acquisition");
+        Math.Abs(atRef.Y).ShouldBeLessThan(0.05);
+
+        // Track 5 sidereal minutes -> the misaligned mount drifts (mostly Dec); the
+        // next snapshot reflects it on the guide sensor.
+        external.TimeProvider.Advance(TimeSpan.FromMinutes(5));
+        await SnapshotPointingAsync(guideCam, ct);
+        var at5 = guideCam.CurrentMountDriftPixels;
+        var mag5 = Math.Sqrt(at5.X * at5.X + at5.Y * at5.Y);
+        output.WriteLine($"5min guide-star drift: X={at5.X:F2}px Y={at5.Y:F2}px mag={mag5:F2}px");
+
+        // ~28" Dec / 3.8"/px ~ 7.5px after 5 min: a real, mostly-Dec, non-runaway drift.
+        mag5.ShouldBeGreaterThan(1.0, "the guide star must drift as the mount does");
+        mag5.ShouldBeLessThan(60.0, "drift must stay realistic, not run away");
+        Math.Abs(at5.Y).ShouldBeGreaterThan(Math.Abs(at5.X), "polar-misalignment drift is predominantly in Dec");
+
+        // Drift accumulates with tracking time.
+        external.TimeProvider.Advance(TimeSpan.FromMinutes(5));
+        await SnapshotPointingAsync(guideCam, ct);
+        var at10 = guideCam.CurrentMountDriftPixels;
+        var mag10 = Math.Sqrt(at10.X * at10.X + at10.Y * at10.Y);
+        output.WriteLine($"10min guide-star drift: mag={mag10:F2}px");
+        mag10.ShouldBeGreaterThan(mag5, "guide-star drift grows with tracking time");
+    }
+
+    [Fact(Timeout = 60_000)]
+    public async Task GivenMainImagingCameraWhenTrackingMisalignedMountThenNoCouplingDrift()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var external = new FakeExternal(output, now: new DateTimeOffset(2025, 6, 15, 22, 0, 0, TimeSpan.Zero));
+        await using var sp = BuildHubServiceProvider(external);
+        var hub = sp.GetRequiredService<IDeviceHub>();
+
+        var mount = await ConnectMisalignedMountAsync(hub, ct);
+
+        // A main imaging camera (URI does NOT name it GuideCam). It renders at its
+        // stamped Target and must not double-count the mount drift, or the session's
+        // plate-solve centering loop would fight a phantom offset.
+        var mainCam = (FakeCameraDriver)await hub.ConnectAsync(new FakeDevice(DeviceType.Camera, 1), ct);
+        mainCam.FocalLength = 600;
+
+        await mount.SyncRaDecAsync(6.0, 45.0, ct);
+
+        await SnapshotPointingAsync(mainCam, ct);
+        external.TimeProvider.Advance(TimeSpan.FromMinutes(10));
+        await SnapshotPointingAsync(mainCam, ct);
+
+        var drift = mainCam.CurrentMountDriftPixels;
+        drift.X.ShouldBe(0.0, "the main imaging camera does not couple to the mount drift");
+        drift.Y.ShouldBe(0.0);
+    }
+}

--- a/src/TianWen.Lib.Tests.Functional/FakeSkywatcherMountDriverTests.cs
+++ b/src/TianWen.Lib.Tests.Functional/FakeSkywatcherMountDriverTests.cs
@@ -428,5 +428,61 @@ public class FakeSkywatcherMountDriverTests(ITestOutputHelper output)
         (await mount.GetDeclinationAsync(ct)).ShouldBe(-45.0, 0.01);
     }
 
+    [Fact(Timeout = 60_000)]
+    public async Task GivenMisalignedMountWhenTrackingAfterSyncThenFieldDriftsSlowlyAndAccumulates()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var (mount, external) = await CreateConnectedMountAsync(
+            ct, azMisalignmentArcmin: TestAzMisalignArcmin, altMisalignmentArcmin: TestAltMisalignArcmin);
+
+        // Plate-solve sync away from the pole: the static offset is learned, and
+        // the drift reference is set to this freshly-centred position.
+        await mount.SyncRaDecAsync(6.0, 45.0, ct);
+        mount.IsAlignmentCorrected.ShouldBeTrue();
+
+        // At the moment of sync the field sits exactly on target (zero residual) --
+        // this is what lets the centering loop converge.
+        var ra0 = await mount.GetRightAscensionAsync(ct);
+        var dec0 = await mount.GetDeclinationAsync(ct);
+        ra0.ShouldBe(6.0, 0.02);
+        dec0.ShouldBe(45.0, 0.02);
+
+        // Track for 5 sidereal minutes -- the misaligned axis leaks a slow drift.
+        external.TimeProvider.Advance(TimeSpan.FromMinutes(5));
+        var ra5 = await mount.GetRightAscensionAsync(ct);
+        var dec5 = await mount.GetDeclinationAsync(ct);
+
+        var drift5Arcsec = GreatCircleArcsec(ra0, dec0, ra5, dec5);
+        var decDrift5Arcsec = Math.Abs(dec5 - dec0) * 3600.0;
+        output.WriteLine($"5min: total drift={drift5Arcsec:F1}\"  dec drift={decDrift5Arcsec:F1}\"");
+
+        // Realistic polar-misalignment drift for ~30': tens of arcsec over 5 min --
+        // NOT zero (the old "learned alignment zeroes everything" bug) and NOT
+        // degrees (a runaway). Rule of thumb ~0.25"/min per arcmin -> ~40"/5min.
+        drift5Arcsec.ShouldBeGreaterThan(3.0, "a misaligned mount must drift while tracking");
+        drift5Arcsec.ShouldBeLessThan(900.0, "drift must stay realistic, not run away");
+
+        // Drift accumulates with elapsed tracking time (track 5 more minutes).
+        external.TimeProvider.Advance(TimeSpan.FromMinutes(5));
+        var ra10 = await mount.GetRightAscensionAsync(ct);
+        var dec10 = await mount.GetDeclinationAsync(ct);
+        var drift10Arcsec = GreatCircleArcsec(ra0, dec0, ra10, dec10);
+        output.WriteLine($"10min: total drift={drift10Arcsec:F1}\"");
+        drift10Arcsec.ShouldBeGreaterThan(drift5Arcsec, "drift grows with tracking time");
+    }
+
+    /// <summary>Great-circle separation between two (RA hours, Dec deg) points, in arcsec.</summary>
+    private static double GreatCircleArcsec(double ra1Hours, double dec1Deg, double ra2Hours, double dec2Deg)
+    {
+        var ra1 = ra1Hours * 15.0 * Math.PI / 180.0;
+        var ra2 = ra2Hours * 15.0 * Math.PI / 180.0;
+        var dec1 = dec1Deg * Math.PI / 180.0;
+        var dec2 = dec2Deg * Math.PI / 180.0;
+        var cosSep = Math.Sin(dec1) * Math.Sin(dec2)
+            + Math.Cos(dec1) * Math.Cos(dec2) * Math.Cos(ra1 - ra2);
+        var sepRad = Math.Acos(Math.Clamp(cosSep, -1.0, 1.0));
+        return sepRad * 180.0 / Math.PI * 3600.0;
+    }
+
     #endregion
 }

--- a/src/TianWen.Lib.Tests.Functional/FakeSkywatcherMountDriverTests.cs
+++ b/src/TianWen.Lib.Tests.Functional/FakeSkywatcherMountDriverTests.cs
@@ -4,6 +4,7 @@ using System.Collections.Specialized;
 using System.Threading;
 using System.Threading.Tasks;
 using TianWen.DAL;
+using TianWen.Lib.Astrometry;
 using TianWen.Lib.Devices;
 using TianWen.Lib.Devices.Fake;
 using Xunit;
@@ -282,6 +283,149 @@ public class FakeSkywatcherMountDriverTests(ITestOutputHelper output)
 
         (await mount.GetSiteLatitudeAsync(ct)).ShouldBe(48.2, 0.01);
         (await mount.GetSiteLongitudeAsync(ct)).ShouldBe(16.3, 0.01);
+    }
+
+    #endregion
+
+    #region Polar Misalignment — imaging regime
+
+    // ~30'/-10' misalignment used across the imaging-regime tests; magnitude
+    // ~0.5deg, so the pointing offset stays well inside a degree.
+    private const double TestAzMisalignArcmin = 30.0;
+    private const double TestAltMisalignArcmin = -10.0;
+
+    /// <summary>
+    /// Advance fake time in small steps until the mount reports it has stopped
+    /// slewing (or a cap is hit). The fake Skywatcher integrates its goto at
+    /// 3deg/s on a 50ms simulation timer, so the slew only progresses when fake
+    /// time advances.
+    /// </summary>
+    private static async Task PumpUntilNotSlewingAsync(FakeSkywatcherMountDriver mount, FakeExternal external, CancellationToken ct, TimeSpan max)
+    {
+        var step = TimeSpan.FromMilliseconds(200);
+        var pumped = TimeSpan.Zero;
+        while (pumped < max)
+        {
+            if (!await mount.IsSlewingAsync(ct))
+            {
+                break;
+            }
+            external.TimeProvider.Advance(step);
+            pumped += step;
+        }
+    }
+
+    [Fact]
+    public void GivenMisalignedAxisAwayFromPoleWhenApplyAxisTiltThenNearCommandedNotPole()
+    {
+        // Misaligned RA axis tilted ~0.5deg off the +Z (north) celestial pole.
+        var tiltRad = 0.5 * Math.PI / 180.0;
+        var axis = new Vec3(Math.Sin(tiltRad), 0.0, Math.Cos(tiltRad));
+
+        // Believed (commanded/encoder) pointing well away from the pole.
+        const double believedRa = 6.0;   // hours
+        const double believedDec = 45.0; // degrees
+
+        var (ra, dec) = FakeSkywatcherMountDriver.ApplyAxisTiltToPointing(
+            axis, Hemisphere.North, believedRa, believedDec);
+
+        // True pointing must track the commanded Dec to within the misalignment
+        // magnitude -- emphatically NOT snapped to the pole (the original bug).
+        dec.ShouldBe(believedDec, 1.0);
+        dec.ShouldBeLessThan(80.0);
+
+        // ...but it must NOT be identical either: the misalignment carries on so
+        // plate-solve centering has a real offset to detect and sync away.
+        var offsetDeg = Math.Abs(dec - believedDec) + Math.Abs(ra - believedRa) * 15.0;
+        offsetDeg.ShouldBeGreaterThan(0.01);
+    }
+
+    [Fact]
+    public void GivenAlignedAxisWhenApplyAxisTiltThenReturnsBelievedUnchanged()
+    {
+        // Axis exactly on the pole == no misalignment -> identity transform.
+        var pole = new Vec3(0.0, 0.0, 1.0);
+
+        var (ra, dec) = FakeSkywatcherMountDriver.ApplyAxisTiltToPointing(
+            pole, Hemisphere.North, 6.0, 45.0);
+
+        ra.ShouldBe(6.0, 1e-9);
+        dec.ShouldBe(45.0, 1e-9);
+    }
+
+    [Fact(Timeout = 60_000)]
+    public async Task GivenMisalignedMountWhenSlewedAwayFromPoleThenReportsNearTargetNotPole()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var (mount, external) = await CreateConnectedMountAsync(
+            ct, azMisalignmentArcmin: TestAzMisalignArcmin, altMisalignmentArcmin: TestAltMisalignArcmin);
+
+        // Slew Dec from the home pole down to +45; keep RA at the current LST so
+        // the RA delta is ~0 and only the Dec axis has to travel (bounds pump time).
+        var lst = await mount.GetSiderealTimeAsync(ct);
+        await mount.BeginSlewRaDecAsync(lst, 45.0, ct);
+        await PumpUntilNotSlewingAsync(mount, external, ct, TimeSpan.FromSeconds(40));
+
+        var dec = await mount.GetDeclinationAsync(ct);
+
+        // Reports ~commanded (within the misalignment magnitude), NOT the pole.
+        dec.ShouldBe(45.0, 1.5);
+        dec.ShouldBeLessThan(80.0);
+        // No plate-solve sync yet -> the misalignment is still "carried on".
+        mount.IsAlignmentCorrected.ShouldBeFalse();
+    }
+
+    [Fact(Timeout = 60_000)]
+    public async Task GivenMisalignedMountWhenPlateSolveSyncAwayFromPoleThenLearnsAlignmentAndReportsBelieved()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var (mount, _) = await CreateConnectedMountAsync(
+            ct, azMisalignmentArcmin: TestAzMisalignArcmin, altMisalignmentArcmin: TestAltMisalignArcmin);
+
+        mount.IsAlignmentCorrected.ShouldBeFalse();
+
+        // A plate-solve-driven sync to a real target (away from the pole) models
+        // the mount learning its true orientation.
+        await mount.SyncRaDecAsync(6.0, 45.0, ct);
+
+        mount.IsAlignmentCorrected.ShouldBeTrue();
+        // After correction the reported pointing is the believed (encoder)
+        // position verbatim -- no residual offset.
+        (await mount.GetRightAscensionAsync(ct)).ShouldBe(6.0, 0.01);
+        (await mount.GetDeclinationAsync(ct)).ShouldBe(45.0, 0.01);
+    }
+
+    [Fact(Timeout = 60_000)]
+    public async Task GivenMisalignedMountWhenSyncToPoleThenAlignmentNotLearned()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var (mount, _) = await CreateConnectedMountAsync(
+            ct, azMisalignmentArcmin: TestAzMisalignArcmin, altMisalignmentArcmin: TestAltMisalignArcmin);
+
+        // A sync to the pole (startup / park convention) must NOT learn alignment,
+        // or the polar-align simulation would be zeroed before it can run.
+        var lst = await mount.GetSiderealTimeAsync(ct);
+        await mount.SyncRaDecAsync(lst, 90.0, ct);
+
+        mount.IsAlignmentCorrected.ShouldBeFalse();
+    }
+
+    [Fact(Timeout = 60_000)]
+    public async Task GivenSouthernMisalignedMountWhenSyncAwayFromPoleThenLearnsAlignment()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        // Southern site -> the home pole is -90; hemisphere is driven by site lat.
+        var (mount, _) = await CreateConnectedMountAsync(
+            ct, latitude: -33.9, longitude: 18.4,
+            azMisalignmentArcmin: TestAzMisalignArcmin, altMisalignmentArcmin: TestAltMisalignArcmin);
+
+        mount.IsAlignmentCorrected.ShouldBeFalse();
+
+        // Sync to a southern target well away from the -90 pole.
+        await mount.SyncRaDecAsync(6.0, -45.0, ct);
+
+        mount.IsAlignmentCorrected.ShouldBeTrue();
+        (await mount.GetDeclinationAsync(ct)).ShouldBe(-45.0, 0.01);
     }
 
     #endregion

--- a/src/TianWen.Lib.Tests.Functional/GuideLoopTests.cs
+++ b/src/TianWen.Lib.Tests.Functional/GuideLoopTests.cs
@@ -4,6 +4,7 @@ using System;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
+using TianWen.DAL;
 using TianWen.Lib.Devices;
 using TianWen.Lib.Devices.Fake;
 using TianWen.Lib.Devices.Guider;
@@ -126,6 +127,85 @@ public class GuideLoopTests(ITestOutputHelper output)
         // With PE enabled and guiding active, the total RMS should be bounded
         guideLoop.ErrorTracker.TotalSamples.ShouldBeGreaterThan(0u);
         guideLoop.IsGuiding.ShouldBeFalse("loop should have stopped");
+    }
+
+    [Fact(Timeout = 60_000)]
+    public async Task GivenGuideLoopWhenStatsResetRequestedThenPeakAndRmsStartFresh()
+    {
+        // Models the Settling -> Guiding transition: a large transient (calibration/settle)
+        // builds a big Peak/RMS, then RequestErrorStatsReset() at the guiding hand-off must
+        // clear it so the displayed stats reflect guiding quality, not the transient.
+        var ct = TestContext.Current.CancellationToken;
+        var timeProvider = new FakeTimeProviderWrapper(new DateTimeOffset(2025, 6, 15, 22, 0, 0, TimeSpan.Zero));
+
+        // No-op pulse target: we script the star error directly so corrections never move it.
+        var pulseTarget = new NoOpPulseGuideTarget();
+
+        var tracker = new GuiderCentroidTracker(maxStars: 1);
+        var offsetX = 0.0;
+        // A single bright star at frame centre, shifted by offsetX -> fully controlled,
+        // uncontaminated error (no neighbour stars to pull the centroid).
+        ValueTask<Image> Render(CancellationToken token)
+        {
+            ReadOnlySpan<ProjectedStar> stars = [new ProjectedStar(160, 120, Magnitude: 5.0)];
+            return ValueTask.FromResult(Image.FromChannel(SyntheticStarFieldRenderer.Render(
+                320, 240, 0, stars, offsetX: offsetX, offsetY: 0,
+                exposureSeconds: 2.0, pixelScaleArcsec: PixelScaleArcsec)));
+        }
+
+        // Acquire at zero offset and lock there.
+        tracker.ProcessFrame((await Render(ct)).GetChannelArray(0));
+        tracker.IsAcquired.ShouldBeTrue();
+        tracker.SetLockPosition();
+
+        var pController = new ProportionalGuideController { AggressivenessRa = 0.7, AggressivenessDec = 0.7, MinPulseMs = 20 };
+        var guideLoop = new GuideLoop(pulseTarget, tracker, pController, timeProvider);
+        guideLoop.SetCalibration(new GuiderCalibrationResult(
+            CameraAngleRad: 0, RaRatePixPerSec: 2.0, DecRatePixPerSec: 2.0,
+            RaDisplacementPx: 18, DecDisplacementPx: 18, TotalCalibrationTimeSec: 9));
+
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        var iter = 0;
+        var peakDuringTransient = 0.0;
+        var didReset = false;
+
+        ValueTask<Image> Drive(CancellationToken token)
+        {
+            iter++;
+            if (iter <= 5)
+            {
+                offsetX = 8.0; // sustained ~8px error -> Peak/RMS grow (no-op pulse can't fix it)
+            }
+            else if (!didReset)
+            {
+                // Snapshot the large peak built up, then request the reset + clear the error.
+                peakDuringTransient = guideLoop.ErrorTracker.PeakRa;
+                guideLoop.RequestErrorStatsReset();
+                didReset = true;
+                offsetX = 0.0;
+            }
+            if (iter >= 12)
+            {
+                cts.Cancel();
+            }
+            return Render(token);
+        }
+
+        try
+        {
+            await guideLoop.RunAsync(Drive, TimeSpan.FromSeconds(GuideIntervalSeconds),
+                hourAngle: 0, declination: 45.0, siteLatitude: 48.2, cancellationToken: cts.Token);
+        }
+        catch (OperationCanceledException)
+        {
+            // Expected — cancelled after the post-reset frames.
+        }
+
+        output.WriteLine($"peakDuringTransient={peakDuringTransient:F2}px finalPeakRa={guideLoop.ErrorTracker.PeakRa:F2}px finalRaRmsAll={guideLoop.ErrorTracker.RaRmsAll:F2}px");
+
+        peakDuringTransient.ShouldBeGreaterThan(5.0, "a sustained ~8px error must build a large peak before the reset");
+        guideLoop.ErrorTracker.PeakRa.ShouldBeLessThan(2.0, "after the reset, Peak reflects only post-reset (near-zero) errors");
+        guideLoop.ErrorTracker.RaRmsAll.ShouldBeLessThan(2.0, "RMS also starts fresh after the reset");
     }
 
     [Fact(Timeout = 60_000)]
@@ -850,5 +930,15 @@ public class GuideLoopTests(ITestOutputHelper output)
 
         output.WriteLine($"Guide iterations: {iterationCount}");
         output.WriteLine($"Total samples: {guideLoop.ErrorTracker.TotalSamples}");
+    }
+
+    /// <summary>Pulse target that ignores corrections — the test scripts the star error directly.</summary>
+    private sealed class NoOpPulseGuideTarget : IPulseGuideTarget
+    {
+        public ValueTask PulseGuideAsync(GuideDirection direction, TimeSpan duration, CancellationToken cancellationToken)
+            => ValueTask.CompletedTask;
+
+        public ValueTask<bool> IsPulseGuidingAsync(CancellationToken cancellationToken)
+            => ValueTask.FromResult(false);
     }
 }

--- a/src/TianWen.Lib.Tests/GuiderCentroidTrackerTests.cs
+++ b/src/TianWen.Lib.Tests/GuiderCentroidTrackerTests.cs
@@ -203,6 +203,54 @@ public class GuiderCentroidTrackerTests(ITestOutputHelper output)
     }
 
     [Fact]
+    public void GivenBrightEdgeStarAndDimmerInteriorStarWhenAcquireWithEdgeMarginThenPicksInterior()
+    {
+        const int w = 800, h = 600;
+        // A bright star hugging the left edge + a dimmer star well inside the frame.
+        ReadOnlySpan<ProjectedStar> stars =
+        [
+            new ProjectedStar(30, 300, Magnitude: 5.0),   // brightest, but near the left edge
+            new ProjectedStar(400, 300, Magnitude: 6.0),  // dimmer, comfortably interior
+        ];
+        var frame = SyntheticStarFieldRenderer.Render(w, h, 0, stars, exposureSeconds: 2.0);
+
+        // Legacy behaviour (no margin): lock the brightest star, which sits near the edge.
+        var legacy = new GuiderCentroidTracker(maxStars: 1);
+        var rLegacy = legacy.ProcessFrame(frame);
+        rLegacy.ShouldNotBeNull();
+        rLegacy.Value.X.ShouldBeLessThan(100, "without an edge margin the brightest (edge) star is chosen");
+
+        // With an edge margin big enough to exclude the edge star: prefer the interior
+        // one even though it is dimmer -- so the calibration throw won't push it off-frame.
+        var robust = new GuiderCentroidTracker(maxStars: 1) { AcquisitionEdgeMargin = 80 };
+        var rRobust = robust.ProcessFrame(frame);
+        rRobust.ShouldNotBeNull();
+        rRobust.Value.X.ShouldBeGreaterThan(300, "with an edge margin the interior star is preferred");
+        output.WriteLine($"legacy primary X={rLegacy.Value.X:F1}, robust primary X={rRobust.Value.X:F1}");
+    }
+
+    [Fact]
+    public void GivenOnlyEdgeStarsWhenAcquireWithEdgeMarginThenStillAcquires()
+    {
+        const int w = 800, h = 600;
+        // Both stars are within the margin of an edge -> no interior candidate exists.
+        ReadOnlySpan<ProjectedStar> stars =
+        [
+            new ProjectedStar(30, 300, Magnitude: 5.0),
+            new ProjectedStar(w - 30, 300, Magnitude: 6.0),
+        ];
+        var frame = SyntheticStarFieldRenderer.Render(w, h, 0, stars, exposureSeconds: 2.0);
+
+        var tracker = new GuiderCentroidTracker(maxStars: 1) { AcquisitionEdgeMargin = 80 };
+        var result = tracker.ProcessFrame(frame);
+
+        // Fall back to the brightest overall rather than failing to acquire.
+        result.ShouldNotBeNull();
+        tracker.IsAcquired.ShouldBeTrue();
+        result.Value.X.ShouldBeLessThan(100, "falls back to the brightest star when none are interior");
+    }
+
+    [Fact]
     public void GivenMultiStarTrackingWhenOneStarLostThenOthersStillTracked()
     {
         // Use large field with many stars

--- a/src/TianWen.Lib/Devices/Fake/FakeCameraDriver.cs
+++ b/src/TianWen.Lib/Devices/Fake/FakeCameraDriver.cs
@@ -529,10 +529,15 @@ internal sealed class FakeCameraDriver : FakeDeviceDriverBase, ICameraDriver
     /// </summary>
     public ICelestialObjectDB? CelestialObjectDB { get; set; }
 
-    // One-shot guard so the lazy catalog-DB resolve in StartExposureAsync is
-    // attempted at most once even if the DB is unavailable (avoids re-awaiting
-    // every exposure when the resolve yields null / throws).
-    private bool _catalogDbResolveAttempted;
+    // One-shot gate for the lazy catalog-DB resolve in StartExposureAsync.
+    // 0 = open (not yet claimed), 1 = claimed (resolve in-flight or finished).
+    // Claimed atomically via Interlocked so at most one caller ever runs the
+    // (idempotent) resolve even if two exposures overlap -- the resolve block
+    // sits BEFORE the camera-state CAS, so it is not otherwise serialised. The
+    // gate is reset to 0 only on cancellation, so a genuinely transient OCE stays
+    // retryable while a real failure (DB unavailable) gives up for good (avoids
+    // re-awaiting every exposure).
+    private int _catalogDbResolveGate;
 
     /// <summary>
     /// Simulated cloud coverage (0.0 = clear, 1.0 = overcast). Applied to rendered frames
@@ -641,15 +646,33 @@ internal sealed class FakeCameraDriver : FakeDeviceDriverBase, ICameraDriver
         // time StopExposureCore renders, the catalog is loaded. Explicit test
         // wiring of CelestialObjectDB short-circuits this; on failure the synth
         // falls back to a random star field (the prior behaviour).
-        if (CelestialObjectDB is null && !_catalogDbResolveAttempted)
+        // Claim the resolve atomically: only the caller that flips the gate 0 -> 1
+        // runs it. The CelestialObjectDB null-check short-circuits the common
+        // steady-state path (already resolved) so we don't touch the gate once set.
+        if (CelestialObjectDB is null
+            && Interlocked.CompareExchange(ref _catalogDbResolveGate, 1, 0) == 0)
         {
-            _catalogDbResolveAttempted = true;
             try
             {
                 CelestialObjectDB = await External.GetCelestialObjectDBAsync(cancellationToken).ConfigureAwait(false);
+                // Success: leave the gate claimed (1) -- never re-attempt.
+            }
+            catch (OperationCanceledException)
+            {
+                // The token was cancelled mid-resolve (e.g. session abort during
+                // the first exposure). This is transient and tied to THIS call,
+                // not a permanent property of the catalog: release the gate so a
+                // later exposure on this (reused) driver retries, and let the
+                // cancellation propagate instead of arming an exposure on a dead
+                // token.
+                Interlocked.Exchange(ref _catalogDbResolveGate, 0);
+                throw;
             }
             catch (Exception ex)
             {
+                // Genuine failure (e.g. catalog not installed). Leave the gate
+                // claimed so we don't re-await every exposure; the synth falls
+                // back to a random star field (the prior behaviour).
                 Logger.LogDebug(ex, "FakeCamera: catalog DB resolve failed; synthetic frames will use a random star field");
             }
         }

--- a/src/TianWen.Lib/Devices/Fake/FakeCameraDriver.cs
+++ b/src/TianWen.Lib/Devices/Fake/FakeCameraDriver.cs
@@ -519,8 +519,20 @@ internal sealed class FakeCameraDriver : FakeDeviceDriverBase, ICameraDriver
     /// When set together with <see cref="Target"/> and <see cref="TrueBestFocus"/>,
     /// renders catalog stars from Tycho-2 projected onto the sensor via TAN projection
     /// instead of generating random star positions.
+    /// <para>
+    /// Normally left for the driver to resolve itself, lazily, from the DI-provided
+    /// <see cref="FakeDeviceDriverBase.External"/> on the first exposure (see
+    /// <see cref="StartExposureAsync"/>) -- so nothing in the session / shared layer
+    /// needs to know this fake-only dependency exists. Test code may assign it
+    /// directly, which short-circuits the lazy resolve.
+    /// </para>
     /// </summary>
     public ICelestialObjectDB? CelestialObjectDB { get; set; }
+
+    // One-shot guard so the lazy catalog-DB resolve in StartExposureAsync is
+    // attempted at most once even if the DB is unavailable (avoids re-awaiting
+    // every exposure when the resolve yields null / throws).
+    private bool _catalogDbResolveAttempted;
 
     /// <summary>
     /// Simulated cloud coverage (0.0 = clear, 1.0 = overcast). Applied to rendered frames
@@ -608,7 +620,7 @@ internal sealed class FakeCameraDriver : FakeDeviceDriverBase, ICameraDriver
     public ValueTask<bool> GetIsPulseGuidingAsync(CancellationToken cancellationToken = default)
         => ValueTask.FromResult(Connected ? false : throw new InvalidOperationException("Camera is not connected"));
 
-    public ValueTask<DateTimeOffset> StartExposureAsync(TimeSpan duration, FrameType frameType = FrameType.Light, CancellationToken cancellationToken = default)
+    public async ValueTask<DateTimeOffset> StartExposureAsync(TimeSpan duration, FrameType frameType = FrameType.Light, CancellationToken cancellationToken = default)
     {
         // Test seam: simulate a transient driver fault (USB bump, COM glitch).
         // ResilientCall classifies IOException as transient, so it triggers the
@@ -619,6 +631,28 @@ internal sealed class FakeCameraDriver : FakeDeviceDriverBase, ICameraDriver
         }
         // Decrement went below 0 — clamp to 0 so steady state stays at 0.
         Interlocked.CompareExchange(ref TransientStartExposureFailures, 0, -1);
+
+        // Fake-only: the synthetic-star renderer needs the celestial catalog to
+        // project real stars at the target, so the (real) plate solver in a
+        // centering / focus / guider loop can match the rendered frame. Resolve
+        // it lazily from the same DI-provided IExternal the rest of the app uses
+        // -- the session / shared layer stays unaware of this fake-only need.
+        // GetCelestialObjectDBAsync performs the (idempotent) DB init, so by the
+        // time StopExposureCore renders, the catalog is loaded. Explicit test
+        // wiring of CelestialObjectDB short-circuits this; on failure the synth
+        // falls back to a random star field (the prior behaviour).
+        if (CelestialObjectDB is null && !_catalogDbResolveAttempted)
+        {
+            _catalogDbResolveAttempted = true;
+            try
+            {
+                CelestialObjectDB = await External.GetCelestialObjectDBAsync(cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                Logger.LogDebug(ex, "FakeCamera: catalog DB resolve failed; synthetic frames will use a random star field");
+            }
+        }
 
         var minDuration = TimeSpan.FromSeconds(ExposureResolution);
         var intentedDuration = duration < minDuration ? minDuration : duration;
@@ -643,7 +677,7 @@ internal sealed class FakeCameraDriver : FakeDeviceDriverBase, ICameraDriver
                 timer.Change(intentedDuration, Timeout.InfiniteTimeSpan);
             }
 
-            return ValueTask.FromResult(startTime);
+            return startTime;
         }
         else
         {

--- a/src/TianWen.Lib/Devices/Fake/FakeCameraDriver.cs
+++ b/src/TianWen.Lib/Devices/Fake/FakeCameraDriver.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
@@ -126,6 +127,34 @@ internal sealed class FakeCameraDriver : FakeDeviceDriverBase, ICameraDriver
     private double _starPositionY;
     private long _peStartTicks;  // phase reference (never updated)
     private long _lastPeTicks;   // last integration timestamp
+
+    // ── Part 2: guide-camera mount coupling ──────────────────────────────────
+    // The guide star drifts on the sensor by the coupled mount's misalignment
+    // pointing change (the fake SkyWatcher mount drifts mostly in Dec while
+    // tracking about a tilted polar axis). The guider's ST-4 pulses land on the
+    // camera (pulseGuideSource=Camera) and counter that drift via the same
+    // _starPositionX/Y integrator, so the loop closes inside the camera with no
+    // mount changes and no session awareness -- the camera self-resolves the
+    // mount from the device hub, mirroring how it self-resolves the catalog DB.
+    // Cached pointing is read in the (async) StartExposureAsync and consumed by
+    // the (sync) render path; both are guarded by _lock.
+    private IMountDriver? _coupledMount;
+    private bool _mountRefCaptured;     // reference (zero-drift) pointing captured?
+    private double _mountRefRa;         // believed RA at first guide exposure (hours)
+    private double _mountRefDec;        // believed Dec (degrees)
+    private double _mountCachedRa;      // mount RA snapshot from the last StartExposureAsync
+    private double _mountCachedDec;     // mount Dec snapshot
+    private bool _mountPointingValid;   // a snapshot has been taken at least once
+
+    /// <summary>
+    /// True when this fake camera is the rig's guide camera (its URI names it so).
+    /// Reuses the same path convention <see cref="GetPreset"/> keys off to pick the
+    /// IMX178M preset, so "the guide cam" is identified consistently. Only the guide
+    /// camera couples its rendered star field to the mount's drift; main imaging
+    /// cameras render at their stamped <see cref="Target"/> and must not double-count
+    /// the drift (the session's centering loop plate-solves and re-syncs them).
+    /// </summary>
+    private bool IsGuideCamera => _fakeDevice.DeviceUri.AbsolutePath.Contains("GuideCam", StringComparison.OrdinalIgnoreCase);
 
     /// <summary>Periodic error period in seconds (typical worm gear ~10 minutes).</summary>
     internal double PePeriodSeconds { get; set; } = 600.0;
@@ -677,6 +706,41 @@ internal sealed class FakeCameraDriver : FakeDeviceDriverBase, ICameraDriver
             }
         }
 
+        // Fake-only (guide camera): snapshot the coupled mount's current pointing so
+        // the (sync) render path can offset the guide star by the mount's drift.
+        // Reading RA/Dec is async (per-call SOFA recompute) and StopExposureCore is a
+        // sync timer callback, so we cache here and consume it at render time. The
+        // first successful snapshot also fixes the zero-drift reference, so the star
+        // starts centred at acquisition and drifts thereafter -- exactly the residual
+        // a real polar-misaligned mount leaves for the guider to chase. Main imaging
+        // cameras (IsGuideCamera == false) never take this path. OperationCanceledException
+        // propagates (the exposure must not arm on a cancelled token); any other fault
+        // falls back to the self-contained PE+ST-4 drift for this frame.
+        if (IsGuideCamera && FocalLength > 0 && ResolveCoupledMount() is { } coupledMount)
+        {
+            try
+            {
+                var mountRa = await coupledMount.GetRightAscensionAsync(cancellationToken).ConfigureAwait(false);
+                var mountDec = await coupledMount.GetDeclinationAsync(cancellationToken).ConfigureAwait(false);
+                lock (_lock)
+                {
+                    _mountCachedRa = mountRa;
+                    _mountCachedDec = mountDec;
+                    _mountPointingValid = true;
+                    if (!_mountRefCaptured)
+                    {
+                        _mountRefRa = mountRa;
+                        _mountRefDec = mountDec;
+                        _mountRefCaptured = true;
+                    }
+                }
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                Logger.LogDebug(ex, "FakeCamera: mount pointing read failed; guide star falls back to self-contained drift this frame");
+            }
+        }
+
         var minDuration = TimeSpan.FromSeconds(ExposureResolution);
         var intentedDuration = duration < minDuration ? minDuration : duration;
 
@@ -869,17 +933,106 @@ internal sealed class FakeCameraDriver : FakeDeviceDriverBase, ICameraDriver
     }
 
     /// <summary>
-    /// Current star offset: integrated PE drift + accumulated ST-4 corrections.
-    /// Both operate on the same position — corrections push back against drift.
+    /// Current star offset: integrated PE drift + accumulated ST-4 corrections +
+    /// (guide camera only) the coupled mount's misalignment drift. All operate on
+    /// the same sensor position, so the guider's ST-4 corrections push back against
+    /// both the PE wobble and the mount drift.
     /// </summary>
     private (double X, double Y) TotalStarOffset
     {
         get
         {
             IntegratePeDrift();
-            return (_starPositionX, _starPositionY);
+            var (mountX, mountY) = MountDriftPixels();
+            return (_starPositionX + mountX, _starPositionY + mountY);
         }
     }
+
+    /// <summary>
+    /// Lazily finds the connected mount in the device hub (single-mount invariant),
+    /// caching it once found. Returns <c>null</c> when no hub is registered (unit
+    /// tests) or no mount is connected yet -- the guide star then uses only the
+    /// self-contained PE+ST-4 drift. Resolved from the retained
+    /// <see cref="FakeDeviceDriverBase.ServiceProvider"/> so nothing in the session /
+    /// shared layer needs to know this fake-only coupling exists.
+    /// </summary>
+    private IMountDriver? ResolveCoupledMount()
+    {
+        if (_coupledMount is { Connected: true })
+        {
+            return _coupledMount;
+        }
+
+        var hub = ServiceProvider.GetService<IDeviceHub>();
+        if (hub is null)
+        {
+            return null;
+        }
+
+        foreach (var (_, driver) in hub.ConnectedDevices)
+        {
+            if (driver is IMountDriver mount && mount.Connected)
+            {
+                _coupledMount = mount;
+                return mount;
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Guide-camera-only: the star offset (px) induced by the coupled mount's
+    /// misalignment drift since the zero-drift reference was captured, computed from
+    /// the pointing snapshot taken in <see cref="StartExposureAsync"/> (the render path
+    /// is sync and cannot await). Converts the believed-vs-current pointing delta to
+    /// pixels via the guide pixel scale. Returns <c>(0, 0)</c> for main imaging cameras
+    /// (no snapshot ever taken) or before a reference exists. The Dec delta maps to Y
+    /// and the RA delta (scaled by cos Dec) to X, matching the ST-4 accumulator axes
+    /// (N/S -> Y, E/W -> X); the sign is otherwise arbitrary because the guider learns
+    /// the calibration mapping empirically, then nulls whatever it sees.
+    /// </summary>
+    private (double X, double Y) MountDriftPixels()
+    {
+        double ra, dec, refRa, refDec;
+        lock (_lock)
+        {
+            if (!_mountPointingValid || !_mountRefCaptured)
+            {
+                return (0.0, 0.0);
+            }
+            ra = _mountCachedRa;
+            dec = _mountCachedDec;
+            refRa = _mountRefRa;
+            refDec = _mountRefDec;
+        }
+
+        var pixelScaleArcsec = Astrometry.CoordinateUtils.PixelScaleArcsec(PixelSizeX, FocalLength);
+        if (pixelScaleArcsec <= 0)
+        {
+            return (0.0, 0.0);
+        }
+
+        // Wrap the RA delta into (-12, 12]h so a reference near the 0/24h seam never
+        // produces a spurious ~24h jump (the real drift is sub-arcminute).
+        var dRaHours = ra - refRa;
+        if (dRaHours > 12.0) dRaHours -= 24.0;
+        else if (dRaHours < -12.0) dRaHours += 24.0;
+
+        var cosDec = Math.Cos(refDec * Math.PI / 180.0);
+        var raArcsec = dRaHours * 15.0 * 3600.0 * cosDec;
+        var decArcsec = (dec - refDec) * 3600.0;
+        return (raArcsec / pixelScaleArcsec, decArcsec / pixelScaleArcsec);
+    }
+
+    /// <summary>
+    /// Test seam: the guide-star pixel offset currently induced by the coupled
+    /// mount's misalignment drift (the value folded into <see cref="TotalStarOffset"/>
+    /// for rendering). <c>(0, 0)</c> when this is not a guide camera, no mount is
+    /// coupled, or no zero-drift reference has been captured yet. Reflects the mount
+    /// pointing snapshot taken by the most recent <see cref="StartExposureAsync"/>.
+    /// </summary>
+    internal (double X, double Y) CurrentMountDriftPixels => MountDriftPixels();
 
     protected override void Dispose(bool disposing)
     {

--- a/src/TianWen.Lib/Devices/Fake/FakeDeviceDriverBase.cs
+++ b/src/TianWen.Lib/Devices/Fake/FakeDeviceDriverBase.cs
@@ -25,6 +25,16 @@ internal abstract class FakeDeviceDriverBase(FakeDevice fakeDevice, IServiceProv
 
     public DeviceType DriverType => _fakeDevice.DeviceType;
 
+    /// <summary>
+    /// The DI container the driver was instantiated from (the singleton root, via
+    /// <see cref="DeviceHub"/>). Retained so a fake driver can LAZILY self-resolve
+    /// other singletons it needs (e.g. <see cref="IDeviceHub"/> to find the connected
+    /// mount) without the session / shared layer having to wire that dependency in --
+    /// the same self-resolve principle <see cref="FakeCameraDriver"/> uses for the
+    /// celestial-object DB. Resolve lazily (not in a ctor) to avoid construction cycles.
+    /// </summary>
+    protected IServiceProvider ServiceProvider { get; } = serviceProvider;
+
     public IExternal External { get; } = serviceProvider.GetRequiredService<IExternal>();
 
     public ILogger Logger { get; } = serviceProvider.GetRequiredService<ILoggerFactory>().CreateLogger(fakeDevice.GetType().Name);

--- a/src/TianWen.Lib/Devices/Fake/FakeSkywatcherMountDriver.cs
+++ b/src/TianWen.Lib/Devices/Fake/FakeSkywatcherMountDriver.cs
@@ -95,6 +95,28 @@ internal class FakeSkywatcherMountDriver(FakeDevice device, IServiceProvider ser
     internal bool IsAlignmentCorrected => _alignmentCorrected;
 
     /// <summary>
+    /// UTC of the last plate-solve sync away from the pole -- the reference from
+    /// which the post-centering tracking drift accumulates. A sync removes the
+    /// static pointing offset but NOT the polar-axis tilt, so the field keeps
+    /// drifting (mostly in Dec) as the mount tracks about the wrong axis. Reset
+    /// on every away-from-pole sync so the drift always grows from the most
+    /// recently centred position -- exactly the residual a real misaligned mount
+    /// leaves for the guider to chase. <see cref="ApplyTrackingDrift"/> consumes it.
+    /// </summary>
+    private DateTimeOffset _trackingRefUtc;
+
+    /// <summary>
+    /// Believed (commanded) RA/Dec captured at the last away-from-pole sync -- the
+    /// fixed anchor the post-centering drift accumulates from. Anchoring to the
+    /// synced position (rather than the live <c>base</c> RA) keeps the drift purely
+    /// a function of elapsed tracking time: the base driver derives RA as
+    /// <c>LST - HA(steps)</c>, which advances with sidereal time even on a
+    /// stationary encoder, so using it live would swamp the misalignment signal.
+    /// </summary>
+    private double _trackingRefRa;
+    private double _trackingRefDec;
+
+    /// <summary>
     /// Angular distance from the site's celestial pole, in degrees, within which
     /// the OTA is treated as "parked on the pole" for polar-align simulation
     /// (encoder-swept pole) rather than slewed to an imaging target (axis-tilt of
@@ -116,7 +138,10 @@ internal class FakeSkywatcherMountDriver(FakeDevice device, IServiceProvider ser
     public override async ValueTask<double> GetRightAscensionAsync(CancellationToken cancellationToken)
     {
         var baseRa = await base.GetRightAscensionAsync(cancellationToken);
-        if (!MisalignmentEnabled || _alignmentCorrected || CprRa == 0)
+        // Note: a learned alignment (_alignmentCorrected) no longer short-circuits
+        // here -- it removes the STATIC offset but the residual polar-axis tracking
+        // drift is still applied inside ComputeMisalignedPointingAsync.
+        if (!MisalignmentEnabled || CprRa == 0)
         {
             return baseRa;
         }
@@ -129,7 +154,7 @@ internal class FakeSkywatcherMountDriver(FakeDevice device, IServiceProvider ser
     public override async ValueTask<double> GetDeclinationAsync(CancellationToken cancellationToken)
     {
         var baseDec = await base.GetDeclinationAsync(cancellationToken);
-        if (!MisalignmentEnabled || _alignmentCorrected || CprRa == 0)
+        if (!MisalignmentEnabled || CprRa == 0)
         {
             return baseDec;
         }
@@ -153,19 +178,36 @@ internal class FakeSkywatcherMountDriver(FakeDevice device, IServiceProvider ser
     public override async ValueTask SyncRaDecAsync(double ra, double dec, CancellationToken cancellationToken)
     {
         await base.SyncRaDecAsync(ra, dec, cancellationToken);
-        if (!MisalignmentEnabled || _alignmentCorrected)
+        if (!MisalignmentEnabled)
         {
             return;
         }
         var siteLatDeg = await GetSiteLatitudeAsync(cancellationToken);
         var hemisphere = siteLatDeg >= 0 ? Hemisphere.North : Hemisphere.South;
-        if (!IsNearSitePole(dec, hemisphere))
+        if (IsNearSitePole(dec, hemisphere))
+        {
+            // Startup / park syncs go to the pole and must NOT establish the
+            // imaging tracking-drift reference -- the polar-align simulation
+            // (the encoder-swept regime) owns the near-pole behaviour, and
+            // zeroing it here would kill the polar-align routine before it runs.
+            return;
+        }
+        // Plate-solve sync away from the pole. The static pointing offset is now
+        // learned out (so the centering loop converges), but the polar axis is
+        // STILL tilted: reset the drift reference so the field starts drifting
+        // afresh from this freshly-centred position. That residual drift is what
+        // the guider then chases -- exactly like a real polar-misaligned mount,
+        // where plate-solve centering fixes pointing but not polar alignment.
+        if (!_alignmentCorrected)
         {
             _alignmentCorrected = true;
             Logger.LogInformation(
-                "FakeSkywatcher: plate-solve sync to ({Ra:F4}h, {Dec:F4}deg) away from the pole -- modelling alignment as learned; residual misalignment corrected.",
+                "FakeSkywatcher: plate-solve sync to ({Ra:F4}h, {Dec:F4}deg) away from the pole -- static pointing offset learned; residual polar-axis tracking drift retained.",
                 ra, dec);
         }
+        _trackingRefRa = ra;
+        _trackingRefDec = dec;
+        _trackingRefUtc = TimeProvider.GetUtcNow();
     }
 
     /// <summary>
@@ -199,12 +241,27 @@ internal class FakeSkywatcherMountDriver(FakeDevice device, IServiceProvider ser
             return ApplyPolarMisalignment(axis, hemisphere, encoderRad);
         }
 
-        // Imaging regime: the OTA has been slewed away from the pole. The true
-        // sky it reaches is the believed (encoder) pointing rotated rigidly by
-        // the axis tilt -- a small (~misalignment-sized) offset that respects
-        // WHERE the scope was slewed, so a GOTO to Dec=45 reports ~45 (not the
-        // pole). The imaging centering loop plate-solves this offset and syncs
-        // it away (see SyncRaDecAsync).
+        if (_alignmentCorrected)
+        {
+            // Post-centering imaging regime. The static cone-error offset has been
+            // synced out, but the mount is still tracking about its TILTED axis, so
+            // the field drifts from the last sync onward -- predominantly in Dec.
+            // This is the residual the guider corrects; it grows with elapsed
+            // sidereal time, not a single fixed offset (see ApplyTrackingDrift).
+            // Anchored to the synced reference position, NOT the live base RA
+            // (which advances with LST and would swamp the drift -- see the
+            // _trackingRefRa rationale).
+            var trackedSeconds = (TimeProvider.GetUtcNow() - _trackingRefUtc).TotalSeconds;
+            return ApplyTrackingDrift(hemisphere, axis, _trackingRefRa, _trackingRefDec, trackedSeconds);
+        }
+
+        // Imaging regime, pre-centering: the OTA has been slewed away from the
+        // pole. The true sky it reaches is the believed (encoder) pointing rotated
+        // rigidly by the axis tilt -- a small (~misalignment-sized) offset that
+        // respects WHERE the scope was slewed, so a GOTO to Dec=45 reports ~45
+        // (not the pole). The imaging centering loop plate-solves this offset and
+        // syncs it away (see SyncRaDecAsync), after which the drift branch above
+        // takes over.
         return ApplyAxisTiltToPointing(axis, hemisphere, baseRa, baseDec);
     }
 
@@ -424,6 +481,60 @@ internal class FakeSkywatcherMountDriver(FakeDevice device, IServiceProvider ser
 
         var (ra, dec) = PolarAxisSolver.UnitVecToRaDec(new Vec3(tx, ty, tz));
         return (ra, dec);
+    }
+
+    /// <summary>
+    /// True sky direction of a polar-misaligned mount that has been TRACKING for
+    /// <paramref name="trackedSeconds"/> since its pointing was last established
+    /// (the most recent plate-solve sync). The mount drives its OTA about its own
+    /// (tilted) RA axis at the sidereal rate; the sky rotates the same angle about
+    /// the TRUE celestial pole. The residual between those two rotations is the
+    /// classic polar-misalignment field drift -- predominantly in Declination,
+    /// with a rate set by the misalignment magnitude and the target's position.
+    /// </summary>
+    /// <remarks>
+    /// At <paramref name="trackedSeconds"/> == 0 both rotations are the identity,
+    /// so the freshly-centred frame sits exactly on the believed pointing and the
+    /// drift accumulates only thereafter. This is what makes the imaging centering
+    /// loop converge (zero residual at the moment of sync) while still leaving the
+    /// slow drift a guider must correct. Reuses <see cref="PolarAxisSolver.Rotate"/>
+    /// (Rodrigues) rather than re-deriving the rotation inline.
+    /// </remarks>
+    /// <param name="hemisphere">Site hemisphere -- selects the true pole sign.</param>
+    /// <param name="misalignedAxisJ2000">The mount's tilted RA axis in J2000, from
+    /// <see cref="TopocentricMisalignmentToJ2000Axis"/>.</param>
+    /// <param name="believedRa">Believed (commanded/encoder) RA in hours.</param>
+    /// <param name="believedDec">Believed (commanded/encoder) Dec in degrees.</param>
+    /// <param name="trackedSeconds">Seconds tracked since the last sync. Negative
+    /// values are clamped to 0 (a sync timestamped in the future cannot drift).</param>
+    /// <returns>True (RA, Dec). RA in [0, 24) hours; Dec in [-90, 90] degrees.</returns>
+    internal static (double Ra, double Dec) ApplyTrackingDrift(
+        Hemisphere hemisphere,
+        Vec3 misalignedAxisJ2000,
+        double believedRa,
+        double believedDec,
+        double trackedSeconds)
+    {
+        if (trackedSeconds <= 0.0)
+        {
+            return (believedRa, believedDec);
+        }
+
+        // Sidereal angular rate (one full turn per sidereal day).
+        const double siderealRadPerSec = 2.0 * Math.PI / 86164.0905;
+        var theta = siderealRadPerSec * trackedSeconds;
+
+        var poleZ = hemisphere == Hemisphere.North ? 1.0 : -1.0;
+        // The true celestial pole is the J2000 equatorial z-axis by definition.
+        var truePole = new Vec3(0.0, 0.0, poleZ);
+
+        var believed = PolarAxisSolver.RaDecToUnitVec(believedRa, believedDec);
+        // Track about the misaligned axis, then de-rotate by the ideal sidereal
+        // motion about the true pole. Net = the field drift the misalignment leaks.
+        var tracked = PolarAxisSolver.Rotate(believed, misalignedAxisJ2000, theta);
+        var drifted = PolarAxisSolver.Rotate(tracked, truePole, -theta);
+
+        return PolarAxisSolver.UnitVecToRaDec(drifted);
     }
 
     /// <summary>

--- a/src/TianWen.Lib/Devices/Fake/FakeSkywatcherMountDriver.cs
+++ b/src/TianWen.Lib/Devices/Fake/FakeSkywatcherMountDriver.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Logging;
 using System;
 using System.Globalization;
 using System.Threading;
@@ -76,6 +77,32 @@ internal class FakeSkywatcherMountDriver(FakeDevice device, IServiceProvider ser
     /// </summary>
     private bool MisalignmentEnabled => Math.Abs(_azErrArcmin) > 1e-3 || Math.Abs(_altErrArcmin) > 1e-3;
 
+    /// <summary>
+    /// Set once a plate-solve-driven <see cref="SyncRaDecAsync"/> to a target
+    /// away from the pole lands. Models the mount LEARNING its true orientation
+    /// from the sync: after that the residual polar misalignment is corrected,
+    /// so <see cref="GetRightAscensionAsync"/> / <see cref="GetDeclinationAsync"/>
+    /// report the believed (encoder) pointing verbatim and imaging frames render
+    /// on-target. This is how the imaging centering loop converges -- the first
+    /// frame shows the misalignment offset, plate-solve syncs, and the re-slew
+    /// lands true. Startup / park syncs (to the pole) deliberately do NOT set
+    /// this, so the polar-align simulation survives until a real imaging sync.
+    /// </summary>
+    private bool _alignmentCorrected;
+
+    /// <summary>Test seam: whether a plate-solve sync away from the pole has
+    /// modelled the alignment as learned (residual misalignment corrected).</summary>
+    internal bool IsAlignmentCorrected => _alignmentCorrected;
+
+    /// <summary>
+    /// Angular distance from the site's celestial pole, in degrees, within which
+    /// the OTA is treated as "parked on the pole" for polar-align simulation
+    /// (encoder-swept pole) rather than slewed to an imaging target (axis-tilt of
+    /// the believed pointing). Polar align operates with the believed Dec within
+    /// a few degrees of the pole; imaging targets are well below this.
+    /// </summary>
+    private const double NearPoleDeg = 5.0;
+
     /// <inheritdoc/>
     /// <remarks>
     /// Applies a topocentric polar-misalignment transform on top of the base
@@ -89,7 +116,7 @@ internal class FakeSkywatcherMountDriver(FakeDevice device, IServiceProvider ser
     public override async ValueTask<double> GetRightAscensionAsync(CancellationToken cancellationToken)
     {
         var baseRa = await base.GetRightAscensionAsync(cancellationToken);
-        if (!MisalignmentEnabled || CprRa == 0)
+        if (!MisalignmentEnabled || _alignmentCorrected || CprRa == 0)
         {
             return baseRa;
         }
@@ -102,13 +129,43 @@ internal class FakeSkywatcherMountDriver(FakeDevice device, IServiceProvider ser
     public override async ValueTask<double> GetDeclinationAsync(CancellationToken cancellationToken)
     {
         var baseDec = await base.GetDeclinationAsync(cancellationToken);
-        if (!MisalignmentEnabled || CprRa == 0)
+        if (!MisalignmentEnabled || _alignmentCorrected || CprRa == 0)
         {
             return baseDec;
         }
         var baseRa = await base.GetRightAscensionAsync(cancellationToken);
         var (_, decMis) = await ComputeMisalignedPointingAsync(baseRa, baseDec, cancellationToken);
         return decMis;
+    }
+
+    /// <inheritdoc/>
+    /// <remarks>
+    /// A sync to a target away from the pole is plate-solve-driven (the imaging
+    /// centering loop tells the mount its TRUE sky position). We model that as
+    /// the mount LEARNING its orientation: the residual polar misalignment is
+    /// corrected, so subsequent <see cref="GetRightAscensionAsync"/> /
+    /// <see cref="GetDeclinationAsync"/> report the believed (encoder) pointing
+    /// verbatim and the re-slew converges on target. Startup / park syncs go to
+    /// the pole and must NOT trigger this -- otherwise the polar-align
+    /// simulation would be zeroed before it can run. The base call still moves
+    /// the encoders either way.
+    /// </remarks>
+    public override async ValueTask SyncRaDecAsync(double ra, double dec, CancellationToken cancellationToken)
+    {
+        await base.SyncRaDecAsync(ra, dec, cancellationToken);
+        if (!MisalignmentEnabled || _alignmentCorrected)
+        {
+            return;
+        }
+        var siteLatDeg = await GetSiteLatitudeAsync(cancellationToken);
+        var hemisphere = siteLatDeg >= 0 ? Hemisphere.North : Hemisphere.South;
+        if (!IsNearSitePole(dec, hemisphere))
+        {
+            _alignmentCorrected = true;
+            Logger.LogInformation(
+                "FakeSkywatcher: plate-solve sync to ({Ra:F4}h, {Dec:F4}deg) away from the pole -- modelling alignment as learned; residual misalignment corrected.",
+                ra, dec);
+        }
     }
 
     /// <summary>
@@ -123,13 +180,43 @@ internal class FakeSkywatcherMountDriver(FakeDevice device, IServiceProvider ser
         var siteLatDeg = await GetSiteLatitudeAsync(ct);
         var siteLonDeg = await GetSiteLongitudeAsync(ct);
         var siteElevM = await GetSiteElevationAsync(ct);
-        var hemisphere = baseDec >= 0 ? Hemisphere.North : Hemisphere.South;
-        var encoderRad = EncoderAngleRadians(PosRa, CprRa);
+        // Which celestial pole the mount homes to is fixed by the observing
+        // hemisphere (site latitude), NOT by where the OTA currently points.
+        var hemisphere = siteLatDeg >= 0 ? Hemisphere.North : Hemisphere.South;
         var utc = TimeProvider.GetUtcNow();
         var axis = TopocentricMisalignmentToJ2000Axis(
             siteLatDeg, siteLonDeg, siteElevM, utc,
             _azErrArcmin, _altErrArcmin, hemisphere, TimeProvider);
-        return ApplyPolarMisalignment(axis, hemisphere, encoderRad);
+
+        if (IsNearSitePole(baseDec, hemisphere))
+        {
+            // Polar-align regime: the OTA is parked on the pole and the RA axis
+            // is rotated via MoveAxis to trace a small circle about the
+            // misaligned axis. The believed RA is degenerate at the pole, so we
+            // sweep the pole vector by the raw encoder angle (the polar-align
+            // routine recovers the circle centre = the misaligned axis).
+            var encoderRad = EncoderAngleRadians(PosRa, CprRa);
+            return ApplyPolarMisalignment(axis, hemisphere, encoderRad);
+        }
+
+        // Imaging regime: the OTA has been slewed away from the pole. The true
+        // sky it reaches is the believed (encoder) pointing rotated rigidly by
+        // the axis tilt -- a small (~misalignment-sized) offset that respects
+        // WHERE the scope was slewed, so a GOTO to Dec=45 reports ~45 (not the
+        // pole). The imaging centering loop plate-solves this offset and syncs
+        // it away (see SyncRaDecAsync).
+        return ApplyAxisTiltToPointing(axis, hemisphere, baseRa, baseDec);
+    }
+
+    /// <summary>
+    /// True when <paramref name="decDeg"/> sits within <see cref="NearPoleDeg"/>
+    /// of the site's celestial pole -- i.e. the OTA is parked on the pole for
+    /// polar-align, as opposed to slewed to an imaging target.
+    /// </summary>
+    private static bool IsNearSitePole(double decDeg, Hemisphere hemisphere)
+    {
+        var poleDec = hemisphere == Hemisphere.North ? 90.0 : -90.0;
+        return Math.Abs(decDeg - poleDec) <= NearPoleDeg;
     }
 
     /// <summary>
@@ -267,6 +354,75 @@ internal class FakeSkywatcherMountDriver(FakeDevice device, IServiceProvider ser
         var raDeg = Math.Atan2(ry, rx) * 180.0 / Math.PI;
         var ra = raDeg / 15.0;
         if (ra < 0.0) ra += 24.0;
+        return (ra, dec);
+    }
+
+    /// <summary>
+    /// Project the believed (encoder) pointing through the mount's rigid axis
+    /// tilt to recover the true sky direction the OTA reaches when slewed away
+    /// from the pole. Unlike <see cref="ApplyPolarMisalignment"/> -- which pins
+    /// the OTA to the pole and sweeps by the RA encoder, valid only while the
+    /// scope is parked on the pole for polar-align -- this rotates the believed
+    /// pointing by the rotation that carries the true pole onto the misaligned
+    /// axis. The result is a small (~misalignment-magnitude) position-dependent
+    /// offset from the commanded coordinates: exactly the pointing error a real
+    /// polar-misaligned GEM exhibits, which plate-solve centering then detects
+    /// and syncs away.
+    /// </summary>
+    /// <param name="misalignedAxisJ2000">The actual mount RA-axis in J2000 (the
+    /// tilted pole), as produced by <see cref="TopocentricMisalignmentToJ2000Axis"/>.</param>
+    /// <param name="hemisphere">Site hemisphere -- selects which true pole the
+    /// tilt is measured from.</param>
+    /// <param name="baseRa">Believed (encoder-derived) RA in hours.</param>
+    /// <param name="baseDec">Believed (encoder-derived) Dec in degrees.</param>
+    /// <returns>True (RA, Dec). RA in [0, 24) hours; Dec in [-90, 90] degrees.</returns>
+    internal static (double Ra, double Dec) ApplyAxisTiltToPointing(
+        Vec3 misalignedAxisJ2000,
+        Hemisphere hemisphere,
+        double baseRa,
+        double baseDec)
+    {
+        var poleZ = hemisphere == Hemisphere.North ? 1.0 : -1.0;
+        var kx = misalignedAxisJ2000.X;
+        var ky = misalignedAxisJ2000.Y;
+        var kz = misalignedAxisJ2000.Z;
+
+        var believed = PolarAxisSolver.RaDecToUnitVec(baseRa, baseDec);
+
+        // Rotation R that carries the true pole (0, 0, poleZ) onto the misaligned
+        // axis k: rotation axis r = norm(pole x k), angle = acos(pole . k).
+        // pole x k = (-poleZ*ky, poleZ*kx, 0).
+        var dot = Math.Clamp(poleZ * kz, -1.0, 1.0);
+        var angle = Math.Acos(dot);
+        var rxRaw = -poleZ * ky;
+        var ryRaw = poleZ * kx;
+        var axisLen = Math.Sqrt(rxRaw * rxRaw + ryRaw * ryRaw);
+        if (axisLen < 1e-12 || angle < 1e-9)
+        {
+            // Axis already coincides with the pole (no tilt) -- believed == true.
+            return (baseRa, baseDec);
+        }
+        var rx = rxRaw / axisLen;
+        var ry = ryRaw / axisLen;
+        const double rz = 0.0; // pole x k always lies in the equatorial plane
+
+        var cosT = Math.Cos(angle);
+        var sinT = Math.Sin(angle);
+        var oneMinusCos = 1.0 - cosT;
+
+        // Rodrigues: R(r, angle) . v = v.cos + (r x v).sin + r.(r . v).(1 - cos).
+        var vx = believed.X;
+        var vy = believed.Y;
+        var vz = believed.Z;
+        var rDotV = rx * vx + ry * vy + rz * vz;
+        var crossX = ry * vz - rz * vy;
+        var crossY = rz * vx - rx * vz;
+        var crossZ = rx * vy - ry * vx;
+        var tx = vx * cosT + crossX * sinT + rx * rDotV * oneMinusCos;
+        var ty = vy * cosT + crossY * sinT + ry * rDotV * oneMinusCos;
+        var tz = vz * cosT + crossZ * sinT + rz * rDotV * oneMinusCos;
+
+        var (ra, dec) = PolarAxisSolver.UnitVecToRaDec(new Vec3(tx, ty, tz));
         return (ra, dec);
     }
 

--- a/src/TianWen.Lib/Devices/Guider/BuiltInGuiderDriver.cs
+++ b/src/TianWen.Lib/Devices/Guider/BuiltInGuiderDriver.cs
@@ -350,7 +350,7 @@ internal sealed class BuiltInGuiderDriver : IDeviceDependentGuider
     {
         var exposureTime = await ExposureTimeAsync(ct);
 
-        var tracker = new GuiderCentroidTracker(maxStars: 1);
+        var tracker = new GuiderCentroidTracker(maxStars: 1) { AcquisitionEdgeMargin = GuideStarAcquisitionMargin() };
         _calibrationTracker = tracker;
         var frame = await CaptureGuideFrameAsync(camera, exposureTime, TimeProvider, External.ImageReadyPollInterval, ct);
         _lastFrame = frame;
@@ -401,7 +401,7 @@ internal sealed class BuiltInGuiderDriver : IDeviceDependentGuider
 
         // Acquire a guide star for validation
         var exposureTime = await ExposureTimeAsync(ct);
-        var tracker = new GuiderCentroidTracker(maxStars: 1);
+        var tracker = new GuiderCentroidTracker(maxStars: 1) { AcquisitionEdgeMargin = GuideStarAcquisitionMargin() };
         _calibrationTracker = tracker;
         var frame = await CaptureGuideFrameAsync(camera, exposureTime, TimeProvider, External.ImageReadyPollInterval, ct);
         _lastFrame = frame;
@@ -502,7 +502,7 @@ internal sealed class BuiltInGuiderDriver : IDeviceDependentGuider
             }
 
             // Acquire guide star and set lock position
-            var tracker = new GuiderCentroidTracker(maxStars: 1);
+            var tracker = new GuiderCentroidTracker(maxStars: 1) { AcquisitionEdgeMargin = GuideStarAcquisitionMargin() };
             var timeProvider = TimeProvider;
             var pollInterval = External.ImageReadyPollInterval;
             async ValueTask<Image> CaptureFrame(CancellationToken token)
@@ -723,11 +723,37 @@ internal sealed class BuiltInGuiderDriver : IDeviceDependentGuider
 
         if (elapsed.TotalSeconds >= _settleTime)
         {
-            TryTransition(GuiderState.Settling, GuiderState.Guiding);
+            if (TryTransition(GuiderState.Settling, GuiderState.Guiding))
+            {
+                // Start guide-quality stats fresh as guiding begins, so the displayed
+                // RMS / Peak reflect guiding -- not the calibration + settle transient
+                // (matches PHD2, which only shows the guide graph once guiding starts).
+                _guideLoop?.RequestErrorStatsReset();
+            }
             return true;
         }
 
         return false;
+    }
+
+    /// <summary>
+    /// Edge margin (px) to keep an acquired guide star clear of the frame border so it
+    /// survives the calibration throw (backlash clearing + measurement sweep, one
+    /// direction) instead of leaving the sensor and forcing a re-lock onto a different
+    /// star. Derived from the standard 0.5x sidereal guide rate against the guide pixel
+    /// scale; capped to a third of the (binned) frame so small sub-frames still acquire.
+    /// </summary>
+    private int GuideStarAcquisitionMargin()
+    {
+        const double halfSiderealArcsecPerSec = 15.041 * 0.5;
+        var scale = GuiderPixelScale; // arcsec/px (1.0 fallback)
+        var ratePxPerSec = scale > 0 ? halfSiderealArcsecPerSec / scale : 2.0;
+        // Same calibration geometry the driver runs (defaults + backlash clearing on).
+        var throwPx = new GuiderCalibration { BacklashClearingEnabled = true }
+            .ExpectedSweepThrowPixels(ratePxPerSec) + 16.0; // + search-radius tracking headroom
+        var frameMin = _camera is { Connected: true } cam ? Math.Min(cam.NumX, cam.NumY) : 0;
+        var cap = frameMin > 0 ? frameMin / 3 : int.MaxValue;
+        return Math.Clamp((int)Math.Ceiling(throwPx), 0, cap);
     }
 
     private void CancelGuideLoop()

--- a/src/TianWen.Lib/Devices/Guider/GuideLoop.cs
+++ b/src/TianWen.Lib/Devices/Guider/GuideLoop.cs
@@ -114,6 +114,17 @@ internal sealed class GuideLoop
     /// </summary>
     internal GuiderCentroidTracker Tracker => _tracker;
 
+    private int _statsResetRequested;
+
+    /// <summary>
+    /// Requests that the guide-error accumulators be reset at the start of the next loop
+    /// iteration (thread-safe). The driver calls this when guiding actually begins (the
+    /// Settling -&gt; Guiding transition) so the displayed RMS / Peak reflect guiding
+    /// quality, not the calibration + settle transient. Performed on the loop thread to
+    /// avoid racing the per-frame <c>Add</c>.
+    /// </summary>
+    internal void RequestErrorStatsReset() => Interlocked.Exchange(ref _statsResetRequested, 1);
+
     /// <summary>
     /// Guide error statistics.
     /// </summary>
@@ -248,6 +259,13 @@ internal sealed class GuideLoop
         {
             while (!cancellationToken.IsCancellationRequested)
             {
+                // Honour a pending stats reset on the loop thread (set by the driver at
+                // the Settling -> Guiding transition) so guide-quality stats start fresh.
+                if (Interlocked.Exchange(ref _statsResetRequested, 0) == 1)
+                {
+                    _errorTracker.Reset();
+                }
+
                 var frameStart = GetTimestamp();
 
                 // Capture and process frame — release previous frame's ChannelBuffer

--- a/src/TianWen.Lib/Devices/Guider/GuiderCalibration.cs
+++ b/src/TianWen.Lib/Devices/Guider/GuiderCalibration.cs
@@ -97,6 +97,17 @@ internal sealed class GuiderCalibration
     public double BacklashMovementThresholdPx { get; set; } = 1.5;
 
     /// <summary>
+    /// Expected one-direction star excursion (pixels) during calibration: the backlash
+    /// clearing pulses plus the measurement sweep, all in the same direction, before the
+    /// star is returned to start. Callers use this to acquire a guide star with enough
+    /// edge clearance to survive the throw instead of re-locking onto a different star.
+    /// </summary>
+    /// <param name="guideRatePixPerSec">Effective guide rate in pixels per second.</param>
+    public double ExpectedSweepThrowPixels(double guideRatePixPerSec)
+        => (CalibrationSteps + (BacklashClearingEnabled ? MaxBacklashClearingSteps : 0))
+           * CalibrationPulseDuration.TotalSeconds * Math.Max(0.0, guideRatePixPerSec);
+
+    /// <summary>
     /// Runs calibration by pulsing in each direction and measuring displacement.
     /// </summary>
     /// <param name="pulseTarget">Pulse guide target (camera ST-4, mount, or router).</param>

--- a/src/TianWen.Lib/Devices/Guider/GuiderCentroidTracker.cs
+++ b/src/TianWen.Lib/Devices/Guider/GuiderCentroidTracker.cs
@@ -29,6 +29,16 @@ internal sealed class GuiderCentroidTracker
     public float MinSNR { get; set; } = DefaultMinSNR;
 
     /// <summary>
+    /// When &gt; 0, initial acquisition prefers guide stars at least this many pixels from
+    /// every frame edge, so the chosen star survives large excursions (notably the
+    /// calibration throw) without leaving the sensor and forcing a re-lock onto a
+    /// different star mid-calibration. If no candidate is that far inside, the brightest
+    /// overall is used -- acquisition never fails purely for lack of border clearance.
+    /// Default 0 = brightest-anywhere (legacy behaviour).
+    /// </summary>
+    public int AcquisitionEdgeMargin { get; set; }
+
+    /// <summary>
     /// Number of stars currently being tracked.
     /// </summary>
     public int TrackedStarCount => _stars.Count;
@@ -195,8 +205,25 @@ internal sealed class GuiderCentroidTracker
             return null;
         }
 
-        // Sort by flux descending (brightest first)
-        candidates.Sort((a, b) => b.Flux.CompareTo(a.Flux));
+        // Sort brightest-first, but when an acquisition edge margin is set, prefer stars
+        // with enough border clearance to survive the calibration throw (so we don't lock
+        // onto a star the sweep then pushes off-frame). Falls back to brightest-overall
+        // when no candidate is comfortably interior, so acquisition never fails for it.
+        if (AcquisitionEdgeMargin > 0)
+        {
+            var m = AcquisitionEdgeMargin;
+            bool Interior(CandidateStar c) =>
+                c.X >= m && c.X < width - m && c.Y >= m && c.Y < height - m;
+            candidates.Sort((a, b) =>
+            {
+                var byInterior = Interior(b).CompareTo(Interior(a)); // interior first
+                return byInterior != 0 ? byInterior : b.Flux.CompareTo(a.Flux);
+            });
+        }
+        else
+        {
+            candidates.Sort((a, b) => b.Flux.CompareTo(a.Flux));
+        }
 
         // Select well-separated stars up to MaxStars
         _stars.Clear();

--- a/src/TianWen.Lib/Devices/Skywatcher/SkywatcherMountDriverBase.cs
+++ b/src/TianWen.Lib/Devices/Skywatcher/SkywatcherMountDriverBase.cs
@@ -306,7 +306,7 @@ internal abstract class SkywatcherMountDriverBase<TDevice>(TDevice device, IServ
         _isSlewingDec = false;
     }
 
-    public async ValueTask SyncRaDecAsync(double ra, double dec, CancellationToken cancellationToken)
+    public virtual async ValueTask SyncRaDecAsync(double ra, double dec, CancellationToken cancellationToken)
     {
         var raSteps = RaToSteps(ra);
         var decSteps = DecToSteps(dec);

--- a/src/TianWen.Lib/Imaging/Image.Histogram.cs
+++ b/src/TianWen.Lib/Imaging/Image.Histogram.cs
@@ -229,12 +229,12 @@ public partial class Image
         return new ImageHistogram(channel, histogram.ToImmutableArray(), hist_mean, hist_total, threshold, thresholdPct, rescaledMaxValue, median, mad, ignoreBlack);
     }
 
-    public ImageHistogram Statistics(int channel, bool removePedestral = false)
-        => Histogram(channel, thresholdPct: 100, ignoreBlack: false, calcStats: true, removePedestral);
+    public ImageHistogram Statistics(int channel, bool removePedestral = false, int pixelStride = 1)
+        => Histogram(channel, thresholdPct: 100, ignoreBlack: false, calcStats: true, removePedestral, pixelStride);
 
-    public (float Pedestral, float Median, float MAD) GetPedestralMedianAndMADScaledToUnit(int channel)
+    public (float Pedestral, float Median, float MAD) GetPedestralMedianAndMADScaledToUnit(int channel, int pixelStride = 1)
     {
-        var stats = Statistics(channel, removePedestral: true);
+        var stats = Statistics(channel, removePedestral: true, pixelStride: pixelStride);
         if (stats.Median is not { } median || stats.MAD is not { } mad)
         {
             throw new InvalidOperationException("Median and MAD should have been calculated");

--- a/src/TianWen.Lib/Sequencing/Session.Focus.cs
+++ b/src/TianWen.Lib/Sequencing/Session.Focus.cs
@@ -762,77 +762,92 @@ internal partial record Session
         var camDriver = telescope.Camera.Driver;
 
         // Read the mount's CURRENT pointing before exposing. This drives two
-        // things: (1) the camera's render-centre, so the frame reflects where
-        // the scope ACTUALLY points -- including any polar misalignment the
-        // mount hasn't been synced out yet -- which is what makes plate-solve
-        // centering able to measure and correct the offset; and (2) the
-        // plate-solve search hint below (re-used, no second read). On a real
-        // camera Target is just FITS metadata, so stamping the live pointing is
-        // harmless; on the fake camera it is the synthetic-field centre.
+        // things: (1) the camera's render-centre for THIS exposure, so the frame
+        // reflects where the scope ACTUALLY points -- including any polar
+        // misalignment the mount hasn't been synced out yet -- which is what
+        // makes plate-solve centering able to measure and correct the offset;
+        // and (2) the plate-solve search hint below (re-used, no second read).
         var mountRa = await ResilientInvokeAsync(
             mount.Driver, mount.Driver.GetRightAscensionAsync,
             ResilientCallOptions.IdempotentRead, cancellationToken);
         var mountDec = await ResilientInvokeAsync(
             mount.Driver, mount.Driver.GetDeclinationAsync,
             ResilientCallOptions.IdempotentRead, cancellationToken);
+
+        // The mount-pointing stamp below is only needed so the (fake) camera
+        // renders THIS centering frame at the actual pointing; on a real camera
+        // Target is just FITS metadata. It must NOT leak into later science-frame
+        // headers -- e.g. after a mid-observation meridian flip, where no
+        // per-observation Target reset runs afterward -- so we snapshot the
+        // caller's Target and restore it in the finally below.
+        var originalTarget = camDriver.Target;
         if (camDriver.Target is { } currentTarget)
         {
             camDriver.Target = currentTarget with { RA = mountRa, Dec = mountDec };
         }
 
-        // Take a short exposure
-        await camDriver.StartExposureAsync(exposureTime, cancellationToken: cancellationToken);
-
-        // Wait for exposure to complete
-        Image? image = null;
-        var polled = TimeSpan.Zero;
-        var maxPoll = exposureTime + exposureTime; // wait up to 2x exposure time
-        while (polled < maxPoll && !cancellationToken.IsCancellationRequested)
+        try
         {
-            if (await camDriver.GetImageAsync(cancellationToken) is { Width: > 0, Height: > 0 } img)
+            // Take a short exposure
+            await camDriver.StartExposureAsync(exposureTime, cancellationToken: cancellationToken);
+
+            // Wait for exposure to complete
+            Image? image = null;
+            var polled = TimeSpan.Zero;
+            var maxPoll = exposureTime + exposureTime; // wait up to 2x exposure time
+            while (polled < maxPoll && !cancellationToken.IsCancellationRequested)
             {
-                image = img;
-                break;
+                if (await camDriver.GetImageAsync(cancellationToken) is { Width: > 0, Height: > 0 } img)
+                {
+                    image = img;
+                    break;
+                }
+
+                var spinDuration = TimeSpan.FromMilliseconds(250);
+                polled += spinDuration;
+                await _timeProvider.SleepAsync(spinDuration, cancellationToken);
             }
 
-            var spinDuration = TimeSpan.FromMilliseconds(250);
-            polled += spinDuration;
-            await _timeProvider.SleepAsync(spinDuration, cancellationToken);
-        }
+            if (image is null)
+            {
+                _logger.LogWarning("Plate solve: failed to capture image from camera #{CameraNumber}.", telescopeIndex + 1);
+                RecordPlateSolve(context, telescope.Name, succeeded: false, solution: null, elapsed: TimeSpan.Zero);
+                return (false, double.NaN, double.NaN);
+            }
 
-        if (image is null)
+            // Plate solve using the mount position read before the exposure as the
+            // search origin (re-used -- no second driver round-trip).
+            var searchOrigin = new WCS(mountRa, mountDec);
+
+            var result = await PlateSolver.SolveImageAsync(image, searchOrigin: searchOrigin, searchRadius: 10, cancellationToken: cancellationToken);
+            image.Release();
+
+            if (result.Solution is not { } wcs)
+            {
+                _logger.LogWarning("Plate solve: failed to solve image from camera #{CameraNumber}.", telescopeIndex + 1);
+                RecordPlateSolve(context, telescope.Name, succeeded: false, solution: null, result);
+                return (false, double.NaN, double.NaN);
+            }
+
+            _logger.LogInformation(
+                "Plate solve: solved at ({SolvedRA}, {SolvedDec}), mount was at ({MountRA}, {MountDec}), offset=({DeltaRA:F4}h, {DeltaDec:F2}°).",
+                Astrometry.CoordinateUtils.HoursToHMS(wcs.CenterRA), Astrometry.CoordinateUtils.DegreesToDMS(wcs.CenterDec),
+                Astrometry.CoordinateUtils.HoursToHMS(mountRa), Astrometry.CoordinateUtils.DegreesToDMS(mountDec),
+                wcs.CenterRA - mountRa, wcs.CenterDec - mountDec);
+
+            // Sync mount to solved J2000 coordinates
+            await mount.Driver.SyncRaDecJ2000Async(wcs.CenterRA, wcs.CenterDec, cancellationToken);
+
+            _logger.LogInformation("Plate solve: mount synced to solved position.");
+            RecordPlateSolve(context, telescope.Name, succeeded: true, solution: wcs, result);
+            return (true, wcs.CenterRA, wcs.CenterDec);
+        }
+        finally
         {
-            _logger.LogWarning("Plate solve: failed to capture image from camera #{CameraNumber}.", telescopeIndex + 1);
-            RecordPlateSolve(context, telescope.Name, succeeded: false, solution: null, elapsed: TimeSpan.Zero);
-            return (false, double.NaN, double.NaN);
+            // Restore the caller's Target so the transient mount-pointing stamp
+            // does not bleed into subsequent science-frame FITS metadata.
+            camDriver.Target = originalTarget;
         }
-
-        // Plate solve using the mount position read before the exposure as the
-        // search origin (re-used -- no second driver round-trip).
-        var searchOrigin = new WCS(mountRa, mountDec);
-
-        var result = await PlateSolver.SolveImageAsync(image, searchOrigin: searchOrigin, searchRadius: 10, cancellationToken: cancellationToken);
-        image.Release();
-
-        if (result.Solution is not { } wcs)
-        {
-            _logger.LogWarning("Plate solve: failed to solve image from camera #{CameraNumber}.", telescopeIndex + 1);
-            RecordPlateSolve(context, telescope.Name, succeeded: false, solution: null, result);
-            return (false, double.NaN, double.NaN);
-        }
-
-        _logger.LogInformation(
-            "Plate solve: solved at ({SolvedRA}, {SolvedDec}), mount was at ({MountRA}, {MountDec}), offset=({DeltaRA:F4}h, {DeltaDec:F2}°).",
-            Astrometry.CoordinateUtils.HoursToHMS(wcs.CenterRA), Astrometry.CoordinateUtils.DegreesToDMS(wcs.CenterDec),
-            Astrometry.CoordinateUtils.HoursToHMS(mountRa), Astrometry.CoordinateUtils.DegreesToDMS(mountDec),
-            wcs.CenterRA - mountRa, wcs.CenterDec - mountDec);
-
-        // Sync mount to solved J2000 coordinates
-        await mount.Driver.SyncRaDecJ2000Async(wcs.CenterRA, wcs.CenterDec, cancellationToken);
-
-        _logger.LogInformation("Plate solve: mount synced to solved position.");
-        RecordPlateSolve(context, telescope.Name, succeeded: true, solution: wcs, result);
-        return (true, wcs.CenterRA, wcs.CenterDec);
     }
 
     /// <summary>

--- a/src/TianWen.Lib/Sequencing/Session.Focus.cs
+++ b/src/TianWen.Lib/Sequencing/Session.Focus.cs
@@ -761,6 +761,25 @@ internal partial record Session
         var telescope = Setup.Telescopes[telescopeIndex];
         var camDriver = telescope.Camera.Driver;
 
+        // Read the mount's CURRENT pointing before exposing. This drives two
+        // things: (1) the camera's render-centre, so the frame reflects where
+        // the scope ACTUALLY points -- including any polar misalignment the
+        // mount hasn't been synced out yet -- which is what makes plate-solve
+        // centering able to measure and correct the offset; and (2) the
+        // plate-solve search hint below (re-used, no second read). On a real
+        // camera Target is just FITS metadata, so stamping the live pointing is
+        // harmless; on the fake camera it is the synthetic-field centre.
+        var mountRa = await ResilientInvokeAsync(
+            mount.Driver, mount.Driver.GetRightAscensionAsync,
+            ResilientCallOptions.IdempotentRead, cancellationToken);
+        var mountDec = await ResilientInvokeAsync(
+            mount.Driver, mount.Driver.GetDeclinationAsync,
+            ResilientCallOptions.IdempotentRead, cancellationToken);
+        if (camDriver.Target is { } currentTarget)
+        {
+            camDriver.Target = currentTarget with { RA = mountRa, Dec = mountDec };
+        }
+
         // Take a short exposure
         await camDriver.StartExposureAsync(exposureTime, cancellationToken: cancellationToken);
 
@@ -788,13 +807,8 @@ internal partial record Session
             return (false, double.NaN, double.NaN);
         }
 
-        // Plate solve using mount's current position as search origin
-        var mountRa = await ResilientInvokeAsync(
-            mount.Driver, mount.Driver.GetRightAscensionAsync,
-            ResilientCallOptions.IdempotentRead, cancellationToken);
-        var mountDec = await ResilientInvokeAsync(
-            mount.Driver, mount.Driver.GetDeclinationAsync,
-            ResilientCallOptions.IdempotentRead, cancellationToken);
+        // Plate solve using the mount position read before the exposure as the
+        // search origin (re-used -- no second driver round-trip).
         var searchOrigin = new WCS(mountRa, mountDec);
 
         var result = await PlateSolver.SolveImageAsync(image, searchOrigin: searchOrigin, searchRadius: 10, cancellationToken: cancellationToken);
@@ -853,6 +867,10 @@ internal partial record Session
             if (totalOffsetArcmin <= thresholdArcmin)
             {
                 _logger.LogInformation("Centering: converged within {Threshold}' after {Attempt} attempt(s)", thresholdArcmin, attempt);
+                // Clear the transient centering/re-slewing status so the live UI falls
+                // through to the phase text once centering finishes; otherwise the last
+                // "Re-slewing to ..." string lingers on screen through the exposure.
+                _currentActivity = null;
                 return true;
             }
 
@@ -869,6 +887,9 @@ internal partial record Session
         }
 
         _logger.LogWarning("Centering: did not converge within {Max} attempts for {Target}", maxAttempts, target.Name);
+        // Even on non-convergence, drop the transient status so the UI doesn't keep
+        // showing "Re-slewing to ..." into the subsequent exposure.
+        _currentActivity = null;
         return false;
     }
 

--- a/src/TianWen.UI.Abstractions/AppSignalHandler.cs
+++ b/src/TianWen.UI.Abstractions/AppSignalHandler.cs
@@ -1814,7 +1814,10 @@ namespace TianWen.UI.Abstractions
                     // Surface each session phase transition in the notification feed.
                     // Terminal phases (Complete/Aborted/Failed) are emitted in the RunAsync
                     // finally block below, so they are skipped here to avoid duplicates.
-                    session.PhaseChanged += (_, e) =>
+                    // Extracted to a named local so it can be unsubscribed in finally —
+                    // prevents a dangling delegate from keeping a stale session alive
+                    // if the session reference is ever captured here in future refactors.
+                    void OnPhaseChanged(object? _, SessionPhaseChangedEventArgs e)
                     {
                         var phaseMsg = e.NewPhase switch
                         {
@@ -1833,7 +1836,8 @@ namespace TianWen.UI.Abstractions
                             appState.AppendNotification(_timeProvider.GetUtcNow(), NotificationSeverity.Info, phaseMsg);
                             appState.NeedsRedraw = true;
                         }
-                    };
+                    }
+                    session.PhaseChanged += OnPhaseChanged;
 
                     // RunAsync includes Finalise — run as tracked background task so:
                     // 1. UI stays responsive (signal handler returns immediately)
@@ -1850,6 +1854,7 @@ namespace TianWen.UI.Abstractions
                         }
                         finally
                         {
+                            session.PhaseChanged -= OnPhaseChanged;
                             liveSessionState.IsRunning = false;
                             liveSessionState.NeedsRedraw = true;
 

--- a/src/TianWen.UI.Abstractions/AppSignalHandler.cs
+++ b/src/TianWen.UI.Abstractions/AppSignalHandler.cs
@@ -1811,6 +1811,30 @@ namespace TianWen.UI.Abstractions
                         }
                     };
 
+                    // Surface each session phase transition in the notification feed.
+                    // Terminal phases (Complete/Aborted/Failed) are emitted in the RunAsync
+                    // finally block below, so they are skipped here to avoid duplicates.
+                    session.PhaseChanged += (_, e) =>
+                    {
+                        var phaseMsg = e.NewPhase switch
+                        {
+                            SessionPhase.Initialising => "Initialising session…",
+                            SessionPhase.WaitingForDark => "Waiting for astronomical dark…",
+                            SessionPhase.Cooling => "Cooling cameras to setpoint…",
+                            SessionPhase.RoughFocus => "Initial rough focus…",
+                            SessionPhase.AutoFocus => "Auto-focusing…",
+                            SessionPhase.CalibratingGuider => "Calibrating guider…",
+                            SessionPhase.Observing => "Observation loop started",
+                            SessionPhase.Finalising => "Finalising session…",
+                            _ => null
+                        };
+                        if (phaseMsg is not null)
+                        {
+                            appState.AppendNotification(_timeProvider.GetUtcNow(), NotificationSeverity.Info, phaseMsg);
+                            appState.NeedsRedraw = true;
+                        }
+                    };
+
                     // RunAsync includes Finalise — run as tracked background task so:
                     // 1. UI stays responsive (signal handler returns immediately)
                     // 2. DrainAsync at shutdown waits for Finalise to complete

--- a/src/TianWen.UI.Abstractions/GuiderTab.cs
+++ b/src/TianWen.UI.Abstractions/GuiderTab.cs
@@ -159,18 +159,28 @@ namespace TianWen.UI.Abstractions
                         var offsetX = rect.X + (rect.Width - drawW) / 2;
                         var offsetY = rect.Y + (rect.Height - drawH) / 2;
 
-                        // Crosshair overlay on guide star position
+                        // Guide-star overlay. During guiding, draw a full RA/Dec-aligned
+                        // reticle (orange RA / blue Dec) spanning the frame with a centre gap
+                        // so the star stays visible; before guiding, the small fixed crosshair.
                         if (State.GuideStarPosition is var (starX, starY))
                         {
                             var cx = (int)(offsetX + starX * fitScale);
                             var cy = (int)(offsetY + starY * fitScale);
-                            var crossLen = (int)(15 * dpiScale);
-                            var crossGap = (int)(4 * dpiScale);
 
-                            FillRect(cx - crossLen, cy, crossLen - crossGap, 1, CrosshairColor);
-                            FillRect(cx + crossGap, cy, crossLen - crossGap, 1, CrosshairColor);
-                            FillRect(cx, cy - crossLen, 1, crossLen - crossGap, CrosshairColor);
-                            FillRect(cx, cy + crossGap, 1, crossLen - crossGap, CrosshairColor);
+                            if (State.GuideSamples.Length >= 2 && State.CalibrationOverlay is { } reticleCal)
+                            {
+                                RenderGuidingReticle(reticleCal, cx, cy, rect, dpiScale);
+                            }
+                            else
+                            {
+                                var crossLen = (int)(15 * dpiScale);
+                                var crossGap = (int)(4 * dpiScale);
+
+                                FillRect(cx - crossLen, cy, crossLen - crossGap, 1, CrosshairColor);
+                                FillRect(cx + crossGap, cy, crossLen - crossGap, 1, CrosshairColor);
+                                FillRect(cx, cy - crossLen, 1, crossLen - crossGap, CrosshairColor);
+                                FillRect(cx, cy + crossGap, 1, crossLen - crossGap, CrosshairColor);
+                            }
                         }
 
                         // L-shaped calibration overlay: auto-scaled, centered on image.
@@ -199,6 +209,64 @@ namespace TianWen.UI.Abstractions
             DrawText(State.IsRunning ? "Waiting for guide frame\u2026" : "No guide camera",
                 fontPath, rect.X, rect.Y, rect.Width, rect.Height,
                 fontSize, DimText, TextAlign.Center, TextAlign.Center);
+        }
+
+        /// <summary>
+        /// Full-frame RA/Dec reticle centred on the guide star, drawn during guiding. Arms run
+        /// along the calibrated RA axis (orange) and the perpendicular Dec axis (blue), clipped
+        /// to the camera rect, with a centre gap so the star itself stays visible. Persists for
+        /// the whole guiding session as an orientation reference (the calibration L-shape only
+        /// shows before guiding starts).
+        /// </summary>
+        private void RenderGuidingReticle(CalibrationOverlayData cal, int starCx, int starCy, RectF32 rect, float dpiScale)
+        {
+            var theta = cal.CameraAngleRad;
+            var raUx = (float)Math.Cos(theta);
+            var raUy = (float)Math.Sin(theta);
+            // Dec axis = RA axis rotated 90deg on the sensor.
+            var decUx = -raUy;
+            var decUy = raUx;
+            var gap = 14f * dpiScale;
+
+            DrawReticleArm(starCx, starCy, raUx, raUy, rect, gap, CalRaColor);
+            DrawReticleArm(starCx, starCy, -raUx, -raUy, rect, gap, CalRaColor);
+            DrawReticleArm(starCx, starCy, decUx, decUy, rect, gap, CalDecColor);
+            DrawReticleArm(starCx, starCy, -decUx, -decUy, rect, gap, CalDecColor);
+
+            // Tiny centre marker so the exact lock position reads clearly inside the gap.
+            FillRect(starCx - 1, starCy - 1, 3, 3, CrosshairColor);
+        }
+
+        /// <summary>
+        /// Draws one reticle arm from the star (offset outward by <paramref name="gap"/>) along
+        /// (ux, uy) to where the ray leaves <paramref name="rect"/> (slab method), so the arm
+        /// always clips to the guide-camera area instead of bleeding into neighbouring panels.
+        /// </summary>
+        private void DrawReticleArm(int cx, int cy, float ux, float uy, RectF32 rect, float gap, RGBAColor32 color)
+        {
+            var tExit = float.MaxValue;
+            if (MathF.Abs(ux) > 1e-4f)
+            {
+                var t1 = (rect.X - cx) / ux;
+                var t2 = (rect.X + rect.Width - cx) / ux;
+                tExit = MathF.Min(tExit, MathF.Max(t1, t2));
+            }
+            if (MathF.Abs(uy) > 1e-4f)
+            {
+                var t1 = (rect.Y - cy) / uy;
+                var t2 = (rect.Y + rect.Height - cy) / uy;
+                tExit = MathF.Min(tExit, MathF.Max(t1, t2));
+            }
+            if (tExit <= gap)
+            {
+                return; // star sits at the frame edge along this arm
+            }
+
+            var x0 = (int)(cx + ux * gap);
+            var y0 = (int)(cy + uy * gap);
+            var x1 = (int)(cx + ux * tExit);
+            var y1 = (int)(cy + uy * tExit);
+            DrawLine(x0, y0, x1, y1, color);
         }
 
         /// <summary>

--- a/src/TianWen.UI.Abstractions/LiveSessionActions.cs
+++ b/src/TianWen.UI.Abstractions/LiveSessionActions.cs
@@ -51,6 +51,15 @@ namespace TianWen.UI.Abstractions
             _ => new RGBAColor32(0x55, 0x55, 0x88, 0xff)                                // default purple-grey
         };
 
+        /// <summary>
+        /// UI label for a per-frame filter name. A camera with no filter wheel reports
+        /// the <see cref="Filter.Unknown"/> sentinel (DisplayName "Unknown"); surface the
+        /// caller's <paramref name="fallback"/> (e.g. "L" for luminance, "--" for "none")
+        /// instead of the raw sentinel string.
+        /// </summary>
+        public static string FilterDisplayLabel(string? filterName, string fallback)
+            => filterName is { Length: > 0 } name && name != Filter.Unknown.DisplayName ? name : fallback;
+
         /// <summary>Format a timespan as compact duration (e.g. "4h56m" or "23m").</summary>
         public static string FormatDuration(TimeSpan ts)
         {

--- a/src/TianWen.UI.Abstractions/LiveSessionTab.cs
+++ b/src/TianWen.UI.Abstractions/LiveSessionTab.cs
@@ -1110,7 +1110,7 @@ namespace TianWen.UI.Abstractions
                 // Filter
                 if (y < maxY && ota.FilterWheel is not null)
                 {
-                    var filterName = (i < cameraStates.Length && cameraStates[i].FilterName is { Length: > 0 } fn) ? fn : "--";
+                    var filterName = i < cameraStates.Length ? LiveSessionActions.FilterDisplayLabel(cameraStates[i].FilterName, "--") : "--";
                     DrawText($"FW: {filterName}", fontPath,
                         px + pad, y, textW, rowH,
                         smallFs, BodyText, TextAlign.Near, TextAlign.Center);
@@ -1229,7 +1229,7 @@ namespace TianWen.UI.Abstractions
             var fraction = totalSec > 0 ? (float)(elapsedSec / totalSec) : 0f;
 
             // Filter + frame label
-            var filterLabel = cs.FilterName is { Length: > 0 } fn ? fn : "L";
+            var filterLabel = LiveSessionActions.FilterDisplayLabel(cs.FilterName, "L");
             var expLabel = $"{filterLabel} #{cs.FrameNumber} ({elapsedSec:F0}/{totalSec:F0}s)";
             DrawText(expLabel, fontPath,
                 x, y, w, rowH, smallFs, BodyText, TextAlign.Near, TextAlign.Center);
@@ -1941,7 +1941,8 @@ namespace TianWen.UI.Abstractions
                 FillRect(rect.X, y, rect.Width, rowH, bg);
 
                 var target = entry.TargetName.Length > 10 ? entry.TargetName[..10] : entry.TargetName;
-                var filter = entry.FilterName.Length > 6 ? entry.FilterName[..6] : entry.FilterName;
+                var filterRaw = LiveSessionActions.FilterDisplayLabel(entry.FilterName, "L");
+                var filter = filterRaw.Length > 6 ? filterRaw[..6] : filterRaw;
                 var hfd = entry.MedianHfd > 0 ? $"{entry.MedianHfd:F1}\"" : "--";
                 var stars = entry.StarCount > 0 ? $"{entry.StarCount}" : "--";
 

--- a/src/TianWen.UI.Abstractions/SkyMapState.cs
+++ b/src/TianWen.UI.Abstractions/SkyMapState.cs
@@ -87,6 +87,14 @@ namespace TianWen.UI.Abstractions
         /// </summary>
         public ImmutableArray<(double RA, double Dec, string Name, int Row, int Col)> MosaicPanels { get; set; } = [];
 
+        /// <summary>
+        /// Committed observing-plan target(s) for the sky-map overlay: RA/Dec centre (J2000),
+        /// display name, and whether this is the currently-executing observation. Populated by
+        /// the event loop from the built schedule (and the running session's active observation),
+        /// so the user can see where tonight's targets sit. Empty when no plan is committed.
+        /// </summary>
+        public ImmutableArray<(double RA, double Dec, string Name, bool IsActive)> ScheduleTargets { get; set; } = [];
+
         /// <summary>Cached view matrix, updated each frame by the rendering layer.</summary>
         public Matrix4x4 CurrentViewMatrix { get; set; } = Matrix4x4.Identity;
 

--- a/src/TianWen.UI.Abstractions/SkyMapTab.cs
+++ b/src/TianWen.UI.Abstractions/SkyMapTab.cs
@@ -178,6 +178,13 @@ namespace TianWen.UI.Abstractions
                 RenderMosaicPanels(contentRect, dpiScale, ppr, cx, cy);
             }
 
+            // Committed plan target markers (where tonight's targets are). Drawn under the
+            // mount reticle so the reticle stays the topmost element when it overlaps a target.
+            if (State.ScheduleTargets.Length > 0)
+            {
+                RenderScheduleTargets(contentRect, dpiScale, fontPath, BaseFontSize, ppr, cx, cy, site, dimBelowHorizon);
+            }
+
             // Mount reticle on top of everything catalog-related so it's never buried.
             if (State.ShowMountOverlay && State.MountOverlay is { } mountOverlay)
             {
@@ -217,6 +224,18 @@ namespace TianWen.UI.Abstractions
             ICelestialObjectDB db, RectF32 contentRect, float dpiScale, string fontPath,
             float baseFontSize, SiteContext site, bool dimBelowHorizon, PlannerState plannerState,
             bool showAllOverlays)
+        {
+        }
+
+        /// <summary>
+        /// Override in the GPU subclass to draw committed observing-plan target markers
+        /// (a small reticle + label per <see cref="SkyMapState.ScheduleTargets"/> entry,
+        /// the active observation highlighted). Base implementation is a no-op — the
+        /// software / TUI fallback does not render shape markers.
+        /// </summary>
+        protected virtual void RenderScheduleTargets(
+            RectF32 contentRect, float dpiScale, string fontPath, float baseFontSize,
+            double ppr, float cx, float cy, SiteContext site, bool dimBelowHorizon)
         {
         }
 

--- a/src/TianWen.UI.Gui/VkGuiRenderer.cs
+++ b/src/TianWen.UI.Gui/VkGuiRenderer.cs
@@ -478,6 +478,7 @@ namespace TianWen.UI.Gui
                     // preview-mode uses PreviewMountState populated by PollPreviewTelemetry.
                     PopulateSkyMapMountOverlay(appState);
                     PopulateSkyMapMosaicPanels(appState, plannerState);
+                    PopulateSkyMapScheduleTargets();
                     _skyMapTab.Render(plannerState, contentRect, DpiScale,
                         _fontPath ?? "monospace", timeProvider);
                     break;
@@ -530,16 +531,30 @@ namespace TianWen.UI.Gui
             // before the first poll completes (or when no mount is configured at all).
             // Guard on the display name being set, which only happens after a successful
             // poll establishes that a mount is connected.
-            var displayName = LiveSessionState.PreviewMountDisplayName;
+            // Source the mount state AND its display name from the same place: the
+            // session when one is running (it owns the mount and populates MountState),
+            // otherwise the preview poll. Previously the display-name guard always read
+            // the preview poll's name, so a session started without a prior preview poll
+            // (e.g. straight from the Planner) suppressed the reticle even though the
+            // session mount was live.
+            MountState ms;
+            string? displayName;
+            if (LiveSessionState.IsRunning)
+            {
+                ms = LiveSessionState.MountState;
+                displayName = LiveSessionState.ActiveSession?.Setup.Mount.Device.DisplayName;
+            }
+            else
+            {
+                ms = LiveSessionState.PreviewMountState;
+                displayName = LiveSessionState.PreviewMountDisplayName;
+            }
+
             if (string.IsNullOrEmpty(displayName))
             {
                 _skyMapTab.State.MountOverlay = null;
                 return;
             }
-
-            var ms = LiveSessionState.IsRunning
-                ? LiveSessionState.MountState
-                : LiveSessionState.PreviewMountState;
 
             if (double.IsNaN(ms.RightAscension) || double.IsNaN(ms.Declination))
             {
@@ -572,6 +587,36 @@ namespace TianWen.UI.Gui
                 IsSlewing: ms.IsSlewing,
                 IsTracking: ms.IsTracking,
                 SensorFovDeg: sensorFov);
+        }
+
+        /// <summary>
+        /// Surfaces the committed observing plan's target(s) to the sky map so the user can
+        /// see where tonight's targets sit. Sourced from the built schedule
+        /// (<see cref="SessionTabState.Schedule"/>); the running session's
+        /// <see cref="LiveSessionState.ActiveObservation"/> is flagged so the renderer can
+        /// highlight the target currently being imaged / slewed to.
+        /// </summary>
+        private void PopulateSkyMapScheduleTargets()
+        {
+            var schedule = SessionState.Schedule;
+            if (schedule is not { Count: > 0 })
+            {
+                _skyMapTab.State.ScheduleTargets = [];
+                return;
+            }
+
+            var active = LiveSessionState.ActiveObservation?.Target;
+            var targets = new List<(double RA, double Dec, string Name, bool IsActive)>(schedule.Count);
+            foreach (var obs in schedule)
+            {
+                var t = obs.Target;
+                if (double.IsNaN(t.RA) || double.IsNaN(t.Dec))
+                {
+                    continue;
+                }
+                targets.Add((t.RA, t.Dec, t.Name, active is { } a && a == t));
+            }
+            _skyMapTab.State.ScheduleTargets = [.. targets];
         }
 
         /// <summary>

--- a/src/TianWen.UI.Gui/VkGuiRenderer.cs
+++ b/src/TianWen.UI.Gui/VkGuiRenderer.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Immutable;
 using DIR.Lib;
 using Microsoft.Extensions.Logging;
 using SdlVulkan.Renderer;
@@ -27,6 +28,8 @@ namespace TianWen.UI.Gui
         private readonly VkNotificationsTab _notificationsTab;
         private readonly VkMiniViewerWidget _guiderMiniViewer;
         private readonly VkMiniViewerWidget _miniViewer;
+        private ScheduledObservationTree? _cachedSchedule;
+        private Target? _cachedActiveTarget;
         private string? _fontPath;
         private string? _emojiFontPath;
         private uint _width;
@@ -602,10 +605,24 @@ namespace TianWen.UI.Gui
             if (schedule is not { Count: > 0 })
             {
                 _skyMapTab.State.ScheduleTargets = [];
+                _cachedSchedule = null;
+                _cachedActiveTarget = null;
                 return;
             }
 
+            // Rebuild only when the schedule or active observation changes.
+            // The schedule is static during a session; only the active target
+            // changes as observations advance. Comparing the schedule identity
+            // and active target identity avoids a List+ImmutableArray allocation
+            // every render frame (~60 FPS).
             var active = LiveSessionState.ActiveObservation?.Target;
+            if (_cachedSchedule == schedule && _cachedActiveTarget == active)
+            {
+                return;
+            }
+            _cachedSchedule = schedule;
+            _cachedActiveTarget = active;
+
             var targets = new List<(double RA, double Dec, string Name, bool IsActive)>(schedule.Count);
             foreach (var obs in schedule)
             {

--- a/src/TianWen.UI.Gui/VkMiniViewerWidget.cs
+++ b/src/TianWen.UI.Gui/VkMiniViewerWidget.cs
@@ -136,7 +136,15 @@ public sealed unsafe class VkMiniViewerWidget : IMiniViewerWidget, IDisposable
             {
                 _cachedStretchStats = new ChannelStretchStats[_uploadedChannelCount];
             }
-            var (ped, med, mad) = image.GetPedestralMedianAndMADScaledToUnit(0);
+            // Stretch stats only need an aggregate median/MAD, so subsample large
+            // frames on a fixed grid (~1M-sample target). A full 61 MP scan on the
+            // render thread for every new frame is what dragged the live session to
+            // ~1 FPS. Display is unaffected -- the full frame is still uploaded and
+            // rendered, so 1:1 still shows every pixel.
+            var pixels = (long)image.Width * image.Height;
+            const long targetSamples = 1_000_000L;
+            var stride = pixels > targetSamples ? (int)Math.Sqrt((double)pixels / targetSamples) : 1;
+            var (ped, med, mad) = image.GetPedestralMedianAndMADScaledToUnit(0, pixelStride: stride);
             for (var c = 0; c < _cachedStretchStats!.Length; c++)
             {
                 _cachedStretchStats[c] = new ChannelStretchStats(ped, med, mad);

--- a/src/TianWen.UI.Gui/VkSkyMapTab.cs
+++ b/src/TianWen.UI.Gui/VkSkyMapTab.cs
@@ -571,6 +571,46 @@ public sealed unsafe class VkSkyMapTab(VkRenderer renderer) : SkyMapTab<VulkanCo
             screenX, screenY + 20f * dpiScale + lineH, lineH);
     }
 
+    /// <summary>
+    /// Draws the committed plan's target(s): a small reticle + name label per scheduled
+    /// observation. The currently-executing observation is amber (matching the slewing
+    /// mount reticle); the rest are pale green. Below-horizon targets are dimmed.
+    /// </summary>
+    protected override void RenderScheduleTargets(
+        RectF32 contentRect, float dpiScale, string fontPath, float baseFontSize,
+        double ppr, float cx, float cy, SiteContext site, bool dimBelowHorizon)
+    {
+        var fontSize = baseFontSize * dpiScale;
+        var lineH = fontSize * 1.2f;
+        const float margin = 100f;
+
+        foreach (var (ra, dec, name, isActive) in State.ScheduleTargets)
+        {
+            if (!SkyMapProjection.ProjectWithMatrix(ra, dec, State.CurrentViewMatrix,
+                    ppr, cx, cy, out var sx, out var sy))
+            {
+                continue;
+            }
+            if (sx < contentRect.X - margin || sx > contentRect.X + contentRect.Width + margin
+                || sy < contentRect.Y - margin || sy > contentRect.Y + contentRect.Height + margin)
+            {
+                continue;
+            }
+
+            // Dim targets currently below the horizon so they read as "not up yet".
+            var alpha = (byte)(dimBelowHorizon && !site.IsAboveHorizon(ra, dec) ? 0x60 : 0xE0);
+            var color = isActive
+                ? new RGBAColor32(0xFF, 0xB0, 0x40, alpha)  // amber - active observation
+                : new RGBAColor32(0x80, 0xE0, 0xA0, alpha); // pale green - scheduled
+
+            VkOverlayShapes.DrawReticle(renderer, dpiScale,
+                sx, sy, radius: 9f, armLength: 14f, gap: 4f,
+                color: color, thickness: 1.5f);
+            DrawReticleLabel(name, fontPath, fontSize * 0.9f, color,
+                sx, sy + 14f * dpiScale, lineH);
+        }
+    }
+
     private void DrawReticleLabel(string text, string fontPath, float fontSize, RGBAColor32 color,
         float centerX, float topY, float lineH)
     {


### PR DESCRIPTION
## Summary

Three related changes from GUI smoke-testing a fake imaging session (a Skywatcher fake mount defaults to a small polar misalignment, used to exercise the polar-align routine):

1. **`build`** — bump `SdlVulkan.Renderer` 4.1 → 5.0 (multi-page SDF glyph atlas; no more grow stall / Adreno submit-wedge). 5.0.* is published to NuGet, so CI (PackageReference) resolves cleanly.
2. **`fix(gui)`** — live-session usability fixes + fake-camera catalog self-resolve.
3. **`fix(fake-mount)`** — model the polar misalignment for **imaging**, not just polar-align, so plate-solve centering can detect and sync it away.

## The core bug (commit 3)

The fake Skywatcher's misalignment synthesizer pinned the OTA to the **pole** and swept it by the RA encoder, so `GetRA/GetDec` reported ~±89° **regardless of where the mount was slewed**. Imaging reads `GetRA/GetDec` for the plate-solve search hint (`CenterOnTargetAsync` → `PlateSolveAndSyncCoreAsync`) and the rough-focus camera target; a ~44°-off pole hint made the hinted catalog solve fail (no blind fallback), so centering never converged → the session looked stuck "re-slewing".

Polar-align (MoveAxis + plate-solve) genuinely **needs** the swept-pole behaviour, so it had to stay. The fix splits the synthesizer into two regimes keyed on the believed Dec's distance from the **site-latitude pole**:

- **Near the pole (polar-align):** unchanged `ApplyPolarMisalignment` swept-pole.
- **Away from the pole (imaging):** new `ApplyAxisTiltToPointing` rotates the believed (encoder) pointing by the axis tilt → commanded ± ~misalignment, so a GOTO to Dec=45 reports ~45, never the pole.

To make centering **converge**, `SyncRaDecAsync` is overridden: a sync to a target away from the pole is plate-solve-driven, so the mount "learns" its orientation and subsequent reads return the believed pointing verbatim. Startup/park syncs (to the pole) don't trigger it, preserving the polar-align sim. `PlateSolveAndSyncCoreAsync` now reads the mount pointing before the centering exposure and stamps `camera.Target` from it (reused as the search hint, one read), so the fake camera actually renders the misaligned field that plate-solve then measures and syncs away.

Hemisphere is now derived from **site latitude**, not `baseDec`.

## Live-session GUI fixes (commit 2)

- FakeCameraDriver lazily resolves `ICelestialObjectDB` from its DI-provided `IExternal` on first exposure (no fake-only wiring in the session/shared layer).
- `Session.PhaseChanged` → human-readable notification log line.
- `LiveSessionActions.FilterDisplayLabel` — fallback instead of the `Filter.Unknown` sentinel.
- Sky map: mount reticle sourced from the active session when running; committed schedule targets drawn as markers.
- Mini-viewer + `Image.Histogram`: adaptive pixel-stride subsampling for stretch stats (full frame still uploaded).

## Tests

6 new `FakeSkywatcherMountDriverTests` (axis-tilt math, end-to-end slew-not-pole, sync-learns-alignment, pole-sync-does-not, southern hemisphere). Full suite green locally: **2491 unit + 248 functional + 51 polar-align**, GUI builds.

## Verification status

Builds + full test suite pass. End-to-end GUI behaviour against the fake misaligned mount is **pending a night-time manual test** (centering convergence + mount reticle on target).

🤖 Generated with [Claude Code](https://claude.com/claude-code)