### PR TITLE
fix(skymap): chunked star rendering + GPU-wedge-safe drains; stepper column

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -63,8 +63,10 @@
          instead of a (byte[], int, int) tuple.
          4.4 adds renderer clip hooks (PushClip/PopClip) + TabBar / FontFallbackResolver
          widgets. Lockstep with SdlVulkan.Renderer 5.1, which implements the clip hooks
-         via Vulkan scissor, so the two must move together. -->
-    <PackageVersion Include="DIR.Lib" Version="4.4.*" />
+         via Vulkan scissor, so the two must move together.
+         4.5 adds PixelWidgetBase.MeasureValueColumnWidth (shared stepper value-column
+         sizing); released in lockstep with Console.Lib 2.18 + SdlVulkan.Renderer 6.1. -->
+    <PackageVersion Include="DIR.Lib" Version="4.5.*" />
     <!-- DIR.Lib 3.0 extracted its codec layer to these sibling packages, which
          ship as a lockstep family from the StbImageSharp repo. 3.0 brought a
          binary-breaking SharpAstro.Tiff change (TiffPageOptions.IccProfile is
@@ -90,17 +92,19 @@
     <PackageVersion Include="SharpAstro.Jxr" Version="3.3.*" />
     <PackageVersion Include="SharpAstro.Exr" Version="3.3.*" />
     <!-- Console.Lib 2.17 adds ScrollableList + TreeView opt-in auto wheel routing
-         (on top of 2.13-2.16 widget work). Built on DIR.Lib 4.4, same sibling
-         family as SdlVulkan.Renderer 5.1. -->
-    <PackageVersion Include="Console.Lib" Version="2.17.*" />
+         (on top of 2.13-2.16 widget work). 2.18 is a no-code lockstep rebuild against
+         DIR.Lib 4.5, same sibling family as SdlVulkan.Renderer 6.1. -->
+    <PackageVersion Include="Console.Lib" Version="2.18.*" />
     <!-- SdlVulkan.Renderer 5.0 adds a multi-page SDF glyph atlas (no more grow
          stall / Adreno submit-wedge) on top of 4.1's SetSystemCursor + anisotropic
          glyph xScale. 5.1 implements DIR.Lib 4.4's PushClip/PopClip via Vulkan
          scissor, in lockstep with DIR.Lib 4.4 (see above).
          6.0 (PR #22) adds glyph/atlas hot-path perf, draw-call dedup, and Mailbox
-         present mode; it still targets DIR.Lib 4.4.x, so the renderer can move to 6.0
-         without dragging DIR.Lib forward (verified via package restore at bump time). -->
-    <PackageVersion Include="SdlVulkan.Renderer" Version="6.0.*" />
+         present mode.
+         6.1 hardens GPU-wedge recovery: bounded vkWaitForFences drains (no unbounded
+         vkDeviceWaitIdle) + a device-level IsGpuStuck flag, so a stuck GPU can no longer
+         hang the UI thread. Repinned to DIR.Lib 4.5 (lockstep with Console.Lib 2.18). -->
+    <PackageVersion Include="SdlVulkan.Renderer" Version="6.1.*" />
     <PackageVersion Include="SDL3-CS" Version="3.5.0-preview.20260213-150035" />
     <PackageVersion Include="SDL3-CS.Native" Version="3.5.0-preview.20260205-174353" />
     <!-- Canon DSLR -->

--- a/src/TianWen.UI.Abstractions/SessionTab.cs
+++ b/src/TianWen.UI.Abstractions/SessionTab.cs
@@ -53,6 +53,12 @@ namespace TianWen.UI.Abstractions
         /// <summary>Per-observation exposure value hit regions for double-click-to-edit.</summary>
         private readonly List<(RectF32 Rect, int ProposalIndex)> _exposureValueRegions = [];
 
+        /// <summary>Reused scratch buffer for measuring the shared stepper value-column width (no per-frame alloc).</summary>
+        private readonly List<string> _stepperValueScratch = [];
+
+        /// <summary>Reused scratch buffer for measuring the shared per-OTA camera-settings value-column width.</summary>
+        private readonly List<string> _cameraValueScratch = [];
+
         /// <summary>Cached reference to planner state for HandleInput access.</summary>
         private PlannerState? _plannerState;
 
@@ -329,7 +335,7 @@ namespace TianWen.UI.Abstractions
             var itemH = BaseItemHeight * dpiScale;
             var headerH = BaseHeaderHeight * dpiScale;
             var stepperBtnW = BaseStepperBtnW * dpiScale;
-            var valueW = BaseValueW * dpiScale * 0.75f;
+            var labelW = 80f * dpiScale;
 
             var camLayout = new PixelLayout(rect);
             var headerRect = camLayout.Dock(PixelDockStyle.Top, headerH);
@@ -349,6 +355,40 @@ namespace TianWen.UI.Abstractions
                 return;
             }
 
+            var controlX = listRect.X + padding + labelW;
+
+            // Measurement-driven value column shared across every OTA's setpoint/gain row so long
+            // gain-mode names fit and all steppers stay aligned (see PixelWidgetBase.MeasureValueColumnWidth).
+            // Mode cameras contribute all mode names (not just the current one) so the column does not
+            // reflow as the user cycles modes.
+            _cameraValueScratch.Clear();
+            for (var i = 0; i < State.CameraSettings.Count; i++)
+            {
+                var cam = State.CameraSettings[i];
+                if (cam.HasCooling)
+                {
+                    _cameraValueScratch.Add($"{cam.SetpointTempC}°C");
+                }
+
+                if (cam.UsesGainMode && cam.GainModes.Count > 0)
+                {
+                    for (var m = 0; m < cam.GainModes.Count; m++)
+                    {
+                        _cameraValueScratch.Add(cam.GainModes[m]);
+                    }
+                }
+                else
+                {
+                    _cameraValueScratch.Add($"{cam.Gain}");
+                }
+            }
+
+            var valueW = MeasureValueColumnWidth(
+                _cameraValueScratch, fontPath, fontSize,
+                minWidth: BaseValueW * dpiScale * 0.75f,
+                maxWidth: listRect.Width - padding * 2f - labelW - stepperBtnW * 2f,
+                horizontalPadding: padding);
+
             var cursor = listRect.Y;
 
             for (var i = 0; i < State.CameraSettings.Count && cursor + itemH * 2 <= listRect.Y + listRect.Height; i++)
@@ -363,9 +403,6 @@ namespace TianWen.UI.Abstractions
                     listRect.X + padding, cursor, listRect.Width - padding * 2, itemH,
                     fontSize, BodyText, TextAlign.Near, TextAlign.Center);
                 cursor += itemH;
-
-                var labelW = 80f * dpiScale;
-                var controlX = listRect.X + padding + labelW;
 
                 // Setpoint row (hidden for uncooled cameras like DSLRs)
                 if (cam.HasCooling)
@@ -388,7 +425,6 @@ namespace TianWen.UI.Abstractions
                 }
 
                 // Gain row
-                var gainValueW = cam.UsesGainMode ? valueW * 1.6f : valueW;
                 FillRect(listRect.X, cursor, listRect.Width, itemH, RowAltBg);
                 DrawText("Gain", fontPath,
                     listRect.X + padding, cursor, labelW, itemH,
@@ -410,9 +446,9 @@ namespace TianWen.UI.Abstractions
                             State.NeedsRedraw = true;
                         });
                     DrawText(modeName, fontPath,
-                        controlX + stepperBtnW, cursor, gainValueW, itemH,
+                        controlX + stepperBtnW, cursor, valueW, itemH,
                         fontSize * 0.9f, BodyText, TextAlign.Center, TextAlign.Center);
-                    RenderButton("\u25B6", controlX + stepperBtnW + gainValueW, cursor, stepperBtnW, itemH, fontPath, fontSize,
+                    RenderButton("\u25B6", controlX + stepperBtnW + valueW, cursor, stepperBtnW, itemH, fontPath, fontSize,
                         StepperBg, BodyText, $"Inc:Gain:{i}",
                         _ =>
                         {
@@ -636,7 +672,6 @@ namespace TianWen.UI.Abstractions
             var headerH = BaseHeaderHeight * dpiScale;
             var labelW = BaseLabelW * dpiScale;
             var stepperBtnW = BaseStepperBtnW * dpiScale;
-            var valueW = BaseValueW * dpiScale;
 
             FillRect(rect.X, rect.Y, rect.Width, rect.Height, ContentBg);
 
@@ -644,6 +679,33 @@ namespace TianWen.UI.Abstractions
             var cursor = rect.Y - State.ConfigScrollOffset;
             var groups = SessionConfigGroups.Groups;
             var globalFieldIdx = 0;
+
+            // Measurement-driven value column: size the [-] value [+] cell to the widest current
+            // stepper value (e.g. "Auto (3min)") so long strings are neither clipped nor collide
+            // with the steppers, while every stepper stays aligned in one shared column. Clamp to
+            // the space actually available in the panel; MeasureValueColumnWidth falls back to the
+            // minimum when no font is available (headless tests).
+            _stepperValueScratch.Clear();
+            for (var gi = 0; gi < groups.Length; gi++)
+            {
+                var fields = groups[gi].Fields;
+                for (var fi = 0; fi < fields.Length; fi++)
+                {
+                    var field = fields[fi];
+                    if (field.Kind is ConfigFieldKind.BoolToggle or ConfigFieldKind.EnumCycle)
+                    {
+                        continue; // toggles / cycles size their own button, not the value cell
+                    }
+
+                    _stepperValueScratch.Add(FormatStepperDisplay(field, State.Configuration));
+                }
+            }
+
+            var valueW = MeasureValueColumnWidth(
+                _stepperValueScratch, fontPath, fontSize,
+                minWidth: BaseValueW * dpiScale,
+                maxWidth: rect.Width - padding * 3f - labelW - stepperBtnW * 2f,
+                horizontalPadding: padding);
 
             for (var gi = 0; gi < groups.Length; gi++)
             {
@@ -733,15 +795,21 @@ namespace TianWen.UI.Abstractions
         // Stepper row: [-] value [+]
         // -----------------------------------------------------------------------
 
+        /// <summary>Value text (value + optional unit) shown in a stepper's centre cell.</summary>
+        private static string FormatStepperDisplay(ConfigFieldDescriptor field, SessionConfiguration config)
+        {
+            var valueStr = field.FormatValue(config);
+            var unitStr = field.Unit.Length > 0 ? $" {field.Unit}" : "";
+            return $"{valueStr}{unitStr}";
+        }
+
         private void RenderStepperRow(
             ConfigFieldDescriptor field,
             float x, float y,
             float btnW, float valW, float h,
             string fontPath, float fontSize)
         {
-            var valueStr = field.FormatValue(State.Configuration);
-            var unitStr = field.Unit.Length > 0 ? $" {field.Unit}" : "";
-            var displayStr = $"{valueStr}{unitStr}";
+            var displayStr = FormatStepperDisplay(field, State.Configuration);
 
             ConfigButton("\u2212", x, y, btnW, h, fontPath, fontSize,
                 StepperBg, $"Dec:{field.Label}",

--- a/src/TianWen.UI.Shared/VkFitsImagePipeline.cs
+++ b/src/TianWen.UI.Shared/VkFitsImagePipeline.cs
@@ -879,7 +879,12 @@ public sealed unsafe class VkFitsImagePipeline : IDisposable
 
         var api = _ctx.DeviceApi;
 
-        api.vkDeviceWaitIdle();
+        // Skip the pre-teardown drain when the GPU is known wedged — an unbounded wait on a stuck
+        // device would hang Dispose (matches the renderer's recovery/teardown guards).
+        if (!_ctx.IsGpuStuck)
+        {
+            api.vkDeviceWaitIdle();
+        }
 
         // Pipelines
         if (_imagePipeline != VkPipeline.Null)

--- a/src/TianWen.UI.Shared/VkSkyMapPipeline.cs
+++ b/src/TianWen.UI.Shared/VkSkyMapPipeline.cs
@@ -641,6 +641,18 @@ public sealed unsafe class VkSkyMapPipeline : IDisposable
     private VkBuffer _starBuffer;
     private VkDeviceMemory _starMemory;
     private uint _starCount;
+
+    // ── Spatial chunking ──────────────────────────────────────────────────
+    // The star buffer is laid out grouped by spatial chunk (a coarse RA/Dec grid),
+    // sorted by magnitude within each chunk. At draw time only the chunks whose
+    // bounding cone intersects the view cone are submitted, and only their
+    // magnitude-prefix -- so a deep zoom touches a handful of chunks instead of
+    // streaming the whole catalog to the GPU (the unbounded version TDR'd the
+    // Adreno X1-85, which froze the UI thread in the swapchain-recovery path).
+    private const int StarGridCols = 12;                  // RA slices  (2h / 30deg each)
+    private const int StarGridRows = 12;                  // Dec slices (15deg each)
+    private const int StarChunkCount = StarGridCols * StarGridRows;
+    private StarChunk[] _starChunks = [];
 #if DEBUG
     // Slow-frame attribution: the star draw is GPU-side (instanced quads), so its cost never
     // shows in CPU phase timers -- it surfaces as a high 'begin=' (fence wait) in the event
@@ -704,13 +716,25 @@ public sealed unsafe class VkSkyMapPipeline : IDisposable
     private Task<StarBuildResult>? _starRebuildTask;
 
     /// <summary>
-    /// Output of an async star-buffer rebuild: a flat float[] of sorted star
-    /// vertices (5 floats / star), the count actually written (NaN-mag stars
-    /// dropped during the loop), the pre-computed magnitude lookup table,
-    /// and the target month-key so a stale build can be discarded on swap.
+    /// One spatial chunk's slice of the contiguous star buffer: its instance range
+    /// (<see cref="Offset"/> + <see cref="Count"/> within the magnitude-sorted, chunk-grouped
+    /// buffer), the per-chunk magnitude -> prefix-count lookup (brightest-first, same 0.5-mag
+    /// bins as the old global table), and a bounding cone (axis unit vector + angular radius in
+    /// radians) used to cull the chunk against the view cone at draw time.
+    /// </summary>
+    private readonly record struct StarChunk(
+        uint Offset, uint Count, uint[] MagBins,
+        float ConeX, float ConeY, float ConeZ, float ConeRadiusRad);
+
+    /// <summary>
+    /// Output of an async star-buffer rebuild: a flat float[] of star vertices
+    /// (5 floats / star) laid out grouped by spatial chunk and sorted by magnitude
+    /// within each chunk, the count actually written (NaN-mag stars dropped during
+    /// the loop), the per-chunk layout, and the target month-key so a stale build
+    /// can be discarded on swap.
     /// </summary>
     private readonly record struct StarBuildResult(
-        float[] Verts, uint StarCount, uint[] MagBins, int MonthKey);
+        float[] Verts, uint StarCount, StarChunk[] Chunks, int MonthKey);
 
     // ────────────────────────────────────────────────── Construction
 
@@ -813,13 +837,11 @@ public sealed unsafe class VkSkyMapPipeline : IDisposable
         {
             var verts = new float[tycCount * floatsPerStar];
             var written = SkyMapState.FillTycho2StarVertices(db, dtYr, verts);
-            var sortableSpan = verts.AsSpan(0, written * floatsPerStar);
-            SortStarsByMagnitude(sortableSpan, floatsPerStar);
-            var magBins = ComputeMagBins(sortableSpan, floatsPerStar);
+            var chunks = ChunkAndSortStars(verts.AsSpan(0, written * floatsPerStar), floatsPerStar);
             System.Console.Error.WriteLine(
                 $"[VkSkyMapPipeline] async star build month-key {monthKey} (dtYr={dtYr:F3}): " +
                 $"CPU {sw.Elapsed.TotalMilliseconds:N0} ms ({written} stars)");
-            return new StarBuildResult(verts, (uint)written, magBins, monthKey);
+            return new StarBuildResult(verts, (uint)written, chunks, monthKey);
         });
     }
 
@@ -853,9 +875,15 @@ public sealed unsafe class VkSkyMapPipeline : IDisposable
         // referencing the old buffer; CreatePersistentVertexBuffer allocates +
         // uploads the new one; DestroyBuffer frees the old. Atomic from the
         // render thread's perspective -- the swap completes inside this method
-        // and the next Draw uses the new buffer.
+        // and the next Draw uses the new buffer. Skip the drain when the GPU is
+        // known wedged: an unbounded wait on a stuck device would hang the render
+        // thread (the event loop already short-circuits OnRender while stuck, so
+        // this is a belt-and-suspenders guard against ever blocking here).
         var sw = System.Diagnostics.Stopwatch.StartNew();
-        _ctx.DeviceApi.vkDeviceWaitIdle();
+        if (!_ctx.IsGpuStuck)
+        {
+            _ctx.DeviceApi.vkDeviceWaitIdle();
+        }
         var waitMs = sw.Elapsed.TotalMilliseconds;
 
         DestroyBuffer(_starBuffer, _starMemory);
@@ -865,7 +893,7 @@ public sealed unsafe class VkSkyMapPipeline : IDisposable
         var uploadMs = (sw.Elapsed - uploadStart).TotalMilliseconds;
 
         _starCount = result.StarCount;
-        _magBinCounts = result.MagBins;
+        _starChunks = result.Chunks;
         _starBufferMonthKey = result.MonthKey;
 
         System.Console.Error.WriteLine(
@@ -1153,38 +1181,72 @@ public sealed unsafe class VkSkyMapPipeline : IDisposable
         }
 
         // ── Stars ──
-        // Stars are sorted by magnitude (brightest first). Only instance the prefix
-        // that passes the current EffectiveMagnitudeLimit — at full zoom-out (FOV 180°,
-        // mag ~6.5) we draw ~9k instances instead of all ~118k.
-        var visibleStars = _magBinCounts.Length > 0
-            ? GetVisibleStarCount(state.EffectiveMagnitudeLimit)
-            : _starCount;
-#if DEBUG
-        if (visibleStars > _lastLoggedVisibleStars + (_lastLoggedVisibleStars >> 2)
-            || visibleStars < _lastLoggedVisibleStars - (_lastLoggedVisibleStars >> 2))
+        // The star buffer is laid out grouped by spatial chunk, sorted by magnitude
+        // within each chunk. Cull chunks whose bounding cone misses the view cone, then
+        // draw only each visible chunk's magnitude-prefix. A deep zoom (small FOV, high
+        // effective magnitude) touches a handful of chunks instead of streaming the whole
+        // ~2M-star catalog to the GPU — the unbounded version TDR'd the Adreno X1-85.
+        if (_starChunks.Length > 0 && _starCount > 0)
         {
-            Console.Error.WriteLine(
-                $"[rdiag] skymap.stars visible={visibleStars} effMag={state.EffectiveMagnitudeLimit:F1} fov={state.FieldOfViewDeg:F0}");
-            _lastLoggedVisibleStars = visibleStars;
-        }
-#endif
-        if (visibleStars > 0)
-        {
+            var effMag = state.EffectiveMagnitudeLimit;
+
+            // View cone in J2000: axis = the look-at direction (identical to the view
+            // matrix's forward vector, so the cull is exact in both equatorial and horizon
+            // modes). Radius = the full FOV — generous enough to cover the viewport diagonal
+            // for any reasonable aspect, so chunks never pop in/out at the screen edges.
+            var (vx, vy, vz) = SkyMapState.RaDecToUnitVec(state.CenterRA, state.CenterDec);
+            var viewRadiusRad = (float)double.DegreesToRadians(Math.Min(180.0, state.FieldOfViewDeg));
+
             api.vkCmdBindPipeline(cmd, VkPipelineBindPoint.Graphics, _starPipeline);
 
-            // Bind quad (binding 0) and star instance data (binding 1)
-            var quadBuf = _quadBuffer;
-            var starBuf = _starBuffer;
+            // Bind quad (binding 0) and star instance data (binding 1) once; each chunk is a
+            // contiguous instance range drawn via a firstInstance offset into the same buffer.
             var offsets = stackalloc ulong[2];
             offsets[0] = 0;
             offsets[1] = 0;
             var buffers = stackalloc VkBuffer[2];
-            buffers[0] = quadBuf;
-            buffers[1] = starBuf;
+            buffers[0] = _quadBuffer;
+            buffers[1] = _starBuffer;
             api.vkCmdBindVertexBuffers(cmd, 0, 2, buffers, offsets);
 
-            // 6 vertices per quad, only the visible prefix of the sorted star buffer
-            api.vkCmdDraw(cmd, 6, visibleStars, 0, 0);
+            uint drawn = 0;
+            for (var c = 0; c < _starChunks.Length; c++)
+            {
+                var chunk = _starChunks[c];
+                if (chunk.Count == 0)
+                {
+                    continue;
+                }
+
+                // View-cone cull: skip when the two cones cannot intersect, i.e. the angular
+                // separation of their axes exceeds the sum of their radii.
+                var dot = vx * chunk.ConeX + vy * chunk.ConeY + vz * chunk.ConeZ;
+                var sep = MathF.Acos(Math.Clamp(dot, -1f, 1f));
+                if (sep > viewRadiusRad + chunk.ConeRadiusRad)
+                {
+                    continue;
+                }
+
+                // Magnitude cull: only this chunk's brightest-first prefix at the current limit.
+                var n = GetVisibleStarCount(chunk.MagBins, effMag);
+                if (n == 0)
+                {
+                    continue;
+                }
+
+                // 6 vertices per quad, n instances starting at this chunk's offset.
+                api.vkCmdDraw(cmd, 6, n, 0, chunk.Offset);
+                drawn += n;
+            }
+#if DEBUG
+            if (drawn > _lastLoggedVisibleStars + (_lastLoggedVisibleStars >> 2)
+                || drawn < _lastLoggedVisibleStars - (_lastLoggedVisibleStars >> 2))
+            {
+                Console.Error.WriteLine(
+                    $"[rdiag] skymap.stars drawn={drawn} effMag={effMag:F1} fov={state.FieldOfViewDeg:F0} (was {_starCount} unculled)");
+                _lastLoggedVisibleStars = drawn;
+            }
+#endif
         }
     }
 
@@ -1326,23 +1388,18 @@ public sealed unsafe class VkSkyMapPipeline : IDisposable
 
         // The per-star vertex compute lives in SkyMapState so the benchmark
         // project can measure it without needing a Vulkan context. The pipeline
-        // still owns the sort + magnitude-lookup + GPU upload that follow.
+        // still owns the spatial chunking + per-chunk sort + GPU upload that follow.
         const int floatsPerStar = SkyMapState.FloatsPerStar;
         var verts = new float[tycCount * floatsPerStar];
         var written = SkyMapState.FillTycho2StarVertices(db, dtJulianYears, verts);
         _starCount = (uint)written;
 
-        // SortStarsByMagnitude + BuildMagnitudeLookup operate on the contiguous
-        // float[] view directly (the prior List<float>-of-the-same-data wrapping
-        // pattern bought nothing: both helpers immediately called
-        // CollectionsMarshal.AsSpan internally).
         var floats = verts.AsSpan(0, written * floatsPerStar);
 
-        // Sort by magnitude (brightest first) so we can limit instance count at draw
-        // time based on EffectiveMagnitudeLimit — the GPU only processes the prefix of
-        // stars that pass the current mag threshold, instead of all 118k every frame.
-        SortStarsByMagnitude(floats, floatsPerStar);
-        BuildMagnitudeLookup(floats, floatsPerStar);
+        // Group into spatial chunks + sort each chunk by magnitude (brightest first), so the
+        // draw can cull whole chunks by view cone and then submit only each visible chunk's
+        // magnitude-prefix — instead of streaming the entire catalog to the GPU every frame.
+        _starChunks = ChunkAndSortStars(floats, floatsPerStar);
 
         (_starBuffer, _starMemory) = _ctx.CreatePersistentVertexBuffer(floats);
     }
@@ -1379,20 +1436,120 @@ public sealed unsafe class VkSkyMapPipeline : IDisposable
     }
 
     /// <summary>
-    /// Pre-computed magnitude → instance count lookup. For a given mag limit, the number
-    /// of stars to draw is <c>_magBinCounts[bin]</c> where <c>bin = (int)(mag * 2)</c>.
-    /// Bins cover mag 0..15 in 0.5-mag steps (30 entries).
+    /// Partitions the flat star vertex span into a coarse RA/Dec grid, reorders it in place so
+    /// each chunk's stars are contiguous, sorts each chunk brightest-first, and returns the
+    /// per-chunk layout (instance range + 0.5-mag prefix bins + bounding cone). The draw then
+    /// culls whole chunks by view cone and submits only each visible chunk's magnitude prefix,
+    /// bounding GPU work so a deep zoom can't stream the whole catalog and TDR the GPU.
     /// </summary>
-    private uint[] _magBinCounts = [];
+    private static StarChunk[] ChunkAndSortStars(Span<float> verts, int floatsPerStar)
+    {
+        var count = verts.Length / floatsPerStar;
+        var chunks = new StarChunk[StarChunkCount];
+        if (count == 0)
+        {
+            return chunks; // every chunk Count == 0 -> all culled at draw
+        }
 
-    private void BuildMagnitudeLookup(ReadOnlySpan<float> span, int floatsPerStar)
-        => _magBinCounts = ComputeMagBins(span, floatsPerStar);
+        const float raCellDeg = 360f / StarGridCols;
+        const float decCellDeg = 180f / StarGridRows;
+        const float rad2deg = 180f / MathF.PI;
+
+        // 1. Assign each star to a chunk (RA column x Dec row) from its unit vector.
+        var chunkOf = new int[count];
+        var counts = new int[StarChunkCount];
+        for (var i = 0; i < count; i++)
+        {
+            var b = i * floatsPerStar;
+            float x = verts[b], y = verts[b + 1], z = verts[b + 2];
+            var decDeg = MathF.Asin(Math.Clamp(z, -1f, 1f)) * rad2deg;            // [-90, 90]
+            var raDeg = MathF.Atan2(y, x) * rad2deg;                              // (-180, 180]
+            if (raDeg < 0f)
+            {
+                raDeg += 360f;                                                    // [0, 360)
+            }
+            var col = Math.Clamp((int)(raDeg / raCellDeg), 0, StarGridCols - 1);
+            var row = Math.Clamp((int)((decDeg + 90f) / decCellDeg), 0, StarGridRows - 1);
+            var c = row * StarGridCols + col;
+            chunkOf[i] = c;
+            counts[c]++;
+        }
+
+        // 2. Prefix offsets: the instance index where each chunk begins in the grouped buffer.
+        var offsets = new int[StarChunkCount];
+        for (int c = 0, running = 0; c < StarChunkCount; c++)
+        {
+            offsets[c] = running;
+            running += counts[c];
+        }
+
+        // 3. Stable scatter into a chunk-grouped copy, then write it back over the input span.
+        var grouped = new float[count * floatsPerStar];
+        var cursor = (int[])offsets.Clone();
+        for (var i = 0; i < count; i++)
+        {
+            var dst = cursor[chunkOf[i]]++ * floatsPerStar;
+            verts.Slice(i * floatsPerStar, floatsPerStar).CopyTo(grouped.AsSpan(dst, floatsPerStar));
+        }
+        grouped.AsSpan().CopyTo(verts);
+
+        // 4. Per chunk: sort by magnitude, then compute prefix bins + bounding cone.
+        for (var c = 0; c < StarChunkCount; c++)
+        {
+            var n = counts[c];
+            if (n == 0)
+            {
+                chunks[c] = new StarChunk(0, 0, [], 0f, 0f, 1f, 0f);
+                continue;
+            }
+            var sub = verts.Slice(offsets[c] * floatsPerStar, n * floatsPerStar);
+            SortStarsByMagnitude(sub, floatsPerStar);
+            var bins = ComputeMagBins(sub, floatsPerStar);
+            var (cx, cy, cz, radRad) = ComputeChunkCone(sub, floatsPerStar);
+            chunks[c] = new StarChunk((uint)offsets[c], (uint)n, bins, cx, cy, cz, radRad);
+        }
+        return chunks;
+    }
 
     /// <summary>
-    /// Computes the magnitude → instance-count lookup table from a brightest-first
-    /// sorted star vertex span. 30 bins covering V_T 0..15 in 0.5-mag steps. Pure
-    /// function so the async rebuild can compute it on a background thread and the
-    /// render thread just installs the returned array into <see cref="_magBinCounts"/>.
+    /// Bounding cone for a chunk's stars: axis = the normalized mean of the member unit vectors,
+    /// radius = the maximum angular distance (radians) from that axis to any member. Drives the
+    /// rotation-invariant view-cone cull in <see cref="Draw"/> (correct in equatorial + horizon).
+    /// </summary>
+    private static (float X, float Y, float Z, float RadiusRad) ComputeChunkCone(
+        ReadOnlySpan<float> span, int floatsPerStar)
+    {
+        var n = span.Length / floatsPerStar;
+        double sx = 0, sy = 0, sz = 0;
+        for (var i = 0; i < n; i++)
+        {
+            var b = i * floatsPerStar;
+            sx += span[b]; sy += span[b + 1]; sz += span[b + 2];
+        }
+        var len = Math.Sqrt(sx * sx + sy * sy + sz * sz);
+        if (len < 1e-9)
+        {
+            return (0f, 0f, 1f, MathF.PI); // antipodal cancellation -> whole-sky cone, never culled
+        }
+        float ax = (float)(sx / len), ay = (float)(sy / len), az = (float)(sz / len);
+
+        var minDot = 1f;
+        for (var i = 0; i < n; i++)
+        {
+            var b = i * floatsPerStar;
+            var dot = ax * span[b] + ay * span[b + 1] + az * span[b + 2];
+            if (dot < minDot)
+            {
+                minDot = dot;
+            }
+        }
+        return (ax, ay, az, MathF.Acos(Math.Clamp(minDot, -1f, 1f)));
+    }
+
+    /// <summary>
+    /// Computes the magnitude → instance-count lookup table from a brightest-first sorted star
+    /// vertex span. 30 bins covering V 0..15 in 0.5-mag steps. Pure function so the async rebuild
+    /// can compute each chunk's table on a background thread.
     /// </summary>
     private static uint[] ComputeMagBins(ReadOnlySpan<float> sortedSpan, int floatsPerStar)
     {
@@ -1414,13 +1571,17 @@ public sealed unsafe class VkSkyMapPipeline : IDisposable
     }
 
     /// <summary>
-    /// Returns the number of star instances to draw for the given magnitude limit.
-    /// Stars are sorted brightest-first, so we just return the prefix count.
+    /// Number of star instances to draw from a chunk for the given magnitude limit. Stars are
+    /// sorted brightest-first within the chunk, so this is just the prefix count from its bins.
     /// </summary>
-    private uint GetVisibleStarCount(float magLimit)
+    private static uint GetVisibleStarCount(uint[] magBins, float magLimit)
     {
-        var bin = Math.Clamp((int)(magLimit * 2) - 1, 0, _magBinCounts.Length - 1);
-        return _magBinCounts[bin];
+        if (magBins.Length == 0)
+        {
+            return 0;
+        }
+        var bin = Math.Clamp((int)(magLimit * 2) - 1, 0, magBins.Length - 1);
+        return magBins[bin];
     }
 
     /// <summary>
@@ -1453,8 +1614,7 @@ public sealed unsafe class VkSkyMapPipeline : IDisposable
 
         _starCount = (uint)(floats.Count / 5);
         var floatsSpan = System.Runtime.InteropServices.CollectionsMarshal.AsSpan(floats);
-        SortStarsByMagnitude(floatsSpan, 5);
-        BuildMagnitudeLookup(floatsSpan, 5);
+        _starChunks = ChunkAndSortStars(floatsSpan, 5);
         (_starBuffer, _starMemory) = _ctx.CreatePersistentVertexBuffer(floatsSpan);
     }
 
@@ -2267,7 +2427,12 @@ public sealed unsafe class VkSkyMapPipeline : IDisposable
         _disposed = true;
 
         var api = _ctx.DeviceApi;
-        api.vkDeviceWaitIdle();
+        // Skip the pre-teardown drain when the GPU is known wedged — an unbounded wait on a stuck
+        // device would hang Dispose (matches the renderer's recovery/teardown guards).
+        if (!_ctx.IsGpuStuck)
+        {
+            api.vkDeviceWaitIdle();
+        }
 
         // Milky Way resources
         _milkyWayTexture?.Dispose();


### PR DESCRIPTION
Consumes the lockstep sibling release (**DIR.Lib 4.5.991**, **Console.Lib 2.18.851**, **SdlVulkan.Renderer 6.1.1091**) and the TianWen-side work it enables.

## Sky map — fixes the GPU freeze/crash
At deep zoom `EffectiveMagnitudeLimit` grew unbounded and the renderer drew the entire magnitude-prefix globally (~2.1M alpha-blended quads at fov=2°), which wedged the Adreno X1-85 (TDR) and froze the window.

`VkSkyMapPipeline` now lays the star buffer out grouped by a 12×12 RA/Dec chunk grid (sorted by magnitude within each chunk, each chunk carrying its mag-bins + a bounding cone). The draw cone-culls chunks against the view direction and draws only each visible chunk's magnitude-prefix via `firstInstance` offsets into the one shared buffer.

**Verified live:** fov=2° → **100k** drawn (was 2.56M); fov=1° → 126k; no fence stall across the whole zoom sweep. Zoom depth is unchanged (no magnitude clamp).

## GPU-stuck guards (renderer 6.1)
`VkSkyMapPipeline`/`VkFitsImagePipeline` buffer-swap + dispose drains skip `vkDeviceWaitIdle` when `_ctx.IsGpuStuck`, so a wedged GPU can't hang the render/teardown path.

## Stepper layout (DIR.Lib 4.5)
Session config + per-OTA camera-settings steppers size their value column via `PixelWidgetBase.MeasureValueColumnWidth`, so long values like `Auto (3min)` no longer clip into / collide with the `+`/`-` buttons; all rows stay aligned.

## Deps
`Directory.Packages.props`: DIR.Lib `4.4.*`→`4.5.*`, Console.Lib `2.17.*`→`2.18.*`, SdlVulkan.Renderer `6.0.*`→`6.1.*`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)