### PR TITLE
fix(gui): single canonical mount state for the sky-map reticle (no more RA0/Dec0 in-session)

### DIFF
--- a/src/TianWen.Hosting/Dto/MountStateDto.cs
+++ b/src/TianWen.Hosting/Dto/MountStateDto.cs
@@ -14,11 +14,17 @@ public sealed class MountStateDto
 
     public static MountStateDto FromState(MountState state) => new()
     {
-        RightAscension = state.RightAscension,
-        Declination = state.Declination,
-        HourAngle = state.HourAngle,
+        // Coerce NaN -> 0: before the session's first device poll MountState is all-NaN
+        // ("unknown"), and System.Text.Json (no AllowNamedFloatingPointLiterals configured)
+        // throws on NaN. 0 matches the pre-poll wire value clients saw before MountState was
+        // NaN-initialised, so this is not a behaviour change for API consumers.
+        RightAscension = NanToZero(state.RightAscension),
+        Declination = NanToZero(state.Declination),
+        HourAngle = NanToZero(state.HourAngle),
         PierSide = state.PierSide.ToString(),
         IsSlewing = state.IsSlewing,
         IsTracking = state.IsTracking,
     };
+
+    private static double NanToZero(double v) => double.IsNaN(v) ? 0.0 : v;
 }

--- a/src/TianWen.Lib/Sequencing/Session.Lifecycle.cs
+++ b/src/TianWen.Lib/Sequencing/Session.Lifecycle.cs
@@ -197,6 +197,17 @@ internal partial record Session
         _logger.LogDebug("Init: connecting mount {Mount}", mount);
         await mount.Driver.ConnectAsync(cancellationToken).ConfigureAwait(false);
 
+        // Diagnostic snapshot: site + believed pointing right after the (borrowed, already-connected)
+        // mount is reused. If site is NaN here the manual connect never pushed it; if RA/Dec are
+        // already 0,0 the reset happened before the session even touched the mount.
+        _logger.LogDebug(
+            "Init mount snapshot (post-connect): site lat={Lat:F3} lon={Lon:F3}; believed RA={Ra:F4}h Dec={Dec:F3}deg; atPark={Park}",
+            await mount.Driver.GetSiteLatitudeAsync(cancellationToken),
+            await mount.Driver.GetSiteLongitudeAsync(cancellationToken),
+            await _logger.CatchAsync(mount.Driver.GetRightAscensionAsync, cancellationToken, double.NaN),
+            await _logger.CatchAsync(mount.Driver.GetDeclinationAsync, cancellationToken, double.NaN),
+            await mount.Driver.AtParkAsync(cancellationToken));
+
         _currentActivity = "Connecting guider\u2026";
         _logger.LogDebug("Init: connecting guider {Guider}", guider);
         await guider.Driver.ConnectAsync(cancellationToken).ConfigureAwait(false);
@@ -219,6 +230,15 @@ internal partial record Session
             await mount.Driver.SetSiteLatitudeAsync(Configuration.SiteLatitude, cancellationToken);
             await mount.Driver.SetSiteLongitudeAsync(Configuration.SiteLongitude, cancellationToken);
             _logger.LogInformation("Mount site synced to lat={Latitude:F4}, lon={Longitude:F4}", Configuration.SiteLatitude, Configuration.SiteLongitude);
+
+            // Diagnostic snapshot: did setting the site (which re-runs MaybeSyncToPoleAfterSiteSet on
+            // the SkyWatcher) shift/zero the believed pointing? Compare RA/Dec to the post-connect line.
+            _logger.LogDebug(
+                "Init mount snapshot (post-SetSite): site lat={Lat:F3} lon={Lon:F3}; believed RA={Ra:F4}h Dec={Dec:F3}deg",
+                await mount.Driver.GetSiteLatitudeAsync(cancellationToken),
+                await mount.Driver.GetSiteLongitudeAsync(cancellationToken),
+                await _logger.CatchAsync(mount.Driver.GetRightAscensionAsync, cancellationToken, double.NaN),
+                await _logger.CatchAsync(mount.Driver.GetDeclinationAsync, cancellationToken, double.NaN));
         }
         else
         {

--- a/src/TianWen.Lib/Sequencing/Session.cs
+++ b/src/TianWen.Lib/Sequencing/Session.cs
@@ -6,8 +6,10 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
+using TianWen.Lib.Astrometry;
 using TianWen.Lib.Astrometry.Focus;
 using TianWen.Lib.Astrometry.PlateSolve;
+using TianWen.Lib.Astrometry.SOFA;
 using TianWen.Lib.Devices;
 using TianWen.Lib.Devices.Guider;
 using TianWen.Lib.Extensions;
@@ -87,7 +89,16 @@ internal partial record Session(
     public SessionPhase Phase => _phase;
     public string? CurrentActivity => _currentActivity;
     public MountState MountState => _mountState;
-    private MountState _mountState;
+    // Start "unknown" (all-NaN coords), not default(MountState) which would read as a real RA0/Dec0.
+    // The first PollDeviceStatesAsync (RunAsync, right after InitialisationAsync) fills it in. UI
+    // consumers treat NaN RA as "no pointing yet" and keep the last known value rather than snapping
+    // the reticle to the celestial-equator origin during the seconds-long init window.
+    private MountState _mountState = new(double.NaN, double.NaN, double.NaN, default, false, false);
+    // Reused SOFA transform for converting the mount's native (JNOW) pointing to J2000 for the
+    // sky-map reticle. Built once from site conditions (fixed for the session) with only its
+    // DateTime refreshed per poll; dropped + rebuilt if a conversion ever returns NaN (e.g. it
+    // was built before the site sync). Mirrors AppSignalHandler's preview-poll conversion.
+    private Transform? _mountStateTransform;
 
     public string? LastFramePath => _lastFramePath;
     private volatile string? _lastFramePath;
@@ -262,13 +273,52 @@ internal partial record Session(
         var mount = Setup.Mount.Driver;
         if (mount.Connected)
         {
+            var ra = await PollDriverReadAsync(mount, mount.GetRightAscensionAsync, _mountState.RightAscension, cancellationToken);
+            var dec = await PollDriverReadAsync(mount, mount.GetDeclinationAsync, _mountState.Declination, cancellationToken);
+
+            // Derive J2000 coords so the sky-map reticle renders in the same frame as catalog
+            // stars/objects. Treating the native topocentric (JNOW) read as J2000 is off by ~22'
+            // of precession in 2026 -- enough to look like a real pointing error on the map. Mirrors
+            // AppSignalHandler.SamplePreviewMountAsync's idle-path conversion (same shared
+            // EquatorialFrameConversion helper) so the reticle is identical whether or not a session
+            // is running. J2000-native mounts pass the native values through unchanged.
+            var (raJ2000, decJ2000) = (double.NaN, double.NaN);
+            if (!double.IsNaN(ra) && !double.IsNaN(dec))
+            {
+                if (mount.EquatorialSystem == EquatorialCoordinateType.J2000)
+                {
+                    (raJ2000, decJ2000) = (ra, dec);
+                }
+                else if (mount.EquatorialSystem == EquatorialCoordinateType.Topocentric)
+                {
+                    _mountStateTransform ??= await mount.TryGetTransformAsync(ResolveSiteConditions(), cancellationToken);
+                    if (_mountStateTransform is { } transform)
+                    {
+                        transform.DateTime = _timeProvider.GetUtcNow().UtcDateTime;
+                        if (EquatorialFrameConversion.TopocentricToJ2000(transform, ra, dec) is { } j2000)
+                        {
+                            (raJ2000, decJ2000) = j2000;
+                        }
+                        else
+                        {
+                            // Transform not fully initialised (e.g. built before the site sync) ->
+                            // drop it so the next poll rebuilds from the now-valid site. J2000 stays
+                            // NaN this tick and the overlay falls back to the native read.
+                            _mountStateTransform = null;
+                        }
+                    }
+                }
+            }
+
             _mountState = new MountState(
-                RightAscension: await PollDriverReadAsync(mount, mount.GetRightAscensionAsync, _mountState.RightAscension, cancellationToken),
-                Declination: await PollDriverReadAsync(mount, mount.GetDeclinationAsync, _mountState.Declination, cancellationToken),
+                RightAscension: ra,
+                Declination: dec,
                 HourAngle: await PollDriverReadAsync(mount, mount.GetHourAngleAsync, _mountState.HourAngle, cancellationToken),
                 PierSide: await PollDriverReadAsync(mount, mount.GetSideOfPierAsync, _mountState.PierSide, cancellationToken),
                 IsSlewing: await PollDriverReadAsync(mount, mount.IsSlewingAsync, _mountState.IsSlewing, cancellationToken),
-                IsTracking: await PollDriverReadAsync(mount, mount.IsTrackingAsync, _mountState.IsTracking, cancellationToken));
+                IsTracking: await PollDriverReadAsync(mount, mount.IsTrackingAsync, _mountState.IsTracking, cancellationToken),
+                RaJ2000: raJ2000,
+                DecJ2000: decJ2000);
         }
     }
 

--- a/src/TianWen.Lib/Sequencing/SessionFactory.cs
+++ b/src/TianWen.Lib/Sequencing/SessionFactory.cs
@@ -95,6 +95,29 @@ internal class SessionFactory(
 
         var setup = new Setup(mount, guider, guiderSetup, [.. otas], weather);
 
+        // Diagnostic: did the session reuse already-connected hub driver instances, or create fresh
+        // ones? A fresh instance re-runs DoConnectDeviceAsync at InitialisationAsync, which for the fake
+        // SkyWatcher re-homes the encoder ("mount reset to 0,0 at session start") and could equally
+        // reset any device (camera cooling, focuser position, ...). Checked for EVERY device so a
+        // borrow miss (URI-key mismatch with what the manual connect cached) is visible per-device.
+        // borrowed=false while the user was already connected => the hub borrow missed for that device.
+        void LogBorrow(string role, DeviceBase dev, bool borrowed) =>
+            _logger.LogDebug("Session setup: {Role} {Uri} borrowed-from-hub={Borrowed}", role, dev.DeviceUri, borrowed);
+
+        LogBorrow("mount", mount.Device, mount.Borrowed);
+        LogBorrow("guider", guider.Device, guider.Borrowed);
+        if (guiderCamera is not null) LogBorrow("guiderCamera", guiderCamera.Device, guiderCamera.Borrowed);
+        if (guiderFocuser is not null) LogBorrow("guiderFocuser", guiderFocuser.Device, guiderFocuser.Borrowed);
+        if (weather is not null) LogBorrow("weather", weather.Device, weather.Borrowed);
+        for (var i = 0; i < otas.Count; i++)
+        {
+            var o = otas[i];
+            LogBorrow($"ota{i}.camera", o.Camera.Device, o.Camera.Borrowed);
+            if (o.Cover is { } cov) LogBorrow($"ota{i}.cover", cov.Device, cov.Borrowed);
+            if (o.Focuser is { } foc) LogBorrow($"ota{i}.focuser", foc.Device, foc.Borrowed);
+            if (o.FilterWheel is { } fw) LogBorrow($"ota{i}.filterWheel", fw.Device, fw.Borrowed);
+        }
+
         return (setup, profileData);
 
         DeviceBase DeviceFromUri(Uri deviceUri, int? otaIdx = null)

--- a/src/TianWen.UI.Abstractions/AppSignalHandler.cs
+++ b/src/TianWen.UI.Abstractions/AppSignalHandler.cs
@@ -367,7 +367,7 @@ namespace TianWen.UI.Abstractions
             // goto / sync lag by up to the steady interval. Instead: fast while slewing, fast
             // for MountTrackingSettleWindow after the mount lands and starts tracking, then
             // relaxing to the steady rate only once it has tracked undisturbed that long.
-            var prevMount = _liveSessionState.PreviewMountState;
+            var prevMount = _liveSessionState.MountState;
             var steadyNow = prevMount.IsTracking && !prevMount.IsSlewing;
             if (steadyNow && !_wasSteadyTracking)
             {
@@ -421,10 +421,10 @@ namespace TianWen.UI.Abstractions
                             _logger.LogInformation("Preview mount first sample: RA={RA:F4}h Dec={Dec:F4}° HA={HA:F4}h slewing={Slewing} tracking={Tracking}",
                                 ms.RightAscension, ms.Declination, ms.HourAngle, ms.IsSlewing, ms.IsTracking);
                         }
-                        _liveSessionState.PreviewMountState = ms;
+                        _liveSessionState.MountState = ms;
                         if (displayName is not null)
                         {
-                            _liveSessionState.PreviewMountDisplayName = displayName;
+                            _liveSessionState.MountDisplayName = displayName;
                         }
                         _appState.NeedsRedraw = true;
                     }
@@ -477,9 +477,12 @@ namespace TianWen.UI.Abstractions
                 return (default, null);
             }
 
-            var ra = await _logger.CatchAsync(mount.GetRightAscensionAsync, ct);
-            var dec = await _logger.CatchAsync(mount.GetDeclinationAsync, ct);
-            var ha = await _logger.CatchAsync(mount.GetHourAngleAsync, ct);
+            // Default to NaN (not the struct default 0.0) so a FAILED read is treated as "unavailable"
+            // by the !IsNaN guard below, instead of being mistaken for a valid RA0/Dec0 and painted at
+            // the celestial-equator origin (the "mount suddenly jumps to 0,0 / forgets its site" bug).
+            var ra = await _logger.CatchAsync(mount.GetRightAscensionAsync, ct, double.NaN);
+            var dec = await _logger.CatchAsync(mount.GetDeclinationAsync, ct, double.NaN);
+            var ha = await _logger.CatchAsync(mount.GetHourAngleAsync, ct, double.NaN);
             var slewing = await _logger.CatchAsync(mount.IsSlewingAsync, ct);
             var tracking = await _logger.CatchAsync(mount.IsTrackingAsync, ct);
             var pier = await _logger.CatchAsync(mount.GetSideOfPierAsync, ct);

--- a/src/TianWen.UI.Abstractions/EquipmentTab.cs
+++ b/src/TianWen.UI.Abstractions/EquipmentTab.cs
@@ -1772,10 +1772,10 @@ namespace TianWen.UI.Abstractions
         /// <summary>
         /// Renders the mount status panel (RA/Dec/Slewing/Tracking) for the given mount URI,
         /// but only when the mount is currently hub-connected. Hidden otherwise.
-        /// State comes from <see cref="LiveSessionState.PreviewMountState"/>, which is populated
-        /// by <c>AppSignalHandler.PollPreviewTelemetry</c> while the equipment / sky-map / live-session
-        /// tabs are visible. The expander gives the user a visible answer to "is the mount tracking?"
-        /// without having to leave the equipment tab.
+        /// State comes from the single canonical <see cref="LiveSessionState.MountState"/>, populated
+        /// by <c>AppSignalHandler.PollPreviewTelemetry</c> while idle (equipment / sky-map / live-session
+        /// tabs visible) and by the running session's poll otherwise. The expander gives the user a
+        /// visible answer to "is the mount tracking?" without having to leave the equipment tab.
         /// </summary>
         private float RenderMountTelemetryIfAny(
             GuiAppState appState,
@@ -1806,7 +1806,7 @@ namespace TianWen.UI.Abstractions
             if (!isOpen) return cursor;
 
             // Snapshot the mount state once — the field is published atomically via Interlocked.Exchange.
-            var ms = liveSessionState.PreviewMountState;
+            var ms = liveSessionState.MountState;
 
             // ---- Status badge row: Slewing | Tracking | Idle, colour-coded.
             var badgeRowH = rowH;

--- a/src/TianWen.UI.Abstractions/LiveSessionState.cs
+++ b/src/TianWen.UI.Abstractions/LiveSessionState.cs
@@ -77,9 +77,6 @@ namespace TianWen.UI.Abstractions
         /// <summary>Per-camera exposure state for countdown display.</summary>
         public ImmutableArray<CameraExposureState> CameraStates { get; set; } = [];
 
-        /// <summary>Polled mount state (RA, Dec, HA, pier side, slewing, tracking).</summary>
-        public MountState MountState { get; set; }
-
         /// <summary>Fine-grained activity description within the current phase.</summary>
         public string? CurrentActivity { get; set; }
 
@@ -137,26 +134,35 @@ namespace TianWen.UI.Abstractions
         /// </summary>
         public ImmutableArray<PreviewOTATelemetry> PreviewOTATelemetry { get; set; } = [];
 
-        /// <summary>Mount telemetry for preview mode (RA/Dec/tracking). Default when no mount connected.
+        /// <summary>
+        /// The single canonical mount-pointing snapshot (RA, Dec, HA, pier side, slewing, tracking).
+        /// Fed by whichever poller currently owns the mount: <c>AppSignalHandler.PollPreviewTelemetry</c>
+        /// when no session is running, and <see cref="PollSession"/> (copying <c>ISession.MountState</c>)
+        /// while a session is running. The two are mutually exclusive in time — the preview poll bails
+        /// when <see cref="IsRunning"/>, and the session poll only exists during a session — so this one
+        /// field is always the current pointing regardless of which path produced it. Every reticle /
+        /// status reader uses this field; there is deliberately no second copy to drift out of sync.
         /// <para>
-        /// <b>Thread safety:</b> <see cref="MountState"/> is a record struct of ~50 bytes; an
-        /// unsynchronised cross-thread write/read can tear (mix fields from two consecutive
-        /// values). The poll continuation runs on a thread pool thread; the render thread reads
-        /// per frame. We box the value in a small reference holder so the publish is a single
-        /// atomic reference write via <see cref="Interlocked.Exchange{T}(ref T, T)"/> — readers
-        /// see one consistent snapshot, no lock on the render hot path.
+        /// <b>Thread safety:</b> <see cref="Sequencing.MountState"/> is a record struct of ~50 bytes;
+        /// an unsynchronised cross-thread write/read can tear (mix fields from two consecutive values).
+        /// The preview poll continuation runs on a thread pool thread (the session poll runs on the
+        /// render thread); the render thread reads per frame. We box the value in a small reference
+        /// holder so the publish is a single atomic reference write via
+        /// <see cref="Interlocked.Exchange{T}(ref T, T)"/> — readers see one consistent snapshot, no
+        /// lock on the render hot path.
         /// </para>
         /// </summary>
         private sealed record MountStateHolder(MountState Value);
-        private MountStateHolder _previewMountStateHolder = new(default);
-        public MountState PreviewMountState
+        private MountStateHolder _mountStateHolder = new(default);
+        public MountState MountState
         {
-            get => Volatile.Read(ref _previewMountStateHolder).Value;
-            set => Interlocked.Exchange(ref _previewMountStateHolder, new MountStateHolder(value));
+            get => Volatile.Read(ref _mountStateHolder).Value;
+            set => Interlocked.Exchange(ref _mountStateHolder, new MountStateHolder(value));
         }
 
-        /// <summary>Resolved mount display name for preview mode.</summary>
-        public string? PreviewMountDisplayName { get; set; }
+        /// <summary>Resolved mount display name for the current <see cref="MountState"/> source
+        /// (preview poll when idle, the running session's mount otherwise).</summary>
+        public string? MountDisplayName { get; set; }
 
         /// <summary>Whether a preview exposure is currently in progress (per OTA index).</summary>
         public bool[] PreviewCapturing { get; set; } = [];
@@ -370,7 +376,20 @@ namespace TianWen.UI.Abstractions
             CoolingSamples = session.CoolingSamples;
             PhaseTimeline = session.PhaseTimeline;
             CameraStates = session.CameraStates;
-            MountState = session.MountState;
+            // Only adopt the session's mount snapshot once it holds a real (polled) pointing.
+            // ActiveSession is assigned the instant the session is created -- several seconds
+            // before RunAsync's first PollDeviceStatesAsync -- so until then session.MountState
+            // is all-NaN ("unknown"). Copying that would snap the reticle to RA0/Dec0; a NaN RA
+            // mid-session likewise means a transient failed read. In both cases keep the last
+            // good value (the prior preview poll's, or the previous session sample) rather than
+            // overwriting it. The session is the authority on the mount's display name, so the
+            // name moves in lock-step with the pointing it describes.
+            var sessionMount = session.MountState;
+            if (!double.IsNaN(sessionMount.RightAscension))
+            {
+                MountState = sessionMount;
+                MountDisplayName = session.Setup.Mount.Device.DisplayName;
+            }
             CurrentActivity = session.CurrentActivity;
             LastFramePath = session.LastFramePath;
             LastCapturedImages = session.LastCapturedImages;

--- a/src/TianWen.UI.Abstractions/LiveSessionTab.cs
+++ b/src/TianWen.UI.Abstractions/LiveSessionTab.cs
@@ -1789,14 +1789,14 @@ namespace TianWen.UI.Abstractions
             FillRect(rect.X, mountY, rect.Width, 1, SeparatorColor);
             mountY += pad;
 
-            var ms = state.PreviewMountState;
+            var ms = state.MountState;
             var dotColor = ms.IsSlewing ? StatusSlewing
                 : ms.IsTracking ? StatusTracking
                 : DimText;
             var dotSize = rowH * 0.4f;
             FillRect(rect.X + pad, mountY + (rowH - dotSize) / 2, dotSize, dotSize, dotColor);
 
-            var mountName = state.PreviewMountDisplayName ?? "Mount";
+            var mountName = state.MountDisplayName ?? "Mount";
             DrawText(mountName, fontPath,
                 rect.X + pad + dotSize + pad, mountY, rect.Width - pad * 3 - dotSize, rowH,
                 smallFs, HeaderText, TextAlign.Near, TextAlign.Center);
@@ -2020,7 +2020,7 @@ namespace TianWen.UI.Abstractions
             {
                 return (false, "Polar align: no OTA configured");
             }
-            if (string.IsNullOrEmpty(state.PreviewMountDisplayName))
+            if (string.IsNullOrEmpty(state.MountDisplayName))
             {
                 return (false, "Polar align: connect a mount first");
             }

--- a/src/TianWen.UI.Abstractions/SkyMapMountOverlay.cs
+++ b/src/TianWen.UI.Abstractions/SkyMapMountOverlay.cs
@@ -2,10 +2,10 @@ namespace TianWen.UI.Abstractions
 {
     /// <summary>
     /// Snapshot of mount pointing for the sky-map reticle overlay. Populated by the
-    /// event loop from the polled <c>PreviewMountState</c> (preview mode) or
-    /// <c>session.MountState</c> (session running). Coordinates are J2000 — the caller
-    /// is responsible for converting native-frame mount reports to J2000 before
-    /// writing this snapshot (see <c>IMountDriver.GetRaDecJ2000Async</c>).
+    /// event loop from the single canonical <c>LiveSessionState.MountState</c> (fed by
+    /// the preview poll while idle, the running session's poll otherwise). Coordinates
+    /// are J2000 — the caller is responsible for converting native-frame mount reports
+    /// to J2000 before writing this snapshot (see <c>IMountDriver.GetRaDecJ2000Async</c>).
     /// </summary>
     /// <param name="RaJ2000">Right ascension in hours, J2000.</param>
     /// <param name="DecJ2000">Declination in degrees, J2000.</param>

--- a/src/TianWen.UI.Abstractions/SkyMapState.cs
+++ b/src/TianWen.UI.Abstractions/SkyMapState.cs
@@ -75,10 +75,11 @@ namespace TianWen.UI.Abstractions
 
         /// <summary>
         /// Current mount pointing for the reticle overlay. Null when no mount is connected
-        /// or its coordinates can't be read. Populated by the event loop from polled
-        /// <c>LiveSessionState.PreviewMountState</c> (preview mode) or <c>session.MountState</c>
-        /// (session running). RA/Dec are J2000 when available; native coords are used as a
-        /// fallback for mounts where the J2000 conversion hasn't been populated yet.
+        /// or its coordinates can't be read. Populated by the event loop from the single
+        /// canonical <c>LiveSessionState.MountState</c> (fed by the preview poll while idle,
+        /// the running session's poll otherwise). RA/Dec are J2000 when available; native
+        /// coords are used as a fallback for mounts where the J2000 conversion hasn't been
+        /// populated yet.
         /// </summary>
         public SkyMapMountOverlay? MountOverlay { get; set; }
 

--- a/src/TianWen.UI.Gui/VkGuiRenderer.cs
+++ b/src/TianWen.UI.Gui/VkGuiRenderer.cs
@@ -463,11 +463,15 @@ namespace TianWen.UI.Gui
             ITimeProvider timeProvider,
             RectF32 contentRect)
         {
-            // Poll session state for any tab that needs live data (LiveSession, Guider)
-            if (appState.ActiveTab is GuiTab.LiveSession or GuiTab.Guider)
-            {
-                LiveSessionState.PollSession();
-            }
+            // Refresh the cached session snapshot every frame, regardless of tab. PollSession
+            // early-returns when no session is active (cheap volatile-field copies otherwise), so
+            // this is essentially free when idle. Running it unconditionally keeps the single
+            // canonical LiveSessionState.MountState current on EVERY tab while a session runs --
+            // previously this was gated to LiveSession/Guider, so the Sky Map reticle read a stale
+            // default(MountState) (RA0/Dec0) the whole time a session was active and the user was
+            // watching the map. The mount was never wrong; the copy that fed the reticle was never
+            // refreshed.
+            LiveSessionState.PollSession();
 
             switch (appState.ActiveTab)
             {
@@ -488,11 +492,11 @@ namespace TianWen.UI.Gui
                     break;
 
                 case GuiTab.SkyMap:
-                    // Feed the live mount snapshot into the sky map state so the
-                    // reticle overlay tracks the mount without the tab needing its
-                    // own poll path. Session-mode uses the session's own MountState
-                    // (already populated at session's PollDeviceStatesAsync cadence);
-                    // preview-mode uses PreviewMountState populated by PollPreviewTelemetry.
+                    // Feed the live mount snapshot into the sky map state so the reticle overlay
+                    // tracks the mount without the tab needing its own poll path. Reads the single
+                    // canonical LiveSessionState.MountState (kept current every frame by the
+                    // unconditional PollSession above when a session runs, or by PollPreviewTelemetry
+                    // when idle) -- no session-vs-preview branch here any more.
                     PopulateSkyMapMountOverlay(appState, timeProvider);
                     PopulateSkyMapMosaicPanels(appState, plannerState);
                     PopulateSkyMapScheduleTargets();
@@ -535,37 +539,22 @@ namespace TianWen.UI.Gui
         /// Snapshots the current mount pointing into <see cref="SkyMapState.MountOverlay"/>
         /// just before the sky-map tab renders. This keeps the sky map free of any direct
         /// dependency on <see cref="LiveSessionState"/>; the tab itself only sees the tiny
-        /// <see cref="SkyMapMountOverlay"/> snapshot. Picks the session's own MountState
-        /// when a session is running (session drives the poll cadence itself), else the
-        /// preview-mode snapshot (driven by <c>AppSignalHandler.PollPreviewTelemetry</c>).
-        /// J2000 coords are preferred; native coords are used as a fallback for session
-        /// mode which does not yet populate the J2000 fields.
+        /// <see cref="SkyMapMountOverlay"/> snapshot. Reads the single canonical
+        /// <see cref="LiveSessionState.MountState"/> -- fed by the session poll while running and
+        /// the preview poll while idle -- so there is no session-vs-preview branch to keep in sync.
+        /// J2000 coords are preferred; native coords are the fallback when the active source does
+        /// not populate the J2000 fields (the session poll currently does not, so session-mode is
+        /// accurate to within precession until the believed/true split lands).
         /// </summary>
         private void PopulateSkyMapMountOverlay(GuiAppState appState, ITimeProvider timeProvider)
         {
-            // Without an actual poll, default(MountState) has all-zero coords -- not
-            // NaN -- so a NaN check alone would still draw a phantom reticle at (0h, 0)
-            // before the first poll completes (or when no mount is configured at all).
-            // Guard on the display name being set, which only happens after a successful
-            // poll establishes that a mount is connected.
-            // Source the mount state AND its display name from the same place: the
-            // session when one is running (it owns the mount and populates MountState),
-            // otherwise the preview poll. Previously the display-name guard always read
-            // the preview poll's name, so a session started without a prior preview poll
-            // (e.g. straight from the Planner) suppressed the reticle even though the
-            // session mount was live.
-            MountState ms;
-            string? displayName;
-            if (LiveSessionState.IsRunning)
-            {
-                ms = LiveSessionState.MountState;
-                displayName = LiveSessionState.ActiveSession?.Setup.Mount.Device.DisplayName;
-            }
-            else
-            {
-                ms = LiveSessionState.PreviewMountState;
-                displayName = LiveSessionState.PreviewMountDisplayName;
-            }
+            // The single canonical snapshot. NaN RA/Dec (or an empty display name) means "no
+            // current pointing" -- either no mount is configured or no poll has succeeded yet --
+            // and suppresses the reticle. A genuine, freshly-polled RA0/Dec0 would still draw,
+            // which is correct: that is a real (if unusual) pointing, not the old phantom that
+            // came from reading a never-refreshed default(MountState).
+            var ms = LiveSessionState.MountState;
+            var displayName = LiveSessionState.MountDisplayName;
 
             if (string.IsNullOrEmpty(displayName))
             {


### PR DESCRIPTION
## Problem

The sky-map mount reticle rendered at **RA0/Dec0** (celestial-equator origin, below the horizon) for the entire duration of a session.

## Root cause

The mount's live pointing was duplicated across three places — `session.MountState` (live, in Lib) plus two `LiveSessionState` copies (`MountState`, fed by `PollSession()`; and `PreviewMountState`, fed by the idle preview poll) — with the reticle branching between the copies on `IsRunning`.

`LiveSessionState.MountState` is only refreshed by `PollSession()`, which was **gated to the LiveSession/Guider tabs** (`VkGuiRenderer:467`). On the **Sky Map** tab it was never called, so the copy stayed at `default(MountState)` = RA0/Dec0. The mount was always read correctly (verified: it held its `20.66h/-47.2°` pointing and site through connect + SetSite); only the stale UI copy feeding the reticle was wrong.

## Fix

- **Collapse to one canonical `LiveSessionState.MountState`** (+ `MountDisplayName`), fed by whichever poller owns the mount — preview when idle, the running session otherwise (mutually exclusive). Drop `PreviewMountState`/`PreviewMountDisplayName`. The reticle reads the one field with no `IsRunning` branch.
- **Run `PollSession()` every frame** (was tab-gated) so the canonical field stays current on every tab while a session runs. It early-returns when no session is active.
- **NaN-init `Session._mountState`** and gate the copy into the shared field on a valid RA, so the seconds-long pre-first-poll window (`ActiveSession` is assigned before `RunAsync`'s first device poll) and transient failed reads keep the last good value instead of snapping the reticle to the origin. The preview poll defaults its reads to NaN for the same reason.
- **Populate `RaJ2000`/`DecJ2000` in `Session.PollDeviceStatesAsync`** (reusing a cached SOFA transform via the shared `EquatorialFrameConversion` helper) so the in-session reticle is precession-exact rather than ~22' off via the JNOW fallback — matching the idle preview path.
- **`MountStateDto` coerces NaN→0** (`System.Text.Json` has no `AllowNamedFloatingPointLiterals`); 0 matches the pre-poll wire value clients already saw.
- Demote the `SessionFactory` borrow log + `Session` init-mount snapshots to `DBG`.

## Verification

- `dotnet build TianWen.slnx` — 0 warnings, 0 errors.
- `dotnet test TianWen.Lib.Tests` — 2643 passed, 0 failed.
- `dotnet test TianWen.Lib.Tests.Functional` — 293 passed, 0 failed.
- Manually verified in the GUI with the fake SkyWatcher profile: reticle tracks the live mount during a session, no 0,0 phantom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)