### PR TITLE
fix(skymap): unify overlay-ellipse orientation, add dark-nebula [D] toggle

### DIFF
--- a/src/TianWen.Lib.Tests/OverlayEngineTests.cs
+++ b/src/TianWen.Lib.Tests/OverlayEngineTests.cs
@@ -300,6 +300,48 @@ public class OverlayEngineTests
         float.IsFinite(pa).ShouldBeTrue();
     }
 
+    // --- ComputeEllipseScreenAxes (shared CPU selection marker / GPU overlay convention) ---
+
+    [Fact]
+    public void ComputeEllipseScreenAxes_PaZero_MajorAlongNorth()
+    {
+        // North points up on screen (screen +y grows downward, so "up" is -y). A zero
+        // position angle must lay the major axis along celestial north.
+        var (mx, my, _, _) = OverlayEngine.ComputeEllipseScreenAxes(0f, -1f, 0f);
+        mx.ShouldBe(0f, 1e-5f);
+        my.ShouldBe(-1f, 1e-5f);
+    }
+
+    [Fact]
+    public void ComputeEllipseScreenAxes_Pa90_MajorAlongEast_IsScreenLeft()
+    {
+        // The sky map is east-left, so PA = 90 deg (measured north -> east) rotates the
+        // major axis to screen-left (-x). This is the convention the GPU overlay shader
+        // mirrors; a regression here means the selection ellipse and [O] overlay diverge.
+        var (mx, my, _, _) = OverlayEngine.ComputeEllipseScreenAxes(0f, -1f, MathF.PI / 2f);
+        mx.ShouldBe(-1f, 1e-5f);
+        my.ShouldBe(0f, 1e-5f);
+    }
+
+    [Fact]
+    public void ComputeEllipseScreenAxes_AxesAreOrthonormal()
+    {
+        var (mx, my, nx, ny) = OverlayEngine.ComputeEllipseScreenAxes(0.3f, -0.8f, 0.7f);
+        MathF.Sqrt(mx * mx + my * my).ShouldBe(1f, 1e-5f); // major is unit length
+        MathF.Sqrt(nx * nx + ny * ny).ShouldBe(1f, 1e-5f); // minor is unit length
+        (mx * nx + my * ny).ShouldBe(0f, 1e-5f);           // major perpendicular to minor
+    }
+
+    [Fact]
+    public void ComputeEllipseScreenAxes_DegenerateNorth_FallsBackToScreenAxes()
+    {
+        var (mx, my, nx, ny) = OverlayEngine.ComputeEllipseScreenAxes(0f, 0f, 1.23f);
+        mx.ShouldBe(1f);
+        my.ShouldBe(0f);
+        nx.ShouldBe(0f);
+        ny.ShouldBe(1f);
+    }
+
     // --- GetOverlayColor edge cases ---
 
     [Fact]

--- a/src/TianWen.UI.Abstractions/Overlays/OverlayCandidate.cs
+++ b/src/TianWen.UI.Abstractions/Overlays/OverlayCandidate.cs
@@ -23,6 +23,10 @@ public readonly record struct OverlayCandidate
 {
     public required CatalogIndex CatalogIndex { get; init; }
 
+    /// <summary>Catalog object type. Lets the GUI gate overlay visibility by layer --
+    /// e.g. dark nebulae follow the [D] toggle while everything else follows [O].</summary>
+    public required ObjectType ObjectType { get; init; }
+
     /// <summary>Right ascension in hours (J2000).</summary>
     public required double RA { get; init; }
 

--- a/src/TianWen.UI.Abstractions/Overlays/OverlayEngine.cs
+++ b/src/TianWen.UI.Abstractions/Overlays/OverlayEngine.cs
@@ -207,6 +207,52 @@ public static class OverlayEngine
     }
 
     /// <summary>
+    /// Single source of truth for overlay-ellipse orientation, shared by the CPU
+    /// selection marker (<c>SkyMapTab.TryDrawShapeMarker</c>) and -- as a
+    /// hand-maintained GPU mirror -- the sky-map overlay shader
+    /// (<c>VkSkyMapPipeline.OverlayEllipseVertexSource</c>). The shader computes the
+    /// equivalent angle form <c>totalAngle = atan2(north.y, north.x) - paFromNorth</c>
+    /// and draws the major axis along <c>(cos(totalAngle), sin(totalAngle))</c>; keep
+    /// the two in lockstep.
+    /// <para>
+    /// Given the screen-space direction of celestial north at the object (already
+    /// projected; screen +x is right, +y is DOWN) and the position angle in radians
+    /// measured from north toward east, returns the screen-space unit vectors of the
+    /// ellipse major and minor axes. The sky map is east-left (see
+    /// <see cref="SkyMapProjection"/>: "RA increases to the left"), so a positive PA
+    /// rotates the major axis from north toward screen-left -- i.e. true sky position
+    /// angle. At PA = 0 the major axis lies along celestial north.
+    /// </para>
+    /// </summary>
+    /// <returns>Major and minor axis screen-space unit vectors. Falls back to the
+    /// screen axes (1,0)/(0,1) when the supplied north direction is degenerate.</returns>
+    public static (float MajorX, float MajorY, float MinorX, float MinorY)
+        ComputeEllipseScreenAxes(float northX, float northY, float paRad)
+    {
+        var nlen = MathF.Sqrt(northX * northX + northY * northY);
+        if (nlen < 1e-6f)
+        {
+            return (1f, 0f, 0f, 1f);
+        }
+        var nx = northX / nlen;
+        var ny = northY / nlen;
+
+        // East = north rotated -90 deg in screen space (east-left map): (ny, -nx).
+        var ex = ny;
+        var ey = -nx;
+
+        var (sin, cos) = MathF.SinCos(paRad);
+        // Major axis = cos(PA) * north + sin(PA) * east.
+        var majorX = cos * nx + sin * ex;
+        var majorY = cos * ny + sin * ey;
+        // Minor axis is the major axis rotated +90 deg in screen space. The sign is
+        // irrelevant for a symmetric ellipse, but matching the GPU keeps the two exact.
+        var minorX = -majorY;
+        var minorY = majorX;
+        return (majorX, majorY, minorX, minorY);
+    }
+
+    /// <summary>
     /// Computes a label priority score (higher = more important) used to decide
     /// which labels to place when crowded. Factors in: has-common-name bonus,
     /// brightness (V_Mag), and on-sky size (shape major axis).
@@ -870,6 +916,7 @@ public static class OverlayEngine
             output.Add(new OverlayCandidate
             {
                 CatalogIndex = catIdx,
+                ObjectType = obj.ObjectType,
                 RA = obj.RA,
                 Dec = obj.Dec,
                 UnitVec = new Vector3((float)ux, (float)uy, (float)uz),

--- a/src/TianWen.UI.Abstractions/SkyMapState.cs
+++ b/src/TianWen.UI.Abstractions/SkyMapState.cs
@@ -66,6 +66,14 @@ namespace TianWen.UI.Abstractions
         public bool ShowObjectOverlay { get; set; }
 
         /// <summary>
+        /// Show dark nebulae (Barnard / LDN / Dobashi dust lanes) as their own overlay
+        /// layer, toggled with the <c>[D]</c> key. Kept separate from
+        /// <see cref="ShowObjectOverlay"/> (<c>[O]</c>) so the dust-cloud markers don't
+        /// clutter the default deep-sky overlay. Off by default.
+        /// </summary>
+        public bool ShowDarkNebulae { get; set; }
+
+        /// <summary>
         /// Current mount pointing for the reticle overlay. Null when no mount is connected
         /// or its coordinates can't be read. Populated by the event loop from polled
         /// <c>LiveSessionState.PreviewMountState</c> (preview mode) or <c>session.MountState</c>

--- a/src/TianWen.UI.Abstractions/SkyMapTab.Search.cs
+++ b/src/TianWen.UI.Abstractions/SkyMapTab.Search.cs
@@ -390,28 +390,19 @@ namespace TianWen.UI.Abstractions
 
             var dnx = nx - ox;
             var dny = ny - oy;
-            var nlen = MathF.Sqrt(dnx * dnx + dny * dny);
-            if (nlen < 1e-5f) return false;
-            dnx /= nlen;
-            dny /= nlen;
+            if (dnx * dnx + dny * dny < 1e-10f) return false;
 
-            // Position angle (degrees, north through east). Rotating the north unit
-            // by +PA (CW on a sky-map viewed from inside the celestial sphere) gives
-            // the major-axis direction. CW on screen = rotation matrix R(-PA) in
-            // standard math; Y-axis is already inverted, so the sign works out to
-            // a regular CCW rotation on screen.
             var paDeg = (double)shape.PositionAngle;
             if (double.IsNaN(paDeg)) paDeg = 0;
-            var paRad = double.DegreesToRadians(paDeg);
-            var (sinPa, cosPa) = Math.SinCos(paRad);
-            // Major direction = cos(PA) * north + sin(PA) * east.
-            // East on screen = rotate north by +90 deg (screen CW, which is CCW in
-            // math with Y-inverted): east_screen = (dny, -dnx).
-            var majorX = (float)(cosPa * dnx + sinPa * dny);
-            var majorY = (float)(cosPa * dny - sinPa * dnx);
-            // Minor direction is major rotated +90 deg (same convention):
-            var minorX = majorY;
-            var minorY = -majorX;
+            var paRad = (float)double.DegreesToRadians(paDeg);
+
+            // Major / minor axis screen directions come from the single shared helper so
+            // this selection ellipse and the [O] overlay ellipse for the same object are
+            // oriented identically (true sky position angle). The GPU overlay shader is a
+            // hand-maintained mirror of the same convention -- see
+            // Overlays.OverlayEngine.ComputeEllipseScreenAxes.
+            var (majorX, majorY, minorX, minorY) =
+                Overlays.OverlayEngine.ComputeEllipseScreenAxes(dnx, dny, paRad);
 
             // Trace the ellipse.
             const int Segments = 36;

--- a/src/TianWen.UI.Abstractions/SkyMapTab.cs
+++ b/src/TianWen.UI.Abstractions/SkyMapTab.cs
@@ -585,7 +585,7 @@ namespace TianWen.UI.Abstractions
                 : $"FOV: {State.FieldOfViewDeg:F1}\u00B0";
             var modeLabel = State.Mode == SkyMapMode.Equatorial ? "EQ" : "AZ";
             var skyHint = State.MilkyWayAvailable ? " [S]ky" : "";
-            var info = $"RA: {State.CenterRA:F2}h  Dec: {State.CenterDec:F1}\u00B0    {fovText}    [{modeLabel}]  [H]orizon [G]rid [A]lt/Az [B]oundaries [C]onst [P]roj [O]bjects [M]ount{skyHint}";
+            var info = $"RA: {State.CenterRA:F2}h  Dec: {State.CenterDec:F1}\u00B0    {fovText}    [{modeLabel}]  [H]orizon [G]rid [A]lt/Az [B]oundaries [C]onst [P]roj [O]bjects [D]ark [M]ount{skyHint}";
 
             DrawText(info.AsSpan(), fontPath,
                 rect.X + 8, stripY, rect.Width - 16, stripH,
@@ -848,6 +848,10 @@ namespace TianWen.UI.Abstractions
                     return true;
                 case InputKey.O:
                     State.ShowObjectOverlay = !State.ShowObjectOverlay;
+                    State.NeedsRedraw = true;
+                    return true;
+                case InputKey.D:
+                    State.ShowDarkNebulae = !State.ShowDarkNebulae;
                     State.NeedsRedraw = true;
                     return true;
                 case InputKey.M:

--- a/src/TianWen.UI.Gui/VkSkyMapTab.cs
+++ b/src/TianWen.UI.Gui/VkSkyMapTab.cs
@@ -61,6 +61,7 @@ public sealed unsafe class VkSkyMapTab(VkRenderer renderer) : SkyMapTab<VulkanCo
     private int _overlayRectWKey, _overlayRectHKey;
     private float _overlayDpiKey;
     private bool _overlayShowAllKey;
+    private bool _overlayShowDarkNebKey;
     private ImmutableArray<ProposedObservation> _overlayProposalsKey;
     private ICelestialObjectDB? _overlayDbKey;
     private readonly List<OverlayCandidate> _overlayCandidates = [];
@@ -239,18 +240,20 @@ public sealed unsafe class VkSkyMapTab(VkRenderer renderer) : SkyMapTab<VulkanCo
         // so the candidate list is independent of viewMatrix. Below that threshold the
         // scan bounds are derived from the current view matrix, so it stays in the key.
         var wideFov = fov >= WideFovThresholdDeg;
+        var showDarkNebulae = State.ShowDarkNebulae;
         var cacheHit = ReferenceEquals(db, _overlayDbKey)
             && fov == _overlayFovKey
             && rectW == _overlayRectWKey
             && rectH == _overlayRectHKey
             && dpiScale == _overlayDpiKey
             && showAllOverlays == _overlayShowAllKey
+            && showDarkNebulae == _overlayShowDarkNebKey
             && proposals == _overlayProposalsKey
             && (wideFov || viewMatrix.Equals(_overlayViewKey));
 
         if (!cacheHit)
         {
-            RebuildOverlayCandidates(db, contentRect, dpiScale, proposals, showAllOverlays);
+            RebuildOverlayCandidates(db, contentRect, dpiScale, proposals, showAllOverlays, showDarkNebulae);
             _overlayDbKey = db;
             _overlayViewKey = viewMatrix;
             _overlayFovKey = fov;
@@ -258,6 +261,7 @@ public sealed unsafe class VkSkyMapTab(VkRenderer renderer) : SkyMapTab<VulkanCo
             _overlayRectHKey = rectH;
             _overlayDpiKey = dpiScale;
             _overlayShowAllKey = showAllOverlays;
+            _overlayShowDarkNebKey = showDarkNebulae;
             _overlayProposalsKey = proposals;
         }
 
@@ -463,7 +467,7 @@ public sealed unsafe class VkSkyMapTab(VkRenderer renderer) : SkyMapTab<VulkanCo
     /// </summary>
     private void RebuildOverlayCandidates(
         ICelestialObjectDB db, RectF32 contentRect, float dpiScale,
-        ImmutableArray<ProposedObservation> proposals, bool showAllOverlays)
+        ImmutableArray<ProposedObservation> proposals, bool showAllOverlays, bool showDarkNebulae)
     {
         _overlayCandidates.Clear();
 
@@ -485,10 +489,10 @@ public sealed unsafe class VkSkyMapTab(VkRenderer renderer) : SkyMapTab<VulkanCo
             if (pinnedIndices.Count == 0) pinnedIndices = null;
         }
 
-        // Skip the full catalog scan entirely when the overlay is off AND there are
-        // no pinned targets to show -- avoids iterating ~100k spatial-index cells for
-        // nothing when the user just wants a clean sky map.
-        if (!showAllOverlays && pinnedIndices is null)
+        // Skip the full catalog scan entirely when both overlay layers are off AND
+        // there are no pinned targets to show -- avoids iterating ~100k spatial-index
+        // cells for nothing when the user just wants a clean sky map.
+        if (!showAllOverlays && !showDarkNebulae && pinnedIndices is null)
         {
             return;
         }
@@ -496,11 +500,19 @@ public sealed unsafe class VkSkyMapTab(VkRenderer renderer) : SkyMapTab<VulkanCo
         OverlayEngine.GatherSkyMapOverlayCandidates(
             State, contentRect, dpiScale, db, pinnedIndices, _overlayCandidates);
 
-        // When the full overlay is off, strip non-pinned candidates so only the
-        // user's planned targets remain visible as landmarks.
-        if (!showAllOverlays)
+        // Per-layer visibility: dark nebulae follow the [D] toggle, every other catalog
+        // object follows [O]. Pinned planner targets always survive both gates so the
+        // user's planned observations stay visible as landmarks regardless of layer state.
+        if (!showAllOverlays || !showDarkNebulae)
         {
-            _overlayCandidates.RemoveAll(c => !c.IsPinned);
+            _overlayCandidates.RemoveAll(c =>
+            {
+                if (c.IsPinned)
+                {
+                    return false;
+                }
+                return c.ObjectType == ObjectType.DarkNeb ? !showDarkNebulae : !showAllOverlays;
+            });
         }
     }
 

--- a/src/TianWen.UI.Shared/VkSkyMapPipeline.cs
+++ b/src/TianWen.UI.Shared/VkSkyMapPipeline.cs
@@ -359,10 +359,14 @@ public sealed unsafe class VkSkyMapPipeline : IDisposable
             vec3 tipUnit = normalize(aUnitVec + nTangent * stepRad);
             vec3 tipProj = stereoProject((ubo.viewMatrix * vec4(tipUnit, 1.0)).xyz);
             vec2 north2d = tipProj.xy - center;
-            // Screen y grows downward, so "up on screen" is -Y; atan(x, -y) gives the
-            // angle of the screen-north direction measured CCW from screen up.
-            float screenNorthAngle = atan(north2d.x, -north2d.y);
-            float totalAngle = screenNorthAngle + aPaFromNorth;
+            // Screen-space angle of celestial north, measured from screen +x (right).
+            // Hand-maintained mirror of OverlayEngine.ComputeEllipseScreenAxes (the CPU
+            // selection marker shares the same convention): the major axis points along
+            // (cos(totalAngle), sin(totalAngle)) with totalAngle = northAngle - PA, so a
+            // positive PA rotates the major axis from north toward east. The sky map is
+            // east-left, so this is true sky position angle (PA = 0 -> major along north).
+            float screenNorthAngle = atan(north2d.y, north2d.x);
+            float totalAngle = screenNorthAngle - aPaFromNorth;
 
             // 4. Convert arcmin -> pixels using the UBO's pixelsPerRadian.
             float arcminToPx = ubo.pixelsPerRadian * 0.00029088820866;  // pi / (180 * 60)


### PR DESCRIPTION
## Summary
- Extract a single source of truth for overlay-ellipse orientation, `OverlayEngine.ComputeEllipseScreenAxes(north, pa)` (PA north -> east on an east-left map). The GPU `[O]` overlay shader previously computed `atan2(north.x, -north.y) + PA` (~90 deg off, flipped handedness) while the CPU selection marker was astronomically correct; the CPU marker now calls the helper (behavior-preserving) and the GLSL `OverlayEllipseVertexSource` is a documented mirror (`atan2(north.y, north.x) - PA`). Galaxy/nebula overlay ellipses now sit at true sky position angle and coincide with the selection ellipse.
- Split dark nebulae onto their own `[D]` toggle (`SkyMapState.ShowDarkNebulae`, default off) so `[O]` no longer clutters the default overlay with dust lanes. Adds `ObjectType` to `OverlayCandidate` for the per-layer filter; pinned planner targets bypass both gates.

## Test plan
- [x] New `OverlayEngineTests` covering `ComputeEllipseScreenAxes` orientation cases
- [x] `dotnet test TianWen.Lib.Tests --filter "OverlayEngine|SkyMap"` — 105/105 pass on the rebased branch
- [x] Full solution builds clean after rebase onto main (`6431c1e`)
- [ ] Visual check in GUI: `[D]` toggles dark nebulae, `[O]` no longer shows them by default, overlay ellipse coincides with selection ellipse

🤖 Generated with [Claude Code](https://claude.com/claude-code)