### PR TITLE
fix(gui): load-shed to a safe view on GPU stall + dedup/trace runaway sky-map zoom

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -103,8 +103,11 @@
          present mode.
          6.1 hardens GPU-wedge recovery: bounded vkWaitForFences drains (no unbounded
          vkDeviceWaitIdle) + a device-level IsGpuStuck flag, so a stuck GPU can no longer
-         hang the UI thread. Repinned to DIR.Lib 4.5 (lockstep with Console.Lib 2.18). -->
-    <PackageVersion Include="SdlVulkan.Renderer" Version="6.1.*" />
+         hang the UI thread. Repinned to DIR.Lib 4.5 (lockstep with Console.Lib 2.18).
+         6.2 (PR #27) extends that: bounded swapchain readback (no unbounded vkQueueWaitIdle),
+         TryWaitPriorFramesIdle for font-atlas grow/evict, and a once-per-storm
+         SdlWindowView.OnRenderDegraded callback so the app can load-shed to a safe view. -->
+    <PackageVersion Include="SdlVulkan.Renderer" Version="6.2.*" />
     <PackageVersion Include="SDL3-CS" Version="3.5.0-preview.20260213-150035" />
     <PackageVersion Include="SDL3-CS.Native" Version="3.5.0-preview.20260205-174353" />
     <!-- Canon DSLR -->

--- a/src/TianWen.UI.Abstractions/SkyMapTab.cs
+++ b/src/TianWen.UI.Abstractions/SkyMapTab.cs
@@ -696,6 +696,7 @@ namespace TianWen.UI.Abstractions
 
         private bool HandlePinchZoom(float scale, float centerX, float centerY)
         {
+            _sincePinch.Restart(); // keep the wheel-dedup grace window fresh for the whole gesture
             if (!State.IsPinching)
             {
                 // Pinch start — suppress drag, undo any drag the first finger caused
@@ -720,8 +721,36 @@ namespace TianWen.UI.Abstractions
             return true;
         }
 
+        // Runaway-zoom flood detector. Zoom events arriving faster than any human could scroll
+        // (a stuck wheel, or a Windows precision touchpad firing both FingerMotion AND MouseWheel for
+        // one gesture) ramp the FOV every frame until a wide-FOV frame wedges the GPU. We log one
+        // warning per burst so a recurrence is instantly visible in the log instead of inferred from
+        // the FOV ramp. Stopwatch is a monotonic elapsed timer (input pacing), not a wall-clock read.
+        private readonly System.Diagnostics.Stopwatch _zoomFloodWindow = System.Diagnostics.Stopwatch.StartNew();
+        private int _zoomEventsInWindow;
+        private const int ZoomFloodWarnThreshold = 20; // >20 zoom events in <200ms (~100/s) is not a human
+
+        // Trackpad-pinch dedup: a Windows precision touchpad fires both FingerMotion (pinch) AND
+        // MouseWheel for one zoom gesture. Track the time since the last pinch event so the wheel path
+        // can ignore the duplicate wheel zoom during a pinch and for a short grace window after it
+        // (trailing OS-momentum wheel events). Not started until the first pinch, so a plain mouse
+        // wheel before any pinch is never suppressed.
+        private readonly System.Diagnostics.Stopwatch _sincePinch = new();
+        private const long PinchWheelGraceMs = 300;
+
         private bool HandleZoom(float scrollY, float mouseX, float mouseY)
         {
+            // While a pinch is active -- or just ended -- the simultaneous mouse-wheel events are the
+            // OS's duplicate of the same trackpad gesture, so ignore them. This is the targeted fix for
+            // the dual-fire FOV runaway; a pure mouse wheel with no pinch is unaffected.
+            if (State.IsPinching || (_sincePinch.IsRunning && _sincePinch.ElapsedMilliseconds < PinchWheelGraceMs))
+            {
+#if DEBUG
+                Logger?.LogDebug("SkyMap wheel zoom ignored (trackpad pinch active/recent); scrollY={ScrollY:F2}", scrollY);
+#endif
+                return true; // consume the duplicate wheel event without zooming
+            }
+
             // Scale proportionally to scroll magnitude — each unit ≈ 15% zoom
             var factor = Math.Pow(0.85, scrollY);
             return HandleZoomByFactor(factor, mouseX, mouseY);
@@ -729,6 +758,7 @@ namespace TianWen.UI.Abstractions
 
         private bool HandleZoomByFactor(double factor, float mouseX, float mouseY)
         {
+            var oldFovDeg = State.FieldOfViewDeg;
 
             // Center-point zoom: zoom toward the sky position under the mouse cursor
             var ppr = SkyMapProjection.PixelsPerRadian(_contentHeight, State.FieldOfViewDeg);
@@ -760,6 +790,23 @@ namespace TianWen.UI.Abstractions
             }
 
             State.NeedsRedraw = true;
+
+            // Flood detection (see fields above): one-shot warning per burst when zoom events arrive
+            // impossibly fast — the signature of the touchpad-dual-fire / stuck-scroll FOV runaway.
+            if (_zoomFloodWindow.ElapsedMilliseconds > 200)
+            {
+                _zoomFloodWindow.Restart();
+                _zoomEventsInWindow = 0;
+            }
+            if (++_zoomEventsInWindow == ZoomFloodWarnThreshold)
+            {
+                Logger?.LogWarning(
+                    "SkyMap zoom flood: {Count}+ events in <200ms (FOV {Old:F1} -> {New:F1} deg) - likely a stuck scroll / touchpad dual-fire, not user input.",
+                    _zoomEventsInWindow, oldFovDeg, State.FieldOfViewDeg);
+            }
+#if DEBUG
+            Logger?.LogDebug("SkyMap zoom: factor={Factor:F3} FOV {Old:F1} -> {New:F1} deg", factor, oldFovDeg, State.FieldOfViewDeg);
+#endif
             return true;
         }
 

--- a/src/TianWen.UI.Gui/Program.cs
+++ b/src/TianWen.UI.Gui/Program.cs
@@ -195,6 +195,24 @@ var loop = new SdlEventLoop(sdlWindow, renderer)
         guiRenderer.Resize(rw, rh);
     },
 
+    // The renderer's swapchain recovery isn't sticking — it kept wedging + recovering, meaning the
+    // current workload keeps re-saturating the GPU (the classic case: a runaway sky-map zoom producing
+    // a multi-second frame). Shed load so the GPU can drain: leave the heavy view for the cheap
+    // Notifications tab and reset the sky-map zoom so the runaway frame stops being submitted. Runs on
+    // the render thread; hardware + session control run on a background task and are unaffected by a
+    // render stall, so this only changes what's on screen, never what the mount/camera are doing.
+    OnRenderDegraded = () =>
+    {
+        var wasTab = appState.ActiveTab;
+        var fovAtStall = guiRenderer.SkyMapState.FieldOfViewDeg; // capture for the trace before resetting
+        appState.ActiveTab = GuiTab.Notifications;
+        guiRenderer.SkyMapState.FieldOfViewDeg = 60.0; // reset a runaway zoom to a sane default
+        guiRenderer.SkyMapState.NeedsRedraw = true;
+        appState.NeedsRedraw = true;
+        appState.RecordNotification(timeProvider.GetUtcNow(), NotificationSeverity.Warning,
+            $"Display recovered from a GPU stall on the {wasTab} view (sky-map FOV was {fovAtStall:F0} deg) - switched to a safe view and reset the zoom. Hardware and session control were unaffected.");
+    },
+
     OnMouseDown = (button, x, y, clicks, mods) =>
     {
         if (button == 1) handlers.HandleInput(new InputEvent.MouseDown(x, y, Modifiers: mods, ClickCount: clicks));


### PR DESCRIPTION
The GUI-side of the GPU-wedge hardening (the SdlVulkan.Renderer side shipped in SharpAstro/SdlVulkan.Renderer#27 -> 6.2.x).

## Background

On win-arm64 / Adreno X1-85 (immature Vulkan driver) the GUI could **freeze unkillably at 100% GPU**: a runaway sky-map zoom ramped FOV every frame until a wide-FOV frame got heavy, and an inspector screenshot readback piled on, leaving a fence stuck >2.5s. The kernel held the process in the GPU driver (only `Win+Ctrl+Shift+B` reaped it). This app drives real hardware, so an unrecoverable freeze is unacceptable.

The renderer-side fixes (bounded GPU waits, `IsGpuStuck` guard, `TryWaitPriorFramesIdle`, bounded swapchain readback, and a once-per-storm `SdlWindowView.OnRenderDegraded` callback) shipped in SdlVulkan.Renderer 6.2. This PR is the **app-side response** to that callback plus trigger-hardening for the zoom runaway.

## Changes

- **Load-shed on render degradation** (`Program.cs`): on `OnRenderDegraded` (fired once per recover-storm, streak >= 2), the GUI switches to the **Notifications** tab, resets sky-map FOV to 60°, and records a notification — bailing out of whatever heavy view wedged the GPU instead of hammering it.
- **Pinch/wheel dedup** (`SkyMapTab.cs`): Windows precision touchpads emit both `FingerMotion` (pinch) **and** `MouseWheel` for one gesture, so a single pinch fanned out into a per-frame `FieldOfViewDeg *= factor` runaway. Now mouse-wheel zoom is ignored while a trackpad pinch is active or just ended (300 ms grace).
- **Zoom-flood warning + per-zoom DEBUG trace** so a future runaway is diagnosable from the log.
- **Bump SdlVulkan.Renderer `6.1.*` -> `6.2.*`** so CI resolves the package carrying `OnRenderDegraded` et al.

## Verification

- Release build with `-p:UseLocalSiblings=false` restores SdlVulkan.Renderer **6.2.1111** from NuGet and compiles clean (0 warnings/errors) — confirms the CI PackageReference path.
- Verified live: GUI stays responsive at FOV 180 / 77k stars; clean exit; no fence-stall / recovery / degrade storm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)