### PR TITLE
chore(deps): bump SdlVulkan.Renderer 5.1->6.0 and SharpAstro codecs 3.2->3.3

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -74,19 +74,21 @@
          raw bytes to H.273 enums (binary-breaking) + SharpAstro.Color.Icc adds
          the H.273 enums + IccProfiles.WithCicp helper.
          3.2 = the new SharpAstro.Exr (OpenEXR read+write) package joins the family.
-         The whole family floats to 3.2.* in lockstep so all members resolve to the
+         3.3 = family minor bump (StbImageSharp repo); members continue to ship as a
+         matched set.
+         The whole family floats to 3.3.* in lockstep so all members resolve to the
          matched set (mixing minors across a lockstep break is a runtime hazard). -->
-    <PackageVersion Include="SharpAstro.Tiff" Version="3.2.*" />
-    <PackageVersion Include="SharpAstro.Exif" Version="3.2.*" />
-    <PackageVersion Include="SharpAstro.Png" Version="3.2.*" />
-    <PackageVersion Include="SharpAstro.Color.Icc" Version="3.2.*" />
-    <PackageVersion Include="SharpAstro.Jpeg.IccInjector" Version="3.2.*" />
+    <PackageVersion Include="SharpAstro.Tiff" Version="3.3.*" />
+    <PackageVersion Include="SharpAstro.Exif" Version="3.3.*" />
+    <PackageVersion Include="SharpAstro.Png" Version="3.3.*" />
+    <PackageVersion Include="SharpAstro.Color.Icc" Version="3.3.*" />
+    <PackageVersion Include="SharpAstro.Jpeg.IccInjector" Version="3.3.*" />
     <!-- Pure-managed JPEG XR (T.832) + OpenEXR codecs. Image.WriteJxrAsync emits
          HDR float pixels (BD32F mono / BD16F RGB); Image.WriteExrAsync emits OpenEXR
-         (FLOAT mono / HALF RGB). Same StbImageSharp repo + 3.2.* lockstep as the
+         (FLOAT mono / HALF RGB). Same StbImageSharp repo + 3.3.* lockstep as the
          other SharpAstro codec siblings. -->
-    <PackageVersion Include="SharpAstro.Jxr" Version="3.2.*" />
-    <PackageVersion Include="SharpAstro.Exr" Version="3.2.*" />
+    <PackageVersion Include="SharpAstro.Jxr" Version="3.3.*" />
+    <PackageVersion Include="SharpAstro.Exr" Version="3.3.*" />
     <!-- Console.Lib 2.17 adds ScrollableList + TreeView opt-in auto wheel routing
          (on top of 2.13-2.16 widget work). Built on DIR.Lib 4.4, same sibling
          family as SdlVulkan.Renderer 5.1. -->
@@ -94,8 +96,11 @@
     <!-- SdlVulkan.Renderer 5.0 adds a multi-page SDF glyph atlas (no more grow
          stall / Adreno submit-wedge) on top of 4.1's SetSystemCursor + anisotropic
          glyph xScale. 5.1 implements DIR.Lib 4.4's PushClip/PopClip via Vulkan
-         scissor, in lockstep with DIR.Lib 4.4 (see above). -->
-    <PackageVersion Include="SdlVulkan.Renderer" Version="5.1.*" />
+         scissor, in lockstep with DIR.Lib 4.4 (see above).
+         6.0 (PR #22) adds glyph/atlas hot-path perf, draw-call dedup, and Mailbox
+         present mode; it still targets DIR.Lib 4.4.x, so the renderer can move to 6.0
+         without dragging DIR.Lib forward (verified via package restore at bump time). -->
+    <PackageVersion Include="SdlVulkan.Renderer" Version="6.0.*" />
     <PackageVersion Include="SDL3-CS" Version="3.5.0-preview.20260213-150035" />
     <PackageVersion Include="SDL3-CS.Native" Version="3.5.0-preview.20260205-174353" />
     <!-- Canon DSLR -->


### PR DESCRIPTION
Both SharpAstro-family pin groups were a release behind the published NuGet versions. Every other sibling pin (DIR.Lib 4.4, Console.Lib 2.17, FITS.Lib 4.6, FC.SDK 1.3, QHYCCD.SDK 1.0, TianWen.DAL 2.0, ZWOptical.SDK 4.2) was already current.

## Changes
| Package | Before | After |
|---|---|---|
| SdlVulkan.Renderer | `5.1.*` | `6.0.*` |
| SharpAstro.{Tiff,Exif,Png,Color.Icc,Jpeg.IccInjector,Jxr,Exr} | `3.2.*` | `3.3.*` |

- **SdlVulkan 6.0** brings PR #22 (glyph/atlas hot-path perf, draw-call dedup, Mailbox present mode). It still targets DIR.Lib 4.4.x, so the renderer moves without a DIR.Lib/Console.Lib cascade.
- **SharpAstro codecs** bump as a lockstep family.

## Validation
- CI-parity build (`-c Release -p:UseLocalSiblings=false -p:UseLocalFitsLib=false`): **0 errors / 0 warnings**; no `NU1605`/`NU1107` on the forced PackageReference restore (graph resolves coherently).
- TIFF/JXR/EXR/ICC/PNG/Export round-trip tests against the real 3.3 packages: **41/41 passing**.

Third-party pins (Microsoft.Extensions, ONNX, xunit, etc.) intentionally left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)