### PR TITLE
feat(inspector): sky-map view-control signal + readback for scripted Solve & Sync

### DIFF
--- a/src/TianWen.Lib.Tests/SkyMapViewActionsTests.cs
+++ b/src/TianWen.Lib.Tests/SkyMapViewActionsTests.cs
@@ -1,0 +1,109 @@
+using Shouldly;
+using TianWen.UI.Abstractions;
+using Xunit;
+
+namespace TianWen.Lib.Tests;
+
+/// <summary>
+/// Unit tests for <see cref="SkyMapViewActions"/> — the single source of truth for sky-map
+/// viewport mutation (centre + FOV clamp + overlay toggles), shared by the search-commit path
+/// and the DEBUG inspector's <c>SkyMapSetViewSignal</c> handler.
+/// </summary>
+public class SkyMapViewActionsTests
+{
+    private static SkyMapState NewState() => new()
+    {
+        CenterRA = 6.0,
+        CenterDec = 30.0,
+        FieldOfViewDeg = 60.0,
+        NeedsRedraw = false, // start "clean" so we can assert a redraw was flagged
+    };
+
+    [Fact]
+    public void CenterOn_SetsCentreNormalisesAndFlagsRedraw()
+    {
+        var s = NewState();
+
+        SkyMapViewActions.CenterOn(s, 12.5, -10.0);
+
+        s.CenterRA.ShouldBe(12.5);
+        s.CenterDec.ShouldBe(-10.0);
+        s.NeedsRedraw.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void CenterOn_WrapsRaIntoRangeAndClampsDecAwayFromPole()
+    {
+        var s = NewState();
+
+        SkyMapViewActions.CenterOn(s, 26.0, 95.0);
+
+        s.CenterRA.ShouldBe(2.0, 1e-9);   // 26h wraps to 2h
+        s.CenterDec.ShouldBe(89.5, 1e-9); // clamped off the projection pole
+    }
+
+    [Fact]
+    public void SetView_PartialFovOnly_LeavesCentreUnchanged()
+    {
+        var s = NewState();
+
+        var changed = SkyMapViewActions.SetView(s, fieldOfViewDeg: 5.0);
+
+        changed.ShouldBeTrue();
+        s.FieldOfViewDeg.ShouldBe(5.0);
+        s.CenterRA.ShouldBe(6.0);   // untouched
+        s.CenterDec.ShouldBe(30.0); // untouched
+        s.NeedsRedraw.ShouldBeTrue();
+    }
+
+    [Theory]
+    [InlineData(0.1, SkyMapViewActions.MinFieldOfViewDeg)]
+    [InlineData(500.0, SkyMapViewActions.MaxFieldOfViewDeg)]
+    [InlineData(45.0, 45.0)]
+    public void SetView_ClampsFovToScrollZoomBounds(double requested, double expected)
+    {
+        var s = NewState();
+
+        SkyMapViewActions.SetView(s, fieldOfViewDeg: requested);
+
+        s.FieldOfViewDeg.ShouldBe(expected);
+    }
+
+    [Fact]
+    public void SetView_SingleAxisCentre_KeepsOtherAxis()
+    {
+        var s = NewState();
+
+        SkyMapViewActions.SetView(s, centerRaHours: 18.0); // RA only
+
+        s.CenterRA.ShouldBe(18.0);
+        s.CenterDec.ShouldBe(30.0); // Dec preserved from current value
+    }
+
+    [Fact]
+    public void SetView_TogglesOverlayLayers()
+    {
+        var s = NewState();
+        s.ShowObjectOverlay = false;
+        s.ShowDarkNebulae = false;
+
+        SkyMapViewActions.SetView(s, showObjectOverlay: true, showDarkNebulae: true);
+
+        s.ShowObjectOverlay.ShouldBeTrue();
+        s.ShowDarkNebulae.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void SetView_AllNull_IsNoOpAndDoesNotForceRedraw()
+    {
+        var s = NewState();
+
+        var changed = SkyMapViewActions.SetView(s);
+
+        changed.ShouldBeFalse();
+        s.NeedsRedraw.ShouldBeFalse(); // nothing changed -> no redraw forced
+        s.CenterRA.ShouldBe(6.0);
+        s.CenterDec.ShouldBe(30.0);
+        s.FieldOfViewDeg.ShouldBe(60.0);
+    }
+}

--- a/src/TianWen.UI.Abstractions/AppSignalHandler.cs
+++ b/src/TianWen.UI.Abstractions/AppSignalHandler.cs
@@ -927,6 +927,17 @@ namespace TianWen.UI.Abstractions
                 appState.NeedsRedraw = true;
             });
 
+            bus.Subscribe<SkyMapSetViewSignal>(sig =>
+            {
+                // Route-only: the actions helper owns the centre + FOV-clamp + toggle logic.
+                if (SkyMapViewActions.SetView(skyMapState,
+                        sig.CenterRaHours, sig.CenterDecDeg, sig.FieldOfViewDeg,
+                        sig.ShowObjectOverlay, sig.ShowDarkNebulae))
+                {
+                    appState.NeedsRedraw = true;
+                }
+            });
+
             bus.Subscribe<SkyMapShowFixedPointInfoSignal>(sig =>
             {
                 var viewingUtc = plannerState.PlanningDate?.ToUniversalTime() ?? _timeProvider.GetUtcNow();

--- a/src/TianWen.UI.Abstractions/GuiSignals.cs
+++ b/src/TianWen.UI.Abstractions/GuiSignals.cs
@@ -283,3 +283,25 @@ public readonly record struct SkyMapSolveSyncSignal(
     double ExposureSeconds = 5.0,
     int? Gain = null,
     short Binning = 1);
+
+/// <summary>
+/// Set the sky-map viewport directly: recentre on the given J2000 RA/Dec and/or change
+/// the field of view, and optionally flip overlay layers. Every field is nullable so a
+/// caller can do a partial update (e.g. just the FOV). Primarily a programmatic control
+/// seam for the DEBUG inspector - it lets an agent frame the view deterministically (on
+/// the mount marker, on a known sky position) without synthesising drag/scroll gestures,
+/// which is what makes a scripted Solve &amp; Sync / jank-measurement loop possible. Routed
+/// to <c>SkyMapViewActions.SetView</c>; the handler is route-only (just mutates
+/// <see cref="SkyMapState"/> and flags a redraw).
+/// </summary>
+/// <param name="CenterRaHours">New viewport-centre RA in hours (J2000), [0, 24). Null leaves it unchanged.</param>
+/// <param name="CenterDecDeg">New viewport-centre Dec in degrees (J2000). Null leaves it unchanged.</param>
+/// <param name="FieldOfViewDeg">New vertical FOV in degrees; clamped to [0.5, 180]. Null leaves it unchanged.</param>
+/// <param name="ShowObjectOverlay">When set, toggles the catalog object overlay ([O]).</param>
+/// <param name="ShowDarkNebulae">When set, toggles the dark-nebula overlay ([D]).</param>
+public readonly record struct SkyMapSetViewSignal(
+    double? CenterRaHours = null,
+    double? CenterDecDeg = null,
+    double? FieldOfViewDeg = null,
+    bool? ShowObjectOverlay = null,
+    bool? ShowDarkNebulae = null);

--- a/src/TianWen.UI.Abstractions/SkyMapSearchActions.cs
+++ b/src/TianWen.UI.Abstractions/SkyMapSearchActions.cs
@@ -471,10 +471,5 @@ public static class SkyMapSearchActions
         => db.TryGetShape(idx, out var shape) ? shape : null;
 
     private static void SlewTo(SkyMapState skyMap, double raHours, double decDeg)
-    {
-        skyMap.CenterRA = raHours;
-        skyMap.CenterDec = decDeg;
-        skyMap.NormalizeCenter();
-        skyMap.NeedsRedraw = true;
-    }
+        => SkyMapViewActions.CenterOn(skyMap, raHours, decDeg);
 }

--- a/src/TianWen.UI.Abstractions/SkyMapViewActions.cs
+++ b/src/TianWen.UI.Abstractions/SkyMapViewActions.cs
@@ -1,0 +1,83 @@
+using System;
+
+namespace TianWen.UI.Abstractions;
+
+/// <summary>
+/// Pure viewport mutations for the sky map. Renderer-agnostic - shared by the search
+/// commit path, the DEBUG inspector's <c>SkyMapSetViewSignal</c> handler, and any other
+/// caller that needs to recentre or rescale the view. Centralising the centring + FOV
+/// clamp here keeps "where the map looks" to a single source of truth (the [0.5, 180]
+/// FOV clamp must match <c>SkyMapTab</c>'s scroll-zoom clamp).
+/// </summary>
+public static class SkyMapViewActions
+{
+    /// <summary>Minimum vertical field of view in degrees (matches the scroll-zoom clamp).</summary>
+    public const double MinFieldOfViewDeg = 0.5;
+
+    /// <summary>Maximum vertical field of view in degrees (matches the scroll-zoom clamp).</summary>
+    public const double MaxFieldOfViewDeg = 180.0;
+
+    /// <summary>
+    /// Recentre the viewport on a J2000 RA/Dec, normalising RA to [0, 24) and clamping
+    /// Dec away from the projection poles. Flags a redraw. This is the single centring
+    /// primitive - the search-commit path and the inspector view-control signal both
+    /// route through it.
+    /// </summary>
+    public static void CenterOn(SkyMapState skyMap, double raHours, double decDeg)
+    {
+        skyMap.CenterRA = raHours;
+        skyMap.CenterDec = decDeg;
+        skyMap.NormalizeCenter();
+        skyMap.NeedsRedraw = true;
+    }
+
+    /// <summary>
+    /// Apply a partial viewport update: any non-null argument is applied, the rest are
+    /// left as-is. FOV is clamped to [<see cref="MinFieldOfViewDeg"/>,
+    /// <see cref="MaxFieldOfViewDeg"/>]. Always flags a redraw when anything changed.
+    /// </summary>
+    /// <returns>True when at least one field was applied.</returns>
+    public static bool SetView(
+        SkyMapState skyMap,
+        double? centerRaHours = null,
+        double? centerDecDeg = null,
+        double? fieldOfViewDeg = null,
+        bool? showObjectOverlay = null,
+        bool? showDarkNebulae = null)
+    {
+        var changed = false;
+
+        // Centre: only call CenterOn when at least one of RA/Dec is supplied, falling
+        // back to the current value for the missing axis so a one-axis nudge works.
+        if (centerRaHours.HasValue || centerDecDeg.HasValue)
+        {
+            CenterOn(skyMap, centerRaHours ?? skyMap.CenterRA, centerDecDeg ?? skyMap.CenterDec);
+            changed = true;
+        }
+
+        if (fieldOfViewDeg is { } fov)
+        {
+            skyMap.FieldOfViewDeg = Math.Clamp(fov, MinFieldOfViewDeg, MaxFieldOfViewDeg);
+            changed = true;
+        }
+
+        if (showObjectOverlay is { } showObjects)
+        {
+            skyMap.ShowObjectOverlay = showObjects;
+            changed = true;
+        }
+
+        if (showDarkNebulae is { } showDark)
+        {
+            skyMap.ShowDarkNebulae = showDark;
+            changed = true;
+        }
+
+        if (changed)
+        {
+            skyMap.NeedsRedraw = true;
+        }
+
+        return changed;
+    }
+}

--- a/src/TianWen.UI.Gui/Program.cs
+++ b/src/TianWen.UI.Gui/Program.cs
@@ -568,6 +568,38 @@ using var debugInspector = DebugInspector.Attach(loop, new DebugInspectorOptions
         s.Set("sessionRunning", ls.IsRunning);
         s.Set("phase", ls.Phase.ToString());
         s.Set("unreadNotifications", appState.UnreadNotificationCount);
+
+        // Sky-map viewport — lets the inspector frame the view deterministically (via the
+        // SkyMapSetView signal) and read back where it landed instead of eyeballing a screenshot.
+        var sky = guiRenderer.SkyMapState;
+        s.Set("mapCenterRaHours", sky.CenterRA);
+        s.Set("mapCenterDec", sky.CenterDec);
+        s.Set("mapFovDeg", sky.FieldOfViewDeg);
+        s.Set("mapMode", sky.Mode.ToString());
+        s.Set("mapShowObjectOverlay", sky.ShowObjectOverlay);
+        s.Set("mapShowDarkNebulae", sky.ShowDarkNebulae);
+
+        // Mount marker (the believed-pointing reticle) — the Solve & Sync witness. After a
+        // sync the believed pointing jumps to truth, so polling this RA/Dec before/after
+        // shows the marker move; the arcmin offset itself surfaces in lastNotification.
+        if (sky.MountOverlay is { } mo)
+        {
+            s.Set("mountConnected", true);
+            s.Set("mountName", mo.DisplayName);
+            s.Set("mountRaJ2000", mo.RaJ2000);
+            s.Set("mountDecJ2000", mo.DecJ2000);
+            s.Set("mountSlewing", mo.IsSlewing);
+            s.Set("mountTracking", mo.IsTracking);
+        }
+        else
+        {
+            s.Set("mountConnected", false);
+        }
+
+        // Newest notification text — where the Solve & Sync arcmin offset, slew results,
+        // and error messages all land. Newest entry is at index 0.
+        var notes = appState.Notifications;
+        s.Set("lastNotification", notes.IsDefaultOrEmpty ? null : notes[0].Message);
     },
     SignalFactories = new Dictionary<string, Action<System.Text.Json.JsonElement>>
     {
@@ -577,6 +609,31 @@ using var debugInspector = DebugInspector.Attach(loop, new DebugInspectorOptions
             IncludeFake: el.TryGetProperty("includeFake", out var f) && f.GetBoolean())),
         ["BuildSchedule"] = _ => bus.Post(new BuildScheduleSignal()),
         ["StartSession"] = _ => bus.Post(new StartSessionSignal()),
+
+        // Sky-map view control: frame the map deterministically (on the mount marker, a known
+        // position) without synthesising drag/scroll. Every field optional -> partial update.
+        ["SkyMapSetView"] = el => bus.Post(new SkyMapSetViewSignal(
+            CenterRaHours: el.OptDouble("centerRaHours"),
+            CenterDecDeg: el.OptDouble("centerDec"),
+            FieldOfViewDeg: el.OptDouble("fovDeg"),
+            ShowObjectOverlay: el.OptBool("showObjectOverlay"),
+            ShowDarkNebulae: el.OptBool("showDarkNebulae"))),
+
+        // Solve & Sync: capture -> plate-solve -> sync the mount to truth. Gated handler-side
+        // (no session running, sync-capable mount + camera connected). The arcmin offset lands
+        // in lastNotification; the mount marker (mountRaJ2000/Dec) jumps after the sync.
+        ["SkyMapSolveSync"] = el => bus.Post(new SkyMapSolveSyncSignal(
+            OtaIndex: el.OptInt("otaIndex") ?? 0,
+            ExposureSeconds: el.OptDouble("exposureSeconds") ?? 5.0,
+            Gain: el.OptInt("gain"),
+            Binning: (short)(el.OptInt("binning") ?? 1))),
+
+        // Single transient preview exposure into the mini viewer (no disk write).
+        ["TakePreview"] = el => bus.Post(new TakePreviewSignal(
+            OtaIndex: el.OptInt("otaIndex") ?? 0,
+            ExposureSeconds: el.OptDouble("exposureSeconds") ?? 1.0,
+            Gain: el.OptInt("gain"),
+            Binning: (short)(el.OptInt("binning") ?? 1))),
     },
 });
 #endif


### PR DESCRIPTION
Give the DEBUG inspector a deterministic reach into the sky map so an agent can frame the view, trigger Solve & Sync, and verify the result — entirely over the existing `post_signal` / `describe_ui` plumbing (no new MCP tool needed).

## What

- **`SkyMapSetViewSignal`** (every field nullable → partial updates): recentre on J2000 RA/Dec and/or change FOV, flip overlay layers. Lets the inspector position the view without synthesising drag/scroll.
- **`SkyMapViewActions.SetView` / `CenterOn`**: single source of truth for viewport mutation (centre + `[0.5, 180]` FOV clamp matching the scroll-zoom path + toggles). `SkyMapSearchActions.SlewTo` now delegates to `CenterOn` — one centring path.
- **`AppSignalHandler`**: route-only handler (mutate state + flag redraw).
- **`Program.cs` `SignalFactories`**: expose `SkyMapSetView`, `SkyMapSolveSync`, `TakePreview` alongside the existing curated signals — reading args via the framework's new `DebugSignalArgs` optional readers (`el.OptInt(...)`), so the `Attach` block stays wiring-only.
- **`Program.cs` `AppState`** readback: sky-map centre/FOV/mode/overlay flags, the mount marker (believed RA/Dec J2000, slewing/tracking), and `lastNotification` — where the Solve & Sync arcmin offset lands. So a scripted loop can confirm the marker jumped to truth.

**Net:** `click_label(Tab:SkyMap)` → `SkyMapSetView{centerRaHours, centerDec}` → `SkyMapSolveSync` → `describe_ui` (read the marker jump + offset), all in one inspector `batch`.

## Test

- 9 new `SkyMapViewActions` unit tests (clamp, RA wrap, Dec pole-clamp, partial update, single-axis, toggles, no-op); 29/29 SkyMap tests green; GUI builds clean.

## Merge order

Depends on SdlVulkan.Renderer PR #25 (`DebugSignalArgs`). Merge **#25 first**, let it publish to NuGet, then this PR's CI goes green. Locally both are fine via ProjectReference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)