### PR TITLE
ci: bump download-artifact v6 -> v8 (Node 24)

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -139,7 +139,7 @@ jobs:
     # be newer than .json.lz so MSBuild's Inputs/Outputs check skips the
     # PreprocessCatalogs target.
     - name: Download preprocessed catalogs
-      uses: actions/download-artifact@v6
+      uses: actions/download-artifact@v8
       with:
         name: preprocessed-catalogs
         path: src/TianWen.Lib/Astrometry/Catalogs/
@@ -235,7 +235,7 @@ jobs:
     - name: Fetch required LFS objects
       run: git lfs pull --include="*.lz,*.ttf,*.bin.gz,*.fits.gz"
     - name: Download preprocessed catalogs
-      uses: actions/download-artifact@v6
+      uses: actions/download-artifact@v8
       with:
         name: preprocessed-catalogs
         path: src/TianWen.Lib/Astrometry/Catalogs/
@@ -306,7 +306,7 @@ jobs:
     # preprocess-catalog.ps1 script on the multi-platform publish matrix
     # (Windows / Linux / macOS).
     - name: Download preprocessed catalogs
-      uses: actions/download-artifact@v6
+      uses: actions/download-artifact@v8
       with:
         name: preprocessed-catalogs
         path: src/TianWen.Lib/Astrometry/Catalogs/


### PR DESCRIPTION
GitHub forces Node 20 actions onto Node 24 on **2026-06-16** and removes the Node 20 runtime on **2026-09-16**. The CI deprecation annotation flags two Node 20 actions:

1. `actions/download-artifact@v6` — **fixed here** (3 usages → `@v8`). The `release` + `publish-nuget` jobs already use `@v8`, so this just makes build/test/publish-apps consistent. Artifact format is unchanged across v4–v8, so v8 downloads still read the v7-uploaded `preprocessed-catalogs` / `nuget-packages` artifacts (already proven: the release job pairs upload@v7 with download@v8).

2. `actions/cache/restore@v4` — **NOT in this repo.** It comes from inside `SharpAstro/cache-apt-pkgs-action@v1`, which pins `actions/cache/restore@v4.3.0`, `actions/cache/save@v4.3.0`, and `actions/upload-artifact@v4.6.2` (all Node 20). Needs a follow-up bump in that fork + a `v1`/`latest` tag move. Upstream `awalsh128` hasn't bumped either, so there's no newer ref to re-point to.

This PR's own CI run exercises the new `download-artifact@v8` download path (build uploads via v7 → test jobs download via v8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)