### PR TITLE
fix(time): render all UI times in site-local timezone, never machine TZ or raw UTC

### DIFF
--- a/src/TianWen.Cli/Plan/AsciiAltitudeChart.cs
+++ b/src/TianWen.Cli/Plan/AsciiAltitudeChart.cs
@@ -49,7 +49,7 @@ internal static class AsciiAltitudeChart
             var col = (int)((t - start).TotalHours / totalHours * chartWidth);
             if (col >= 0 && col < chartWidth)
             {
-                var label = t.ToLocalTime().ToString("HH");
+                var label = t.ToOffset(state.SiteTimeZone).ToString("HH");
                 while (header.Length < nameWidth + 3 + col)
                 {
                     header += ' ';

--- a/src/TianWen.Cli/Plan/PlanSubCommand.cs
+++ b/src/TianWen.Cli/Plan/PlanSubCommand.cs
@@ -86,7 +86,7 @@ internal class PlanSubCommand(
             var s = plannerState.TonightsBest[i];
             var pin = plannerState.Proposals.Any(p => p.Target == s.Target) ? "\u2605" : "";
             var objType = s.ObjectType.ToAbbreviation();
-            var window = $"{s.OptimalStart.ToOffset(plannerState.SiteTimeZone):HH:mm}\u2013{(s.OptimalStart + s.OptimalDuration).ToOffset(plannerState.SiteTimeZone):HH:mm}";
+            var window = $"{s.OptimalStart.ToOffset(plannerState.SiteTimeZone):HH:mm}-{(s.OptimalStart + s.OptimalDuration).ToOffset(plannerState.SiteTimeZone):HH:mm}";
             var rating = PlannerActions.ScoreToRating(s.CombinedScore, maxScore);
 
             sb.AppendLine($"| {pin}{i + 1} | {s.Target.Name} | {objType} | {s.OptimalAltitude:F0}\u00b0 | {window} | {rating:F1}\u2605 |");

--- a/src/TianWen.Cli/Tui/NotificationListItem.cs
+++ b/src/TianWen.Cli/Tui/NotificationListItem.cs
@@ -8,7 +8,7 @@ namespace TianWen.Cli.Tui;
 /// <see cref="NotificationEntry"/> as <c>HH:mm:ss  [SEV ]  message</c> with
 /// severity-coloured tag and dim timestamp.
 /// </summary>
-internal sealed class NotificationListItem(NotificationEntry entry) : IRowFormatter
+internal sealed class NotificationListItem(NotificationEntry entry, System.TimeSpan siteTimeZone) : IRowFormatter
 {
     private static readonly VtStyle DimStyle = new(SgrColor.BrightBlack, SgrColor.Black);
     private static readonly VtStyle BodyStyle = new(SgrColor.White, SgrColor.Black);
@@ -20,7 +20,7 @@ internal sealed class NotificationListItem(NotificationEntry entry) : IRowFormat
 
     public string FormatRow(int width, ColorMode colorMode, bool isSelected)
     {
-        var ts = entry.When.ToLocalTime().ToString("HH:mm:ss");
+        var ts = entry.When.ToOffset(siteTimeZone).ToString("HH:mm:ss");
         var (tag, sevStyle) = entry.Severity switch
         {
             NotificationSeverity.Error => ("ERR ", ErrorStyle),

--- a/src/TianWen.Cli/Tui/TuiNotificationsTab.cs
+++ b/src/TianWen.Cli/Tui/TuiNotificationsTab.cs
@@ -36,7 +36,7 @@ internal sealed class TuiNotificationsTab(GuiAppState appState) : TuiTabBase
         var items = new NotificationListItem[entries.Length];
         for (var i = 0; i < entries.Length; i++)
         {
-            items[i] = new NotificationListItem(entries[i]);
+            items[i] = new NotificationListItem(entries[i], appState.SiteTimeZone);
         }
 
         var header = entries.Length > 0

--- a/src/TianWen.Cli/Tui/TuiPlannerTab.cs
+++ b/src/TianWen.Cli/Tui/TuiPlannerTab.cs
@@ -104,7 +104,7 @@ internal sealed class TuiPlannerTab(
         _canvasRenderer.FillRectangle(
             new RectInt(new PointInt((int)canvasPixelSize.Width, (int)canvasPixelSize.Height), new PointInt(0, 0)),
             new RGBAColor32(0x1a, 0x1a, 0x2e, 0xff));
-        var chartCurrentTime = plannerState.PlanningDate.HasValue ? null as DateTimeOffset? : timeProvider.System.GetLocalNow();
+        var chartCurrentTime = plannerState.PlanningDate.HasValue ? null as DateTimeOffset? : timeProvider.GetUtcNow().ToOffset(plannerState.SiteTimeZone);
         AltitudeChartRenderer.Render(_canvasRenderer, plannerState, fontPath,
             0, 0, (int)_canvasRenderer.Width, (int)_canvasRenderer.Height,
             highlightTargetIndex: plannerState.SelectedTargetIndex,

--- a/src/TianWen.Cli/Tui/TuiTabBar.cs
+++ b/src/TianWen.Cli/Tui/TuiTabBar.cs
@@ -32,7 +32,7 @@ internal sealed class TuiTabBar(ITerminalViewport viewport)
 
         var tabText = string.Join(" ", parts);
         var profileName = appState.ActiveProfile?.DisplayName ?? "No profile";
-        var clock = timeProvider.System.GetLocalNow().ToOffset(siteTimeZone).ToString("HH:mm:ss");
+        var clock = timeProvider.GetUtcNow().ToOffset(siteTimeZone).ToString("HH:mm:ss");
 
         _bar.Text($" {tabText}").RightText($"{profileName}  {clock} ");
         _bar.Render();

--- a/src/TianWen.Hosting/Api/NinaV2/NinaSequenceEndpoints.cs
+++ b/src/TianWen.Hosting/Api/NinaV2/NinaSequenceEndpoints.cs
@@ -55,7 +55,7 @@ internal static class NinaSequenceEndpoints
         });
 
         // GET /v2/api/sequence/start — start session using active profile + pending targets
-        group.MapGet("/start", (IHostedSession hosted, ISessionFactory factory, ILogger<HostedSession> logger, CancellationToken ct) =>
+        group.MapGet("/start", (IHostedSession hosted, ISessionFactory factory, ILogger<HostedSession> logger, ITimeProvider timeProvider, CancellationToken ct) =>
         {
             if (hosted.CurrentSession is not null)
             {
@@ -73,9 +73,10 @@ internal static class NinaSequenceEndpoints
 
             // Drain pending targets
             var pendingTargets = hosted is HostedSession hs2 ? hs2.DrainTargets() : [];
+            var startUtc = timeProvider.GetUtcNow();
             var observations = pendingTargets.Select(t => new ScheduledObservation(
                 new Target(t.RA, t.Dec, t.Name, null),
-                DateTimeOffset.UtcNow,
+                startUtc,
                 TimeSpan.FromMinutes(t.DurationMinutes ?? 30),
                 AcrossMeridian: false,
                 FilterPlan: FilterPlanBuilder.BuildSingleFilterPlan(

--- a/src/TianWen.Hosting/Api/NinaV2/NinaSystemEndpoints.cs
+++ b/src/TianWen.Hosting/Api/NinaV2/NinaSystemEndpoints.cs
@@ -28,38 +28,42 @@ internal static class NinaSystemEndpoints
             ResponseEnvelope<string>.Ok(_version),
             NinaApiJsonContext.Default.ResponseEnvelopeString));
 
-        // GET /v2/api/time — current server time in ISO 8601
-        group.MapGet("/time", () => Results.Json(
-            ResponseEnvelope<string>.Ok(DateTimeOffset.UtcNow.ToString("o")),
+        // GET /v2/api/time — current server time in ISO 8601 (UTC wire format, ninaAPI contract)
+        group.MapGet("/time", (ITimeProvider timeProvider) => Results.Json(
+            ResponseEnvelope<string>.Ok(timeProvider.GetUtcNow().ToString("o")),
             NinaApiJsonContext.Default.ResponseEnvelopeString));
 
         // GET /v2/api/event-history — synthesized from session phase changes
-        group.MapGet("/event-history", (IHostedSession hosted) =>
+        group.MapGet("/event-history", (IHostedSession hosted, ITimeProvider timeProvider) =>
         {
             var events = new List<NinaEventDto>();
+
+            // One timestamp for the whole snapshot. ISO 8601 UTC ("o") is the ninaAPI wire
+            // contract Touch N Stars expects -- this is API payload, not UI display.
+            var nowIso = timeProvider.GetUtcNow().ToString("o");
 
             if (hosted.CurrentSession is { } session)
             {
                 // Report device connections as events
                 if (session.Setup.Mount.Driver.Connected)
                 {
-                    events.Add(new NinaEventDto { Time = DateTimeOffset.UtcNow.ToString("o"), Event = "MOUNT-CONNECTED" });
+                    events.Add(new NinaEventDto { Time = nowIso, Event = "MOUNT-CONNECTED" });
                 }
                 if (session.Setup.Telescopes.Length > 0 && session.Setup.Telescopes[0].Camera.Driver.Connected)
                 {
-                    events.Add(new NinaEventDto { Time = DateTimeOffset.UtcNow.ToString("o"), Event = "CAMERA-CONNECTED" });
+                    events.Add(new NinaEventDto { Time = nowIso, Event = "CAMERA-CONNECTED" });
                 }
                 if (session.Setup.Guider.Driver.Connected)
                 {
-                    events.Add(new NinaEventDto { Time = DateTimeOffset.UtcNow.ToString("o"), Event = "GUIDER-CONNECTED" });
+                    events.Add(new NinaEventDto { Time = nowIso, Event = "GUIDER-CONNECTED" });
                 }
                 if (session.Setup.Telescopes.Length > 0 && session.Setup.Telescopes[0].Focuser?.Driver.Connected == true)
                 {
-                    events.Add(new NinaEventDto { Time = DateTimeOffset.UtcNow.ToString("o"), Event = "FOCUSER-CONNECTED" });
+                    events.Add(new NinaEventDto { Time = nowIso, Event = "FOCUSER-CONNECTED" });
                 }
                 if (session.Setup.Telescopes.Length > 0 && session.Setup.Telescopes[0].FilterWheel?.Driver.Connected == true)
                 {
-                    events.Add(new NinaEventDto { Time = DateTimeOffset.UtcNow.ToString("o"), Event = "FILTERWHEEL-CONNECTED" });
+                    events.Add(new NinaEventDto { Time = nowIso, Event = "FILTERWHEEL-CONNECTED" });
                 }
             }
 

--- a/src/TianWen.Hosting/Api/SessionEndpoints.cs
+++ b/src/TianWen.Hosting/Api/SessionEndpoints.cs
@@ -42,7 +42,7 @@ internal static class SessionEndpoints
         /// Consumes pending targets from IHostedSession.
         /// Accepts optional JSON body with SessionConfigApiDto.
         /// </summary>
-        group.MapPost("/start", async (HttpContext httpContext, IHostedSession hosted, ISessionFactory factory, CancellationToken ct) =>
+        group.MapPost("/start", async (HttpContext httpContext, IHostedSession hosted, ISessionFactory factory, ITimeProvider timeProvider, CancellationToken ct) =>
         {
             if (hosted.CurrentSession is not null)
             {
@@ -93,9 +93,10 @@ internal static class SessionEndpoints
 
             // Drain pending targets
             var pendingTargets = hosted is HostedSession hs ? hs.DrainTargets() : [];
+            var startUtc = timeProvider.GetUtcNow();
             var observations = pendingTargets.Select(t => new ScheduledObservation(
                 new Target(t.RA, t.Dec, t.Name, null),
-                DateTimeOffset.UtcNow,
+                startUtc,
                 TimeSpan.FromMinutes(t.DurationMinutes ?? 30),
                 AcrossMeridian: false,
                 FilterPlan: FilterPlanBuilder.BuildSingleFilterPlan(

--- a/src/TianWen.Lib.Tests/SessionTabTests.cs
+++ b/src/TianWen.Lib.Tests/SessionTabTests.cs
@@ -260,4 +260,53 @@ namespace TianWen.Lib.Tests
             state.FieldCount.ShouldBe(expectedCount);
         }
     }
+
+    /// <summary>
+    /// Regression guard for "the session captured 120s, not the 45s shown in the config screen".
+    /// The Session config displays the per-OTA f-ratio default exposure, but schedule building
+    /// used to pass a hardcoded 120s -- so what the user saw on the target rows was NOT what the
+    /// session captured. <see cref="SessionContent.EffectiveDefaultSubExposure"/> is now the
+    /// single source of truth both the display and the scheduler read.
+    /// </summary>
+    [Collection("UI")]
+    public class EffectiveDefaultSubExposureTests
+    {
+        // f/3 OTA (FL 300mm / aperture 100mm) -> DefaultExposureFromFRatio = 5*3*3 = 45s,
+        // i.e. exactly the "45s in the config" the user saw -- and crucially NOT 120s.
+        private static SessionTabState StateWithF3Ota()
+        {
+            var state = new SessionTabState();
+            state.CameraSettings.Add(new PerOtaCameraSettings
+            {
+                OtaName = "Telescope #0",
+                FocalLength = 300,
+                Aperture = 100,
+            });
+            return state;
+        }
+
+        [Fact]
+        public void WhenNoConfigOverride_EffectiveDefaultEqualsDisplayedFRatioDefaultNot120()
+        {
+            var state = StateWithF3Ota();
+            state.Configuration = state.Configuration with { DefaultSubExposure = null };
+
+            // What the config screen displays for an unoverridden target:
+            var displayedSec = SessionContent.DefaultExposureSeconds(state);
+            displayedSec.ShouldBe(45); // f/3 -> 45s shown; NOT the old hardcoded 120
+
+            // The scheduler's default MUST equal what the screen shows (the broken invariant).
+            SessionContent.EffectiveDefaultSubExposure(state).ShouldBe(TimeSpan.FromSeconds(displayedSec));
+            SessionContent.EffectiveDefaultSubExposure(state).ShouldNotBe(TimeSpan.FromSeconds(120));
+        }
+
+        [Fact]
+        public void WhenConfigOverrideSet_EffectiveDefaultHonoursConfigValue()
+        {
+            var state = StateWithF3Ota();
+            state.Configuration = state.Configuration with { DefaultSubExposure = TimeSpan.FromSeconds(90) };
+
+            SessionContent.EffectiveDefaultSubExposure(state).ShouldBe(TimeSpan.FromSeconds(90));
+        }
+    }
 }

--- a/src/TianWen.Lib/Devices/Alpaca/AlpacaCameraDriver.cs
+++ b/src/TianWen.Lib/Devices/Alpaca/AlpacaCameraDriver.cs
@@ -341,7 +341,7 @@ public void ReleaseImageData() { }
             new("Light", frameType.NeedsOpenShutter.ToString())
         ], cancellationToken);
 
-        var startTime = TimeProvider.System.GetLocalNow();
+        var startTime = TimeProvider.GetUtcNow();
         LastExposureStartTime = startTime;
         LastExposureFrameType = frameType;
         return startTime;

--- a/src/TianWen.Lib/Devices/Ascom/AscomCameraDriver.cs
+++ b/src/TianWen.Lib/Devices/Ascom/AscomCameraDriver.cs
@@ -375,7 +375,7 @@ internal class AscomCameraDriver : AscomDeviceDriverBase, ICameraDriver
                 _device.DeviceId, ex.GetType().Name, ex.Message);
             return ValueTask.FromException<DateTimeOffset>(ex);
         }
-        var startTime = TimeProvider.System.GetLocalNow();
+        var startTime = TimeProvider.GetUtcNow();
         LastExposureStartTime = startTime;
         LastExposureFrameType = frameType;
         return ValueTask.FromResult(startTime);

--- a/src/TianWen.Lib/Logging/FileLoggerProvider.cs
+++ b/src/TianWen.Lib/Logging/FileLoggerProvider.cs
@@ -16,7 +16,9 @@ public sealed class FileLoggerProvider : ILoggerProvider
 
     public FileLoggerProvider(string appName)
     {
-        var now = DateTime.Now;
+        // Machine-local wall clock (carries the local offset). Sourced from TimeProvider.System
+        // rather than DateTime.Now so we never touch the banned BCL now-statics.
+        var now = TimeProvider.System.GetLocalNow();
         var dateDir = now.ToString("yyyyMMdd");
         var timestamp = now.ToString("yyyyMMdd'T'HH_mm_ss");
 
@@ -51,7 +53,9 @@ internal sealed class FileLogger(string categoryName, StreamWriter writer, Lock 
         }
 
         var message = formatter(state, exception);
-        var timestamp = DateTime.Now.ToString("HH:mm:ss.fff");
+        // Carry the UTC offset (e.g. "12:34:56.789 +02:00") so log timestamps are unambiguous
+        // across timezones. Machine-local via TimeProvider.System -- never the banned BCL now-statics.
+        var timestamp = TimeProvider.System.GetLocalNow().ToString("HH:mm:ss.fff zzz");
         var level = logLevel switch
         {
             LogLevel.Trace => "TRC",

--- a/src/TianWen.UI.Abstractions/AltitudeChartRenderer.cs
+++ b/src/TianWen.UI.Abstractions/AltitudeChartRenderer.cs
@@ -378,7 +378,9 @@ public static class AltitudeChartRenderer
             DrawVLine(renderer, x, plotY, plotY + plotH, GridColor);
 
             var labelRect = MakeRect(x - 24, plotY + plotH + 2, 48, 16);
-            renderer.DrawText(t.ToString("HH:mm"), fontFamily, FontSize(h, 10), TextColor,
+            // Axis is "Local Time": label hour ticks in the site timezone, never the
+            // machine TZ (a bare ToString would render the stored UTC offset).
+            renderer.DrawText(t.ToOffset(state.SiteTimeZone).ToString("HH:mm"), fontFamily, FontSize(h, 10), TextColor,
                 labelRect, TextAlign.Center, TextAlign.Near);
         }
 

--- a/src/TianWen.UI.Abstractions/AppSignalHandler.cs
+++ b/src/TianWen.UI.Abstractions/AppSignalHandler.cs
@@ -248,7 +248,7 @@ namespace TianWen.UI.Abstractions
             catch { }
 
             return new CameraTelemetrySample(
-                _timeProvider.System.GetLocalNow(),
+                _timeProvider.GetUtcNow(),
                 ccd, sink, setpoint, power, coolerOn, busy);
         }
 
@@ -612,6 +612,13 @@ namespace TianWen.UI.Abstractions
             _tracker = tracker;
             _cts = cts;
             _external = external;
+
+            // Single site-timezone source: planner + live-session read through to
+            // GuiAppState.SiteTimeZone so every time display shares one value and the
+            // two states cannot drift apart (see PlannerState.AttachAppState).
+            plannerState.AttachAppState(appState);
+            liveSessionState.AttachAppState(appState);
+
             _logger = sp.GetRequiredService<ILoggerFactory>().CreateLogger(nameof(AppSignalHandler));
             _timeProvider = sp.GetRequiredService<ITimeProvider>();
 
@@ -1662,9 +1669,14 @@ namespace TianWen.UI.Abstractions
 
                 var profileData = profile.Data ?? ProfileData.Empty;
                 var (filters, design) = GetFirstOtaFilterConfig(profileData);
+                // Use the SAME effective defaults the session-start path uses so the planner
+                // PREVIEW matches what the session will actually capture (it previously hardcoded
+                // gain=120/offset=10/sub=120s here, diverging from both the config and the
+                // f-ratio exposure shown on the target rows). Gain/offset stay null so the per-OTA
+                // camera settings drive them, exactly as StartSession does.
                 PlannerActions.BuildSchedule(plannerState, sessionState, transform,
-                    defaultGain: 120, defaultOffset: 10,
-                    defaultSubExposure: TimeSpan.FromSeconds(120),
+                    defaultGain: null, defaultOffset: null,
+                    defaultSubExposure: SessionContent.EffectiveDefaultSubExposure(sessionState),
                     defaultObservationTime: TimeSpan.FromMinutes(60),
                     availableFilters: filters,
                     opticalDesign: design);
@@ -1727,9 +1739,10 @@ namespace TianWen.UI.Abstractions
 
                     var (filters, design) = GetFirstOtaFilterConfig(profileData);
 
-                    var subExposure = sessionState.Configuration.DefaultSubExposure ?? TimeSpan.FromSeconds(120);
-                    _logger.LogInformation("BuildSchedule: DefaultSubExposure={SubExposure} (config={Config})",
-                        subExposure, sessionState.Configuration.DefaultSubExposure);
+                    var subExposure = SessionContent.EffectiveDefaultSubExposure(sessionState);
+                    _logger.LogInformation(
+                        "BuildSchedule: effective default sub-exposure={SubExposure} (config={Config}, f-ratio default={FRatioSec}s)",
+                        subExposure, sessionState.Configuration.DefaultSubExposure, SessionContent.DefaultExposureSeconds(sessionState));
                     PlannerActions.BuildSchedule(plannerState, sessionState, transform,
                         defaultGain: null, defaultOffset: null,
                         defaultSubExposure: subExposure,
@@ -1777,7 +1790,8 @@ namespace TianWen.UI.Abstractions
                         session.Setup.Telescopes.Length);
 
                     liveSessionState.ActiveSession = session;
-                    liveSessionState.SiteTimeZone = plannerState.SiteTimeZone;
+                    // SiteTimeZone is no longer copied here -- LiveSessionState reads it
+                    // through to the single app-wide GuiAppState.SiteTimeZone.
                     appState.AppendNotification(_timeProvider.GetUtcNow(),
                         NotificationSeverity.Info, "Session started");
                     appState.NeedsRedraw = true;

--- a/src/TianWen.UI.Abstractions/GuiAppState.cs
+++ b/src/TianWen.UI.Abstractions/GuiAppState.cs
@@ -41,6 +41,17 @@ public class GuiAppState
 
     public GuiTab ActiveTab { get; set; } = GuiTab.Planner;
     public Profile? ActiveProfile { get; set; }
+
+    /// <summary>
+    /// Single app-wide site timezone offset (from GeoTimeZone via the profile site).
+    /// The one source of truth for "local time" display across planner, live session,
+    /// sky map, and notifications -- <see cref="PlannerState"/> and
+    /// <see cref="LiveSessionState"/> read through to this (see their AttachAppState).
+    /// Display code converts UTC instants with <c>dto.ToOffset(SiteTimeZone)</c>; never
+    /// render machine-local time or raw UTC.
+    /// </summary>
+    public TimeSpan SiteTimeZone { get; set; }
+
     public bool NeedsRedraw { get; set; } = true;
     public (float X, float Y) MouseScreenPosition { get; set; }
     public InputModifier LastClickModifiers { get; set; }

--- a/src/TianWen.UI.Abstractions/LiveSessionActions.cs
+++ b/src/TianWen.UI.Abstractions/LiveSessionActions.cs
@@ -60,16 +60,16 @@ namespace TianWen.UI.Abstractions
         public static string FilterDisplayLabel(string? filterName, string fallback)
             => filterName is { Length: > 0 } name && name != Filter.Unknown.DisplayName ? name : fallback;
 
-        /// <summary>Format a timespan as compact duration (e.g. "4h56m" or "23m").</summary>
+        /// <summary>Format a timespan as a duration (e.g. "4h 56m" or "23m 45s").</summary>
         public static string FormatDuration(TimeSpan ts)
         {
             if (ts.TotalHours >= 1)
             {
-                return $"{(int)ts.TotalHours}h{ts.Minutes:D2}m";
+                return $"{(int)ts.TotalHours}h {ts.Minutes:D2}m";
             }
             if (ts.TotalMinutes >= 1)
             {
-                return $"{(int)ts.TotalMinutes}m{ts.Seconds:D2}s";
+                return $"{(int)ts.TotalMinutes}m {ts.Seconds:D2}s";
             }
             return $"{(int)ts.TotalSeconds}s";
         }

--- a/src/TianWen.UI.Abstractions/LiveSessionState.cs
+++ b/src/TianWen.UI.Abstractions/LiveSessionState.cs
@@ -116,8 +116,18 @@ namespace TianWen.UI.Abstractions
         /// <summary>Calibration overlay data for guide camera L-overlay.</summary>
         public CalibrationOverlayData? CalibrationOverlay { get; set; }
 
-        /// <summary>Site timezone offset for displaying times in local site time.</summary>
-        public TimeSpan SiteTimeZone { get; set; }
+        // Site timezone reads through to the single app-wide GuiAppState.SiteTimeZone
+        // (wired via AttachAppState in the AppSignalHandler ctor) instead of being an
+        // independently-set copy that could drift from the planner's value.
+        private GuiAppState? _appState;
+
+        /// <summary>Site timezone offset for displaying times in local site time. Sourced
+        /// from the single app-wide <see cref="GuiAppState.SiteTimeZone"/>.</summary>
+        public TimeSpan SiteTimeZone => _appState?.SiteTimeZone ?? TimeSpan.Zero;
+
+        /// <summary>Attach the app-wide state so <see cref="SiteTimeZone"/> reflects the
+        /// single shared value. Called once during app composition (AppSignalHandler ctor).</summary>
+        internal void AttachAppState(GuiAppState appState) => _appState = appState;
 
         // --- Preview mode telemetry (populated when !IsRunning, from hub-connected drivers) ---
 

--- a/src/TianWen.UI.Abstractions/LiveSessionTab.cs
+++ b/src/TianWen.UI.Abstractions/LiveSessionTab.cs
@@ -629,11 +629,8 @@ namespace TianWen.UI.Abstractions
                         state.NeedsRedraw = true;
                     });
 
-                // Current time (right side)
-                var timeText = timeProvider.GetUtcNow().ToOffset(state.SiteTimeZone).ToString("HH:mm:ss");
-                DrawText(timeText, fontPath,
-                    rect.X + rect.Width - 120f * dpiScale, rect.Y, 116f * dpiScale, rect.Height,
-                    fontSize, DimText, TextAlign.Far, TextAlign.Center);
+                // Current time is shown by the global status-bar clock (top-right on every
+                // tab) -- no separate in-content clock here, to avoid a duplicate display.
                 return;
             }
 
@@ -1946,7 +1943,7 @@ namespace TianWen.UI.Abstractions
                 var hfd = entry.MedianHfd > 0 ? $"{entry.MedianHfd:F1}\"" : "--";
                 var stars = entry.StarCount > 0 ? $"{entry.StarCount}" : "--";
 
-                DrawText(entry.Timestamp.ToString("HH:mm"), fontPath, colTime, y, colTarget - colTime, rowH, rowFs, DimText, TextAlign.Near, TextAlign.Center);
+                DrawText(entry.Timestamp.ToOffset(state.SiteTimeZone).ToString("HH:mm"), fontPath, colTime, y, colTarget - colTime, rowH, rowFs, DimText, TextAlign.Near, TextAlign.Center);
                 DrawText(target, fontPath, colTarget, y, colFilter - colTarget, rowH, rowFs, BodyText, TextAlign.Near, TextAlign.Center);
                 DrawText(filter, fontPath, colFilter, y, colHfd - colFilter, rowH, rowFs, DimText, TextAlign.Near, TextAlign.Center);
                 DrawText(hfd, fontPath, colHfd, y, colStars - colHfd, rowH, rowFs, BodyText, TextAlign.Far, TextAlign.Center);

--- a/src/TianWen.UI.Abstractions/NotificationsTab.cs
+++ b/src/TianWen.UI.Abstractions/NotificationsTab.cs
@@ -119,9 +119,9 @@ namespace TianWen.UI.Abstractions
                 };
                 FillRect(_listRect.X, rowY, 3f * dpiScale, rowH, stripeColor);
 
-                // Timestamp (HH:mm:ss, site-local-ish — we just render whatever the
-                // DateTimeOffset captured at record time).
-                var tsText = entry.When.ToLocalTime().ToString("HH:mm:ss");
+                // Timestamp (HH:mm:ss) in the single app-wide site timezone -- never the
+                // machine TZ (.ToLocalTime would show UTC on a UTC-set machine).
+                var tsText = entry.When.ToOffset(appState.SiteTimeZone).ToString("HH:mm:ss");
                 var tsX = _listRect.X + 10f * dpiScale;
                 var tsW = 70f * dpiScale;
                 DrawText(tsText.AsSpan(), fontPath,

--- a/src/TianWen.UI.Abstractions/PlannerActions.cs
+++ b/src/TianWen.UI.Abstractions/PlannerActions.cs
@@ -26,7 +26,9 @@ public static class PlannerActions
     /// </summary>
     public static void ShiftPlanningDate(PlannerState state, ITimeProvider timeProvider, int days)
     {
-        var current = state.PlanningDate ?? timeProvider.System.GetLocalNow();
+        // Default "tonight" in the site's timezone, not the machine's, so the calendar date we
+        // step from matches the observing night the user sees on the chart.
+        var current = state.PlanningDate ?? timeProvider.GetUtcNow().ToOffset(state.SiteTimeZone);
         state.PlanningDate = current.AddDays(days);
         state.NeedsRecompute = true;
         state.NeedsRedraw = true;
@@ -38,7 +40,7 @@ public static class PlannerActions
     /// </summary>
     public static void ShiftPlanningHours(PlannerState state, ITimeProvider timeProvider, int hours)
     {
-        var current = state.PlanningDate ?? timeProvider.System.GetLocalNow();
+        var current = state.PlanningDate ?? timeProvider.GetUtcNow().ToOffset(state.SiteTimeZone);
         state.PlanningDate = current.AddHours(hours);
         state.NeedsRecompute = true;
         state.NeedsRedraw = true;

--- a/src/TianWen.UI.Abstractions/PlannerDetails.cs
+++ b/src/TianWen.UI.Abstractions/PlannerDetails.cs
@@ -84,6 +84,6 @@ public static class PlannerDetails
     {
         var start = scored.OptimalStart.ToOffset(state.SiteTimeZone);
         var end = (scored.OptimalStart + scored.OptimalDuration).ToOffset(state.SiteTimeZone);
-        return $"{start:HH:mm}\u2013{end:HH:mm}";
+        return $"{start:HH:mm}-{end:HH:mm}";
     }
 }

--- a/src/TianWen.UI.Abstractions/PlannerState.cs
+++ b/src/TianWen.UI.Abstractions/PlannerState.cs
@@ -136,8 +136,29 @@ public class PlannerState
     /// <summary>Maximum number of autocomplete suggestions to show.</summary>
     public const int MaxSuggestions = 8;
 
+    // Single app-wide site timezone source. In the interactive app (GUI/TUI) this reads
+    // and writes through to GuiAppState.SiteTimeZone (wired via AttachAppState) so the
+    // planner, live session, sky map, and notifications share one value and cannot drift
+    // apart. The standalone `plan` CLI command has no GuiAppState, so it falls back to a
+    // local field. Used for display instead of machine-local time (never render UTC).
+    private GuiAppState? _appState;
+    private TimeSpan _siteTimeZoneFallback;
+
     /// <summary>Site timezone offset (from GeoTimeZone). Used for display instead of machine local time.</summary>
-    public TimeSpan SiteTimeZone { get; set; }
+    public TimeSpan SiteTimeZone
+    {
+        get => _appState?.SiteTimeZone ?? _siteTimeZoneFallback;
+        set
+        {
+            if (_appState is not null) _appState.SiteTimeZone = value;
+            else _siteTimeZoneFallback = value;
+        }
+    }
+
+    /// <summary>Attach the app-wide state so <see cref="SiteTimeZone"/> reads/writes the
+    /// single shared <see cref="GuiAppState.SiteTimeZone"/>. Called once during app
+    /// composition (the AppSignalHandler constructor).</summary>
+    internal void AttachAppState(GuiAppState appState) => _appState = appState;
 
     /// <summary>
     /// The date to plan for. Null = tonight (uses current time).

--- a/src/TianWen.UI.Abstractions/PlannerTab.cs
+++ b/src/TianWen.UI.Abstractions/PlannerTab.cs
@@ -136,7 +136,7 @@ namespace TianWen.UI.Abstractions
                 ? state.SelectedTargetIndex
                 : (int?)null;
 
-            var now = timeProvider.System.GetLocalNow();
+            var now = timeProvider.GetUtcNow().ToOffset(state.SiteTimeZone);
             _currentTime = now;
             _timeProvider = timeProvider;
 

--- a/src/TianWen.UI.Abstractions/SessionContent.cs
+++ b/src/TianWen.UI.Abstractions/SessionContent.cs
@@ -58,6 +58,19 @@ namespace TianWen.UI.Abstractions
         }
 
         /// <summary>
+        /// The effective default sub-exposure for a proposal that has no per-target override:
+        /// the session config's <see cref="SessionConfiguration.DefaultSubExposure"/> when set,
+        /// otherwise the per-OTA f-ratio default (<see cref="DefaultExposureSeconds"/>). This is
+        /// the SINGLE source of truth shared by the Session-tab display AND schedule building,
+        /// so what the user sees on the target rows is exactly what the session captures. The old
+        /// code displayed the f-ratio default but scheduled a hardcoded 120s -- "exposure is 120s,
+        /// not the one I set in the session".
+        /// </summary>
+        public static TimeSpan EffectiveDefaultSubExposure(SessionTabState sessionState)
+            => sessionState.Configuration.DefaultSubExposure
+               ?? TimeSpan.FromSeconds(DefaultExposureSeconds(sessionState));
+
+        /// <summary>
         /// Builds display-ready camera settings rows from the session state.
         /// </summary>
         public static List<CameraSettingsRow> GetCameraRows(SessionTabState sessionState)
@@ -136,10 +149,10 @@ namespace TianWen.UI.Abstractions
                 {
                     var startStr = windowStart.ToOffset(tz).ToString("HH:mm");
                     var endStr = windowEnd.ToOffset(tz).ToString("HH:mm");
-                    timeWindow = $"{startStr}\u2013{endStr}";
+                    timeWindow = $"{startStr}-{endStr}";
                     duration = window.TotalHours >= 1
-                        ? $"{window.TotalHours:0.0}h"
-                        : $"{window.TotalMinutes:0}min";
+                        ? $"{(int)window.TotalHours}h {window.Minutes:D2}m"
+                        : $"{(int)window.TotalMinutes}m";
                     isWarning = window.TotalHours < 1.5;
                 }
                 else

--- a/src/TianWen.UI.Abstractions/SessionTab.cs
+++ b/src/TianWen.UI.Abstractions/SessionTab.cs
@@ -601,10 +601,10 @@ namespace TianWen.UI.Abstractions
                     var endStr = windowEnd.ToOffset(tz).ToString("HH:mm");
                     var durColor = window.TotalHours < 1.5 ? WarningColor : AccentColor;
                     var durStr = window.TotalHours >= 1
-                        ? $"{window.TotalHours:0.0}h"
-                        : $"{window.TotalMinutes:0}min";
+                        ? $"{(int)window.TotalHours}h {window.Minutes:D2}m"
+                        : $"{(int)window.TotalMinutes}m";
 
-                    DrawText($"  {startStr}\u2013{endStr}  ({durStr})", fontPath,
+                    DrawText($"  {startStr}-{endStr}  ({durStr})", fontPath,
                         colTargetX, cursor, listRect.Width - colNumW - padding * 2, rowH * 0.8f,
                         fontSize * 0.85f, durColor, TextAlign.Near, TextAlign.Center);
                 }

--- a/src/TianWen.UI.Abstractions/SkyMapRenderer.cs
+++ b/src/TianWen.UI.Abstractions/SkyMapRenderer.cs
@@ -86,7 +86,7 @@ namespace TianWen.UI.Abstractions
 
             if (state.ShowPlanets)
             {
-                DrawPlanets(image, db, site, cRA, cDec, ppr, cx, cy, w, h);
+                DrawPlanets(image, db, site, timeProvider, cRA, cDec, ppr, cx, cy, w, h);
             }
 
             // Horizon drawn last so it's visible on top of everything
@@ -476,6 +476,7 @@ namespace TianWen.UI.Abstractions
             RgbaImage image,
             ICelestialObjectDB db,
             SiteContext site,
+            ITimeProvider timeProvider,
             double cRA, double cDec, double ppr,
             float cx, float cy, int w, int h)
         {
@@ -484,7 +485,7 @@ namespace TianWen.UI.Abstractions
                 return;
             }
 
-            var now = DateTimeOffset.UtcNow; // planets need current time, not cached
+            var now = timeProvider.GetUtcNow(); // planets need current time, not cached
 
             foreach (var planetIdx in PlanetIndices)
             {

--- a/src/TianWen.UI.Abstractions/SkyMapTab.Search.cs
+++ b/src/TianWen.UI.Abstractions/SkyMapTab.Search.cs
@@ -247,9 +247,10 @@ namespace TianWen.UI.Abstractions
             row += rowH;
 
             // Rise / Transit / Set — three lines or one combined line when space is tight.
+            var tz = plannerState.SiteTimeZone;
             var rtsLine = info.NeverRises ? "Never rises (below horizon)"
-                        : info.Circumpolar ? $"Circumpolar   Transit {FormatHHMM(info.TransitTime)}"
-                        : $"Rise {FormatHHMM(info.RiseTime)}   Transit {FormatHHMM(info.TransitTime)}   Set {FormatHHMM(info.SetTime)}";
+                        : info.Circumpolar ? $"Circumpolar   Transit {FormatHHMM(info.TransitTime, tz)}"
+                        : $"Rise {FormatHHMM(info.RiseTime, tz)}   Transit {FormatHHMM(info.TransitTime, tz)}   Set {FormatHHMM(info.SetTime, tz)}";
             DrawText(rtsLine.AsSpan(), fontPath,
                 textX, py + row, textW, rowH, fontSize, SearchText, TextAlign.Near, TextAlign.Center);
 
@@ -440,8 +441,10 @@ namespace TianWen.UI.Abstractions
             return true;
         }
 
-        private static string FormatHHMM(DateTimeOffset? t)
-            => t is { } dt ? $"{dt.LocalDateTime:HH:mm}" : "--:--";
+        // Rise/Transit/Set are UTC instants; render them in the site timezone, never the
+        // machine timezone (.LocalDateTime would show UTC on a UTC-set machine).
+        private static string FormatHHMM(DateTimeOffset? t, TimeSpan siteTimeZone)
+            => t is { } dt ? $"{dt.ToOffset(siteTimeZone):HH:mm}" : "--:--";
 
         // Walk PlannerState.Proposals to see if this catalog index is pinned.
         // Called once per frame while the info panel is visible — proposals are few

--- a/src/TianWen.UI.Gui/Program.cs
+++ b/src/TianWen.UI.Gui/Program.cs
@@ -267,14 +267,13 @@ var loop = new SdlEventLoop(sdlWindow, renderer)
             return true; // always redraw during shutdown
         }
 
-        // Redraw periodically on the Live Session / Guider / Sky Map tabs so the
-        // clock and live time-dependent overlays tick smoothly. 500ms while a session
-        // OR a polar-alignment routine is running (progress bars, per-rung "Probing
-        // 200ms (3/8)" status, axis-error needles, locked-exposure indicator); 1s in
-        // plain preview / sky-map mode (clock + sky-map LST advance) -- otherwise the
-        // only periodic redraw trigger is the 2s preview-telemetry poll, which shows
-        // up as a visible 2s tick.
-        if (appState.ActiveTab is GuiTab.LiveSession or GuiTab.Guider or GuiTab.SkyMap)
+        // The status-bar wall clock (HH:mm:ss) is shown on EVERY tab, so we need at
+        // least a 1 Hz redraw on all tabs to make it tick. This used to be gated to the
+        // Live Session / Guider / Sky Map tabs, which is exactly why the clock on the
+        // Planner (and other tabs) only updated when an input event happened to force a
+        // frame. 500ms while a session OR a polar-alignment routine is running (progress
+        // bars, per-rung "Probing 200ms (3/8)" status, axis-error needles, locked-exposure
+        // indicator); 1s otherwise (clock tick + sky-map LST advance).
         {
             var now = timeProvider.GetTimestamp();
             var liveState = guiRenderer.LiveSessionState;

--- a/src/TianWen.UI.Gui/VkGuiRenderer.cs
+++ b/src/TianWen.UI.Gui/VkGuiRenderer.cs
@@ -316,7 +316,7 @@ namespace TianWen.UI.Gui
                 return;
             }
 
-            var now = timeProvider.System.GetLocalNow().ToOffset(plannerState.SiteTimeZone);
+            var now = timeProvider.GetUtcNow().ToOffset(plannerState.SiteTimeZone);
             var clockText = now.ToString("ddd d MMM HH:mm:ss");
 
             // Profile name (left)
@@ -363,13 +363,13 @@ namespace TianWen.UI.Gui
                 {
                     var dark = plannerState.AstroDark.ToOffset(plannerState.SiteTimeZone);
                     var twilight = plannerState.AstroTwilight.ToOffset(plannerState.SiteTimeZone);
-                    dateStr = $"Tonight {dark:HH:mm}\u2013{twilight:HH:mm}";
+                    dateStr = $"Tonight {dark:HH:mm}-{twilight:HH:mm}";
                 }
                 else if (plannerState.AstroDark != default)
                 {
                     var dark = plannerState.AstroDark.ToOffset(plannerState.SiteTimeZone);
                     var twilight = plannerState.AstroTwilight.ToOffset(plannerState.SiteTimeZone);
-                    dateStr = $"{planDate:ddd d MMM} {dark:HH:mm}\u2013{twilight:HH:mm}";
+                    dateStr = $"{planDate:ddd d MMM} {dark:HH:mm}-{twilight:HH:mm}";
                 }
                 else
                 {
@@ -390,13 +390,10 @@ namespace TianWen.UI.Gui
                 }
             }
 
-            // Clock (right) — on tabs that benefit from live time display
-            if (appState.ActiveTab is GuiTab.Planner or GuiTab.LiveSession or GuiTab.Guider)
-            {
-                DrawText(clockText.AsSpan(), _fontPath,
-                    w * 0.7f, 0, w * 0.3f - 4f, sbh,
-                    FontSize, StatusText, TextAlign.Far, TextAlign.Center);
-            }
+            // Wall clock (right) - shown on every tab for consistent placement.
+            DrawText(clockText.AsSpan(), _fontPath,
+                w * 0.7f, 0, w * 0.3f - 4f, sbh,
+                FontSize, StatusText, TextAlign.Far, TextAlign.Center);
 
             // Status message — placed after the profile name (measured, not assumed) and
             // bounded by the date-arrow region to the right. Over-long messages are


### PR DESCRIPTION
## What

Every clock, timestamp, and time-window in the GUI / TUI / CLI now renders in the
**site timezone** instead of the machine's local time (or a bare UTC render). On a
UTC-set machine the old `.ToLocalTime()` / `.LocalDateTime` / `GetLocalNow()` paths
displayed UTC, which is wrong for an observer at a different longitude.

## Why

"Local time" in this app must mean *the observing site's* local time, derived from the
profile's geographic location via `GeoTimeZone` — not the box the binary happens to run
on (often a UTC headless Pi or a laptop in another zone).

## Changes

**Single source of truth for the site timezone**
- `GuiAppState.SiteTimeZone` is now the one app-wide offset. `PlannerState` and
  `LiveSessionState` read (and `PlannerState` writes) through to it via `AttachAppState`,
  wired once in the `AppSignalHandler` ctor — planner, live session, sky map, and
  notifications can no longer drift apart. `LiveSessionState.SiteTimeZone` is read-only
  now (the duplicate copy set at session-start is gone). The standalone `plan` CLI has
  no `GuiAppState` and falls back to a local field.

**Banned BCL now-statics removed from hot paths**
- `DateTime.Now` / `DateTimeOffset.UtcNow` / `TimeProvider.System.GetLocalNow()` in UI
  and driver code replaced with the injected `ITimeProvider`. Camera drivers (Alpaca /
  Ascom) record `LastExposureStartTime` as `GetUtcNow()`; `SkyMapRenderer.DrawPlanets`
  takes `ITimeProvider`; planner date stepping defaults "tonight" in the site TZ.
- `FileLoggerProvider` timestamps now carry the UTC offset (`HH:mm:ss.fff zzz`) so log
  lines are unambiguous across timezones.

**Hosting API** (ninaAPI v2 + native)
- `/time`, `/event-history`, and session-start take `ITimeProvider`; the ISO 8601 UTC
  wire format (`"o"`) is **preserved on purpose** (this is API payload Touch N Stars
  expects, not UI display), and session-start stamps one consistent instant.

**Status-bar clock**
- The wall clock (`HH:mm:ss`) is shown on **every** tab now, with a 1 Hz redraw on all
  tabs — fixing the Planner clock that only ticked when an input event forced a frame.
  The duplicate in-content Live Session clock was removed.

**Bundled UI polish** (separated from the in-flight guider workstream)
- `SessionContent.EffectiveDefaultSubExposure` is now the single default-sub-exposure
  source shared by the Session-tab display **and** schedule building, so the planner
  preview matches what the session actually captures (it previously displayed the
  f-ratio default but scheduled a hardcoded 120s). Regression test added.
- Durations render as `4h 56m` / `23m 45s`; time ranges use an ASCII hyphen instead of
  the en-dash (the en-dash is an AI tell and breaks the GLSL shader compiler).

## Testing

- Full solution builds clean (only the pre-existing `NU5104` sibling-package warning).
- `TianWen.Lib.Tests` time/session unit tests green (22/22 for the
  `EffectiveDefaultSubExposure` / `SessionTab` / `TimeZone` filter).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
