### PR TITLE
fix(skymap): stop catalog labels overlapping the mount reticle label

### DIFF
--- a/src/TianWen.Lib.Tests/OverlayEngineTests.cs
+++ b/src/TianWen.Lib.Tests/OverlayEngineTests.cs
@@ -588,6 +588,94 @@ public class OverlayEngineTests
         items[0].LabelPriority.ShouldBeLessThan(15f);
     }
 
+    // --- PlaceLabels reserved regions (mount reticle label collision avoidance) ---
+
+    private static OverlayItem MakeLabelItem(float screenX, float screenY, int slotHint = 0) =>
+        new OverlayItem
+        {
+            ScreenX = screenX,
+            ScreenY = screenY,
+            Marker = new OverlayMarker { Kind = OverlayMarkerKind.Cross },
+            LabelLines = ["X"],
+            LabelPriority = 10f,
+            LabelSlotHint = slotHint,
+            StableSortKey = 1,
+        };
+
+    [Fact]
+    public void PlaceLabels_NoReservation_LabelTakesPreferredSlot()
+    {
+        var item = MakeLabelItem(500f, 500f, slotHint: 0); // prefers slot 0 (right of marker)
+        var placed = new List<(OverlayItem Item, float X, float Y)>();
+
+        OverlayEngine.PlaceLabels([item], labelSize: 10f, labelPad: 4f,
+            measureText: (_, _) => 100f,
+            drawLabelLines: (it, x, y) => placed.Add((it, x, y)));
+
+        placed.Count.ShouldBe(1);
+        placed[0].X.ShouldBe(510f); // right slot: cx + labelPad + 6
+        placed[0].Y.ShouldBe(494f); // cy - totalH/2 (totalH = 10*1.2 = 12)
+    }
+
+    [Fact]
+    public void PlaceLabels_ReservedRegionOverPreferredSlot_PushesLabelToFreeSlot()
+    {
+        var item = MakeLabelItem(500f, 500f, slotHint: 0);
+        var placed = new List<(OverlayItem Item, float X, float Y)>();
+
+        // Reserve exactly the right-slot box (where the label would otherwise land),
+        // mimicking the mount reticle label occupying that space. Named-tuple element
+        // names don't affect the type, so this array satisfies the reservedRegions param.
+        (float X, float Y, float W, float H)[] reserved = [(510f, 494f, 100f, 12f)];
+
+        OverlayEngine.PlaceLabels([item], labelSize: 10f, labelPad: 4f,
+            measureText: (_, _) => 100f,
+            drawLabelLines: (it, x, y) => placed.Add((it, x, y)),
+            reservedRegions: reserved);
+
+        placed.Count.ShouldBe(1);
+        // Rotated to the left slot, clear of the reserved box.
+        placed[0].X.ShouldBe(390f); // cx - maxLineW - labelPad - 6
+        placed[0].Y.ShouldBe(494f);
+        // And the chosen label box must not intersect the reserved region.
+        var (lx, ly) = (placed[0].X, placed[0].Y);
+        var intersects = lx < 610f && lx + 100f > 510f && ly < 506f && ly + 12f > 494f;
+        intersects.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void PlaceLabelsBestEffort_NoReservation_DrawsLabel()
+    {
+        var item = MakeLabelItem(500f, 500f, slotHint: 3); // below slot
+        var placed = new List<(OverlayItem Item, float X, float Y)>();
+
+        OverlayEngine.PlaceLabelsBestEffort([item], labelSize: 10f, labelPad: 4f,
+            measureText: (_, _) => 100f,
+            drawLabelLines: (it, x, y) => placed.Add((it, x, y)));
+
+        placed.Count.ShouldBe(1);
+        placed[0].X.ShouldBe(450f); // below slot: cx - maxLineW/2
+        placed[0].Y.ShouldBe(510f); // cy + labelPad + 6
+    }
+
+    [Fact]
+    public void PlaceLabelsBestEffort_ReservedRegionOverSlot_DropsLabel()
+    {
+        var item = MakeLabelItem(500f, 500f, slotHint: 3);
+        var placed = new List<(OverlayItem Item, float X, float Y)>();
+
+        // The best-effort "below" slot lands at (450, 510); reserve it so the label
+        // would bury the mount reticle label and must therefore be dropped instead.
+        (float X, float Y, float W, float H)[] reserved = [(450f, 510f, 100f, 12f)];
+
+        OverlayEngine.PlaceLabelsBestEffort([item], labelSize: 10f, labelPad: 4f,
+            measureText: (_, _) => 100f,
+            drawLabelLines: (it, x, y) => placed.Add((it, x, y)),
+            reservedRegions: reserved);
+
+        placed.ShouldBeEmpty();
+    }
+
     // --- Helpers ---
 
     private static WCS MakeSimpleWCS()

--- a/src/TianWen.UI.Abstractions/Overlays/OverlayEngine.cs
+++ b/src/TianWen.UI.Abstractions/Overlays/OverlayEngine.cs
@@ -1048,13 +1048,18 @@ public static class OverlayEngine
     /// <param name="drawLabelLines">Callback: draw a label block at (x, y) with the given
     /// base RGB color. The block's top-left is at (x, y); line-height is <paramref name="labelSize"/> * 1.2.</param>
     /// <param name="maxLabels">Label cap to prevent clutter. Defaults to <see cref="MaxOverlayLabels"/>.</param>
+    /// <param name="reservedRegions">Screen-space boxes (x, y, w, h) that are already
+    /// occupied by something the engine doesn't own — e.g. the live mount-reticle label,
+    /// drawn later in a separate pass. Catalog labels treat them as pre-placed and stack
+    /// around them, so the mount label is never overlapped by an object name.</param>
     public static void PlaceLabels(
         IReadOnlyList<OverlayItem> items,
         float labelSize,
         float labelPad,
         Func<string, float, float> measureText,
         Action<OverlayItem, float, float> drawLabelLines,
-        int maxLabels = MaxOverlayLabels)
+        int maxLabels = MaxOverlayLabels,
+        IReadOnlyList<(float X, float Y, float W, float H)>? reservedRegions = null)
     {
         // Iterate in priority order (high -> low) so bright / named / large
         // objects claim their preferred slot first; lower-priority labels drop
@@ -1073,7 +1078,13 @@ public static class OverlayEngine
             return a.StableSortKey.CompareTo(b.StableSortKey);
         });
 
+        // Seed the occupied set with any externally-owned boxes (the mount reticle label)
+        // so the first catalog label that would land there is forced to another slot.
         var placedLabels = new List<(float X, float Y, float W, float H)>();
+        if (reservedRegions is { Count: > 0 })
+        {
+            placedLabels.AddRange(reservedRegions);
+        }
         var labelCount = 0;
 
         foreach (var item in sorted)
@@ -1157,7 +1168,8 @@ public static class OverlayEngine
         float labelPad,
         Func<string, float, float> measureText,
         Action<OverlayItem, float, float> drawLabelLines,
-        int maxLabels = MaxOverlayLabels)
+        int maxLabels = MaxOverlayLabels,
+        IReadOnlyList<(float X, float Y, float W, float H)>? reservedRegions = null)
     {
         var sorted = new List<OverlayItem>(items);
         sorted.Sort((a, b) =>
@@ -1206,6 +1218,27 @@ public static class OverlayEngine
                     lx = item.ScreenX + labelPad + 6f;
                     ly = item.ScreenY - totalH / 2f;
                     break;
+            }
+
+            // Best-effort placement has no inter-label collision check (overlapping labels
+            // are accepted, Stellarium-style), but a reserved box belongs to something more
+            // important than a catalog name (the mount reticle label) — drop the few labels
+            // that would land on it rather than letting them bury it.
+            if (reservedRegions is { Count: > 0 })
+            {
+                var blocked = false;
+                foreach (var (px, py, pw, ph) in reservedRegions)
+                {
+                    if (lx < px + pw && lx + maxLineW > px && ly < py + ph && ly + totalH > py)
+                    {
+                        blocked = true;
+                        break;
+                    }
+                }
+                if (blocked)
+                {
+                    continue;
+                }
             }
 
             drawLabelLines(item, lx, ly);

--- a/src/TianWen.UI.Gui/VkSkyMapTab.cs
+++ b/src/TianWen.UI.Gui/VkSkyMapTab.cs
@@ -359,13 +359,19 @@ public sealed unsafe class VkSkyMapTab(VkRenderer renderer) : SkyMapTab<VulkanCo
         var placementLabelSize = baseFontSize * dpiScale * 0.85f;
         var measureText = (string text, float size) => Renderer.MeasureText(text.AsSpan(), fontPath, size).Width;
         Action<OverlayItem, float, float> record = (item, lx, ly) => _overlayPlacedLabels.Add((item, lx, ly));
+
+        // Reserve the mount reticle's label footprint (drawn later, in RenderMountOverlay) so
+        // an object name never renders on top of it when the mount sits on a catalogued target.
+        var mountLabelReservation = BuildMountLabelReservation(contentRect, dpiScale, fontPath, baseFontSize);
         if (_useCollisionPlacement)
         {
-            OverlayEngine.PlaceLabels(_overlayItems, placementLabelSize, 4f, measureText, record);
+            OverlayEngine.PlaceLabels(_overlayItems, placementLabelSize, 4f, measureText, record,
+                reservedRegions: mountLabelReservation);
         }
         else
         {
-            OverlayEngine.PlaceLabelsBestEffort(_overlayItems, placementLabelSize, 4f, measureText, record);
+            OverlayEngine.PlaceLabelsBestEffort(_overlayItems, placementLabelSize, 4f, measureText, record,
+                reservedRegions: mountLabelReservation);
         }
 #if DEBUG
         diagLabelsDone = System.Diagnostics.Stopwatch.GetTimestamp();
@@ -733,14 +739,9 @@ public sealed unsafe class VkSkyMapTab(VkRenderer renderer) : SkyMapTab<VulkanCo
         // should be at the pole, the label tells the truth immediately.
         var fontSize = baseFontSize * dpiScale;
         var lineH = fontSize * 1.2f;
-        // No '+' for positive Dec — at small font a thin '+' was misread as '-' (and
-        // vice versa) on the bug-hunt screenshots. Bare sign-when-negative is unambiguous.
-        // Proper DMS punctuation (' for arcmin, " for arcsec) reads cleanly as a
-        // sky coordinate vs the default ':' which looked like a time.
-        var coordsText = $"RA {CoordinateUtils.HoursToHMS(mountOverlay.RaJ2000, hourSeparator: 'h', withFrac: false, minuteSeparator: 'm', secondSuffix: "s")}"
-            + $"  Dec {CoordinateUtils.DegreesToDMS(mountOverlay.DecJ2000, withPlus: false, degreeSign: '\u00B0', withFrac: false, arcMinuteSign: '\u2032', arcSecondSign: "\u2033")}";
+        var (nameText, coordsText) = MountLabelLines(mountOverlay);
 
-        DrawReticleLabel(mountOverlay.DisplayName, fontPath, fontSize, color,
+        DrawReticleLabel(nameText, fontPath, fontSize, color,
             screenX, screenY + 20f * dpiScale, lineH);
         DrawReticleLabel(coordsText, fontPath, fontSize * 0.9f,
             new RGBAColor32(color.Red, color.Green, color.Blue, (byte)(color.Alpha * 0.8f)),
@@ -904,6 +905,60 @@ public sealed unsafe class VkSkyMapTab(VkRenderer renderer) : SkyMapTab<VulkanCo
                 new PointInt((int)(centerX + textW * 0.5f + 4), (int)(topY + lineH)),
                 new PointInt((int)(centerX - textW * 0.5f - 4), (int)topY)),
             TextAlign.Center, TextAlign.Center);
+    }
+
+    /// <summary>
+    /// The two lines of the mount reticle label: display name + believed J2000 RA/Dec.
+    /// Single source of truth shared by <see cref="RenderMountOverlay"/> (which draws them)
+    /// and <see cref="BuildMountLabelReservation"/> (which reserves their footprint so
+    /// catalog labels don't overlap), so the rendered text and the reserved box can't drift.
+    /// </summary>
+    // No '+' for positive Dec — at small font a thin '+' was misread as '-' (and
+    // vice versa) on the bug-hunt screenshots. Bare sign-when-negative is unambiguous.
+    // Proper DMS punctuation (' for arcmin, " for arcsec) reads cleanly as a
+    // sky coordinate vs the default ':' which looked like a time.
+    private static (string Name, string Coords) MountLabelLines(SkyMapMountOverlay mountOverlay) => (
+        mountOverlay.DisplayName,
+        $"RA {CoordinateUtils.HoursToHMS(mountOverlay.RaJ2000, hourSeparator: 'h', withFrac: false, minuteSeparator: 'm', secondSuffix: "s")}"
+            + $"  Dec {CoordinateUtils.DegreesToDMS(mountOverlay.DecJ2000, withPlus: false, degreeSign: '°', withFrac: false, arcMinuteSign: '′', arcSecondSign: "″")}");
+
+    /// <summary>
+    /// Screen-space box occupied by the mount reticle's two-line label, or <c>null</c> when
+    /// no mount overlay is shown or the mount projects off-screen. Passed to
+    /// <see cref="OverlayEngine.PlaceLabels"/> as a reserved region so an object name never
+    /// renders on top of the mount label when the mount is parked on a catalogued target.
+    /// The geometry mirrors <see cref="RenderMountOverlay"/>'s label layout exactly (two
+    /// centred lines below the reticle: name at <c>fontSize</c>, coords at <c>fontSize*0.9</c>,
+    /// each <see cref="DrawReticleLabel"/> block padded ±4px horizontally).
+    /// </summary>
+    private IReadOnlyList<(float X, float Y, float W, float H)>? BuildMountLabelReservation(
+        RectF32 contentRect, float dpiScale, string fontPath, float baseFontSize)
+    {
+        if (!State.ShowMountOverlay || State.MountOverlay is not { } mountOverlay)
+        {
+            return null;
+        }
+
+        // Recompute the projection the same way the base render loop does (it doesn't pass
+        // ppr/cx/cy into RenderObjectOverlay) so the box lands exactly where RenderMountOverlay
+        // will draw the label a few passes later this frame.
+        var ppr = SkyMapProjection.PixelsPerRadian(contentRect.Height, State.FieldOfViewDeg);
+        var cx = contentRect.X + contentRect.Width * 0.5f;
+        var cy = contentRect.Y + contentRect.Height * 0.5f;
+        if (!SkyMapProjection.ProjectWithMatrix(mountOverlay.RaJ2000, mountOverlay.DecJ2000,
+                State.CurrentViewMatrix, ppr, cx, cy, out var sx, out var sy))
+        {
+            return null;
+        }
+
+        var fontSize = baseFontSize * dpiScale;
+        var lineH = fontSize * 1.2f;
+        var (nameText, coordsText) = MountLabelLines(mountOverlay);
+        var nameW = Renderer.MeasureText(nameText.AsSpan(), fontPath, fontSize).Width + 8f;
+        var coordsW = Renderer.MeasureText(coordsText.AsSpan(), fontPath, fontSize * 0.9f).Width + 8f;
+        var blockW = MathF.Max(nameW, coordsW);
+        var top = sy + 20f * dpiScale;
+        return [(sx - blockW * 0.5f, top, blockW, lineH * 2f)];
     }
 
     // Color palette for fixed-frame markers


### PR DESCRIPTION
## Summary

When the mount parks on a catalogued target, the live **mount reticle label** ("Fake Mount (SkyWatcher)" + believed RA/Dec) and the **object's catalog label** ("Ophiuchus Molecular Cloud") were drawn by two independent passes (`RenderMountOverlay` vs `RenderObjectOverlay` → `OverlayEngine.PlaceLabels`) with no shared collision avoidance, so they rendered on top of each other.

## Fix
- **`OverlayEngine.PlaceLabels` / `PlaceLabelsBestEffort`** gained an optional `reservedRegions` param (screen-space boxes owned by something the engine doesn't place — i.e. the mount reticle label). `PlaceLabels` seeds them into its occupied-set so catalog labels rotate to a free slot; `PlaceLabelsBestEffort` (no inter-label collision check by design) drops the few labels that would land on a reserved box rather than burying it.
- **`VkSkyMapTab.RenderObjectOverlay`** builds the mount-label box via `BuildMountLabelReservation` (projecting the mount the same way the base render loop does, since the override isn't handed `ppr/cx/cy`) and passes it through.
- **`MountLabelLines`** extracted as the single source of truth for the two label lines, so the text drawn by `RenderMountOverlay` and the box reserved for it can't drift.

Net effect: the **object name yields** to a free side, the **mount reticle label stays anchored** to its reticle — the correct priority, since the reticle label is the "where is my mount pointing right now" readout.

## Test plan
- Full solution builds clean (0 warnings / 0 errors).
- `OverlayEngineTests` — 89 pass, including 4 new tests pinning the reservation behavior:
  - `PlaceLabels_NoReservation_LabelTakesPreferredSlot` (baseline)
  - `PlaceLabels_ReservedRegionOverPreferredSlot_PushesLabelToFreeSlot`
  - `PlaceLabelsBestEffort_NoReservation_DrawsLabel` (baseline)
  - `PlaceLabelsBestEffort_ReservedRegionOverSlot_DropsLabel`

🤖 Generated with [Claude Code](https://claude.com/claude-code)