### PR TITLE
feat(gui): Session Setup affordance + dynamic Live Session icon + Ctrl+Tab cycling

### DIFF
--- a/src/TianWen.Lib.Tests/GuiTabNavigationTests.cs
+++ b/src/TianWen.Lib.Tests/GuiTabNavigationTests.cs
@@ -1,0 +1,59 @@
+using Shouldly;
+using TianWen.UI.Abstractions;
+using Xunit;
+
+namespace TianWen.Lib.Tests;
+
+/// <summary>
+/// Tab-cycling logic behind Ctrl+Tab / Ctrl+Shift+Tab. The order itself lives in
+/// <see cref="GuiAppState.TabOrder"/> (single source of truth shared with the GUI sidebar).
+/// </summary>
+public class GuiTabNavigationTests
+{
+    [Fact]
+    public void TabOrder_IsTheSidebarLayoutOrder()
+    {
+        GuiAppState.TabOrder.ShouldBe(new[]
+        {
+            GuiTab.Equipment,
+            GuiTab.Planner,
+            GuiTab.SkyMap,
+            GuiTab.Session,
+            GuiTab.LiveSession,
+            GuiTab.Guider,
+            GuiTab.Notifications,
+        });
+    }
+
+    [Fact]
+    public void NextTab_Forward_AdvancesOneStepAndWrapsAtEnd()
+    {
+        var order = GuiAppState.TabOrder;
+        for (var i = 0; i < order.Length; i++)
+        {
+            var expected = order[(i + 1) % order.Length];
+            GuiAppState.NextTab(order[i], forward: true).ShouldBe(expected);
+        }
+    }
+
+    [Fact]
+    public void NextTab_Backward_StepsBackOneAndWrapsAtStart()
+    {
+        var order = GuiAppState.TabOrder;
+        for (var i = 0; i < order.Length; i++)
+        {
+            var expected = order[(i - 1 + order.Length) % order.Length];
+            GuiAppState.NextTab(order[i], forward: false).ShouldBe(expected);
+        }
+    }
+
+    [Fact]
+    public void NextTab_ForwardThenBackward_ReturnsToStartForEveryTab()
+    {
+        foreach (var tab in GuiAppState.TabOrder)
+        {
+            GuiAppState.NextTab(GuiAppState.NextTab(tab, forward: true), forward: false)
+                .ShouldBe(tab);
+        }
+    }
+}

--- a/src/TianWen.UI.Abstractions/GuiAppState.cs
+++ b/src/TianWen.UI.Abstractions/GuiAppState.cs
@@ -36,6 +36,40 @@ public readonly record struct NotificationEntry(
 
 public class GuiAppState
 {
+    /// <summary>
+    /// Canonical left-to-right (sidebar top-to-bottom) tab order. Single source of truth for
+    /// both the GUI sidebar rendering and Ctrl+Tab / Ctrl+Shift+Tab cycling, so the visual order
+    /// and the cycle order can never drift apart. The <see cref="GuiTab"/> enum declaration order
+    /// is historical and intentionally not used for ordering.
+    /// </summary>
+    public static readonly ImmutableArray<GuiTab> TabOrder =
+    [
+        GuiTab.Equipment,
+        GuiTab.Planner,
+        GuiTab.SkyMap,
+        GuiTab.Session,
+        GuiTab.LiveSession,
+        GuiTab.Guider,
+        GuiTab.Notifications,
+    ];
+
+    /// <summary>
+    /// Returns the tab one step from <paramref name="current"/> in <see cref="TabOrder"/>
+    /// (<paramref name="forward"/> = next, otherwise previous), wrapping around at both ends.
+    /// Backs Ctrl+Tab / Ctrl+Shift+Tab cycling.
+    /// </summary>
+    public static GuiTab NextTab(GuiTab current, bool forward)
+    {
+        var order = TabOrder;
+        var idx = order.IndexOf(current);
+        if (idx < 0) idx = 0;
+
+        var next = forward
+            ? (idx + 1) % order.Length
+            : (idx - 1 + order.Length) % order.Length;
+        return order[next];
+    }
+
     /// <summary>Device URI registry for resolving camera URIs to device instances.</summary>
     public IDeviceHub? DeviceHub { get; init; }
 

--- a/src/TianWen.UI.Abstractions/GuiEventHandlerBase.cs
+++ b/src/TianWen.UI.Abstractions/GuiEventHandlerBase.cs
@@ -266,6 +266,14 @@ namespace TianWen.UI.Abstractions
                 return true;
             }
 
+            // Ctrl+Tab / Ctrl+Shift+Tab cycle through tabs in sidebar order (wraps around).
+            // Also global so it works while a search field is focused.
+            if (inputKey == InputKey.Tab && (inputModifier & InputModifier.Ctrl) != 0)
+            {
+                CycleTab(forward: (inputModifier & InputModifier.Shift) == 0);
+                return true;
+            }
+
             var activeInput = _appState.ActiveTextInput;
             if (activeInput is { IsActive: true })
             {
@@ -299,6 +307,21 @@ namespace TianWen.UI.Abstractions
             }
             _appState.NeedsRedraw = true;
             return true;
+        }
+
+        /// <summary>
+        /// Cycles the active tab one step through <see cref="GuiAppState.TabOrder"/> (Ctrl+Tab forward,
+        /// Ctrl+Shift+Tab backward), wrapping around at the ends.
+        /// </summary>
+        private void CycleTab(bool forward)
+        {
+            var tab = GuiAppState.NextTab(_appState.ActiveTab, forward);
+            _appState.ActiveTab = tab;
+            if (tab == GuiTab.Notifications)
+            {
+                _appState.UnreadNotificationCount = 0;
+            }
+            _appState.NeedsRedraw = true;
         }
 
         // ===================================================================

--- a/src/TianWen.UI.Gui/VkGuiRenderer.cs
+++ b/src/TianWen.UI.Gui/VkGuiRenderer.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using DIR.Lib;
 using Microsoft.Extensions.Logging;
@@ -89,17 +90,25 @@ namespace TianWen.UI.Gui
         private float StatusBarHeight => BaseStatusBarHeight * DpiScale;
         private float FontSize => BaseFontSize * DpiScale;
 
-        // Sidebar tab definitions. Tooltip shows the name + Ctrl+letter shortcut.
-        private static readonly (string Icon, GuiTab Tab, string Tooltip)[] SidebarTabs =
-        [
-            ("\U0001F52D", GuiTab.Equipment,     "Equipment (Ctrl+E)"),
-            ("\U0001F4C5", GuiTab.Planner,       "Planner (Ctrl+P)"),
-            ("\U0001F30C", GuiTab.SkyMap,        "Sky Map (Ctrl+M)"),
-            ("\U0001F4F7", GuiTab.Session,       "Session (Ctrl+S)"),
-            ("\U0001F4F8", GuiTab.LiveSession,   "Live Session (Ctrl+L)"),
-            ("\U0001F3AF", GuiTab.Guider,        "Guider (Ctrl+G)"),
-            ("\U0001F514", GuiTab.Notifications, "Notifications (Ctrl+N)"),
-        ];
+        // Live Session sidebar icon reflects session state (overridden per-frame in RenderSidebar):
+        // idle = camera, running = camera with flash. The rocket marks the Session Setup tab as the
+        // "set up and launch here" entry point so the Start Session button is easy to find.
+        private const string LiveSessionIdleIcon    = "\U0001F4F7"; // camera
+        private const string LiveSessionRunningIcon = "\U0001F4F8"; // camera with flash
+
+        // Per-tab sidebar chrome (icon + hover tooltip with the Ctrl+letter shortcut). The sidebar
+        // ORDER comes from GuiAppState.TabOrder (shared with Ctrl+Tab cycling) so the visual order
+        // and the cycle order can't drift apart.
+        private static readonly Dictionary<GuiTab, (string Icon, string Tooltip)> TabChrome = new()
+        {
+            [GuiTab.Equipment]     = ("\U0001F52D",        "Equipment (Ctrl+E)"),
+            [GuiTab.Planner]       = ("\U0001F4C5",        "Planner (Ctrl+P)"),
+            [GuiTab.SkyMap]        = ("\U0001F30C",        "Sky Map (Ctrl+M)"),
+            [GuiTab.Session]       = ("\U0001F680",        "Session Setup (Ctrl+S)"),
+            [GuiTab.LiveSession]   = (LiveSessionIdleIcon, "Live Session (Ctrl+L)"),
+            [GuiTab.Guider]        = ("\U0001F3AF",        "Guider (Ctrl+G)"),
+            [GuiTab.Notifications] = ("\U0001F514",        "Notifications (Ctrl+N)"),
+        };
 
         // Sidebar colors
         private static readonly RGBAColor32 SidebarBg     = new RGBAColor32(0x1a, 0x1a, 0x22, 0xff);
@@ -229,9 +238,16 @@ namespace TianWen.UI.Gui
             string? hoverTooltip = null;
             float hoverY = 0f;
 
-            for (var i = 0; i < SidebarTabs.Length; i++)
+            var tabs = GuiAppState.TabOrder;
+            for (var i = 0; i < tabs.Length; i++)
             {
-                var (icon, tab, tooltip) = SidebarTabs[i];
+                var tab = tabs[i];
+                var (icon, tooltip) = TabChrome[tab];
+                // Live Session icon flips to "camera with flash" while a session is actually running.
+                if (tab is GuiTab.LiveSession && LiveSessionState.IsRunning)
+                {
+                    icon = LiveSessionRunningIcon;
+                }
                 var btnY = startY + i * buttonSize;
                 var isActive = appState.ActiveTab == tab;
                 var isLocked = (noProfile && tab is not GuiTab.Equipment)


### PR DESCRIPTION
## GUI tab affordance

Makes the **Start Session** button discoverable and the two session tabs distinguishable, plus adds Ctrl+Tab tab cycling.

### Changes
- **Session tab → 🚀 "Session Setup"** (was a 📷 camera icon + "Session"). The rocket marks it as the "set up and launch here" entry point, so the `▶ Start Session` button is easy to find.
- **Live Session tab icon is now dynamic** — 📷 idle when no session is running, 📸 (camera-with-flash) while a session is running. This reuses the camera glyph freed up by the Session tab, so the two tabs are no longer near-identical camera icons.
- **Ctrl+Tab / Ctrl+Shift+Tab** cycle through tabs in sidebar order (wraps around), global so they work even while a search field is focused (alongside the existing Ctrl+letter shortcuts).

### Design
- `GuiAppState.TabOrder` is the **single source of truth** for tab order (the visual sidebar order, distinct from the historical `GuiTab` enum declaration order). Both the sidebar render loop and the cycle logic consume it, so they can't drift. Per-tab icon+tooltip moved to a `GuiTab`-keyed `TabChrome` lookup so only the order lives in one place.
- Cycle math extracted to the testable static `GuiAppState.NextTab`.

### Verification
- 4 unit tests in `GuiTabNavigationTests` (order pin, forward/backward wrap, round-trip).
- End-to-end via the live UI inspector: forward (Planner→SkyMap), backward (SkyMap→Planner→Equipment), wrap (Equipment→Notifications), and the Notifications unread-clear side effect.
- Rocket glyph renders correctly in the emoji font (no tofu), confirmed by screenshot.
- Full unit suite green (2594, 0 failed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
