### PR TITLE
fix(session): calibrate guider east of the meridian (HA -0.5h), not west

### DIFF
--- a/src/TianWen.Lib.Tests.Functional/SessionLifecycleTests.cs
+++ b/src/TianWen.Lib.Tests.Functional/SessionLifecycleTests.cs
@@ -100,12 +100,21 @@ public class SessionLifecycleTests(ITestOutputHelper output)
 
     // --- CalibrateGuiderAsync ---
 
-    [Fact(Timeout = 120_000)]
-    public async Task GivenConnectedMountWhenCalibrateGuiderThenSlewsAndStartsGuiding()
+    // Both hemispheres: Vienna (northern) and Melbourne (southern). The calibration must slew
+    // EAST of the meridian (before crossing) in BOTH, so the GEM stays on its pre-flip pier side
+    // for the whole calibration. "East/before crossing" is HA < 0 in either hemisphere (the
+    // convention is absolute); only the apparent left/right motion mirrors south of the equator.
+    [Theory(Timeout = 120_000)]
+    [InlineData(48.2, 16.3)]                  // Vienna, northern
+    [InlineData(-37.8743502, 145.1668205)]    // Melbourne, southern
+    public async Task GivenConnectedMountWhenCalibrateGuiderThenSlewsEastOfMeridianAndStartsGuiding(double latitude, double longitude)
     {
-        // Use winter night when dec=0 near meridian is well above horizon from Vienna
+        // Use winter night when dec=0 near meridian is well above horizon. dec=0 culminates at a
+        // fixed altitude (90 - |lat|) regardless of season, so it is well clear of the horizon from
+        // both sites, and CalibrateGuiderAsync does not gate on darkness.
         var ct = TestContext.Current.CancellationToken;
-        using var ctx = await SessionTestHelper.CreateSessionAsync(output, now: WinterNight, cancellationToken: ct);
+        using var ctx = await SessionTestHelper.CreateSessionAsync(
+            output, now: WinterNight, latitude: latitude, longitude: longitude, cancellationToken: ct);
 
         IMountDriver mount = ctx.Mount;
         await mount.EnsureTrackingAsync(cancellationToken: ct);
@@ -121,6 +130,16 @@ public class SessionLifecycleTests(ITestOutputHelper output)
 
         calibrateTask.IsCompleted.ShouldBeTrue("CalibrateGuiderAsync should complete within timeout");
         await calibrateTask; // propagate any exceptions
+
+        // The calibration target must sit EAST of the meridian (HA < 0): it is approaching the
+        // meridian but has not crossed it, so the mount stays on its pre-flip pier side. The slew
+        // lands at HA = -0.5h and tracking only drifts it UP toward 0 (it stays negative for ~30
+        // min), so HA in (-0.7, 0) confirms east. The old +0.5h bug landed WEST (~+0.5h) -- past
+        // the meridian on the opposite pier side -- which would fail this in BOTH hemispheres.
+        var ha = await mount.GetHourAngleAsync(ct);
+        output.WriteLine($"Hour angle after calibration slew: {ha:F3}h ({(ha < 0 ? "EAST, before crossing" : "WEST, after crossing")}) at lat={latitude}");
+        ha.ShouldBeLessThan(0.0, $"calibration must slew EAST of the meridian (HA < 0, before crossing), but HA={ha:F3}h");
+        ha.ShouldBeGreaterThan(-0.7, $"calibration target should be ~30 min east of the meridian, but HA={ha:F3}h");
 
         // After calibration, guider should be guiding
         var guider = (FakeGuider)ctx.Session.Setup.Guider.Driver;

--- a/src/TianWen.Lib.Tests/SessionTestHelper.cs
+++ b/src/TianWen.Lib.Tests/SessionTestHelper.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Immutable;
 using System.Collections.Specialized;
+using System.Globalization;
 using System.Threading;
 using System.Threading.Tasks;
 using TianWen.Lib.Astrometry.Focus;
@@ -57,6 +58,8 @@ internal static class SessionTestHelper
         DateTimeOffset? now = null,
         int focalLength = 1000,
         string? mountPort = null,
+        double latitude = 48.2,
+        double longitude = 16.3,
         CancellationToken cancellationToken = default)
     {
         var timeProvider = new FakeTimeProviderWrapper(now ?? new DateTimeOffset(2025, 6, 15, 22, 0, 0, TimeSpan.Zero));
@@ -91,8 +94,8 @@ internal static class SessionTestHelper
 
         var mountQuery = new NameValueCollection
         {
-            { "latitude", "48.2" },
-            { "longitude", "16.3" },
+            { "latitude", latitude.ToString(CultureInfo.InvariantCulture) },
+            { "longitude", longitude.ToString(CultureInfo.InvariantCulture) },
             { "elevation", "200" }
         };
         if (mountPort is not null)

--- a/src/TianWen.Lib/Sequencing/Session.Lifecycle.cs
+++ b/src/TianWen.Lib/Sequencing/Session.Lifecycle.cs
@@ -17,9 +17,15 @@ internal partial record Session
         var mount = Setup.Mount;
 
         // TODO: maybe slew slightly above/below 0 declination to avoid trees, etc.
-        // slew half an hour east of meridian, plate solve and slew closer
+        // Slew to 30 min of hour-angle EAST of the meridian (HA = -0.5h) at the celestial
+        // equator: the target is approaching the meridian but has not yet crossed it, so the GEM
+        // stays on its pre-flip pier side for the whole (short) calibration and the Dec guide
+        // sense matches the side imaging begins on. The previous value (+0.5h) slewed WEST of the
+        // meridian, already past the flip boundary onto the opposite pier side, which inverts the
+        // Dec calibration sense and sits right on the ambiguous flip edge -> Dec runaway. HA is
+        // LST - RA, so HA < 0 means east, i.e. before crossing (see BeginSlewHourAngleDecAsync).
         var dec = 0;
-        await mount.Driver.BeginSlewHourAngleDecAsync(TimeSpan.FromMinutes(30).TotalHours, dec, cancellationToken).ConfigureAwait(false);
+        await mount.Driver.BeginSlewHourAngleDecAsync(-TimeSpan.FromMinutes(30).TotalHours, dec, cancellationToken).ConfigureAwait(false);
 
         if (!await mount.Driver.WaitForSlewCompleteAsync(PollDeviceStatesAsync, cancellationToken).ConfigureAwait(false))
         {


### PR DESCRIPTION
## Problem

`CalibrateGuiderAsync` slewed the mount to **HA +0.5h** — 30 min **west** of the meridian — to run guider calibration. That position is already **past the GEM meridian-flip boundary, onto the opposite pier side** from where most imaging targets are acquired (rising, east of the meridian).

Consequences:
- The Dec guide-calibration sense is **inverted** relative to the pier side imaging begins on, so corrections push the wrong way after the implicit flip → **Dec runaway**.
- HA +0.5h sits right on the **ambiguous flip edge**, where `DestinationSideOfPier` / `GetSideOfPier` can disagree frame-to-frame.

## Fix

Slew to **HA -0.5h** (30 min **east**, target still *approaching* the meridian) instead. The GEM stays on its **pre-flip pier side** for the whole (short) calibration, and the Dec sense matches the side imaging starts on.

`HA = LST - RA`, so `HA < 0` ⇒ east ⇒ before crossing (per `BeginSlewHourAngleDecAsync`). One-character intent, fully commented at the call site.

## Tests

- Parameterised `SessionTestHelper.CreateSessionAsync` with site `latitude` / `longitude`.
- Turned the calibration test into a both-hemisphere `[Theory]`:
  - **Vienna** `48.2, 16.3` (northern)
  - **Melbourne** `-37.87, 145.17` (southern)
- New assertions after calibration: post-calibration `HA < 0` (east of meridian) and `HA > -0.7h` (within ~40 min, i.e. it actually slewed near the target, not somewhere stale).

Functional suite green locally: **17 passed / 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)