### PR TITLE
perf(skymap): run Phase A overlay gather off the render thread

### DIFF
--- a/src/TianWen.UI.Abstractions/Overlays/OverlayEngine.cs
+++ b/src/TianWen.UI.Abstractions/Overlays/OverlayEngine.cs
@@ -609,13 +609,18 @@ public static class OverlayEngine
     /// that previously made wide-FOV panning sluggish.
     /// </remarks>
     public static void GatherSkyMapOverlayCandidates(
-        SkyMapState state,
+        in Matrix4x4 viewMatrix,
+        double fieldOfViewDeg,
         RectF32 contentRect,
         float dpiScale,
         ICelestialObjectDB db,
         IReadOnlySet<CatalogIndex>? pinnedCatalogIndices,
         List<OverlayCandidate> output)
     {
+        // NOTE: this walk is the heavy Phase A pass (60-170ms in dense regions / pole-in-view).
+        // It takes the view matrix + FOV by value rather than reading a live SkyMapState so it
+        // can run on a background thread (see VkSkyMapTab's async gather) without tearing on the
+        // render thread's view updates. It only reads the (immutable-after-init) catalog DB.
         output.Clear();
 
         if (contentRect.Width <= 0 || contentRect.Height <= 0)
@@ -623,13 +628,12 @@ public static class OverlayEngine
             return;
         }
 
-        var viewMatrix = state.CurrentViewMatrix;
-        var ppr = SkyMapProjection.PixelsPerRadian(contentRect.Height, state.FieldOfViewDeg);
+        var ppr = SkyMapProjection.PixelsPerRadian(contentRect.Height, fieldOfViewDeg);
         var cxView = contentRect.X + contentRect.Width * 0.5f;
         var cyView = contentRect.Y + contentRect.Height * 0.5f;
 
         // FOV-driven magnitude cutoffs share the viewer's heuristics; FOV is in arcminutes.
-        var fovArcmin = state.FieldOfViewDeg * 60.0;
+        var fovArcmin = fieldOfViewDeg * 60.0;
         var magCutoff = GetExtendedMagCutoff(fovArcmin);
         var starMagCutoff = GetStarMagCutoff(fovArcmin);
 
@@ -705,7 +709,7 @@ public static class OverlayEngine
         // must stay valid while the centre drifts anywhere inside a cell
         // (max step/2 * sqrt(2) ~= 0.09 * FOV). 0.15 * FOV covers that with slack;
         // the 1 deg floor keeps the old near-edge behaviour at narrow FOVs.
-        var marginDeg = Math.Max(1.0, state.FieldOfViewDeg * 0.15);
+        var marginDeg = Math.Max(1.0, fieldOfViewDeg * 0.15);
 
         if (poleInView)
         {
@@ -721,7 +725,7 @@ public static class OverlayEngine
             minDec = Math.Max(-90.0, minDec - Math.Max(2.0, marginDeg));
             maxDec = Math.Min(90.0, maxDec + Math.Max(2.0, marginDeg));
         }
-        else if (state.FieldOfViewDeg >= 90.0)
+        else if (fieldOfViewDeg >= 90.0)
         {
             minRA = 0.0;
             maxRA = 24.0;
@@ -764,7 +768,7 @@ public static class OverlayEngine
         // Zoom-equivalent knob for label verbosity. At narrow FOV (zoomed in) we show more
         // cross-index detail; the viewer's BuildOverlayLabel uses an image-zoom scalar with
         // the same 0.5/1.0 breakpoints, so map FOV to an equivalent zoom value.
-        var labelZoom = (float)Math.Clamp(10.0 / Math.Max(state.FieldOfViewDeg, 0.5), 0.25, 2.0);
+        var labelZoom = (float)Math.Clamp(10.0 / Math.Max(fieldOfViewDeg, 0.5), 0.25, 2.0);
 
         // Scratch list used so the magnitude sort happens before label/priority
         // construction -- keeps output in brightest-first order without sorting

--- a/src/TianWen.UI.Gui/VkSkyMapTab.cs
+++ b/src/TianWen.UI.Gui/VkSkyMapTab.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Numerics;
+using System.Threading.Tasks;
 using DIR.Lib;
 using SdlVulkan.Renderer;
 using TianWen.Lib.Astrometry;
@@ -65,15 +66,34 @@ public sealed unsafe class VkSkyMapTab(VkRenderer renderer) : SkyMapTab<VulkanCo
     // matrix made the expensive catalog grid scan re-run on EVERY pan frame below the
     // wide-FOV threshold -- the "jank when the SCP comes into view at ~70 deg FOV"
     // (pole-in-view scans a full-RA Dec strip, the worst case).
-    private double _overlayCentreRaKey = double.NaN;
-    private double _overlayCentreDecKey = double.NaN;
-    private double _overlayFovKey = -1.0;
-    private int _overlayRectWKey, _overlayRectHKey;
-    private float _overlayDpiKey;
-    private bool _overlayShowAllKey;
-    private bool _overlayShowDarkNebKey;
-    private ImmutableArray<ProposedObservation> _overlayProposalsKey;
-    private ICelestialObjectDB? _overlayDbKey;
+    // Identity of a Phase A gather: the quantized view key plus the catalog/visibility
+    // inputs the walk depends on. Record-struct equality compares ImmutableArray by its
+    // underlying-array reference and ICelestialObjectDB by reference (matches the old
+    // per-field comparison). When the FOV is wide the centre is dropped from the key
+    // (Ra=Dec=0) so the candidate set is centre-independent up there, exactly like before.
+    private readonly record struct OverlayGatherKey(
+        ICelestialObjectDB? Db,
+        ImmutableArray<ProposedObservation> Proposals,
+        double Ra, double Dec, double Fov,
+        int RectW, int RectH, float Dpi,
+        bool ShowAll, bool ShowDark);
+
+    // Result handed back from the background walk: a freshly-built candidate list plus the
+    // key it was computed for (so the render thread knows what view it corresponds to).
+    private readonly record struct OverlayGatherResult(
+        List<OverlayCandidate> Candidates, OverlayGatherKey Key);
+
+    // Async Phase A. The candidate walk is a 60-170ms grid scan; running it inline on the
+    // render thread made a fast pan re-trigger it every frame (slow gather -> the view had
+    // already moved -> cache miss -> slow gather), which was THE residual sky-map jank.
+    // Mirror the star-buffer pattern (StartStarBufferRebuildAsync / TryApplyPendingStarBuild):
+    // the walk runs on a Task, the render thread keeps projecting + drawing the last-good
+    // candidate list EVERY frame, and the fresh list is swapped in when the task lands. Only
+    // one walk is in flight at a time; if the view moved on by the time it lands we apply it
+    // anyway (it is still closer than what we have) and the next frame kicks a fresh one.
+    private Task<OverlayGatherResult>? _overlayGatherTask;
+    private OverlayGatherKey _overlayAppliedKey;
+    private bool _overlayHasAppliedKey;
     private readonly List<OverlayCandidate> _overlayCandidates = [];
     private readonly List<OverlayItem> _overlayItems = [];
     private readonly List<(OverlayItem Item, float X, float Y)> _overlayPlacedLabels = [];
@@ -246,20 +266,29 @@ public sealed unsafe class VkSkyMapTab(VkRenderer renderer) : SkyMapTab<VulkanCo
         var rectW = (int)contentRect.Width;
         var rectH = (int)contentRect.Height;
 
-        // Phase A cache hit: when FOV >= 90 deg the scan bounds are the whole sphere
-        // so the candidate list is independent of the view. Below that threshold the
-        // view contributes a QUANTIZED centre + FOV (see the key fields' comment):
-        // panning only re-runs the expensive catalog grid scan when the centre crosses
-        // a FOV/8 cell, and the gather's widened scan margin keeps the cached set
-        // valid for every view inside the cell. Phase B's per-frame projection culls
-        // off-screen candidates, so correctness is unaffected between rebuilds.
+#if DEBUG
+        // Slow-frame attribution (pairs with SdlEventLoop's [rdiag] frame.slow
+        // begin/render/end split): logs which overlay phase ate the time. The Phase A
+        // gather is logged at its call site (it only runs on cache miss and is the usual
+        // spike); the per-frame log at the end of this method covers the always-on phases.
+        // On a cache-miss frame the 'project' bucket below includes the gather -- the
+        // separate skymap.gather line is what attributes it.
+        var diagStart = System.Diagnostics.Stopwatch.GetTimestamp();
+        long diagProjectDone = 0, diagLabelsDone = 0;
+#endif
+
+        // Phase A: the candidate set is keyed on a QUANTIZED view centre + FOV (not the raw
+        // view matrix) so a pan only invalidates it when the centre crosses a FOV/8 cell;
+        // when FOV >= 90 deg the scan bounds are the whole sphere so the centre drops out of
+        // the key entirely. The walk itself is 60-170ms in dense regions, so it runs on a
+        // BACKGROUND task (see StartOverlayGatherAsync): the render thread keeps projecting +
+        // drawing the last-good list every frame and swaps in the fresh one when it lands.
         var wideFov = fov >= WideFovThresholdDeg;
         var showDarkNebulae = State.ShowDarkNebulae;
 
-        // ~10% logarithmic FOV steps: zoom rebuilds a handful of times across a 2x
-        // range instead of once per wheel tick. The magnitude cutoffs the gather
-        // derives from FOV drift by at most ~10% before a rebuild picks them up --
-        // visually indistinguishable.
+        // ~10% logarithmic FOV steps: zoom re-gathers a handful of times across a 2x range
+        // instead of once per wheel tick. The magnitude cutoffs the gather derives from FOV
+        // drift by at most ~10% before a re-gather picks them up -- visually indistinguishable.
         var quantFov = Math.Pow(1.1, Math.Round(Math.Log(Math.Max(fov, 0.1)) / Math.Log(1.1)));
 
         var centreX = contentRect.X + contentRect.Width * 0.5f;
@@ -267,9 +296,9 @@ public sealed unsafe class VkSkyMapTab(VkRenderer renderer) : SkyMapTab<VulkanCo
         var pprKey = SkyMapProjection.PixelsPerRadian(contentRect.Height, fov);
         var (centreRa, centreDec) = SkyMapProjection.UnprojectWithMatrix(
             centreX, centreY, viewMatrix, pprKey, centreX, centreY);
-        // Quantize the centre to FOV/8 cells. The RA step widens by 1/cos(dec)
-        // (clamped) so cells stay roughly square on the sky; near the pole RA
-        // quantization is meaningless anyway -- the gather sweeps the full 24h there.
+        // Quantize the centre to FOV/8 cells. The RA step widens by 1/cos(dec) (clamped) so
+        // cells stay roughly square on the sky; near the pole RA quantization is meaningless
+        // anyway -- the gather sweeps the full 24h there.
         var quantStepDeg = fov / 8.0;
         var quantDec = Math.Round(centreDec / quantStepDeg) * quantStepDeg;
         var cosDec = Math.Max(Math.Abs(Math.Cos(quantDec * Math.PI / 180.0)), 0.05);
@@ -277,31 +306,24 @@ public sealed unsafe class VkSkyMapTab(VkRenderer renderer) : SkyMapTab<VulkanCo
         var quantRa = Math.Round(centreRa / quantStepRaHours) * quantStepRaHours;
         var centreValid = !double.IsNaN(quantRa) && !double.IsNaN(quantDec);
 
-        var cacheHit = ReferenceEquals(db, _overlayDbKey)
-            && quantFov == _overlayFovKey
-            && rectW == _overlayRectWKey
-            && rectH == _overlayRectHKey
-            && dpiScale == _overlayDpiKey
-            && showAllOverlays == _overlayShowAllKey
-            && showDarkNebulae == _overlayShowDarkNebKey
-            && proposals == _overlayProposalsKey
-            && (wideFov || (centreValid
-                            && quantRa == _overlayCentreRaKey
-                            && quantDec == _overlayCentreDecKey));
+        // Wide FOV: drop the centre from the key (whole-sphere scan). Invalid centre (NaN):
+        // leave it NaN so the key never matches and we keep trying (matches old behaviour).
+        var desiredKey = new OverlayGatherKey(
+            db, proposals,
+            wideFov ? 0.0 : (centreValid ? quantRa : double.NaN),
+            wideFov ? 0.0 : (centreValid ? quantDec : double.NaN),
+            quantFov, rectW, rectH, dpiScale, showAllOverlays, showDarkNebulae);
 
-        if (!cacheHit)
+        // 1. Install a completed background gather (swaps _overlayCandidates, records its key).
+        TryApplyPendingOverlayGather();
+
+        // 2. If our candidates don't match the view we want, make sure a walk is running for it.
+        //    Only one is in flight at a time; when it lands (step 1, a later frame) we apply it
+        //    and, if the view has moved on, kick a fresh one. The render thread never blocks.
+        if (!(_overlayHasAppliedKey && _overlayAppliedKey == desiredKey) && _overlayGatherTask is null)
         {
-            RebuildOverlayCandidates(db, contentRect, dpiScale, proposals, showAllOverlays, showDarkNebulae);
-            _overlayDbKey = db;
-            _overlayCentreRaKey = centreValid ? quantRa : double.NaN; // NaN never equals -> rebuild next frame
-            _overlayCentreDecKey = centreValid ? quantDec : double.NaN;
-            _overlayFovKey = quantFov;
-            _overlayRectWKey = rectW;
-            _overlayRectHKey = rectH;
-            _overlayDpiKey = dpiScale;
-            _overlayShowAllKey = showAllOverlays;
-            _overlayShowDarkNebKey = showDarkNebulae;
-            _overlayProposalsKey = proposals;
+            StartOverlayGatherAsync(db, contentRect, dpiScale, proposals,
+                showAllOverlays, showDarkNebulae, desiredKey);
         }
 
         // Phase B: project cached candidates into screen items every frame. This is
@@ -315,6 +337,9 @@ public sealed unsafe class VkSkyMapTab(VkRenderer renderer) : SkyMapTab<VulkanCo
         }
         OverlayEngine.ProjectSkyMapCandidatesInto(_overlayCandidates, State, contentRect,
             dpiScale, _overlayItems);
+#if DEBUG
+        diagProjectDone = System.Diagnostics.Stopwatch.GetTimestamp();
+#endif
 
         if (_overlayItems.Count == 0)
         {
@@ -342,6 +367,9 @@ public sealed unsafe class VkSkyMapTab(VkRenderer renderer) : SkyMapTab<VulkanCo
         {
             OverlayEngine.PlaceLabelsBestEffort(_overlayItems, placementLabelSize, 4f, measureText, record);
         }
+#if DEBUG
+        diagLabelsDone = System.Diagnostics.Stopwatch.GetTimestamp();
+#endif
 
         // Overlay fade at wide FOV -- keep overlays readable when zoomed out.
         // At FOV <= 120 there is no fade; between 120 and 180 deg the alpha
@@ -497,23 +525,70 @@ public sealed unsafe class VkSkyMapTab(VkRenderer renderer) : SkyMapTab<VulkanCo
                     TextAlign.Near, TextAlign.Center);
             }
         }
+
+#if DEBUG
+        var overlayTotalMs = System.Diagnostics.Stopwatch.GetElapsedTime(diagStart).TotalMilliseconds;
+        if (overlayTotalMs > 25 && diagProjectDone != 0 && diagLabelsDone != 0)
+        {
+            var projectMs = System.Diagnostics.Stopwatch.GetElapsedTime(diagStart, diagProjectDone).TotalMilliseconds;
+            var labelsMs = System.Diagnostics.Stopwatch.GetElapsedTime(diagProjectDone, diagLabelsDone).TotalMilliseconds;
+            var drawMs = System.Diagnostics.Stopwatch.GetElapsedTime(diagLabelsDone).TotalMilliseconds;
+            Console.Error.WriteLine(
+                $"[rdiag] skymap.overlay {overlayTotalMs:F0}ms (project={projectMs:F0} labels={labelsMs:F0} draw={drawMs:F0}) cands={_overlayCandidates.Count} items={_overlayItems.Count} placed={_overlayPlacedLabels.Count}");
+        }
+#endif
     }
 
     /// <summary>
-    /// Rebuilds <see cref="_overlayCandidates"/> via the view-matrix-independent gather
-    /// pass. Called only on cache miss -- per-frame projection and label placement
-    /// happen in <see cref="RenderObjectOverlay"/>, not here.
+    /// Render-thread half of the async Phase A rebuild: when the background walk has
+    /// completed, swap its fresh candidate list into <see cref="_overlayCandidates"/> and
+    /// record the key it was computed for. Called every frame before Phase B; cheap when
+    /// no walk is in flight. We apply the result unconditionally (even if the view has
+    /// moved on since the walk started) -- it is still closer to the current view than
+    /// what we hold, the gather's scan margin keeps it valid for nearby views, and the
+    /// next frame kicks a fresh walk if it no longer matches.
     /// </summary>
-    private void RebuildOverlayCandidates(
-        ICelestialObjectDB db, RectF32 contentRect, float dpiScale,
-        ImmutableArray<ProposedObservation> proposals, bool showAllOverlays, bool showDarkNebulae)
+    private void TryApplyPendingOverlayGather()
     {
-        _overlayCandidates.Clear();
+        if (_overlayGatherTask is not { IsCompleted: true } task)
+        {
+            return;
+        }
+        // Clear the slot regardless of outcome so a faulted/cancelled walk can't wedge the
+        // pipeline (a non-null task would block every future kick). A fault just means we
+        // keep the last-good set and re-gather next frame.
+        _overlayGatherTask = null;
+        if (!task.IsCompletedSuccessfully)
+        {
+            Console.Error.WriteLine(
+                $"[VkSkyMapTab] overlay gather failed: {task.Exception?.GetBaseException().Message}");
+            return;
+        }
 
-        // Build pinned catalog-index set from planner proposals. Targets that have
-        // a CatalogIndex can be matched against the overlay engine's spatial scan;
-        // non-catalog targets (manually typed) would need a separate RA/Dec match
-        // (deferred to a future pass).
+        var result = task.Result;
+        _overlayCandidates.Clear();
+        _overlayCandidates.AddRange(result.Candidates);
+        _overlayAppliedKey = result.Key;
+        _overlayHasAppliedKey = true;
+    }
+
+    /// <summary>
+    /// Kicks off the background Phase A walk for <paramref name="key"/>. The pinned-target
+    /// set and the early-out (both layers off, nothing pinned) are resolved here on the
+    /// render thread; the view matrix + FOV are snapshotted by value so the walk sees a
+    /// consistent view even as the render thread keeps panning. The walk itself
+    /// (<see cref="OverlayEngine.GatherSkyMapOverlayCandidates"/> + the per-layer filter)
+    /// is pure CPU over the immutable-after-init catalog DB, so it is safe off-thread --
+    /// the same property the async star-buffer build relies on. On completion it sets
+    /// <c>State.NeedsRedraw</c> so the loop schedules the frame that applies it.
+    /// </summary>
+    private void StartOverlayGatherAsync(
+        ICelestialObjectDB db, RectF32 contentRect, float dpiScale,
+        ImmutableArray<ProposedObservation> proposals, bool showAllOverlays, bool showDarkNebulae,
+        OverlayGatherKey key)
+    {
+        // Pinned catalog-index set from planner proposals (CatalogIndex-bearing targets only;
+        // manually-typed RA/Dec targets would need a separate match, deferred).
         HashSet<CatalogIndex>? pinnedIndices = null;
         if (proposals.Length > 0)
         {
@@ -528,31 +603,56 @@ public sealed unsafe class VkSkyMapTab(VkRenderer renderer) : SkyMapTab<VulkanCo
             if (pinnedIndices.Count == 0) pinnedIndices = null;
         }
 
-        // Skip the full catalog scan entirely when both overlay layers are off AND
-        // there are no pinned targets to show -- avoids iterating ~100k spatial-index
-        // cells for nothing when the user just wants a clean sky map.
+        // Both layers off and nothing pinned: nothing to gather. Apply an empty set
+        // synchronously (instant) so we don't spin up a task or re-kick every frame.
         if (!showAllOverlays && !showDarkNebulae && pinnedIndices is null)
         {
+            _overlayCandidates.Clear();
+            _overlayAppliedKey = key;
+            _overlayHasAppliedKey = true;
             return;
         }
 
-        OverlayEngine.GatherSkyMapOverlayCandidates(
-            State, contentRect, dpiScale, db, pinnedIndices, _overlayCandidates);
-
-        // Per-layer visibility: dark nebulae follow the [D] toggle, every other catalog
-        // object follows [O]. Pinned planner targets always survive both gates so the
-        // user's planned observations stay visible as landmarks regardless of layer state.
-        if (!showAllOverlays || !showDarkNebulae)
+        // Snapshot the view by value -- the background walk must not read the live (mutating)
+        // SkyMapState. Matrix4x4 is a struct, so this is a consistent copy. The seed capacity
+        // is read HERE on the render thread (reading _overlayCandidates.Count inside the task
+        // would race the render thread's Clear/AddRange/iteration of that list).
+        var snapViewMatrix = State.CurrentViewMatrix;
+        var snapFov = State.FieldOfViewDeg;
+        var seedCapacity = _overlayCandidates.Count > 0 ? _overlayCandidates.Count : 256;
+#if DEBUG
+        var gatherStart = System.Diagnostics.Stopwatch.GetTimestamp();
+#endif
+        _overlayGatherTask = Task.Run(() =>
         {
-            _overlayCandidates.RemoveAll(c =>
+            var list = new List<OverlayCandidate>(seedCapacity);
+            OverlayEngine.GatherSkyMapOverlayCandidates(
+                snapViewMatrix, snapFov, contentRect, dpiScale, db, pinnedIndices, list);
+
+            // Per-layer visibility: dark nebulae follow [D], every other catalog object
+            // follows [O]. Pinned planner targets survive both gates so they stay visible
+            // as landmarks regardless of layer state.
+            if (!showAllOverlays || !showDarkNebulae)
             {
-                if (c.IsPinned)
+                list.RemoveAll(c =>
                 {
-                    return false;
-                }
-                return c.ObjectType == ObjectType.DarkNeb ? !showDarkNebulae : !showAllOverlays;
-            });
-        }
+                    if (c.IsPinned)
+                    {
+                        return false;
+                    }
+                    return c.ObjectType == ObjectType.DarkNeb ? !showDarkNebulae : !showAllOverlays;
+                });
+            }
+#if DEBUG
+            var gatherMs = System.Diagnostics.Stopwatch.GetElapsedTime(gatherStart).TotalMilliseconds;
+            if (gatherMs > 10)
+                Console.Error.WriteLine(
+                    $"[rdiag] skymap.gather(async) {gatherMs:F0}ms cands={list.Count} fov={snapFov:F1}");
+#endif
+            // Schedule the render frame that installs this result (TryApplyPendingOverlayGather).
+            State.NeedsRedraw = true;
+            return new OverlayGatherResult(list, key);
+        });
     }
 
     // Mosaic panel outlines are now drawn by the GPU LinePipeline (see BuildFovLines

--- a/src/TianWen.UI.Shared/VkSkyMapPipeline.cs
+++ b/src/TianWen.UI.Shared/VkSkyMapPipeline.cs
@@ -641,6 +641,13 @@ public sealed unsafe class VkSkyMapPipeline : IDisposable
     private VkBuffer _starBuffer;
     private VkDeviceMemory _starMemory;
     private uint _starCount;
+#if DEBUG
+    // Slow-frame attribution: the star draw is GPU-side (instanced quads), so its cost never
+    // shows in CPU phase timers -- it surfaces as a high 'begin=' (fence wait) in the event
+    // loop's frame.slow split. Logging the visible-instance count whenever it moves by >25%
+    // gives that fence pressure a correlatable cause (FOV/magnitude-limit changes).
+    private uint _lastLoggedVisibleStars;
+#endif
 
     private VkBuffer _figureBuffer;
     private VkDeviceMemory _figureMemory;
@@ -1152,6 +1159,15 @@ public sealed unsafe class VkSkyMapPipeline : IDisposable
         var visibleStars = _magBinCounts.Length > 0
             ? GetVisibleStarCount(state.EffectiveMagnitudeLimit)
             : _starCount;
+#if DEBUG
+        if (visibleStars > _lastLoggedVisibleStars + (_lastLoggedVisibleStars >> 2)
+            || visibleStars < _lastLoggedVisibleStars - (_lastLoggedVisibleStars >> 2))
+        {
+            Console.Error.WriteLine(
+                $"[rdiag] skymap.stars visible={visibleStars} effMag={state.EffectiveMagnitudeLimit:F1} fov={state.FieldOfViewDeg:F0}");
+            _lastLoggedVisibleStars = visibleStars;
+        }
+#endif
         if (visibleStars > 0)
         {
             api.vkCmdBindPipeline(cmd, VkPipelineBindPoint.Graphics, _starPipeline);


### PR DESCRIPTION
## Problem
The catalog-overlay candidate walk (`OverlayEngine.GatherSkyMapOverlayCandidates`) is 60-170ms in dense regions / pole-in-view (it scans a 1° grid over the visible RA/Dec span — up to ~30k cell lookups when a pole is in view). Running it inline on the render thread made a fast pan re-trigger it nearly every frame: the walk was slow enough that the view had already crossed the next quantization cell by the time it finished, so the next frame missed the cache too — a feedback loop that was **the** residual sky-map jank at sub-90° FOV (worst sweeping the Milky Way bulge). It ran regardless of overlay visibility, which is why toggling `[O]` off didn't help.

## Fix
Move the walk to a background `Task`, mirroring the async star-buffer pattern in the same file (`StartStarBufferRebuildAsync` / `TryApplyPendingStarBuild`):
- `StartOverlayGatherAsync` snapshots the view matrix + FOV by value and runs the walk + per-layer filter on a thread-pool thread — pure CPU over the immutable-after-init catalog DB (the same property the star build relies on).
- The render thread keeps projecting + drawing the last-good candidate list every frame (the cheap Phase B) and swaps in the fresh list when the walk lands; if the view moved on, it applies anyway and kicks a fresh walk. One walk in flight at a time. On completion it sets `State.NeedsRedraw` so the loop schedules the apply frame.
- `GatherSkyMapOverlayCandidates` now takes the view matrix + FOV explicitly instead of reading a live `SkyMapState`, so it's safe off-thread.

## Measured
A hard Milky-Way sweep at ~70° ran **106 background gathers with zero correlated render-thread stalls** (vs ~88 frames of 100-246ms before). The only slow frames left are the unavoidable cold-start geometry/catalog builds.

## Notes
- Pairs with SdlVulkan.Renderer #23 (event-loop GPU-timeout robustness) — independent at compile time; TianWen's `6.0.*` float picks up that fix once it publishes.
- Keeps the DEBUG-only `[rdiag]` `begin/render/end` + `skymap.gather/overlay/stars` timing instrumentation used to localise this (cheap, useful for future work).
- 85/85 `OverlayEngineTests` pass against the refactored gather signature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)