### PR TITLE
fix(session): abort in-flight exposure before plate-solve centering frame (meridian-flip flake)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -14,7 +14,7 @@
 - [x] `SessionImagingTests.GivenDitherEveryNth...DitheringTriggered` — fixed: same root cause (SleepAsync pump race)
 - [x] `SessionImagingTests.GivenFocusDrift...AutoRefocusTriggered` — fixed: same root cause
 - [x] `SessionPhaseTests.AbortDuringCooling_StopsRampAndWarmsBack` — fixed: removed wall-clock CancellationTokenSource timeouts
-- [ ] `SessionObservationLoopTests.GivenAcrossMeridianTargetWhenHACrossesDeadbandThenFlipAndContinueImaging` -- intermittently fails with `TotalFramesWritten=0`; surfaced during the stretch-tests branch, not introduced by it. Likely the same cooperative-time-pump class as the fixed flakes above.
+- [x] `SessionObservationLoopTests.GivenAcrossMeridianTargetWhenHACrossesDeadbandThenFlipAndContinueImaging` -- fixed: root cause was `PlateSolveAndSyncCoreAsync` (`Session.Focus.cs`) being the only `StartExposureAsync` call site with no Idle/abort precondition. During a meridian flip (`PerformMeridianFlipAsync` -> `CenterOnTargetAsync` -> 5s plate-solve frame) the prior science sub-exposure could still be `Exposing` under the two-thread time-pump interleaving, so the driver rejected the solve frame with `InvalidOperationException: camera state being Exposing` (which also surfaced as `TotalFramesWritten=0` when it aborted the flip). Now aborts any in-progress exposure and lets `Download->Idle` settle before the solve exposure, mirroring the condition-recovery / obstruction-scout guards. Verified 20/20 green.
 
 ## Next Up
 

--- a/src/TianWen.Lib/Sequencing/Session.Focus.cs
+++ b/src/TianWen.Lib/Sequencing/Session.Focus.cs
@@ -806,6 +806,19 @@ internal partial record Session
 
         try
         {
+            // A plate-solve / centering frame must start from Idle. Unlike the imaging loop
+            // (which only starts an exposure when the camera reads Idle) and the condition-
+            // recovery / obstruction-scout paths (which abort first), this path can be entered
+            // straight off a meridian flip while a science sub-exposure is still in flight, so
+            // abort any in-progress exposure and let the Download->Idle transition settle before
+            // the short solve exposure. Without this the driver -- real ASCOM/Alpaca and the
+            // FakeCameraDriver alike -- rejects StartExposure while CameraState is Exposing.
+            if (await ResilientInvokeAsync(camDriver, camDriver.GetCameraStateAsync, ResilientCallOptions.IdempotentRead, cancellationToken) is Devices.CameraState.Exposing)
+            {
+                await ResilientInvokeAsync(camDriver, camDriver.AbortExposureAsync, ResilientCallOptions.NonIdempotentAction, cancellationToken);
+                await _timeProvider.SleepAsync(TimeSpan.FromSeconds(1), cancellationToken);
+            }
+
             // Take a short exposure
             await camDriver.StartExposureAsync(exposureTime, cancellationToken: cancellationToken);
 


### PR DESCRIPTION
## Problem

`SessionObservationLoopTests.GivenAcrossMeridianTargetWhenHACrossesDeadbandThenFlipAndContinueImaging` was an intermittent CI flake (`TODO.md` "Flaky CI Tests"). It surfaced on the last merge to `main` as:

```
System.InvalidOperationException : Failed to start exposure frame type=Light and
duration 00:00:05 due to camera state being Exposing
```

A re-run with identical code passed, confirming a non-deterministic race rather than a logic break.

## Root cause

`PlateSolveAndSyncCoreAsync` (`Session.Focus.cs`) was the **only** `StartExposureAsync` call site in the session that fired a frame **without first ensuring the camera was `Idle`**. Every other site guards it:

| Call site | Guard |
|---|---|
| Imaging loop (`Session.Imaging.cs:505`) | only starts when `GetCameraStateAsync is Idle` |
| Condition-recovery (`Session.Imaging.cs:1329`) | aborts if `Exposing` first |
| Obstruction-scout (`Session.Imaging.Obstruction.cs:423`) | aborts if `Exposing` first |
| **Centering / plate-solve** (`Session.Focus.cs:810`) | **none** |

During a meridian flip the path is `imaging-loop -> PerformMeridianFlipAsync -> CenterOnTargetAsync -> PlateSolveAndSyncCoreAsync`, which fires a **5 s** plate-solve frame. Under the cooperative-time-pump's two-thread interleaving (the pump thread firing the exposure-stop timer vs. the loop thread), the prior **30 s** science sub-exposure can still be in `Exposing` when the solve frame starts. The driver -- `FakeCameraDriver` and real ASCOM/Alpaca alike -- rejects `StartExposure` while `CameraState != Idle`. That exception aborting the flip is also what produced the alternate `TotalFramesWritten=0` symptom recorded in the TODO.

## Fix

Mirror the established abort-then-settle guard at the centering site: if the camera reads `Exposing`, abort and let the `Download -> Idle` transition settle before the short solve exposure. It is airtight there because while centering runs the imaging-loop thread is blocked awaiting the flip, so nothing can re-enter `Exposing`. This also hardens real-hardware behaviour, not just the fake.

## Verification

- Previously-flaky test: **20/20 green** in a tight loop.
- Full functional suite: **294 passed, 0 failed**, 6 skipped (CI previously: 293 passed + 1 failed).
- Build: 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
