### PR TITLE
fix: Solve & Sync 0s-exposure (record-struct trap) + responsive sky-map reticle

### DIFF
--- a/src/TianWen.Lib.Tests/SignalDefaultsTests.cs
+++ b/src/TianWen.Lib.Tests/SignalDefaultsTests.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Shouldly;
+using TianWen.UI.Abstractions;
+using Xunit;
+
+namespace TianWen.Lib.Tests;
+
+/// <summary>
+/// Guards against a C# record-struct footgun that produced the Solve and Sync "0s exposure"
+/// bug: a record struct's IMPLICIT parameterless constructor zero-inits every field and
+/// SKIPS the primary-ctor default values. So <c>new SomeSignal()</c> silently differs from
+/// the declared defaults whenever a default is non-zero / non-null / non-false (e.g.
+/// <c>ExposureSeconds = 5.0</c> came through as 0, capturing a floored ~10 ms frame).
+/// <para>
+/// The fix is an explicit parameterless ctor that chains to the primary ctor
+/// (<c>public T() : this(...) {}</c>). This test fails the build the moment a signal record
+/// struct re-introduces the trap, so the next person does not have to rediscover it the hard way.
+/// </para>
+/// </summary>
+public class SignalDefaultsTests
+{
+    [Fact]
+    public void SignalRecordStructs_ParameterlessNew_ReproduceDeclaredDefaults()
+    {
+        var assembly = typeof(SkyMapSolveSyncSignal).Assembly;
+        var offenders = new List<string>();
+
+        foreach (var type in assembly.GetTypes())
+        {
+            if (!type.IsValueType || type.IsEnum
+                || !type.Name.EndsWith("Signal", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            // The "primary" ctor is the public instance ctor with the most parameters.
+            var primary = type.GetConstructors(BindingFlags.Public | BindingFlags.Instance)
+                .OrderByDescending(c => c.GetParameters().Length)
+                .FirstOrDefault();
+            var pars = primary?.GetParameters() ?? Array.Empty<ParameterInfo>();
+
+            // Only signals whose every parameter has a default can be built no-arg AND rely
+            // on those defaults. Signals with a required parameter document "always specify",
+            // so a parameterless `new()` is a clear misuse rather than a silent default drop.
+            if (pars.Length == 0 || pars.Any(p => !p.HasDefaultValue))
+            {
+                continue;
+            }
+
+            var withDeclaredDefaults = primary!.Invoke(pars.Select(p => p.DefaultValue).ToArray());
+            // Mirrors what `new T()` does at the call site (honours an explicit parameterless
+            // ctor when present, otherwise zero-inits the struct).
+            var parameterless = Activator.CreateInstance(type);
+
+            if (!Equals(withDeclaredDefaults, parameterless))
+            {
+                offenders.Add(type.Name);
+            }
+        }
+
+        offenders.ShouldBeEmpty(
+            "these signal record structs declare non-default primary-ctor defaults that a "
+            + "parameterless `new()` silently drops -- add an explicit "
+            + "`public <Signal>() : this(...) {}` ctor that chains to the primary ctor: "
+            + string.Join(", ", offenders));
+    }
+}

--- a/src/TianWen.Lib/Astrometry/CoordinateUtils.cs
+++ b/src/TianWen.Lib/Astrometry/CoordinateUtils.cs
@@ -25,6 +25,26 @@ public static class CoordinateUtils
             : double.NaN;
 
     /// <summary>
+    /// Great-circle angular separation in degrees between two sky positions given as
+    /// (RA in hours, Dec in degrees). Haversine form - numerically stable for small
+    /// separations. Single source of truth for sky-coordinate separations in the
+    /// RA-hours convention used across the app (sky map, plate-solve annotator, etc.).
+    /// </summary>
+    public static double AngularSeparationDeg(double ra1Hours, double dec1Deg, double ra2Hours, double dec2Deg)
+    {
+        const double DegPerRad = 180.0 / Math.PI;
+        var ra1 = ra1Hours * 15.0 / DegPerRad;
+        var dec1 = dec1Deg / DegPerRad;
+        var ra2 = ra2Hours * 15.0 / DegPerRad;
+        var dec2 = dec2Deg / DegPerRad;
+        var sinHalfDdec = Math.Sin((dec2 - dec1) * 0.5);
+        var sinHalfDra = Math.Sin((ra2 - ra1) * 0.5);
+        var a = sinHalfDdec * sinHalfDdec
+              + Math.Cos(dec1) * Math.Cos(dec2) * sinHalfDra * sinHalfDra;
+        return 2.0 * Math.Asin(Math.Min(1.0, Math.Sqrt(a))) * DegPerRad;
+    }
+
+    /// <summary>
     /// Inverse of <see cref="PixelScaleArcsec"/>: derives focal length from an
     /// (already-measured) pixel scale. Useful for stamping the master FITS
     /// with a focal length consistent with the plate-solve result rather than

--- a/src/TianWen.Lib/Devices/Ascom/AscomTelescopeDriver.cs
+++ b/src/TianWen.Lib/Devices/Ascom/AscomTelescopeDriver.cs
@@ -339,13 +339,14 @@ internal class AscomTelescopeDriver : AscomDeviceDriverBase, IMountDriver
         return SafeValueTask(() => _telescope.MoveAxis((int)axis, rate));
     }
 
+    // The COM TargetRightAscension/TargetDeclination properties throw an ASCOM
+    // ValueNotSet exception until a target has actually been assigned (e.g. by a
+    // SlewToCoordinates call). SafeGet swallows that and returns NaN, matching the
+    // GetRightAscension/GetDeclination idiom above, so callers see "no target set"
+    // as NaN rather than an exception.
     public ValueTask<double> GetTargetRightAscensionAsync(CancellationToken cancellationToken)
-    {
-        throw new NotImplementedException();
-    }
+        => ValueTask.FromResult(SafeGet(() => _telescope.TargetRightAscension, double.NaN));
 
     public ValueTask<double> GetTargetDeclinationAsync(CancellationToken cancellationToken)
-    {
-        throw new NotImplementedException();
-    }
+        => ValueTask.FromResult(SafeGet(() => _telescope.TargetDeclination, double.NaN));
 }

--- a/src/TianWen.Lib/Devices/Ascom/ComInterop/AscomDispatchTelescope.cs
+++ b/src/TianWen.Lib/Devices/Ascom/ComInterop/AscomDispatchTelescope.cs
@@ -40,6 +40,10 @@ internal sealed partial class AscomDispatchTelescope : IDisposable
     // Coordinate properties
     public partial double RightAscension { get; }
     public partial double Declination { get; }
+    // ASCOM target coordinates (the last commanded goto target). The COM getter throws
+    // a ValueNotSet exception until a target is assigned; callers go through SafeGet.
+    public partial double TargetRightAscension { get; }
+    public partial double TargetDeclination { get; }
     public partial double SiderealTime { get; }
     public partial double SiteElevation { get; set; }
     public partial double SiteLatitude { get; set; }

--- a/src/TianWen.UI.Abstractions/AppSignalHandler.cs
+++ b/src/TianWen.UI.Abstractions/AppSignalHandler.cs
@@ -139,6 +139,34 @@ namespace TianWen.UI.Abstractions
         private int _previewMountInFlight;
         private bool _loggedFirstPreviewMountSample;
 
+        // Mount-reticle poll cadence ramps down instead of snapping straight to the slow
+        // steady rate the instant tracking is detected. Fast while slewing, fast for a
+        // settle window after the mount lands and starts tracking, then relaxing to the
+        // slow steady cadence only once it has tracked undisturbed for that window.
+        // Sidereal tracking is sub-pixel on any sky-map FOV, so the slow cadence is purely
+        // a serial-load saver - the ramp means the reticle never lags a deliberate move by
+        // up to the steady interval. _steadyTrackingSinceTicks holds the timestamp steady
+        // tracking began (0 = not steady); _wasSteadyTracking is last frame's flag for the
+        // transition edge. Both are UI-thread-only - read + written only in the
+        // PollPreviewTelemetry gate, never from tracker continuations.
+        private long _steadyTrackingSinceTicks;
+        private bool _wasSteadyTracking;
+        // Set by RequestPreviewMountRefresh (called from the goto / solve-and-sync tracker
+        // continuations) to force the next poll tick to sample immediately, bypassing the
+        // interval so a deliberate move lands on the reticle within a frame. Volatile
+        // because the setter runs on a background thread while the gate reads it on the UI
+        // thread; consumed (cleared) only once a poll actually starts.
+        private int _forcePreviewMountPoll;
+
+        // Mount-reticle poll intervals (see _steadyTrackingSinceTicks). Slewing keeps up
+        // with visible motion; Settling is the fast post-landing rate held for the settle
+        // window; Steady is the relaxed sidereal rate; Idle covers parked / not-tracking.
+        private static readonly TimeSpan MountPollSlewing = TimeSpan.FromMilliseconds(500);
+        private static readonly TimeSpan MountPollSettling = TimeSpan.FromSeconds(1);
+        private static readonly TimeSpan MountPollSteady = TimeSpan.FromSeconds(10);
+        private static readonly TimeSpan MountPollIdle = TimeSpan.FromSeconds(2);
+        private static readonly TimeSpan MountTrackingSettleWindow = TimeSpan.FromSeconds(10);
+
 
         /// <summary>
         /// Polls connected cameras for cooler/temperature telemetry and appends samples
@@ -331,22 +359,52 @@ namespace TianWen.UI.Abstractions
                 }, $"PreviewTelemetry OTA{capturedIndex}");
             }
 
-            // Mount polling — rate-adaptive on last-known slew/tracking state.
-            // Steady sidereal tracking is ~15 arcsec/s, which is sub-pixel on any sky-map
-            // FOV we support — 10s cadence is sensory-overkill and massively reduces the
-            // baseline hardware load (6 serial reads per tick). Fast 500 ms cadence only
-            // while slewing, so the reticle keeps up with visible motion.
+            // Mount polling - rate-adaptive on last-known slew/tracking state, with a
+            // ramp-down so the reticle stays responsive right after a move. Steady sidereal
+            // tracking is ~15 arcsec/s, which is sub-pixel on any sky-map FOV we support, so
+            // the slow steady cadence is purely a serial-load saver (6 reads per tick). But
+            // snapping straight to it the instant tracking is detected made a freshly-landed
+            // goto / sync lag by up to the steady interval. Instead: fast while slewing, fast
+            // for MountTrackingSettleWindow after the mount lands and starts tracking, then
+            // relaxing to the steady rate only once it has tracked undisturbed that long.
             var prevMount = _liveSessionState.PreviewMountState;
-            var mountInterval = prevMount.IsSlewing
-                ? TimeSpan.FromMilliseconds(500)
-                : prevMount.IsTracking
-                    ? TimeSpan.FromSeconds(10)
-                    : TimeSpan.FromSeconds(2);
+            var steadyNow = prevMount.IsTracking && !prevMount.IsSlewing;
+            if (steadyNow && !_wasSteadyTracking)
+            {
+                _steadyTrackingSinceTicks = nowTicks;   // just entered steady tracking - start the settle clock
+            }
+            else if (!steadyNow)
+            {
+                _steadyTrackingSinceTicks = 0;           // moving or parked - cancel the settle clock
+            }
+            _wasSteadyTracking = steadyNow;
 
-            if (_timeProvider.GetElapsedTime(_previewMountLastTicks, nowTicks) >= mountInterval
+            TimeSpan mountInterval;
+            if (prevMount.IsSlewing)
+            {
+                mountInterval = MountPollSlewing;
+            }
+            else if (steadyNow)
+            {
+                var settledFor = _steadyTrackingSinceTicks != 0
+                    ? _timeProvider.GetElapsedTime(_steadyTrackingSinceTicks, nowTicks)
+                    : TimeSpan.Zero;
+                mountInterval = settledFor >= MountTrackingSettleWindow ? MountPollSteady : MountPollSettling;
+            }
+            else
+            {
+                mountInterval = MountPollIdle;
+            }
+
+            // A forced refresh (deliberate move just issued) bypasses the interval entirely.
+            var forceNow = Volatile.Read(ref _forcePreviewMountPoll) == 1;
+            if ((forceNow || _timeProvider.GetElapsedTime(_previewMountLastTicks, nowTicks) >= mountInterval)
                 && profileData.Mount is { Scheme: not "none" } mountUri
                 && Interlocked.CompareExchange(ref _previewMountInFlight, 1, 0) == 0)
             {
+                // Consume the force flag only once a poll actually starts; if the in-flight
+                // guard above lost (a poll is already running) the flag persists for next frame.
+                Volatile.Write(ref _forcePreviewMountPoll, 0);
                 _previewMountLastTicks = nowTicks;
 
                 _tracker.Run(async () =>
@@ -381,6 +439,17 @@ namespace TianWen.UI.Abstractions
                 }, "PreviewMount");
             }
         }
+
+        /// <summary>
+        /// Forces the next <see cref="PollPreviewTelemetry"/> tick to sample the mount
+        /// immediately, bypassing the cadence interval. Call after a deliberate move (a
+        /// goto kicking off, a solve &amp; sync landing) so the reticle reflects the new
+        /// pointing within a frame instead of waiting out the steady poll interval. The
+        /// in-flight guard still serialises against any poll already running; if one is,
+        /// the request persists until the next free tick. Safe to call from a background
+        /// tracker continuation.
+        /// </summary>
+        private void RequestPreviewMountRefresh() => Volatile.Write(ref _forcePreviewMountPoll, 1);
 
         // De-duplicate the mount-transform-unavailable warning so a misconfigured
         // profile doesn't log once per poll. Reset to null to re-arm when the error
@@ -874,6 +943,15 @@ namespace TianWen.UI.Abstractions
                         // stuck on the kick-off "Slewing to ..." message.
                         if (post == SlewPostCondition.Slewing)
                         {
+                            // Surface the slew destination on the sky map (marker + ETA, the
+                            // latter estimated in the render path from the polled reticle).
+                            // The signal carries J2000 catalog coords, matching the overlay frame.
+                            skyMapState.ActiveSlewTarget = new SlewTargetInfo(
+                                capturedSig.Name, capturedSig.RA, capturedSig.Dec);
+                            skyMapState.SlewEtaSeconds = double.NaN;
+                            // Kick the mount poll so the reticle picks up IsSlewing (and the
+                            // fast slew cadence) this frame instead of up to a steady interval later.
+                            RequestPreviewMountRefresh();
                             var (completion, completionMsg) = await MountActions.AwaitSlewCompletionAsync(
                                 capturedMount, capturedSig.Name, _timeProvider,
                                 logger: logger, cancellationToken: cts.Token);
@@ -897,6 +975,10 @@ namespace TianWen.UI.Abstractions
                     }
                     finally
                     {
+                        // Slew finished (reached / timed out / cancelled / failed): drop the
+                        // destination marker so it doesn't linger after the mount settles.
+                        skyMapState.ActiveSlewTarget = null;
+                        skyMapState.SlewEtaSeconds = double.NaN;
                         skyMapState.NeedsRedraw = true;
                         appState.NeedsRedraw = true;
                     }
@@ -971,6 +1053,13 @@ namespace TianWen.UI.Abstractions
                     appState.NeedsRedraw = true;
                     return;
                 }
+                // Re-entrancy guard: ignore a second click while a solve is already in
+                // flight (the button also shows "Solving ..." and drops its handler, but
+                // a queued signal could still arrive). UI-thread-only read here.
+                if (skyMapState.SolveSyncInProgress)
+                {
+                    return;
+                }
                 if (appState.ActiveProfile is not { Data: { } pdata } profile
                     || pdata.Mount is not { Scheme: not "none" } mountUri)
                 {
@@ -1019,6 +1108,8 @@ namespace TianWen.UI.Abstractions
                 }
 
                 // Mirror the preview-capture progress UI while the solve frame exposes.
+                // ExposureSeconds is now trustworthy even for the button's parameterless
+                // `new SkyMapSolveSyncSignal()` thanks to its explicit parameterless ctor.
                 if (sig.OtaIndex < liveSessionState.PreviewCapturing.Length)
                 {
                     liveSessionState.PreviewCapturing[sig.OtaIndex] = true;
@@ -1026,6 +1117,7 @@ namespace TianWen.UI.Abstractions
                     liveSessionState.PreviewExposureDuration[sig.OtaIndex] = TimeSpan.FromSeconds(sig.ExposureSeconds);
                 }
                 appState.StatusMessage = "Solve & sync\u2026";
+                skyMapState.SolveSyncInProgress = true; // drives the "Solving ..." button label
                 appState.NeedsRedraw = true;
 
                 var capturedSig = sig;
@@ -1088,6 +1180,10 @@ namespace TianWen.UI.Abstractions
                         {
                             liveSessionState.PreviewCapturing[capturedSig.OtaIndex] = false;
                         }
+                        skyMapState.SolveSyncInProgress = false; // re-enable the Solve & Sync button
+                        // A sync doesn't change slew/track state, so the cadence ramp won't
+                        // notice it - force a poll so the reticle jumps to the synced pointing.
+                        RequestPreviewMountRefresh();
                         skyMapState.NeedsRedraw = true;
                         liveSessionState.NeedsRedraw = true;
                         appState.NeedsRedraw = true;

--- a/src/TianWen.UI.Abstractions/GuiSignals.cs
+++ b/src/TianWen.UI.Abstractions/GuiSignals.cs
@@ -100,7 +100,13 @@ public readonly record struct StartPolarAlignmentSignal(
     int OtaIndex = -1,
     double DeltaRaDeg = 45.0,
     bool UseGuider = false,
-    PolarAlignmentConfiguration? Configuration = null);
+    PolarAlignmentConfiguration? Configuration = null)
+{
+    // Same record-struct trap as SkyMapSolveSyncSignal: a parameterless `new()` would skip
+    // these defaults (OtaIndex 0 not -1, DeltaRaDeg 0 not 45). Route through the primary
+    // ctor so a no-arg construction means "auto-pick OTA, 45 deg sweep" as declared.
+    public StartPolarAlignmentSignal() : this(OtaIndex: -1) { }
+}
 
 /// <summary>
 /// Cancel an in-flight polar-alignment routine. The orchestrator's reverse-axis
@@ -282,7 +288,16 @@ public readonly record struct SkyMapSolveSyncSignal(
     int OtaIndex = 0,
     double ExposureSeconds = 5.0,
     int? Gain = null,
-    short Binning = 1);
+    short Binning = 1)
+{
+    // A record struct's implicit parameterless constructor zero-inits every field and
+    // SKIPS these primary-ctor defaults, so a plain `new SkyMapSolveSyncSignal()` (as the
+    // mount info-panel button posts) would give ExposureSeconds = 0 -> a floored ~10 ms
+    // solve frame, too few stars to plate-solve in sparse fields. Routing the parameterless
+    // ctor through the primary ctor makes the declared defaults actually apply. See the
+    // SignalDefaultsTests guard that fails the build if any signal struct re-introduces this.
+    public SkyMapSolveSyncSignal() : this(OtaIndex: 0) { }
+}
 
 /// <summary>
 /// Set the sky-map viewport directly: recentre on the given J2000 RA/Dec and/or change

--- a/src/TianWen.UI.Abstractions/PlateSolveAnnotator.cs
+++ b/src/TianWen.UI.Abstractions/PlateSolveAnnotator.cs
@@ -106,7 +106,7 @@ public static class PlateSolveAnnotator
             {
                 if (!db.TryLookupByIndex(idx, out var obj)) continue;
                 if (double.IsNaN(obj.RA) || double.IsNaN(obj.Dec)) continue;
-                var distDeg = AngularSeparationDeg(pos.RA, pos.Dec, obj.RA, obj.Dec);
+                var distDeg = CoordinateUtils.AngularSeparationDeg(pos.RA, pos.Dec, obj.RA, obj.Dec);
                 if (distDeg < bestDistDeg
                     && wcs.SkyToPixel(obj.RA, obj.Dec) is { } projected)
                 {
@@ -164,23 +164,4 @@ public static class PlateSolveAnnotator
         renderer.DrawLine(xi, yi - armPx, xi, yi + armPx, color, thickness: 1);
     }
 
-    /// <summary>
-    /// Great-circle angular separation in degrees between two (RA-hours, Dec-deg)
-    /// points. Mirrors the formula in <see cref="Tycho2ColorCalibration"/>'s
-    /// <c>AngularSeparation</c>; duplicated here so the annotator doesn't pull
-    /// the calibration internals into its dependency surface.
-    /// </summary>
-    private static double AngularSeparationDeg(double ra1Hours, double dec1Deg, double ra2Hours, double dec2Deg)
-    {
-        const double DegPerRad = 180.0 / Math.PI;
-        var ra1 = ra1Hours * 15.0 / DegPerRad;
-        var dec1 = dec1Deg / DegPerRad;
-        var ra2 = ra2Hours * 15.0 / DegPerRad;
-        var dec2 = dec2Deg / DegPerRad;
-        var sinHalfDdec = Math.Sin((dec2 - dec1) * 0.5);
-        var sinHalfDra = Math.Sin((ra2 - ra1) * 0.5);
-        var a = sinHalfDdec * sinHalfDdec
-              + Math.Cos(dec1) * Math.Cos(dec2) * sinHalfDra * sinHalfDra;
-        return 2.0 * Math.Asin(Math.Min(1.0, Math.Sqrt(a))) * DegPerRad;
-    }
 }

--- a/src/TianWen.UI.Abstractions/SkyMapState.cs
+++ b/src/TianWen.UI.Abstractions/SkyMapState.cs
@@ -86,6 +86,31 @@ namespace TianWen.UI.Abstractions
         public bool ShowMountOverlay { get; set; } = true;
 
         /// <summary>
+        /// True while a sky-map Solve &amp; Sync (capture + plate-solve + sync) is in
+        /// flight. Set by the signal handler when the capture starts and cleared when it
+        /// finishes; the mount info-panel button reads it to show "Solving ..." and to
+        /// suppress re-triggering mid-solve.
+        /// </summary>
+        public bool SolveSyncInProgress { get; set; }
+
+        /// <summary>
+        /// The mount's current slew destination (J2000) + display name while a goto issued
+        /// from the sky map is in flight; null when the mount is not slewing to a
+        /// GUI-known target. The renderer draws a destination marker, but when the target
+        /// coincides with an already-rendered scheduled / pinned marker it augments that
+        /// (connecting line + ETA) instead of drawing a duplicate reticle.
+        /// </summary>
+        public SlewTargetInfo? ActiveSlewTarget { get; set; }
+
+        /// <summary>
+        /// Estimated seconds until the <see cref="ActiveSlewTarget"/> slew completes, or
+        /// <see cref="double.NaN"/> when not yet estimable (too little motion observed).
+        /// Computed in the render path from the polled reticle position + wall clock so it
+        /// does not add a second concurrent mount reader alongside the telemetry poll.
+        /// </summary>
+        public double SlewEtaSeconds { get; set; } = double.NaN;
+
+        /// <summary>
         /// Pre-computed mosaic panel centres for pinned targets whose catalog shape
         /// exceeds the sensor FOV. Populated by the event loop alongside the mount
         /// overlay. Each entry is the RA/Dec centre of one panel. The sensor FOV
@@ -462,4 +487,11 @@ namespace TianWen.UI.Abstractions
         Equatorial,
         Horizon
     }
+
+    /// <summary>
+    /// A mount slew destination for the sky-map overlay: target J2000 coordinates + the
+    /// display name of what is being slewed to. A fresh instance is created per goto so
+    /// the renderer can detect a new slew (by reference) and restart its ETA estimate.
+    /// </summary>
+    public sealed record SlewTargetInfo(string Name, double RaJ2000, double DecJ2000);
 }

--- a/src/TianWen.UI.Abstractions/SkyMapTab.Search.cs
+++ b/src/TianWen.UI.Abstractions/SkyMapTab.Search.cs
@@ -192,8 +192,9 @@ namespace TianWen.UI.Abstractions
             RectF32 contentRect, string fontPath, float dpiScale,
             double pixelsPerRadian, float cx, float cy)
         {
-            // Widened from 300 to fit three action buttons (Goto / View / Pin).
-            var pw = 320f * dpiScale;
+            // Widened (300 -> 320 -> 348) to fit three action buttons (Goto / View in
+            // Planner / Pin) without the longer "View in Planner" label clipping.
+            var pw = 348f * dpiScale;
             var ph = 205f * dpiScale;
             var px = contentRect.X + 12f * dpiScale;
             var py = contentRect.Y + contentRect.Height - ph - 32f * dpiScale; // above status strip
@@ -272,16 +273,24 @@ namespace TianWen.UI.Abstractions
                 // Mount entry: the one meaningful action is Solve & Sync (a goto to
                 // the mount's own reported position is a no-op, and pinning it makes
                 // no sense). The handler is the source of truth for the session /
-                // camera / CanSync gates.
+                // camera / CanSync gates. While a solve is in flight the button shows
+                // "Solving ..." (dimmed, no click handler) so it reads as busy and can't
+                // be re-triggered mid-solve.
+                var solving = State.SolveSyncInProgress;
                 var ssBtnW = 110f * dpiScale;
                 var ssBtnX = px + pw - ssBtnW - 10f * dpiScale;
+                Action<InputModifier>? ssOnClick = null;
+                if (!solving)
+                {
+                    ssOnClick = _ => PostSignal(new SkyMapSolveSyncSignal());
+                }
                 RenderButton(
-                    "Solve & Sync",
+                    solving ? "Solving ..." : "Solve & Sync",
                     ssBtnX, btnY, ssBtnW, btnH, fontPath, fontSize,
-                    GotoButtonBg,
+                    solving ? GotoDisabledBg : GotoButtonBg,
                     SearchText,
                     "SkyMapSolveSync",
-                    _ => PostSignal(new SkyMapSolveSyncSignal()));
+                    ssOnClick);
             }
             else
             {
@@ -297,11 +306,13 @@ namespace TianWen.UI.Abstractions
                         pinName, pinRA, pinDec, pinIndex, pinType)));
 
                 // View-in-Planner (left of the Pin button). Jumps to the planner tab
-                // with this target scored, selected, and scrolled into view.
-                var viewBtnX = pinBtnX - btnW - 8f * dpiScale;
+                // with this target scored, selected, and scrolled into view. Wider than
+                // the short Goto / Pin buttons so the longer label doesn't clip.
+                var viewBtnW = 116f * dpiScale;
+                var viewBtnX = pinBtnX - viewBtnW - 8f * dpiScale;
                 RenderButton(
                     "View in Planner",
-                    viewBtnX, btnY, btnW, btnH, fontPath, fontSize * 0.9f,
+                    viewBtnX, btnY, viewBtnW, btnH, fontPath, fontSize * 0.9f,
                     ViewButtonBg,
                     SearchText,
                     "SkyMapViewInPlanner",

--- a/src/TianWen.UI.Gui/VkGuiRenderer.cs
+++ b/src/TianWen.UI.Gui/VkGuiRenderer.cs
@@ -3,6 +3,7 @@ using System.Collections.Immutable;
 using DIR.Lib;
 using Microsoft.Extensions.Logging;
 using SdlVulkan.Renderer;
+using TianWen.Lib.Astrometry;
 using TianWen.Lib.Devices;
 using TianWen.Lib.Sequencing;
 using TianWen.UI.Abstractions;
@@ -476,7 +477,7 @@ namespace TianWen.UI.Gui
                     // own poll path. Session-mode uses the session's own MountState
                     // (already populated at session's PollDeviceStatesAsync cadence);
                     // preview-mode uses PreviewMountState populated by PollPreviewTelemetry.
-                    PopulateSkyMapMountOverlay(appState);
+                    PopulateSkyMapMountOverlay(appState, timeProvider);
                     PopulateSkyMapMosaicPanels(appState, plannerState);
                     PopulateSkyMapScheduleTargets();
                     _skyMapTab.Render(plannerState, contentRect, DpiScale,
@@ -524,7 +525,7 @@ namespace TianWen.UI.Gui
         /// J2000 coords are preferred; native coords are used as a fallback for session
         /// mode which does not yet populate the J2000 fields.
         /// </summary>
-        private void PopulateSkyMapMountOverlay(GuiAppState appState)
+        private void PopulateSkyMapMountOverlay(GuiAppState appState, ITimeProvider timeProvider)
         {
             // Without an actual poll, default(MountState) has all-zero coords -- not
             // NaN -- so a NaN check alone would still draw a phantom reticle at (0h, 0)
@@ -587,6 +588,53 @@ namespace TianWen.UI.Gui
                 IsSlewing: ms.IsSlewing,
                 IsTracking: ms.IsTracking,
                 SensorFovDeg: sensorFov);
+
+            // Refine the slew ETA from the just-read believed position + wall clock. Uses
+            // the position the telemetry poll already produced (raJ2000/decJ2000) rather
+            // than reading the mount again, so it never races PollPreviewTelemetry on the port.
+            UpdateSlewEta(raJ2000, decJ2000, timeProvider);
+        }
+
+        // Render-thread-only ETA tracking for the active slew destination. Observes how
+        // far the reticle has moved toward the target since the slew began and divides the
+        // remaining arc by that rate. NaN until enough motion is seen to be meaningful.
+        private SlewTargetInfo? _etaTrackedTarget;
+        private DateTimeOffset _etaStartUtc;
+        private double _etaStartRemainingDeg;
+
+        private void UpdateSlewEta(double curRaJ2000, double curDecJ2000, ITimeProvider timeProvider)
+        {
+            var target = _skyMapTab.State.ActiveSlewTarget;
+            if (target is null || double.IsNaN(curRaJ2000) || double.IsNaN(curDecJ2000))
+            {
+                _etaTrackedTarget = null;
+                return;
+            }
+
+            var now = timeProvider.GetUtcNow();
+            var remainingDeg = CoordinateUtils.AngularSeparationDeg(
+                curRaJ2000, curDecJ2000, target.RaJ2000, target.DecJ2000);
+
+            // (Re)start the observation window when a new goto sets a fresh target instance.
+            if (!ReferenceEquals(_etaTrackedTarget, target))
+            {
+                _etaTrackedTarget = target;
+                _etaStartUtc = now;
+                _etaStartRemainingDeg = remainingDeg;
+                _skyMapTab.State.SlewEtaSeconds = double.NaN;
+                return;
+            }
+
+            var elapsed = (now - _etaStartUtc).TotalSeconds;
+            var covered = _etaStartRemainingDeg - remainingDeg;
+            // Need a little time + observed motion before a rate estimate is trustworthy.
+            if (elapsed >= 0.75 && covered >= 0.05)
+            {
+                var rateDegPerSec = covered / elapsed;
+                _skyMapTab.State.SlewEtaSeconds = rateDegPerSec > 1e-6
+                    ? Math.Max(0.0, remainingDeg / rateDegPerSec)
+                    : double.NaN;
+            }
         }
 
         /// <summary>

--- a/src/TianWen.UI.Gui/VkSkyMapTab.cs
+++ b/src/TianWen.UI.Gui/VkSkyMapTab.cs
@@ -514,15 +514,35 @@ public sealed unsafe class VkSkyMapTab(VkRenderer renderer) : SkyMapTab<VulkanCo
             var (r, g, b) = item.IsPinned ? (1f, 0.44f, 0.19f) : item.Color;
             var labelAlpha = dimBelowHorizon && !site.IsAboveHorizon(item.RA, item.Dec) ? 0.35f : 1.0f;
             if (!item.IsPinned) labelAlpha *= fovAlpha;
+            var maxLineW = 0f;
             for (var li = 0; li < item.LabelLines.Count; li++)
             {
                 var lineAlpha = (li == 0 ? 1.0f : 0.7f) * labelAlpha;
                 var color = RGBAColor32.FromFloat(r, g, b, lineAlpha);
-                Renderer.DrawText(item.LabelLines[li].AsSpan(), fontPath, labelSize, color,
+                var line = item.LabelLines[li];
+                Renderer.DrawText(line.AsSpan(), fontPath, labelSize, color,
                     new RectInt(
                         new PointInt((int)(lx + 200), (int)(ly + (li + 1) * lineH)),
                         new PointInt((int)lx, (int)(ly + li * lineH))),
                     TextAlign.Near, TextAlign.Center);
+                var (lineW, _) = Renderer.MeasureText(line.AsSpan(), fontPath, labelSize);
+                if (lineW > maxLineW) maxLineW = lineW;
+            }
+
+            // Hit-test the label's bounding box (not the individual glyphs): clicking the
+            // text selects the same object a click on its marker would. We synthesize a
+            // click-select at the object's own screen position so the existing nearest-object
+            // resolver (SkyMapClickSelectSignal -> SelectObjectByClick) runs unchanged -- one
+            // path, no duplicate resolution. Skip near-invisible labels (faded out at wide
+            // FOV) so there are no phantom hit targets, and require a measured text width.
+            if (labelAlpha > 0.15f && maxLineW > 0f && item.LabelLines.Count > 0)
+            {
+                var labelH = item.LabelLines.Count * lineH;
+                var objX = item.ScreenX;
+                var objY = item.ScreenY;
+                RegisterClickable(lx, ly, maxLineW, labelH,
+                    new HitResult.ButtonHit($"SkyMapObjectLabel:{item.LabelLines[0]}"),
+                    _ => PostSignal(new SkyMapClickSelectSignal(objX, objY, InputModifier.None)));
             }
         }
 
@@ -677,6 +697,11 @@ public sealed unsafe class VkSkyMapTab(VkRenderer renderer) : SkyMapTab<VulkanCo
             return;
         }
 
+        // Destination marker + ETA for an in-flight slew. Drawn before the mount's own
+        // off-screen early-return so the user still sees where it is heading even when the
+        // reticle itself ends up just outside the viewport during a long slew.
+        RenderSlewTarget(contentRect, dpiScale, fontPath, baseFontSize, ppr, cx, cy, screenX, screenY);
+
         // Skip if the mount is projected well off-screen — no point drawing a reticle
         // we can't see, and it keeps the label clutter off the info strip.
         const float margin = 100f;
@@ -733,6 +758,101 @@ public sealed unsafe class VkSkyMapTab(VkRenderer renderer) : SkyMapTab<VulkanCo
             new HitResult.ButtonHit("SkyMapMountReticle"),
             _ => PostSignal(new SkyMapShowMountInfoSignal(
                 capturedName, capturedRA, capturedDec)));
+    }
+
+    /// <summary>
+    /// Draws the in-flight slew destination: a connecting line from the mount reticle to
+    /// the target, plus a destination ring + "-> name" label and a best-effort ETA. When
+    /// the target coincides with an already-rendered scheduled / pinned marker the ring is
+    /// skipped (no duplicate) and only the line + ETA augment that existing marker.
+    /// </summary>
+    private void RenderSlewTarget(
+        RectF32 contentRect, float dpiScale, string fontPath, float baseFontSize,
+        double ppr, float cx, float cy, float mountScreenX, float mountScreenY)
+    {
+        if (State.ActiveSlewTarget is not { } target)
+        {
+            return;
+        }
+
+        if (!SkyMapProjection.ProjectWithMatrix(target.RaJ2000, target.DecJ2000,
+                State.CurrentViewMatrix, ppr, cx, cy, out var tx, out var ty))
+        {
+            return;
+        }
+
+        const float margin = 100f;
+        if (tx < contentRect.X - margin || tx > contentRect.X + contentRect.Width + margin
+            || ty < contentRect.Y - margin || ty > contentRect.Y + contentRect.Height + margin)
+        {
+            return;
+        }
+
+        // Amber matches the slewing reticle / active scheduled target.
+        var amber = new RGBAColor32(0xFF, 0xB0, 0x40, 0xFF);
+        var fontSize = baseFontSize * dpiScale;
+        var lineH = fontSize * 1.2f;
+
+        // Slew vector: from the mount's current reticle to the destination.
+        DrawLine(mountScreenX, mountScreenY, tx, ty,
+            new RGBAColor32(amber.Red, amber.Green, amber.Blue, 0x70));
+
+        // Don't draw a second reticle when the target is already a scheduled / pinned
+        // marker - just augment it (the line above + the ETA below).
+        var alreadyMarked = IsTargetAlreadyMarked(target);
+        var labelTopY = ty + 16f * dpiScale;
+        if (!alreadyMarked)
+        {
+            DrawCircle(tx, ty, 12f * dpiScale, amber, 1.5f);
+            DrawReticleLabel(target.Name, fontPath, fontSize, amber, tx, labelTopY, lineH);
+            labelTopY += lineH;
+        }
+
+        var eta = State.SlewEtaSeconds;
+        if (!double.IsNaN(eta))
+        {
+            DrawReticleLabel(FormatEta(eta), fontPath, fontSize * 0.9f,
+                new RGBAColor32(amber.Red, amber.Green, amber.Blue, 0xCC), tx, labelTopY, lineH);
+        }
+    }
+
+    /// <summary>
+    /// True when the slew target coincides (within ~6') with an already-rendered scheduled
+    /// observation or pinned overlay object, so the destination shouldn't get a duplicate
+    /// marker. Matched by sky position since scheduled targets don't carry a catalog index.
+    /// </summary>
+    private bool IsTargetAlreadyMarked(SlewTargetInfo target)
+    {
+        const double tolDeg = 0.1; // ~6 arcmin: same object, not a coincidental neighbour
+
+        foreach (var (ra, dec, _, _) in State.ScheduleTargets)
+        {
+            if (CoordinateUtils.AngularSeparationDeg(ra, dec, target.RaJ2000, target.DecJ2000) < tolDeg)
+            {
+                return true;
+            }
+        }
+
+        foreach (var item in _overlayItems)
+        {
+            if (item.IsPinned
+                && CoordinateUtils.AngularSeparationDeg(item.RA, item.Dec, target.RaJ2000, target.DecJ2000) < tolDeg)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>Formats a slew ETA (seconds) as a short "ETA ..." label.</summary>
+    private static string FormatEta(double seconds)
+    {
+        if (seconds < 1.0) return "ETA <1s";
+        if (seconds < 60.0) return $"ETA {seconds:F0}s";
+        var m = (int)(seconds / 60.0);
+        var s = (int)(seconds % 60.0);
+        return $"ETA {m}m {s:D2}s";
     }
 
     /// <summary>


### PR DESCRIPTION
Started from a reported **Solve & Sync plate-solve failure** ("first attempt" failed in a sparse field) and grew into the root-cause fix, a build-time guard against the whole class of bug, and a sky-map reticle UX pass.

## Root cause: a record-struct default trap
The mount info-panel button posts a parameterless `new SkyMapSolveSyncSignal()`. A `record struct`'s implicit parameterless ctor zero-inits every field and **skips the primary-ctor defaults**, so `ExposureSeconds` arrived as `0` (not `5.0`) -> `StartExposure` floored it to the ~10 ms `ExposureResolution` -> a bright synthetic mag cutoff with too few stars to plate-solve in sparse fields. It "worked" earlier only because those fields were denser.

**Verified fixed live** (near-pole field that previously failed):
```
before:  t=0.010s  magCutoff=7.87   placedStars=7    -> 3 detected -> no plate solver could solve
after:   t=5.000s  magCutoff=14.62  placedStars=676  -> 919 detected -> Solved (RA=11.17h Dec=-73.25)
```

## Commits
1. **fix(ascom)** - wire `TargetRightAscension/Declination` through the COM dispatch (were `NotImplementedException` stubs).
2. **refactor(astrometry)** - centralize `AngularSeparationDeg` in `CoordinateUtils`; fold the `PlateSolveAnnotator` copy.
3. **fix(skymap)** - the exposure fix: explicit parameterless ctors on `SkyMapSolveSyncSignal` + `StartPolarAlignmentSignal` so `new()` honours declared defaults, **plus `SignalDefaultsTests`** - a reflection guard that fails the build if any `*Signal` record struct's parameterless `new()` diverges from its declared defaults. (The compiler can't enforce this - every struct is guaranteed a zero default - so the test is the enforcement.)
4. **feat(skymap)** - responsive mount reticle: poll cadence ramps down (fast while slewing / settling, relaxing to 10s steady) + forced refresh after goto/sync; in-flight **slew destination marker + ETA** (no duplicate when the target is already a scheduled/pinned marker); **clickable object labels** (bbox hit-test reusing the click-select resolver); **"Solving ..."** button state + re-entrancy guard; widened **View in Planner** button.

## Audit
Swept all `*Signal` record structs: only `SkyMapSolveSyncSignal` was an active bug. `StartPolarAlignmentSignal` had the same trap latent (hardened preventively); `TakePreviewSignal` has required params (left as-is). All others use zero/null/false defaults (safe). The guard test now backstops the rest.

## Verification
- `dotnet build` (GUI + tests): 0 warnings.
- 34 regression tests (MountActions + SkyMapView) + the new guard test pass.
- Live: plate solve fixed; crop fix, Solving state, slew marker all confirmed in the running GUI via the inspector.

🤖 Generated with [Claude Code](https://claude.com/claude-code)