### PR TITLE
refactor(ui)!: adopt DIR.Lib 6.0 Layout namespace + dogfood Builder DSL

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -75,8 +75,15 @@
          5.1 adds markdown image parsing (![alt](url) -> MdImage node). Lockstep with
          Console.Lib 3.1 + SdlVulkan.Renderer 6.5.
          5.2 adds LayoutNode.Split (two resizable panes + a draw==hit divider), consumed by
-         the FITS-viewer single-source layout. Lockstep with Console.Lib 3.2 + SdlVulkan.Renderer 6.6. -->
-    <PackageVersion Include="DIR.Lib" Version="5.2.*" />
+         the FITS-viewer single-source layout. Lockstep with Console.Lib 3.2 + SdlVulkan.Renderer 6.6.
+         6.0 (MAJOR) moves the layout engine into a new DIR.Lib.Layout namespace and drops the redundant
+         `Layout` prefix (LayoutNode -> Layout.Node, LayoutEngine -> Layout.Engine, LayoutContent ->
+         Layout.Content, LayoutAxis -> Layout.Axis; Sizing/SizeKind/Size/DockChild/DockSide/ArrangedNode/
+         IMeasureContext move into the namespace too) + adds the Layout.Builder DSL & fluent Node modifiers
+         (.RowH()/.WStar()/.Bg()/.Clickable()/...). Source-breaking: consumers alias
+         `using Layout = DIR.Lib.Layout;` and write Layout.Node / Layout.Builder / Layout.Sizing. Lockstep
+         with Console.Lib 3.3 + SdlVulkan.Renderer 6.7. -->
+    <PackageVersion Include="DIR.Lib" Version="6.0.*" />
     <!-- DIR.Lib 3.0 extracted its codec layer to these sibling packages, which
          ship as a lockstep family from the StbImageSharp repo. 3.0 brought a
          binary-breaking SharpAstro.Tiff change (TiffPageOptions.IccProfile is
@@ -108,8 +115,9 @@
          against DIR.Lib 5.0 (lockstep with SdlVulkan.Renderer 6.4).
          3.1 renders markdown images (![alt](url)) to the terminal; rebuilt against
          DIR.Lib 5.1 (lockstep with SdlVulkan.Renderer 6.5).
-         3.2 is a no-code lockstep rebuild against DIR.Lib 5.2. -->
-    <PackageVersion Include="Console.Lib" Version="3.2.*" />
+         3.2 is a no-code lockstep rebuild against DIR.Lib 5.2.
+         3.3 is a no-code lockstep rebuild against DIR.Lib 6.0 (layout namespace + Layout.Builder DSL). -->
+    <PackageVersion Include="Console.Lib" Version="3.3.*" />
     <!-- SdlVulkan.Renderer 5.0 adds a multi-page SDF glyph atlas (no more grow
          stall / Adreno submit-wedge) on top of 4.1's SetSystemCursor + anisotropic
          glyph xScale. 5.1 implements DIR.Lib 4.4's PushClip/PopClip via Vulkan
@@ -128,8 +136,9 @@
          VkMenuWidget, superseded by DIR.Lib's surface-agnostic PixelMenuWidget.
          6.5 adds live-device offscreen thumbnail capture + per-page SDF LRU eviction;
          repinned to DIR.Lib 5.1 (lockstep with Console.Lib 3.1).
-         6.6 is a no-code lockstep rebuild against DIR.Lib 5.2 (LayoutNode.Split). -->
-    <PackageVersion Include="SdlVulkan.Renderer" Version="6.6.*" />
+         6.6 is a no-code lockstep rebuild against DIR.Lib 5.2 (LayoutNode.Split).
+         6.7 is a no-code lockstep rebuild against DIR.Lib 6.0 (layout namespace + Layout.Builder DSL). -->
+    <PackageVersion Include="SdlVulkan.Renderer" Version="6.7.*" />
     <PackageVersion Include="SDL3-CS" Version="3.5.0-preview.20260213-150035" />
     <PackageVersion Include="SDL3-CS.Native" Version="3.5.0-preview.20260205-174353" />
     <!-- Canon DSLR -->

--- a/src/TianWen.Lib.Tests/EquipmentPanelLayoutTests.cs
+++ b/src/TianWen.Lib.Tests/EquipmentPanelLayoutTests.cs
@@ -10,7 +10,7 @@ namespace TianWen.Lib.Tests
     /// <summary>
     /// Structural tests for <see cref="EquipmentPanelLayout"/> -- the bridge that turns the data-driven
     /// equipment content models (<see cref="DeviceSlotRow"/> / <see cref="OtaSummaryRow"/>) into the single
-    /// <see cref="LayoutNode"/> tree both the GPU and TUI painters consume. Asserts the per-OTA loop, the
+    /// <see cref="Layout.Node"/> tree both the GPU and TUI painters consume. Asserts the per-OTA loop, the
     /// whole-row clickable Hit carrying the <see cref="AssignTarget"/>, and the active-slot highlight.
     /// </summary>
     public class EquipmentPanelLayoutTests
@@ -29,42 +29,42 @@ namespace TianWen.Lib.Tests
             new DeviceSlotRow("Guider", "None", false, new AssignTarget.ProfileLevel("Guider")),
         ];
 
-        private static IEnumerable<LayoutNode> Flatten(LayoutNode node)
+        private static IEnumerable<Layout.Node> Flatten(Layout.Node node)
         {
             yield return node;
             switch (node)
             {
-                case LayoutNode.Stack s:
+                case Layout.Node.Stack s:
                     foreach (var child in s.Children)
                     {
                         foreach (var n in Flatten(child)) yield return n;
                     }
                     break;
-                case LayoutNode.Dock d:
+                case Layout.Node.Dock d:
                     foreach (var dc in d.Docked)
                     {
                         foreach (var n in Flatten(dc.Child)) yield return n;
                     }
                     foreach (var n in Flatten(d.Fill)) yield return n;
                     break;
-                case LayoutNode.Grid g:
+                case Layout.Node.Grid g:
                     foreach (var cell in g.Cells)
                     {
                         foreach (var n in Flatten(cell)) yield return n;
                     }
                     break;
-                case LayoutNode.Overlay o:
+                case Layout.Node.Overlay o:
                     foreach (var n in Flatten(o.Base)) yield return n;
                     foreach (var n in Flatten(o.Top)) yield return n;
                     break;
             }
         }
 
-        private static IEnumerable<string> TextLeaves(LayoutNode tree) =>
+        private static IEnumerable<string> TextLeaves(Layout.Node tree) =>
             Flatten(tree)
-                .OfType<LayoutNode.Leaf>()
+                .OfType<Layout.Node.Leaf>()
                 .Select(l => l.Content)
-                .OfType<LayoutContent.Text>()
+                .OfType<Layout.Content.Text>()
                 .Select(t => t.Value);
 
         [Fact]
@@ -124,7 +124,7 @@ namespace TianWen.Lib.Tests
                 n.Hit is HitResult.SlotHit<AssignTarget> { Slot: AssignTarget.ProfileLevel { Field: "Mount" } });
 
             mount.ShouldNotBeNull();
-            mount.ShouldBeOfType<LayoutNode.Stack>(); // the whole row, not just a leaf
+            mount.ShouldBeOfType<Layout.Node.Stack>(); // the whole row, not just a leaf
         }
 
         [Fact]
@@ -135,7 +135,7 @@ namespace TianWen.Lib.Tests
 
             var tree = EquipmentPanelLayout.Build("Rig", ProfileSlots(), [], style, activeSlot: active);
 
-            LayoutNode? RowFor(string field) => Flatten(tree).FirstOrDefault(n =>
+            Layout.Node? RowFor(string field) => Flatten(tree).FirstOrDefault(n =>
                 n.Hit is HitResult.SlotHit<AssignTarget> { Slot: AssignTarget.ProfileLevel p } && p.Field == field);
 
             RowFor("Mount")!.Background.ShouldBe(style.SlotActive);
@@ -193,7 +193,7 @@ namespace TianWen.Lib.Tests
             var row = FormRowLayout.LabeledInputRow(
                 "  Lat:", 50f, 24f, 6f, 12f, new RGBAColor32(0x80, 0x80, 0x80, 0xff));
             TextLeaves(row).ShouldContain("  Lat:");
-            var fills = Flatten(row).OfType<LayoutNode.Leaf>().Where(l => l.Content is LayoutContent.Fill).ToList();
+            var fills = Flatten(row).OfType<Layout.Node.Leaf>().Where(l => l.Content is Layout.Content.Fill).ToList();
             fills.ShouldHaveSingleItem();
         }
 
@@ -231,7 +231,7 @@ namespace TianWen.Lib.Tests
 
             // Full-height click target lives on the OUTER stack (so margin clicks hit the button, not
             // whatever is behind it); the coloured background lives on the INNER pill (the inset band).
-            row.ShouldBeOfType<LayoutNode.Stack>();
+            row.ShouldBeOfType<Layout.Node.Stack>();
             row.Hit.ShouldBeOfType<HitResult.ButtonHit>();
             row.Background.ShouldBeNull();
             TextLeaves(row).ShouldContain("Cancel");

--- a/src/TianWen.Lib.Tests/GlobalUsings.cs
+++ b/src/TianWen.Lib.Tests/GlobalUsings.cs
@@ -1,0 +1,3 @@
+// Namespace alias so layout call sites read as the qualified Layout.Node / Layout.Builder / Layout.Sizing
+// form (DIR.Lib's layout engine + DSL live in DIR.Lib.Layout). See TianWen.UI.Abstractions/GlobalUsings.cs.
+global using Layout = DIR.Lib.Layout;

--- a/src/TianWen.Lib.Tests/SessionConfigLayoutTests.cs
+++ b/src/TianWen.Lib.Tests/SessionConfigLayoutTests.cs
@@ -11,7 +11,7 @@ namespace TianWen.Lib.Tests
 {
     /// <summary>
     /// Structural tests for <see cref="SessionConfigLayout"/> -- the "full single-panel tree" (Phase 4):
-    /// the whole <see cref="SessionConfiguration"/> form built as ONE <see cref="LayoutNode"/> tree
+    /// the whole <see cref="SessionConfiguration"/> form built as ONE <see cref="Layout.Node"/> tree
     /// instead of a per-row cursor walk. Asserts one header per group, one selectable row per field with
     /// sequential indices, the right control per <see cref="ConfigFieldKind"/>, the selected-row
     /// highlight, the running-state handler drop, and that the click callbacks are wired.
@@ -42,47 +42,47 @@ namespace TianWen.Lib.Tests
         private static ConfigFieldDescriptor Field(string label) =>
             Groups.SelectMany(g => g.Fields).First(f => f.Label == label);
 
-        private static IEnumerable<LayoutNode> Flatten(LayoutNode node)
+        private static IEnumerable<Layout.Node> Flatten(Layout.Node node)
         {
             yield return node;
             switch (node)
             {
-                case LayoutNode.Stack s:
+                case Layout.Node.Stack s:
                     foreach (var child in s.Children)
                     {
                         foreach (var n in Flatten(child)) yield return n;
                     }
                     break;
-                case LayoutNode.Dock d:
+                case Layout.Node.Dock d:
                     foreach (var dc in d.Docked)
                     {
                         foreach (var n in Flatten(dc.Child)) yield return n;
                     }
                     foreach (var n in Flatten(d.Fill)) yield return n;
                     break;
-                case LayoutNode.Grid g:
+                case Layout.Node.Grid g:
                     foreach (var cell in g.Cells)
                     {
                         foreach (var n in Flatten(cell)) yield return n;
                     }
                     break;
-                case LayoutNode.Overlay o:
+                case Layout.Node.Overlay o:
                     foreach (var n in Flatten(o.Base)) yield return n;
                     foreach (var n in Flatten(o.Top)) yield return n;
                     break;
             }
         }
 
-        private static IEnumerable<string> TextLeaves(LayoutNode tree) =>
+        private static IEnumerable<string> TextLeaves(Layout.Node tree) =>
             Flatten(tree)
-                .OfType<LayoutNode.Leaf>()
+                .OfType<Layout.Node.Leaf>()
                 .Select(l => l.Content)
-                .OfType<LayoutContent.Text>()
+                .OfType<Layout.Content.Text>()
                 .Select(t => t.Value);
 
         // The top-level row for a given field index: the root child whose subtree carries that ConfigField hit.
-        private static LayoutNode RowFor(LayoutNode tree, int index) =>
-            ((LayoutNode.Stack)tree).Children.First(c =>
+        private static Layout.Node RowFor(Layout.Node tree, int index) =>
+            ((Layout.Node.Stack)tree).Children.First(c =>
                 Flatten(c).Any(n => n.Hit is HitResult.ListItemHit { ListId: "ConfigField" } li && li.Index == index));
 
         [Fact]

--- a/src/TianWen.UI.Abstractions/EquipmentPanelLayout.cs
+++ b/src/TianWen.UI.Abstractions/EquipmentPanelLayout.cs
@@ -27,13 +27,18 @@ namespace TianWen.UI.Abstractions
     }
 
     /// <summary>
-    /// Builds the surface-agnostic <see cref="LayoutNode"/> tree for the profile/equipment panel from the
+    /// Builds the surface-agnostic <see cref="Layout.Node"/> tree for the profile/equipment panel from the
     /// data-driven content models (<see cref="DeviceSlotRow"/> / <see cref="OtaSummaryRow"/> emitted by
     /// <see cref="EquipmentContent"/>). One tree, arranged + painted by BOTH the GPU pixel painter and the
     /// TUI cell painter -- so the per-OTA panel is genuinely data-driven (loop over the OTA set, no hardcoded
     /// slot sequence) and the two surfaces can no longer drift. Stateful/interactive sub-widgets (site editor,
     /// camera telemetry graph, filter-offset editors, device dropdowns) stay as imperative helpers; this
     /// builder owns the vertical flow + the repeating header/slot/OTA/filter structure.
+    /// <para>
+    /// Built with the <c>Layout.Builder</c> DSL -- the static row builders compose <c>Text</c>/<c>HStack</c>/
+    /// <c>Fill</c> with fluent <c>.WStar()</c>/<c>.RowH()</c>/<c>.Bg()</c>/<c>.Clickable()</c> modifiers; the
+    /// dynamic vertical flow aggregates the rows into <c>Builder.VStack(...)</c>.
+    /// </para>
     /// </summary>
     public static class EquipmentPanelLayout
     {
@@ -49,7 +54,7 @@ namespace TianWen.UI.Abstractions
         /// mode; <paramref name="onSlotClick"/> supplies the per-slot click handler (the host wires it to
         /// toggle assignment + request a redraw). Both are optional so the builder stays unit-testable.
         /// </summary>
-        public static LayoutNode Build(
+        public static Layout.Node Build(
             string profileName,
             IReadOnlyList<DeviceSlotRow> profileSlots,
             IReadOnlyList<OtaSummaryRow> otas,
@@ -59,7 +64,7 @@ namespace TianWen.UI.Abstractions
         {
             var palette = style.Theme.Palette;
             var metrics = style.Theme.Metrics;
-            var children = ImmutableArray.CreateBuilder<LayoutNode>();
+            var children = ImmutableArray.CreateBuilder<Layout.Node>();
 
             // Profile name header.
             children.Add(Header($"Profile: {profileName}", metrics.BaseFontSize * 1.1f, metrics.HeaderHeight, palette.HeaderText));
@@ -90,47 +95,35 @@ namespace TianWen.UI.Abstractions
                 }
             }
 
-            return new LayoutNode.Stack(children.ToImmutable(), LayoutAxis.Vertical, Gap: metrics.Padding * 0.25f)
-            {
-                Padding = metrics.Padding,
-                Width = Sizing.Star(),
-                Height = Sizing.Star(),
-                Background = palette.PanelBg,
-            };
+            return Layout.Builder.VStack(children.ToImmutable().AsSpan())
+                .WithGap(metrics.Padding * 0.25f)
+                .Pad(metrics.Padding)
+                .Stretch()
+                .Bg(palette.PanelBg);
         }
 
-        private static LayoutNode Header(string text, float fontSize, float height, RGBAColor32 color, RGBAColor32? background = null) =>
-            new LayoutNode.Leaf(new LayoutContent.Text(text, fontSize) { Color = color })
-            {
-                Height = Sizing.Fixed(height),
-                Width = Sizing.Star(),
-                Background = background,
-            };
+        private static Layout.Node Header(string text, float fontSize, float height, RGBAColor32 color, RGBAColor32? background = null)
+        {
+            var header = Layout.Builder.Text(text, fontSize, color).RowH(height);
+            return background is { } bg ? header.Bg(bg) : header;
+        }
 
-        private static LayoutNode Properties(string properties, UiMetrics metrics, UiPalette palette) =>
-            new LayoutNode.Leaf(new LayoutContent.Text(properties, metrics.BaseFontSize * 0.85f) { Color = palette.DimText })
-            {
-                Height = Sizing.Fixed(metrics.ItemHeight * 0.8f),
-                Width = Sizing.Star(),
-            };
+        private static Layout.Node Properties(string properties, UiMetrics metrics, UiPalette palette) =>
+            Layout.Builder.Text(properties, metrics.BaseFontSize * 0.85f, palette.DimText).RowH(metrics.ItemHeight * 0.8f);
 
-        private static LayoutNode SeparatorRow(UiPalette palette) =>
-            new LayoutNode.Leaf(new LayoutContent.Box(0f, 1f) { Color = palette.Separator })
-            {
-                Height = Sizing.Fixed(1f),
-                Width = Sizing.Star(),
-            };
+        private static Layout.Node SeparatorRow(UiPalette palette) =>
+            Layout.Builder.Box(0f, 1f, palette.Separator).RowH(1f);
 
         /// <summary>
         /// Builds one device-slot row: <c>[pad | label .35 | name * | indicator]</c> as a horizontal Stack
         /// whose whole rect carries the click <see cref="HitResult.SlotHit{T}"/> + handler + background
-        /// (draw-rect == hit-rect by construction). The indicator is a surface-neutral <see cref="LayoutContent.Fill"/>
+        /// (draw-rect == hit-rect by construction). The indicator is a surface-neutral <see cref="Layout.Content.Fill"/>
         /// slot painted by the caller's <c>drawFill</c> (the GPU panel draws a reachability dot or the
         /// <c>[&gt;]</c> arrow; a terminal panel draws its own glyph) -- which is what lets the live equipment
         /// panel and the (eventual) TUI panel share this exact structure. Public so the live
         /// <c>EquipmentTab</c> consumes it directly instead of re-deriving the row inline.
         /// </summary>
-        public static LayoutNode SlotRow(
+        public static Layout.Node SlotRow(
             DeviceSlotRow slot, EquipmentPanelStyle style, AssignTarget? activeSlot,
             Func<AssignTarget, Action<InputModifier>?>? onSlotClick)
         {
@@ -140,55 +133,38 @@ namespace TianWen.UI.Abstractions
 
             // Lead pad gives the label its left inset; every column's Height is Star so it stretches to
             // the full row height for vertical centring (Auto would collapse a Text leaf to glyph height).
-            var pad = new LayoutNode.Leaf(new LayoutContent.Box(0f, 0f)) { Width = Sizing.Fixed(metrics.Padding), Height = Sizing.Star() };
-            var label = new LayoutNode.Leaf(new LayoutContent.Text(slot.Label, metrics.BaseFontSize * 0.9f) { Color = palette.DimText })
-            {
-                Width = Sizing.Star(LabelShare), Height = Sizing.Star(),
-            };
-            var name = new LayoutNode.Leaf(new LayoutContent.Text(slot.DeviceName, metrics.BaseFontSize) { Color = palette.BodyText })
-            {
-                Width = Sizing.Star(1f - LabelShare), Height = Sizing.Star(),
-            };
-            var indicator = new LayoutNode.Leaf(new LayoutContent.Fill()) { Width = Sizing.Fixed(ArrowWidth), Height = Sizing.Star() };
+            var pad = Layout.Builder.Spacer().ColW(metrics.Padding);
+            var label = Layout.Builder.Text(slot.Label, metrics.BaseFontSize * 0.9f, palette.DimText).WStar(LabelShare).HStar();
+            var name = Layout.Builder.Text(slot.DeviceName, metrics.BaseFontSize, palette.BodyText).WStar(1f - LabelShare).HStar();
+            var indicator = Layout.Builder.Fill().ColW(ArrowWidth);
 
             // The whole row is clickable (Hit on the Stack), so a click anywhere toggles assignment.
-            return new LayoutNode.Stack([pad, label, name, indicator], LayoutAxis.Horizontal)
-            {
-                Height = Sizing.Fixed(metrics.ItemHeight),
-                Width = Sizing.Star(),
-                Background = isActive ? style.SlotActive : style.SlotNormal,
-                Hit = new HitResult.SlotHit<AssignTarget>(slot.Slot),
-                OnClick = onSlotClick?.Invoke(slot.Slot),
-            };
+            return Layout.Builder.HStack(pad, label, name, indicator)
+                .RowH(metrics.ItemHeight)
+                .Bg(isActive ? style.SlotActive : style.SlotNormal)
+                .Clickable(new HitResult.SlotHit<AssignTarget>(slot.Slot), onSlotClick?.Invoke(slot.Slot));
         }
 
-        private static LayoutNode FilterTable(IReadOnlyList<FilterSlotRow> filters, EquipmentPanelStyle style)
+        private static Layout.Node FilterTable(IReadOnlyList<FilterSlotRow> filters, EquipmentPanelStyle style)
         {
             var palette = style.Theme.Palette;
             var metrics = style.Theme.Metrics;
-            var rows = ImmutableArray.CreateBuilder<LayoutNode>();
+            var fontSize = metrics.BaseFontSize * 0.85f;
+            var rows = ImmutableArray.CreateBuilder<Layout.Node>();
             foreach (var f in filters)
             {
                 var offset = f.FocusOffset >= 0 ? $"+{f.FocusOffset}" : f.FocusOffset.ToString();
-                rows.Add(new LayoutNode.Stack(
-                [
-                    new LayoutNode.Leaf(new LayoutContent.Text($"{f.Position}", metrics.BaseFontSize * 0.85f) { Color = palette.DimText, HAlign = TextAlign.Far }) { Width = Sizing.Fixed(24f) },
-                    new LayoutNode.Leaf(new LayoutContent.Text(f.Name, metrics.BaseFontSize * 0.85f) { Color = palette.BodyText }) { Width = Sizing.Star() },
-                    new LayoutNode.Leaf(new LayoutContent.Text(offset, metrics.BaseFontSize * 0.85f) { Color = palette.DimText, HAlign = TextAlign.Far }) { Width = Sizing.Fixed(48f) },
-                ], LayoutAxis.Horizontal)
-                {
-                    Height = Sizing.Fixed(metrics.ItemHeight * 0.85f),
-                    Width = Sizing.Star(),
-                });
+                rows.Add(Layout.Builder.HStack(
+                    Layout.Builder.Text($"{f.Position}", fontSize, palette.DimText, TextAlign.Far).WFixed(24f),
+                    Layout.Builder.Text(f.Name, fontSize, palette.BodyText).WStar(),
+                    Layout.Builder.Text(offset, fontSize, palette.DimText, TextAlign.Far).WFixed(48f))
+                    .RowH(metrics.ItemHeight * 0.85f));
             }
 
-            return new LayoutNode.Stack(rows.ToImmutable(), LayoutAxis.Vertical)
-            {
-                Width = Sizing.Star(),
-                Height = Sizing.Auto,
-                Padding = metrics.Padding * 0.5f,
-                Background = style.FilterTableBg,
-            };
+            return Layout.Builder.VStack(rows.ToImmutable().AsSpan())
+                .WStar()
+                .Pad(metrics.Padding * 0.5f)
+                .Bg(style.FilterTableBg);
         }
     }
 }

--- a/src/TianWen.UI.Abstractions/EquipmentTab.cs
+++ b/src/TianWen.UI.Abstractions/EquipmentTab.cs
@@ -547,16 +547,16 @@ namespace TianWen.UI.Abstractions
                 var siteStr = $"  Site: {latStr}, {lonStr}{elevStr}";
 
                 var siteBtnW = w - padding * 2f;
-                var siteRow = new LayoutNode.Stack(
+                var siteRow = new Layout.Node.Stack(
                 [
-                    new LayoutNode.Leaf(new LayoutContent.Text(siteStr, BaseFontSize * 0.9f) { Color = SiteText, HAlign = TextAlign.Near, VAlign = TextAlign.Center })
-                        { Width = Sizing.Star(), Height = Sizing.Star() },
-                    new LayoutNode.Leaf(new LayoutContent.Text("[>]", BaseFontSize * 0.85f) { Color = DimText, HAlign = TextAlign.Center, VAlign = TextAlign.Center })
-                        { Width = Sizing.Fixed(arrowW), Height = Sizing.Star() },
-                ], LayoutAxis.Horizontal)
+                    new Layout.Node.Leaf(new Layout.Content.Text(siteStr, BaseFontSize * 0.9f) { Color = SiteText, HAlign = TextAlign.Near, VAlign = TextAlign.Center })
+                        { Width = Layout.Sizing.Star(), Height = Layout.Sizing.Star() },
+                    new Layout.Node.Leaf(new Layout.Content.Text("[>]", BaseFontSize * 0.85f) { Color = DimText, HAlign = TextAlign.Center, VAlign = TextAlign.Center })
+                        { Width = Layout.Sizing.Fixed(arrowW), Height = Layout.Sizing.Star() },
+                ], Layout.Axis.Horizontal)
                 {
-                    Width = Sizing.Fixed(siteBtnW),
-                    Height = Sizing.Fixed(itemH),
+                    Width = Layout.Sizing.Fixed(siteBtnW),
+                    Height = Layout.Sizing.Fixed(itemH),
                     Background = SlotNormal,
                     Hit = new HitResult.ButtonHit("EditSite"),
                     OnClick = _ => PostSignal(new EditSiteSignal()),
@@ -568,10 +568,10 @@ namespace TianWen.UI.Abstractions
             {
                 // No site configured -- show "Set Site" button
                 var setSiteBtnW = Renderer.MeasureText("Set Site".AsSpan(), fontPath, fontSize).Width + padding * 4f;
-                var setSiteLeaf = new LayoutNode.Leaf(new LayoutContent.Text("Set Site", BaseFontSize) { Color = BodyText, HAlign = TextAlign.Center, VAlign = TextAlign.Center })
+                var setSiteLeaf = new Layout.Node.Leaf(new Layout.Content.Text("Set Site", BaseFontSize) { Color = BodyText, HAlign = TextAlign.Center, VAlign = TextAlign.Center })
                 {
-                    Width = Sizing.Fixed(setSiteBtnW),
-                    Height = Sizing.Fixed(buttonH),
+                    Width = Layout.Sizing.Fixed(setSiteBtnW),
+                    Height = Layout.Sizing.Fixed(buttonH),
                     Background = CreateButton,
                     Hit = new HitResult.ButtonHit("EditSite"),
                     OnClick = _ => PostSignal(new EditSiteSignal()),
@@ -623,22 +623,22 @@ namespace TianWen.UI.Abstractions
                 || OtaDeviceConnected(ota.FilterWheel) || OtaDeviceConnected(ota.Cover);
 
             // Title leaf (left, takes remaining width after the two buttons)
-            var titleLeaf = new LayoutNode.Leaf(
-                new LayoutContent.Text($"Telescope #{index}: {ota.Name}", BaseFontSize) { Color = HeaderText, HAlign = TextAlign.Near, VAlign = TextAlign.Center })
+            var titleLeaf = new Layout.Node.Leaf(
+                new Layout.Content.Text($"Telescope #{index}: {ota.Name}", BaseFontSize) { Color = HeaderText, HAlign = TextAlign.Near, VAlign = TextAlign.Center })
             {
-                Width = Sizing.Star(),
-                Height = Sizing.Star(),
+                Width = Layout.Sizing.Star(),
+                Height = Layout.Sizing.Star(),
             };
 
             // [Remove] button leaf -- disabled grey when a device is connected; armed/normal otherwise
-            LayoutNode removeLeaf;
+            Layout.Node removeLeaf;
             if (otaHasConnectedDevice)
             {
-                removeLeaf = new LayoutNode.Leaf(
-                    new LayoutContent.Text("Remove", BaseFontSize * 0.85f) { Color = DimmedText, HAlign = TextAlign.Center, VAlign = TextAlign.Center })
+                removeLeaf = new Layout.Node.Leaf(
+                    new Layout.Content.Text("Remove", BaseFontSize * 0.85f) { Color = DimmedText, HAlign = TextAlign.Center, VAlign = TextAlign.Center })
                 {
-                    Width = Sizing.Fixed(removeBtnW),
-                    Height = Sizing.Star(),
+                    Width = Layout.Sizing.Fixed(removeBtnW),
+                    Height = Layout.Sizing.Star(),
                     Background = SegmentDisabled,
                     // No Hit, no OnClick -- disabled
                 };
@@ -646,11 +646,11 @@ namespace TianWen.UI.Abstractions
             else
             {
                 var armed = State.PendingRemoveOtaIndex == index;
-                removeLeaf = new LayoutNode.Leaf(
-                    new LayoutContent.Text(armed ? "Confirm?" : "Remove", BaseFontSize * 0.85f) { Color = BodyText, HAlign = TextAlign.Center, VAlign = TextAlign.Center })
+                removeLeaf = new Layout.Node.Leaf(
+                    new Layout.Content.Text(armed ? "Confirm?" : "Remove", BaseFontSize * 0.85f) { Color = BodyText, HAlign = TextAlign.Center, VAlign = TextAlign.Center })
                 {
-                    Width = Sizing.Fixed(removeBtnW),
-                    Height = Sizing.Star(),
+                    Width = Layout.Sizing.Fixed(removeBtnW),
+                    Height = Layout.Sizing.Star(),
                     Background = armed ? ConfirmDangerBg : RemoveButtonBg,
                     Hit = new HitResult.ButtonHit($"RemoveOta{index}"),
                     OnClick = _ =>
@@ -673,19 +673,19 @@ namespace TianWen.UI.Abstractions
             }
 
             // Gap leaf between Remove and Edit
-            var gapLeaf = new LayoutNode.Leaf(new LayoutContent.Box(0f, 0f))
+            var gapLeaf = new Layout.Node.Leaf(new Layout.Content.Box(0f, 0f))
             {
-                Width = Sizing.Fixed(btnGap),
-                Height = Sizing.Star(),
+                Width = Layout.Sizing.Fixed(btnGap),
+                Height = Layout.Sizing.Star(),
             };
 
             // [Edit]/[Save] toggle button leaf
             var editLabel = isEditingOta ? "Save" : "Edit";
-            var editLeaf = new LayoutNode.Leaf(
-                new LayoutContent.Text(editLabel, BaseFontSize * 0.85f) { Color = BodyText, HAlign = TextAlign.Center, VAlign = TextAlign.Center })
+            var editLeaf = new Layout.Node.Leaf(
+                new Layout.Content.Text(editLabel, BaseFontSize * 0.85f) { Color = BodyText, HAlign = TextAlign.Center, VAlign = TextAlign.Center })
             {
-                Width = Sizing.Fixed(editBtnW),
-                Height = Sizing.Star(),
+                Width = Layout.Sizing.Fixed(editBtnW),
+                Height = Layout.Sizing.Star(),
                 Background = EditButtonBg,
                 Hit = new HitResult.ButtonHit($"EditOta{index}"),
                 OnClick = _ =>
@@ -712,10 +712,10 @@ namespace TianWen.UI.Abstractions
             };
 
             // Build the full header row as a horizontal Stack
-            var headerRow = new LayoutNode.Stack([titleLeaf, removeLeaf, gapLeaf, editLeaf], LayoutAxis.Horizontal)
+            var headerRow = new Layout.Node.Stack([titleLeaf, removeLeaf, gapLeaf, editLeaf], Layout.Axis.Horizontal)
             {
-                Width = Sizing.Fixed(w),
-                Height = Sizing.Fixed(itemH),
+                Width = Layout.Sizing.Fixed(w),
+                Height = Layout.Sizing.Fixed(itemH),
                 Background = OtaHeaderBg,
             };
             RenderLayout(headerRow, new RectF32(x, cursor, w, itemH), fontPath, dpiScale);
@@ -906,7 +906,7 @@ namespace TianWen.UI.Abstractions
                 var capturedIdx = i;
                 // Row background + whole-row select hit as one draw==hit leaf; the badge/name/status/segment
                 // content draws on top below (later registrations win, so the segment beats the row hit).
-                var rowLeaf = new LayoutNode.Leaf(new LayoutContent.Box(0f, 0f))
+                var rowLeaf = new Layout.Node.Leaf(new Layout.Content.Box(0f, 0f))
                 {
                     Background = isCurrentForSlot ? SlotActive : baseBg,
                     Hit = new HitResult.ListItemHit("Devices", i),
@@ -1107,7 +1107,7 @@ namespace TianWen.UI.Abstractions
             var capUri = cameraUri;
             const float font = 0.78f;
             // Three equal inset pills; gap is a design unit (2 du) so it scales with DPI.
-            var strip = new LayoutNode.Stack(
+            var strip = new Layout.Node.Stack(
             [
                 FormRowLayout.InsetPillButton("Warm up & Off", BaseFontSize * font, ConfirmWarmBg, BodyText,
                     new HitResult.ButtonHit("WarmCoolerOff"), _ => PostSignal(new WarmAndCoolerOffSignal(capUri))),
@@ -1125,7 +1125,7 @@ namespace TianWen.UI.Abstractions
                         State.PendingCoolerOffConfirm = null;
                         State.PendingCoolerOffForceConfirm = null;
                     }),
-            ], LayoutAxis.Horizontal, 2f);
+            ], Layout.Axis.Horizontal, 2f);
             RenderLayout(strip, new RectF32(x, y, w, h), fontPath, dpiScale);
 
             return y + h;
@@ -1140,7 +1140,7 @@ namespace TianWen.UI.Abstractions
         {
             var capUri = cameraUri;
             // [Cancel] LEFT, destructive [REALLY FORCE] RIGHT (anti-double-click position swap); two pills, gap 4 du.
-            var strip = new LayoutNode.Stack(
+            var strip = new Layout.Node.Stack(
             [
                 FormRowLayout.InsetPillButton("Cancel", BaseFontSize * 0.8f, ConfirmCancelBg, BodyText,
                     new HitResult.ButtonHit("CancelForceCoolerOff"),
@@ -1156,7 +1156,7 @@ namespace TianWen.UI.Abstractions
                         State.PendingCoolerOffForceConfirm = null;
                         PostSignal(new SetCoolerOffSignal(capUri));
                     }),
-            ], LayoutAxis.Horizontal, 4f);
+            ], Layout.Axis.Horizontal, 4f);
             RenderLayout(strip, new RectF32(x, y, w, h), fontPath, dpiScale);
 
             return y + h;
@@ -1184,7 +1184,7 @@ namespace TianWen.UI.Abstractions
             var capUri = deviceUri;
             const float font = 0.75f;
             // Order: [Warm/Wait & Off] [Force Off -> escalates to stage 2] [Cancel]; three equal inset pills, gap 2 du.
-            var strip = new LayoutNode.Stack(
+            var strip = new Layout.Node.Stack(
             [
                 FormRowLayout.InsetPillButton(safetyLabel, BaseFontSize * font, ConfirmWarmBg, BodyText,
                     new HitResult.ButtonHit("WarmDisconnect"), _ => PostSignal(new WarmAndDisconnectDeviceSignal(capUri))),
@@ -1202,7 +1202,7 @@ namespace TianWen.UI.Abstractions
                         State.PendingDisconnectConfirm = null;
                         State.PendingForceConfirm = null;
                     }),
-            ], LayoutAxis.Horizontal, 2f);
+            ], Layout.Axis.Horizontal, 2f);
             RenderLayout(strip, new RectF32(x, y, w, h), fontPath, dpiScale);
         }
 
@@ -1219,7 +1219,7 @@ namespace TianWen.UI.Abstractions
             // [Cancel] LEFT (where [Warm & Off] was), destructive [REALLY FORCE] RIGHT (where [Cancel] was):
             // the reversed pairing means a double-click that started on [Force Off] (middle of stage 1) lands
             // on the [Cancel] half, never the destructive button. Two equal inset pills, gap 4 du.
-            var strip = new LayoutNode.Stack(
+            var strip = new Layout.Node.Stack(
             [
                 FormRowLayout.InsetPillButton("Cancel", BaseFontSize * 0.8f, ConfirmCancelBg, BodyText,
                     new HitResult.ButtonHit("CancelForce"),
@@ -1235,7 +1235,7 @@ namespace TianWen.UI.Abstractions
                         State.PendingForceConfirm = null;
                         PostSignal(new ForceDisconnectDeviceSignal(capUri));
                     }),
-            ], LayoutAxis.Horizontal, 4f);
+            ], Layout.Axis.Horizontal, 4f);
             RenderLayout(strip, new RectF32(x, y, w, h), fontPath, dpiScale);
         }
 
@@ -1273,13 +1273,13 @@ namespace TianWen.UI.Abstractions
             var capturedUri = deviceUri;
             Action<InputModifier> onAction = _ => { if (!isConnected) PostSignal(new ConnectDeviceSignal(capturedUri)); };
             Action<InputModifier> offAction = _ => { if (isConnected) PostSignal(new DisconnectDeviceSignal(capturedUri)); };
-            var seg = new LayoutNode.Stack(
+            var seg = new Layout.Node.Stack(
             [
                 FormRowLayout.InsetPillButton(onLabel, BaseFontSize * 0.85f, onBg, BodyText,
                     pending ? null : new HitResult.ButtonHit("Connect"), pending ? null : onAction),
                 FormRowLayout.InsetPillButton(offLabel, BaseFontSize * 0.85f, offBg, BodyText,
                     pending ? null : new HitResult.ButtonHit("Disconnect"), pending ? null : offAction),
-            ], LayoutAxis.Horizontal, 1f);
+            ], Layout.Axis.Horizontal, 1f);
             RenderLayout(seg, new RectF32(x, y, w, h), fontPath, dpiScale);
         }
 
@@ -1821,7 +1821,7 @@ namespace TianWen.UI.Abstractions
             var btnW = Math.Max(measured, minBtnW);
             var btnX = x + w - padding - btnW;
             // Background + label + (enabled-only) hit as one draw==hit leaf.
-            var connectAllBtn = new LayoutNode.Leaf(new LayoutContent.Text(label, BaseFontSize * 0.95f) { Color = BodyText, HAlign = TextAlign.Center, VAlign = TextAlign.Center })
+            var connectAllBtn = new Layout.Node.Leaf(new Layout.Content.Text(label, BaseFontSize * 0.95f) { Color = BodyText, HAlign = TextAlign.Center, VAlign = TextAlign.Center })
             {
                 Background = bg,
                 Hit = enabled ? new HitResult.ButtonHit("ConnectAll") : null,

--- a/src/TianWen.UI.Abstractions/FormRowLayout.cs
+++ b/src/TianWen.UI.Abstractions/FormRowLayout.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Immutable;
 using DIR.Lib;
 
 namespace TianWen.UI.Abstractions
@@ -12,6 +11,11 @@ namespace TianWen.UI.Abstractions
     /// truth, so the GPU panel and a future TUI panel build the same trees. Equipment-panel structure
     /// that is genuinely equipment-typed (the per-OTA <see cref="EquipmentPanelLayout.Build"/>,
     /// <c>SlotRow</c>, header/properties/filter-table) stays in <see cref="EquipmentPanelLayout"/>.
+    /// <para>
+    /// Built with the <c>Layout.Builder</c> DSL: factories (<c>Text</c>/<c>HStack</c>/<c>Spacer</c>) plus
+    /// fluent modifiers (<c>.WFixed()</c>/<c>.RowH()</c>/<c>.Bg()</c>/<c>.Clickable()</c>) emit the same
+    /// <c>Layout.Node</c> records a hand-written initializer would, with the chrome read as a chain.
+    /// </para>
     /// </summary>
     public static class FormRowLayout
     {
@@ -26,7 +30,7 @@ namespace TianWen.UI.Abstractions
             float ButtonFontSize, float ButtonDesignW);
 
         /// <summary>
-        /// Builds a control-only stepper <c>[dec | value | inc]</c> as one <see cref="LayoutNode"/>.
+        /// Builds a control-only stepper <c>[dec | value | inc]</c> as one <see cref="Layout.Node"/>.
         /// The buttons are <c>Fixed</c> at <see cref="StepperStyle.ButtonDesignW"/> design units (the
         /// engine scales by dpiScale); the value cell is <c>Star</c> so it fills the remaining width --
         /// callers size the bounds rect = buttonW + valueW + buttonW so the value column equals the
@@ -34,7 +38,7 @@ namespace TianWen.UI.Abstractions
         /// (PaintLayout re-applies dpiScale). A disabled control keeps its hit regions but drops the
         /// click handlers (dimmed), so the layout/hit-test surface is unchanged.
         /// </summary>
-        public static LayoutNode StepperControl(
+        public static Layout.Node StepperControl(
             in StepperStyle style,
             string decGlyph, string decHit, Action<InputModifier> onDec,
             string incGlyph, string incHit, Action<InputModifier> onInc,
@@ -46,102 +50,66 @@ namespace TianWen.UI.Abstractions
             var btnW = style.ButtonDesignW;
             var canClick = enabled;
 
-            LayoutNode Btn(string glyph, string hit, Action<InputModifier> onClick) =>
-                new LayoutNode.Leaf(new LayoutContent.Text(glyph, btnFont) { Color = btnText, HAlign = TextAlign.Center, VAlign = TextAlign.Center })
-                {
-                    Width = Sizing.Fixed(btnW),
-                    Height = Sizing.Star(),
-                    Background = btnBg,
-                    Hit = new HitResult.ButtonHit(hit),
-                    OnClick = canClick ? onClick : null,
-                };
+            Layout.Node Btn(string glyph, string hit, Action<InputModifier> onClick) =>
+                Layout.Builder.Text(glyph, btnFont, btnText, TextAlign.Center, TextAlign.Center)
+                    .WFixed(btnW).HStar().Bg(btnBg)
+                    .Clickable(new HitResult.ButtonHit(hit), canClick ? onClick : null);
 
-            var value = new LayoutNode.Leaf(
-                new LayoutContent.Text(valueText, valueFontSize) { Color = valueColor, HAlign = TextAlign.Center, VAlign = TextAlign.Center })
-            {
-                Width = Sizing.Star(),
-                Height = Sizing.Star(),
-            };
+            var value = Layout.Builder.Text(valueText, valueFontSize, valueColor, TextAlign.Center, TextAlign.Center).Stretch();
 
-            return new LayoutNode.Stack([Btn(decGlyph, decHit, onDec), value, Btn(incGlyph, incHit, onInc)], LayoutAxis.Horizontal);
+            return Layout.Builder.HStack(Btn(decGlyph, decHit, onDec), value, Btn(incGlyph, incHit, onInc));
         }
 
         /// <summary>
         /// One "pill" button for a confirmation / segmented strip: a full-cell click target whose coloured
         /// background is inset vertically to <paramref name="fillFraction"/> of the cell height (the classic
         /// inset-pill look), with the label centred over the whole cell. The engine binds both
-        /// <see cref="LayoutNode.Background"/> and <see cref="LayoutNode.Hit"/> to a node's <i>whole</i> rect, so
+        /// <see cref="Layout.Node.Background"/> and <see cref="Layout.Node.Hit"/> to a node's <i>whole</i> rect, so
         /// an inset background and a full-height hit cannot share one leaf -- this is a vertical Stack
         /// <c>[spacer | pill | spacer]</c> with the Hit on the outer Stack (full height) and the Background on
         /// the inner pill (the inset band). The spacers are <c>Star</c>-sized, so the inset stays a true
         /// fraction of the row at any DPI with no pixel/design-unit conversion. A null <paramref name="hit"/>
         /// (or <paramref name="onClick"/>) leaves the cell inert -- clicks fall through to whatever is behind.
         /// </summary>
-        public static LayoutNode InsetPillButton(
+        public static Layout.Node InsetPillButton(
             string label, float fontSize, RGBAColor32 bg, RGBAColor32 textColor,
             HitResult? hit, Action<InputModifier>? onClick,
             float widthWeight = 1f, float fillFraction = 0.7f)
         {
             var insetWeight = (1f - fillFraction) * 0.5f;
-            LayoutNode Spacer() => new LayoutNode.Leaf(new LayoutContent.Box(0f, 0f)) { Height = Sizing.Star(insetWeight) };
-            var pill = new LayoutNode.Leaf(new LayoutContent.Text(label, fontSize) { Color = textColor, HAlign = TextAlign.Center, VAlign = TextAlign.Center })
-            {
-                Width = Sizing.Star(),
-                Height = Sizing.Star(fillFraction),
-                Background = bg,
-            };
-            return new LayoutNode.Stack([Spacer(), pill, Spacer()], LayoutAxis.Vertical)
-            {
-                Width = Sizing.Star(widthWeight),
-                Height = Sizing.Star(),
-                Hit = hit,
-                OnClick = onClick,
-            };
+            Layout.Node Spacer() => Layout.Builder.Spacer().HStar(insetWeight);
+            var pill = Layout.Builder.Text(label, fontSize, textColor, TextAlign.Center, TextAlign.Center)
+                .WStar().HStar(fillFraction).Bg(bg);
+            return Layout.Builder.VStack(Spacer(), pill, Spacer())
+                .WStar(widthWeight).HStar()
+                .Clickable(hit, onClick);
         }
 
         /// <summary>
         /// Builds a clickable toggle-header row: background + hit + label text.
         /// Used for collapsible sections (Filter table, Cooler Control, Mount Status, Device Settings, Advanced sub-section).
         /// </summary>
-        public static LayoutNode ToggleHeaderRow(
+        public static Layout.Node ToggleHeaderRow(
             string label, float rowH,
             RGBAColor32 bg, RGBAColor32 textColor, float fontSize,
             HitResult hit, Action<InputModifier>? onClick)
         {
-            return new LayoutNode.Leaf(new LayoutContent.Text(label, fontSize) { Color = textColor, HAlign = TextAlign.Near, VAlign = TextAlign.Center })
-            {
-                Width = Sizing.Star(),
-                Height = Sizing.Fixed(rowH),
-                Background = bg,
-                Hit = hit,
-                OnClick = onClick,
-            };
+            return Layout.Builder.Text(label, fontSize, textColor)
+                .RowH(rowH).Bg(bg).Clickable(hit, onClick);
         }
 
         /// <summary>
         /// Builds a horizontal labeled-input row: [label fixed-labelW | Fill *].
         /// The Fill is the escape hatch for the caller's RenderTextInput call (one per RenderLayout).
         /// </summary>
-        public static LayoutNode LabeledInputRow(
+        public static Layout.Node LabeledInputRow(
             string label, float labelW, float rowH, float padding, float fontSize,
             RGBAColor32 textColor, RGBAColor32? bg = null)
         {
-            var labelLeaf = new LayoutNode.Leaf(new LayoutContent.Text(label, fontSize) { Color = textColor, HAlign = TextAlign.Near, VAlign = TextAlign.Center })
-            {
-                Width = Sizing.Fixed(labelW),
-                Height = Sizing.Star(),
-            };
-            var fillLeaf = new LayoutNode.Leaf(new LayoutContent.Fill())
-            {
-                Width = Sizing.Star(),
-                Height = Sizing.Star(),
-            };
-            return new LayoutNode.Stack([labelLeaf, fillLeaf], LayoutAxis.Horizontal)
-            {
-                Width = Sizing.Star(),
-                Height = Sizing.Fixed(rowH),
-                Background = bg,
-            };
+            var labelLeaf = Layout.Builder.Text(label, fontSize, textColor).WFixed(labelW).HStar();
+            var fillLeaf = Layout.Builder.Fill().Stretch();
+            var row = Layout.Builder.HStack(labelLeaf, fillLeaf).WStar().HFixed(rowH);
+            return bg is { } b ? row.Bg(b) : row;
         }
 
         /// <summary>
@@ -149,7 +117,7 @@ namespace TianWen.UI.Abstractions
         /// Disabled dec/inc = no Hit on the respective button leaf. (The control-only variant, where the
         /// label is drawn by the caller, is <see cref="StepperControl"/>.)
         /// </summary>
-        public static LayoutNode StepperRow(
+        public static Layout.Node StepperRow(
             string label, string valueText, float rowH, float padding,
             float fontSize, float stepBtnW,
             RGBAColor32 rowBg, RGBAColor32 btnBg, RGBAColor32 labelColor, RGBAColor32 valueColor, RGBAColor32 bodyText,
@@ -157,38 +125,22 @@ namespace TianWen.UI.Abstractions
             string incHitKey, Action<InputModifier>? onInc,
             bool decEnabled = true, bool incEnabled = true)
         {
-            var labelLeaf = new LayoutNode.Leaf(new LayoutContent.Text(label, fontSize) { Color = labelColor, HAlign = TextAlign.Near, VAlign = TextAlign.Center })
+            var labelLeaf = Layout.Builder.Text(label, fontSize, labelColor).Stretch();
+
+            // A disabled step button keeps its cell but drops the background fill + hit + handler (dimmed).
+            Layout.Node StepBtn(string glyph, string hitKey, Action<InputModifier>? onClick, bool stepEnabled)
             {
-                Width = Sizing.Star(),
-                Height = Sizing.Star(),
-            };
-            var decLeaf = new LayoutNode.Leaf(new LayoutContent.Text("-", fontSize) { Color = bodyText, HAlign = TextAlign.Center, VAlign = TextAlign.Center })
-            {
-                Width = Sizing.Fixed(stepBtnW),
-                Height = Sizing.Star(),
-                Background = decEnabled ? btnBg : (RGBAColor32?)null,
-                Hit = decEnabled ? new HitResult.ButtonHit(decHitKey) : null,
-                OnClick = decEnabled ? onDec : null,
-            };
-            var valueLeaf = new LayoutNode.Leaf(new LayoutContent.Text(valueText, fontSize) { Color = valueColor, HAlign = TextAlign.Center, VAlign = TextAlign.Center })
-            {
-                Width = Sizing.Fixed(stepBtnW * 2f),
-                Height = Sizing.Star(),
-            };
-            var incLeaf = new LayoutNode.Leaf(new LayoutContent.Text("+", fontSize) { Color = bodyText, HAlign = TextAlign.Center, VAlign = TextAlign.Center })
-            {
-                Width = Sizing.Fixed(stepBtnW),
-                Height = Sizing.Star(),
-                Background = incEnabled ? btnBg : (RGBAColor32?)null,
-                Hit = incEnabled ? new HitResult.ButtonHit(incHitKey) : null,
-                OnClick = incEnabled ? onInc : null,
-            };
-            return new LayoutNode.Stack([labelLeaf, decLeaf, valueLeaf, incLeaf], LayoutAxis.Horizontal)
-            {
-                Width = Sizing.Star(),
-                Height = Sizing.Fixed(rowH),
-                Background = rowBg,
-            };
+                var btn = Layout.Builder.Text(glyph, fontSize, bodyText, TextAlign.Center, TextAlign.Center).WFixed(stepBtnW).HStar();
+                return stepEnabled
+                    ? btn.Bg(btnBg).Clickable(new HitResult.ButtonHit(hitKey), onClick)
+                    : btn;
+            }
+
+            var decLeaf = StepBtn("-", decHitKey, onDec, decEnabled);
+            var valueLeaf = Layout.Builder.Text(valueText, fontSize, valueColor, TextAlign.Center, TextAlign.Center).WFixed(stepBtnW * 2f).HStar();
+            var incLeaf = StepBtn("+", incHitKey, onInc, incEnabled);
+
+            return Layout.Builder.HStack(labelLeaf, decLeaf, valueLeaf, incLeaf).RowH(rowH).Bg(rowBg);
         }
     }
 }

--- a/src/TianWen.UI.Abstractions/GlobalUsings.cs
+++ b/src/TianWen.UI.Abstractions/GlobalUsings.cs
@@ -1,0 +1,4 @@
+// Namespace alias so layout call sites read as the qualified Layout.Node / Layout.Builder / Layout.Sizing
+// form. DIR.Lib's layout engine + the Builder DSL live in the DIR.Lib.Layout namespace; aliasing it keeps the
+// call sites qualified without importing the namespace's collision-prone barewords (Node, Content, Size<T>).
+global using Layout = DIR.Lib.Layout;

--- a/src/TianWen.UI.Abstractions/ImageRendererBase.cs
+++ b/src/TianWen.UI.Abstractions/ImageRendererBase.cs
@@ -306,7 +306,7 @@ namespace TianWen.UI.Abstractions
         // Single-source layout pass
         //
         // The whole below-toolbar chrome derives its geometry from ONE arrangement:
-        // LayoutNode.Split (file list + draggable divider) wrapping a Dock (right-edge
+        // Layout.Node.Split (file list + draggable divider) wrapping a Dock (right-edge
         // info panel + fill image). Every consumer reads the arranged pane rects + the
         // single image placement below -- the fileListW/panelW/areaW/offsetX formula is
         // no longer copy-pasted per consumer and "happens to agree". The divider is the
@@ -318,7 +318,7 @@ namespace TianWen.UI.Abstractions
         private readonly record struct ImagePlacement(float OffsetX, float OffsetY, float DrawW, float DrawH, float Scale);
 
         private ViewerLayout _layout;
-        private ImmutableArray<ArrangedNode<float>> _layoutArranged;
+        private ImmutableArray<Layout.ArrangedNode<float>> _layoutArranged;
         private ImagePlacement _placement;
 
         /// <summary>Design-unit thickness of the file-list resize divider (the Split divider IS the grab bar).</summary>
@@ -328,17 +328,17 @@ namespace TianWen.UI.Abstractions
         {
             var below = new RectF32(0f, ToolbarHeight, Width, Height - ToolbarHeight - StatusBarHeight);
 
-            LayoutNode content = state.ShowInfoPanel
-                ? new LayoutNode.Dock(
-                    [new DockChild(DockSide.Right, new LayoutNode.Leaf(new LayoutContent.Fill(Key: "infoPanel")), Sizing.Fixed(BaseInfoPanelWidth))],
-                    new LayoutNode.Leaf(new LayoutContent.Fill(Key: "image")))
-                : new LayoutNode.Leaf(new LayoutContent.Fill(Key: "image"));
+            Layout.Node content = state.ShowInfoPanel
+                ? new Layout.Node.Dock(
+                    [new Layout.DockChild(Layout.DockSide.Right, new Layout.Node.Leaf(new Layout.Content.Fill(Key: "infoPanel")), Layout.Sizing.Fixed(BaseInfoPanelWidth))],
+                    new Layout.Node.Leaf(new Layout.Content.Fill(Key: "image")))
+                : new Layout.Node.Leaf(new Layout.Content.Fill(Key: "image"));
 
-            LayoutNode root = state.ShowFileList
-                ? new LayoutNode.Split(
-                    new LayoutNode.Leaf(new LayoutContent.Fill(Key: "fileList")),
+            Layout.Node root = state.ShowFileList
+                ? new Layout.Node.Split(
+                    new Layout.Node.Leaf(new Layout.Content.Fill(Key: "fileList")),
                     content,
-                    LayoutAxis.Horizontal,
+                    Layout.Axis.Horizontal,
                     FirstExtent: state.FileListWidthBase,
                     DividerThickness: BaseFileListDividerWidth,
                     DividerHit: new ResizeHandleHit("FileList"),
@@ -350,7 +350,7 @@ namespace TianWen.UI.Abstractions
             RectF32 fileList = default, image = default, infoPanel = default;
             foreach (var (node, b) in _layoutArranged)
             {
-                if (node is LayoutNode.Leaf { Content: LayoutContent.Fill fill })
+                if (node is Layout.Node.Leaf { Content: Layout.Content.Fill fill })
                 {
                     var r = new RectF32(b.X, b.Y, b.Width, b.Height);
                     switch (fill.Key)

--- a/src/TianWen.UI.Abstractions/LiveSessionTab.cs
+++ b/src/TianWen.UI.Abstractions/LiveSessionTab.cs
@@ -570,11 +570,11 @@ namespace TianWen.UI.Abstractions
                 // draw==hit leaf -- background, label, and click region all bind to one node's rect
                 // (rendered via the layout engine) so the hit target can never drift from the paint.
                 var dropdown = state.ModeDropdown;
-                var modeLeaf = new LayoutNode.Leaf(
-                    new LayoutContent.Text(pillLabel, fontSize * 0.9f / dpiScale) { Color = AbortText, HAlign = TextAlign.Center, VAlign = TextAlign.Center })
+                var modeLeaf = new Layout.Node.Leaf(
+                    new Layout.Content.Text(pillLabel, fontSize * 0.9f / dpiScale) { Color = AbortText, HAlign = TextAlign.Center, VAlign = TextAlign.Center })
                 {
-                    Width = Sizing.Star(),
-                    Height = Sizing.Star(),
+                    Width = Layout.Sizing.Star(),
+                    Height = Layout.Sizing.Star(),
                     Background = modePillColor,
                     Hit = new HitResult.ButtonHit("ModePill"),
                     OnClick = _ =>
@@ -2319,11 +2319,11 @@ namespace TianWen.UI.Abstractions
                 _ => "?"
             };
             DrawText("On done", fontPath, x0, y, labelW, rowH, smallFs, DimText, TextAlign.Near, TextAlign.Center);
-            var onDoneBtn = new LayoutNode.Leaf(
-                new LayoutContent.Text(onDoneLabel, smallFs / dpiScale) { Color = BodyText, HAlign = TextAlign.Center, VAlign = TextAlign.Center })
+            var onDoneBtn = new Layout.Node.Leaf(
+                new Layout.Content.Text(onDoneLabel, smallFs / dpiScale) { Color = BodyText, HAlign = TextAlign.Center, VAlign = TextAlign.Center })
             {
-                Width = Sizing.Star(),
-                Height = Sizing.Star(),
+                Width = Layout.Sizing.Star(),
+                Height = Layout.Sizing.Star(),
                 Background = new RGBAColor32(0x44, 0x66, 0x99, 0xff),
                 Hit = new HitResult.ButtonHit("PolarSetupOnDone"),
                 OnClick = _ =>
@@ -2347,11 +2347,11 @@ namespace TianWen.UI.Abstractions
                 ? new RGBAColor32(0x44, 0x66, 0x99, 0xff)
                 : new RGBAColor32(0x2a, 0x2a, 0x35, 0xff);
             DrawText("Save frames", fontPath, x0, y, labelW, rowH, smallFs, DimText, TextAlign.Near, TextAlign.Center);
-            var saveBtn = new LayoutNode.Leaf(
-                new LayoutContent.Text(saveLabel, smallFs / dpiScale) { Color = BodyText, HAlign = TextAlign.Center, VAlign = TextAlign.Center })
+            var saveBtn = new Layout.Node.Leaf(
+                new Layout.Content.Text(saveLabel, smallFs / dpiScale) { Color = BodyText, HAlign = TextAlign.Center, VAlign = TextAlign.Center })
             {
-                Width = Sizing.Star(),
-                Height = Sizing.Star(),
+                Width = Layout.Sizing.Star(),
+                Height = Layout.Sizing.Star(),
                 Background = saveBg,
                 Hit = new HitResult.ButtonHit("PolarSetupSaveFrames"),
                 OnClick = _ =>
@@ -2369,11 +2369,11 @@ namespace TianWen.UI.Abstractions
                 ? new RGBAColor32(0x44, 0x66, 0x99, 0xff)
                 : new RGBAColor32(0x2a, 0x2a, 0x35, 0xff);
             DrawText("Incremental", fontPath, x0, y, labelW, rowH, smallFs, DimText, TextAlign.Near, TextAlign.Center);
-            var incBtn = new LayoutNode.Leaf(
-                new LayoutContent.Text(incLabel, smallFs / dpiScale) { Color = BodyText, HAlign = TextAlign.Center, VAlign = TextAlign.Center })
+            var incBtn = new Layout.Node.Leaf(
+                new Layout.Content.Text(incLabel, smallFs / dpiScale) { Color = BodyText, HAlign = TextAlign.Center, VAlign = TextAlign.Center })
             {
-                Width = Sizing.Star(),
-                Height = Sizing.Star(),
+                Width = Layout.Sizing.Star(),
+                Height = Layout.Sizing.Star(),
                 Background = incBg,
                 Hit = new HitResult.ButtonHit("PolarSetupUseIncremental"),
                 OnClick = _ =>

--- a/src/TianWen.UI.Abstractions/NotificationsTab.cs
+++ b/src/TianWen.UI.Abstractions/NotificationsTab.cs
@@ -62,14 +62,14 @@ namespace TianWen.UI.Abstractions
                 var btnX = contentRect.X + contentRect.Width - btnW - pad;
                 var btnY = contentRect.Y + 3f * dpiScale;
 
-                // Clear button as one draw==hit LayoutNode leaf instead of separate FillRect +
+                // Clear button as one draw==hit Layout.Node leaf instead of separate FillRect +
                 // DrawText + RegisterClickable (which can drift). Font is a raw design unit --
                 // PaintLayout re-applies dpiScale.
-                var clearBtn = new LayoutNode.Leaf(
-                    new LayoutContent.Text("Clear", BaseFontSize * 0.95f) { Color = BodyText, HAlign = TextAlign.Center, VAlign = TextAlign.Center })
+                var clearBtn = new Layout.Node.Leaf(
+                    new Layout.Content.Text("Clear", BaseFontSize * 0.95f) { Color = BodyText, HAlign = TextAlign.Center, VAlign = TextAlign.Center })
                 {
-                    Width = Sizing.Star(),
-                    Height = Sizing.Star(),
+                    Width = Layout.Sizing.Star(),
+                    Height = Layout.Sizing.Star(),
                     Background = new RGBAColor32(0x3a, 0x3a, 0x46, 0xff),
                     Hit = new HitResult.ButtonHit("NotificationsClear"),
                     OnClick = _ =>

--- a/src/TianWen.UI.Abstractions/PlannerTab.cs
+++ b/src/TianWen.UI.Abstractions/PlannerTab.cs
@@ -326,14 +326,14 @@ namespace TianWen.UI.Abstractions
 
                 // Pin/unpin button leaf: [-] removes a pinned target, [+] pins an unpinned one. Its own
                 // hit wins over the row-selection hit for the button column (inner registrations win).
-                LayoutNode pinLeaf;
+                Layout.Node pinLeaf;
                 if (isPinned)
                 {
                     var capturedPinIdx = PlannerActions.FindProposalIndex(state.Proposals, scored.Target);
-                    pinLeaf = new LayoutNode.Leaf(new LayoutContent.Text("\u2212", BaseFontSize) { Color = RemoveBtnText, HAlign = TextAlign.Center, VAlign = TextAlign.Center })
+                    pinLeaf = new Layout.Node.Leaf(new Layout.Content.Text("\u2212", BaseFontSize) { Color = RemoveBtnText, HAlign = TextAlign.Center, VAlign = TextAlign.Center })
                     {
-                        Width = Sizing.Fixed(BaseFontSize * 1.5f),
-                        Height = Sizing.Star(),
+                        Width = Layout.Sizing.Fixed(BaseFontSize * 1.5f),
+                        Height = Layout.Sizing.Star(),
                         Background = RemoveBtnBg,
                         Hit = capturedPinIdx >= 0 ? new HitResult.ButtonHit("RemoveProposal") : null,
                         OnClick = capturedPinIdx >= 0 ? (Action<InputModifier>)(_ =>
@@ -349,10 +349,10 @@ namespace TianWen.UI.Abstractions
                 else
                 {
                     var capturedTarget = scored.Target;
-                    pinLeaf = new LayoutNode.Leaf(new LayoutContent.Text("+", BaseFontSize) { Color = PinnedText, HAlign = TextAlign.Center, VAlign = TextAlign.Center })
+                    pinLeaf = new Layout.Node.Leaf(new Layout.Content.Text("+", BaseFontSize) { Color = PinnedText, HAlign = TextAlign.Center, VAlign = TextAlign.Center })
                     {
-                        Width = Sizing.Fixed(BaseFontSize * 1.5f),
-                        Height = Sizing.Star(),
+                        Width = Layout.Sizing.Fixed(BaseFontSize * 1.5f),
+                        Height = Layout.Sizing.Star(),
                         Background = PinnedBg,
                         Hit = new HitResult.ButtonHit("AddProposal"),
                         OnClick = _ => PlannerActions.ToggleProposal(state, capturedTarget),
@@ -362,14 +362,14 @@ namespace TianWen.UI.Abstractions
                 // Whole row: [pad | name * | type | info | pad | pin]. Column widths + fonts are raw design
                 // units (the engine applies dpiScale); the bounds rect is listW px wide so the Star name cell
                 // fills exactly what the old nameW computed. The row carries the select hit; pinLeaf its own.
-                LayoutNode Spacer() => new LayoutNode.Leaf(new LayoutContent.Box(0f, 0f)) { Width = Sizing.Fixed(BasePadding), Height = Sizing.Star() };
-                LayoutNode Cell(string text, float fontMul, RGBAColor32 color, TextAlign halign, float widthDesign) =>
-                    new LayoutNode.Leaf(new LayoutContent.Text(text, BaseFontSize * fontMul) { Color = color, HAlign = halign, VAlign = TextAlign.Center })
+                Layout.Node Spacer() => new Layout.Node.Leaf(new Layout.Content.Box(0f, 0f)) { Width = Layout.Sizing.Fixed(BasePadding), Height = Layout.Sizing.Star() };
+                Layout.Node Cell(string text, float fontMul, RGBAColor32 color, TextAlign halign, float widthDesign) =>
+                    new Layout.Node.Leaf(new Layout.Content.Text(text, BaseFontSize * fontMul) { Color = color, HAlign = halign, VAlign = TextAlign.Center })
                     {
-                        Width = widthDesign > 0f ? Sizing.Fixed(widthDesign) : Sizing.Star(),
-                        Height = Sizing.Star(),
+                        Width = widthDesign > 0f ? Layout.Sizing.Fixed(widthDesign) : Layout.Sizing.Star(),
+                        Height = Layout.Sizing.Star(),
                     };
-                var row = new LayoutNode.Stack(
+                var row = new Layout.Node.Stack(
                 [
                     Spacer(),
                     Cell(scored.Target.Name, 1f, rowTextColor, TextAlign.Near, 0f),
@@ -377,7 +377,7 @@ namespace TianWen.UI.Abstractions
                     Cell(infoStr, 1f, isSelected ? SelectedText : DimText, TextAlign.Far, BaseFontSize * 3.5f),
                     Spacer(),
                     pinLeaf,
-                ], LayoutAxis.Horizontal)
+                ], Layout.Axis.Horizontal)
                 {
                     Background = rowBg,
                     Hit = new HitResult.ListItemHit("TargetList", i),

--- a/src/TianWen.UI.Abstractions/SessionConfigLayout.cs
+++ b/src/TianWen.UI.Abstractions/SessionConfigLayout.cs
@@ -25,17 +25,17 @@ namespace TianWen.UI.Abstractions
 
     /// <summary>
     /// Builds the entire <see cref="SessionConfiguration"/> form as ONE surface-agnostic
-    /// <see cref="LayoutNode"/> tree -- the "full single-panel tree" (Phase 4 of the layout-engine plan).
+    /// <see cref="Layout.Node"/> tree -- the "full single-panel tree" (Phase 4 of the layout-engine plan).
     /// Earlier tabs adopted the engine per row (each stepper / toggle its own <c>RenderLayout</c>, the
     /// vertical flow still an imperative <c>cursor += itemH</c> walk); this builder owns the <i>whole</i>
     /// vertical flow -- section headers, alternating row backgrounds, the selected-row highlight, the
-    /// per-field label + control -- as a single declarative <see cref="LayoutNode.Stack"/>. The host
+    /// per-field label + control -- as a single declarative <see cref="Layout.Node.Stack"/>. The host
     /// arranges it once into a tall bounds offset by the scroll position and clips to the panel
     /// (scroll-via-root-bounds-offset), so there is no per-row cursor math left.
     ///
     /// The config form is the cleanest candidate for this because it is flat and data-driven
     /// (<see cref="SessionConfigGroups.Groups"/> -> groups -> typed fields). Every node is a real
-    /// Text / Box / control subtree -- NOT a <see cref="LayoutContent.Fill"/> leaf that re-dispatches to an
+    /// Text / Box / control subtree -- NOT a <see cref="Layout.Content.Fill"/> leaf that re-dispatches to an
     /// imperative renderer, which is the facade the EquipmentTab whole-tree attempt degraded into and was
     /// reverted for. Interactive widgets that genuinely resist the static engine (the right-hand camera
     /// settings + observation list) stay imperative; this is only the left config form.
@@ -62,7 +62,7 @@ namespace TianWen.UI.Abstractions
         /// request a redraw. When <paramref name="running"/> is true the controls keep their hit surface
         /// but drop their handlers (dimmed / inert), matching the rest of the tabs.
         /// </summary>
-        public static LayoutNode Build(
+        public static Layout.Node Build(
             ImmutableArray<ConfigGroup> groups,
             SessionConfiguration config,
             int selectedFieldIndex,
@@ -74,7 +74,7 @@ namespace TianWen.UI.Abstractions
             Func<ConfigFieldDescriptor, Action<InputModifier>?>? onIncrement = null)
         {
             var btnW = style.Stepper.ButtonDesignW;
-            var children = ImmutableArray.CreateBuilder<LayoutNode>();
+            var children = ImmutableArray.CreateBuilder<Layout.Node>();
             var globalIdx = 0;
 
             for (var gi = 0; gi < groups.Length; gi++)
@@ -97,39 +97,39 @@ namespace TianWen.UI.Abstractions
                 children.Add(GroupGap(style.Padding * 0.5f));
             }
 
-            return new LayoutNode.Stack(children.ToImmutable(), LayoutAxis.Vertical)
+            return new Layout.Node.Stack(children.ToImmutable(), Layout.Axis.Vertical)
             {
-                Width = Sizing.Star(),
-                Height = Sizing.Auto,
+                Width = Layout.Sizing.Star(),
+                Height = Layout.Sizing.Auto,
             };
         }
 
         // Section header: inset label over a header-coloured band. A Text leaf cannot carry padding (the
         // painter draws it at the node's full rect), so the left inset is a fixed pad cell in a Stack.
-        private static LayoutNode Header(string name, in SessionConfigStyle style) =>
-            new LayoutNode.Stack(
+        private static Layout.Node Header(string name, in SessionConfigStyle style) =>
+            new Layout.Node.Stack(
             [
                 Pad(style.Padding),
-                new LayoutNode.Leaf(new LayoutContent.Text(name, style.FontSize) { Color = style.HeaderText, HAlign = TextAlign.Near, VAlign = TextAlign.Center })
+                new Layout.Node.Leaf(new Layout.Content.Text(name, style.FontSize) { Color = style.HeaderText, HAlign = TextAlign.Near, VAlign = TextAlign.Center })
                 {
-                    Width = Sizing.Star(),
-                    Height = Sizing.Star(),
+                    Width = Layout.Sizing.Star(),
+                    Height = Layout.Sizing.Star(),
                 },
-            ], LayoutAxis.Horizontal)
+            ], Layout.Axis.Horizontal)
             {
-                Width = Sizing.Star(),
-                Height = Sizing.Fixed(style.HeaderHeight),
+                Width = Layout.Sizing.Star(),
+                Height = Layout.Sizing.Fixed(style.HeaderHeight),
                 Background = style.HeaderBg,
             };
 
-        private static LayoutNode GroupGap(float height) =>
-            new LayoutNode.Leaf(new LayoutContent.Box(0f, 0f)) { Width = Sizing.Star(), Height = Sizing.Fixed(height) };
+        private static Layout.Node GroupGap(float height) =>
+            new Layout.Node.Leaf(new Layout.Content.Box(0f, 0f)) { Width = Layout.Sizing.Star(), Height = Layout.Sizing.Fixed(height) };
 
-        private static LayoutNode Pad(float width) =>
-            new LayoutNode.Leaf(new LayoutContent.Box(0f, 0f)) { Width = Sizing.Fixed(width), Height = Sizing.Star() };
+        private static Layout.Node Pad(float width) =>
+            new Layout.Node.Leaf(new Layout.Content.Box(0f, 0f)) { Width = Layout.Sizing.Fixed(width), Height = Layout.Sizing.Star() };
 
         // One field row: [ pad | label ]  [ control ]  over a full-width row background.
-        private static LayoutNode FieldRow(
+        private static Layout.Node FieldRow(
             ConfigFieldDescriptor field, int idx, RGBAColor32 rowBg,
             SessionConfiguration config, float valueWidth, float btnW, bool running, in SessionConfigStyle style,
             Func<int, Action<InputModifier>?>? onSelectField,
@@ -139,32 +139,32 @@ namespace TianWen.UI.Abstractions
             // pad + label = the select-clickable region. Height = Star so the whole-row-height hit matches
             // the old RegisterClickable(rect.X, cursor, labelW + padding, itemH) exactly -- the control
             // buttons register later (children win), so dec/inc still get their own clicks.
-            var selectCell = new LayoutNode.Stack(
+            var selectCell = new Layout.Node.Stack(
             [
                 Pad(style.Padding),
-                new LayoutNode.Leaf(new LayoutContent.Text(field.Label, style.FontSize) { Color = style.BodyText, HAlign = TextAlign.Near, VAlign = TextAlign.Center })
+                new Layout.Node.Leaf(new Layout.Content.Text(field.Label, style.FontSize) { Color = style.BodyText, HAlign = TextAlign.Near, VAlign = TextAlign.Center })
                 {
-                    Width = Sizing.Fixed(style.LabelWidth),
-                    Height = Sizing.Star(),
+                    Width = Layout.Sizing.Fixed(style.LabelWidth),
+                    Height = Layout.Sizing.Star(),
                 },
-            ], LayoutAxis.Horizontal)
+            ], Layout.Axis.Horizontal)
             {
-                Height = Sizing.Star(),
+                Height = Layout.Sizing.Star(),
                 Hit = new HitResult.ListItemHit("ConfigField", idx),
                 OnClick = onSelectField?.Invoke(idx),
             };
 
             var control = Control(field, config, valueWidth, btnW, running, style, onDecrement, onIncrement);
 
-            return new LayoutNode.Stack([selectCell, control], LayoutAxis.Horizontal)
+            return new Layout.Node.Stack([selectCell, control], Layout.Axis.Horizontal)
             {
-                Width = Sizing.Star(),
-                Height = Sizing.Fixed(style.ItemHeight),
+                Width = Layout.Sizing.Star(),
+                Height = Layout.Sizing.Fixed(style.ItemHeight),
                 Background = rowBg,
             };
         }
 
-        private static LayoutNode Control(
+        private static Layout.Node Control(
             ConfigFieldDescriptor field, SessionConfiguration config, float valueWidth, float btnW, bool running,
             in SessionConfigStyle style,
             Func<ConfigFieldDescriptor, Action<InputModifier>?>? onDecrement,
@@ -176,10 +176,10 @@ namespace TianWen.UI.Abstractions
                 {
                     var valueStr = field.FormatValue(config);
                     var isOn = valueStr == "ON";
-                    return new LayoutNode.Leaf(new LayoutContent.Text(valueStr, style.FontSize) { Color = running ? style.DimText : style.BodyText, HAlign = TextAlign.Center, VAlign = TextAlign.Center })
+                    return new Layout.Node.Leaf(new Layout.Content.Text(valueStr, style.FontSize) { Color = running ? style.DimText : style.BodyText, HAlign = TextAlign.Center, VAlign = TextAlign.Center })
                     {
-                        Width = Sizing.Fixed(style.ToggleButtonWidth),
-                        Height = Sizing.Star(),
+                        Width = Layout.Sizing.Fixed(style.ToggleButtonWidth),
+                        Height = Layout.Sizing.Star(),
                         Background = running ? style.DisabledBg : (isOn ? style.ToggleOnBg : style.ToggleOffBg),
                         Hit = new HitResult.ButtonHit($"Toggle:{field.Label}"),
                         OnClick = running ? null : onIncrement?.Invoke(field),
@@ -189,10 +189,10 @@ namespace TianWen.UI.Abstractions
                 case ConfigFieldKind.EnumCycle:
                 {
                     var valueStr = field.FormatValue(config);
-                    return new LayoutNode.Leaf(new LayoutContent.Text($"{valueStr} \u25B6", style.FontSize * 0.9f) { Color = running ? style.DimText : style.BodyText, HAlign = TextAlign.Center, VAlign = TextAlign.Center })
+                    return new Layout.Node.Leaf(new Layout.Content.Text($"{valueStr} \u25B6", style.FontSize * 0.9f) { Color = running ? style.DimText : style.BodyText, HAlign = TextAlign.Center, VAlign = TextAlign.Center })
                     {
-                        Width = Sizing.Fixed(style.CycleButtonWidth),
-                        Height = Sizing.Star(),
+                        Width = Layout.Sizing.Fixed(style.CycleButtonWidth),
+                        Height = Layout.Sizing.Star(),
                         Background = running ? style.DisabledBg : style.CycleBg,
                         Hit = new HitResult.ButtonHit($"Cycle:{field.Label}"),
                         OnClick = running ? null : onIncrement?.Invoke(field),
@@ -209,7 +209,7 @@ namespace TianWen.UI.Abstractions
                         "+", $"Inc:{field.Label}", onIncrement?.Invoke(field) ?? NoOp,
                         display, style.FontSize, running ? style.DimText : style.BodyText, enabled: !running);
 
-                    return ctrl with { Width = Sizing.Fixed(btnW * 2f + valueWidth), Height = Sizing.Star() };
+                    return ctrl with { Width = Layout.Sizing.Fixed(btnW * 2f + valueWidth), Height = Layout.Sizing.Star() };
                 }
             }
         }

--- a/src/TianWen.UI.Abstractions/SessionTab.cs
+++ b/src/TianWen.UI.Abstractions/SessionTab.cs
@@ -596,17 +596,17 @@ namespace TianWen.UI.Abstractions
                 var expBtnW = stepperBtnW;
                 var expValW = colExpW - expBtnW * 2;
 
-                LayoutNode ExpButton(string glyph, string hit, Action<InputModifier> onClick) =>
-                    new LayoutNode.Leaf(new LayoutContent.Text(glyph, BaseFontSize * 0.85f) { Color = BodyText, HAlign = TextAlign.Center, VAlign = TextAlign.Center })
+                Layout.Node ExpButton(string glyph, string hit, Action<InputModifier> onClick) =>
+                    new Layout.Node.Leaf(new Layout.Content.Text(glyph, BaseFontSize * 0.85f) { Color = BodyText, HAlign = TextAlign.Center, VAlign = TextAlign.Center })
                     {
-                        Width = Sizing.Fixed(BaseStepperBtnW * 0.85f),
-                        Height = Sizing.Star(),
+                        Width = Layout.Sizing.Fixed(BaseStepperBtnW * 0.85f),
+                        Height = Layout.Sizing.Star(),
                         Background = StepperBg,
                         Hit = new HitResult.ButtonHit(hit),
                         OnClick = onClick,
                     };
 
-                var expRow = new LayoutNode.Stack(
+                var expRow = new Layout.Node.Stack(
                 [
                     ExpButton("\u2212", $"Dec:Exp:{i}",
                         _ =>
@@ -617,7 +617,7 @@ namespace TianWen.UI.Abstractions
                                 capturedI, p with { SubExposure = SessionTabState.StepExposure(cur, false) });
                             State.NeedsRedraw = true;
                         }),
-                    new LayoutNode.Leaf(new LayoutContent.Fill(Key: "exp")) { Width = Sizing.Star(), Height = Sizing.Star() },
+                    new Layout.Node.Leaf(new Layout.Content.Fill(Key: "exp")) { Width = Layout.Sizing.Star(), Height = Layout.Sizing.Star() },
                     ExpButton("+", $"Inc:Exp:{i}",
                         _ =>
                         {
@@ -627,7 +627,7 @@ namespace TianWen.UI.Abstractions
                                 capturedI, p with { SubExposure = SessionTabState.StepExposure(cur, true) });
                             State.NeedsRedraw = true;
                         }),
-                ], LayoutAxis.Horizontal);
+                ], Layout.Axis.Horizontal);
 
                 RenderLayout(expRow, new RectF32(colExpX, cursor, expBtnW + expValW + expBtnW, rowH), fontPath, dpiScale,
                     drawFill: (_, r) =>
@@ -769,7 +769,7 @@ namespace TianWen.UI.Abstractions
             // what the per-row index-virtualised path used to get for free by skipping off-screen rows).
             var top = rect.Y;
             var bottom = rect.Y + rect.Height;
-            var visible = ImmutableArray.CreateBuilder<ArrangedNode<float>>(arranged.Length);
+            var visible = ImmutableArray.CreateBuilder<Layout.ArrangedNode<float>>(arranged.Length);
             foreach (var node in arranged)
             {
                 var b = node.Bounds;

--- a/src/TianWen.UI.Abstractions/SkyMapTab.Search.cs
+++ b/src/TianWen.UI.Abstractions/SkyMapTab.Search.cs
@@ -85,10 +85,10 @@ namespace TianWen.UI.Abstractions
             // leaf (fill and hit are the same arranged rect) instead of a FillRect +
             // RegisterClickable pair whose rects could silently drift apart.
             RenderLayout(
-                new LayoutNode.Leaf(new LayoutContent.Box(0f, 0f))
+                new Layout.Node.Leaf(new Layout.Content.Box(0f, 0f))
                 {
-                    Width = Sizing.Star(),
-                    Height = Sizing.Star(),
+                    Width = Layout.Sizing.Star(),
+                    Height = Layout.Sizing.Star(),
                     Background = SearchBackdrop,
                     Hit = new HitResult.ButtonHit("SearchBackdrop"),
                     OnClick = _ => PostSignal(new CloseSkyMapSearchSignal()),
@@ -115,10 +115,10 @@ namespace TianWen.UI.Abstractions
             // (fontSize / dpiScale); RenderLayout re-applies dpiScale.
             var closeW = headerH;
             RenderLayout(
-                new LayoutNode.Leaf(new LayoutContent.Text("X", fontSize / dpiScale) { Color = SearchText, HAlign = TextAlign.Center, VAlign = TextAlign.Center })
+                new Layout.Node.Leaf(new Layout.Content.Text("X", fontSize / dpiScale) { Color = SearchText, HAlign = TextAlign.Center, VAlign = TextAlign.Center })
                 {
-                    Width = Sizing.Star(),
-                    Height = Sizing.Star(),
+                    Width = Layout.Sizing.Star(),
+                    Height = Layout.Sizing.Star(),
                     Hit = new HitResult.ButtonHit("SearchClose"),
                     OnClick = _ => PostSignal(new CloseSkyMapSearchSignal()),
                 },
@@ -178,27 +178,27 @@ namespace TianWen.UI.Abstractions
                 // Each row is one draw==hit Stack: the selected-row highlight, the name +
                 // optional V-mag text, and the click surface are all the same arranged rect,
                 // so the hit region can no longer drift away from what's drawn.
-                var rowChildren = ImmutableArray.CreateBuilder<LayoutNode>();
-                rowChildren.Add(new LayoutNode.Leaf(new LayoutContent.Box(0f, 0f)) { Width = Sizing.Fixed(12f), Height = Sizing.Star() });
-                rowChildren.Add(new LayoutNode.Leaf(new LayoutContent.Text(entry.Display, nameFont) { Color = isSelected ? selectedTextColor : SearchText, HAlign = TextAlign.Near, VAlign = TextAlign.Center })
+                var rowChildren = ImmutableArray.CreateBuilder<Layout.Node>();
+                rowChildren.Add(new Layout.Node.Leaf(new Layout.Content.Box(0f, 0f)) { Width = Layout.Sizing.Fixed(12f), Height = Layout.Sizing.Star() });
+                rowChildren.Add(new Layout.Node.Leaf(new Layout.Content.Text(entry.Display, nameFont) { Color = isSelected ? selectedTextColor : SearchText, HAlign = TextAlign.Near, VAlign = TextAlign.Center })
                 {
-                    Width = Sizing.Star(),
-                    Height = Sizing.Star(),
+                    Width = Layout.Sizing.Star(),
+                    Height = Layout.Sizing.Star(),
                 });
                 if (!float.IsNaN(entry.VMag))
                 {
-                    rowChildren.Add(new LayoutNode.Leaf(new LayoutContent.Text($"{entry.VMag:F1}m", magFont) { Color = isSelected ? selectedTextColor : SearchDimText, HAlign = TextAlign.Far, VAlign = TextAlign.Center })
+                    rowChildren.Add(new Layout.Node.Leaf(new Layout.Content.Text($"{entry.VMag:F1}m", magFont) { Color = isSelected ? selectedTextColor : SearchDimText, HAlign = TextAlign.Far, VAlign = TextAlign.Center })
                     {
-                        Width = Sizing.Fixed(52f),
-                        Height = Sizing.Star(),
+                        Width = Layout.Sizing.Fixed(52f),
+                        Height = Layout.Sizing.Star(),
                     });
                 }
-                rowChildren.Add(new LayoutNode.Leaf(new LayoutContent.Box(0f, 0f)) { Width = Sizing.Fixed(10f), Height = Sizing.Star() });
+                rowChildren.Add(new Layout.Node.Leaf(new Layout.Content.Box(0f, 0f)) { Width = Layout.Sizing.Fixed(10f), Height = Layout.Sizing.Star() });
 
-                var rowNode = new LayoutNode.Stack(rowChildren.ToImmutable(), LayoutAxis.Horizontal)
+                var rowNode = new Layout.Node.Stack(rowChildren.ToImmutable(), Layout.Axis.Horizontal)
                 {
-                    Width = Sizing.Star(),
-                    Height = Sizing.Star(),
+                    Width = Layout.Sizing.Star(),
+                    Height = Layout.Sizing.Star(),
                     Background = isSelected ? SearchRowHover : (RGBAColor32?)null,
                     Hit = new HitResult.ListItemHit("SearchResult", capturedIndex),
                     OnClick = _ =>
@@ -368,10 +368,10 @@ namespace TianWen.UI.Abstractions
             // glyph box and the click surface are the same arranged rect.
             var closeSize = 20f * dpiScale;
             RenderLayout(
-                new LayoutNode.Leaf(new LayoutContent.Text("X", fontSize / dpiScale * 0.9f) { Color = SearchDimText, HAlign = TextAlign.Center, VAlign = TextAlign.Center })
+                new Layout.Node.Leaf(new Layout.Content.Text("X", fontSize / dpiScale * 0.9f) { Color = SearchDimText, HAlign = TextAlign.Center, VAlign = TextAlign.Center })
                 {
-                    Width = Sizing.Star(),
-                    Height = Sizing.Star(),
+                    Width = Layout.Sizing.Star(),
+                    Height = Layout.Sizing.Star(),
                     Hit = new HitResult.ButtonHit("InfoPanelClose"),
                     OnClick = _ =>
                     {


### PR DESCRIPTION
## Adopt DIR.Lib 6.0 Layout namespace + dogfood the Builder DSL

Consumes the lockstep SharpAstro release (DIR.Lib **6.0**, Console.Lib **3.3**, SdlVulkan.Renderer **6.7**).

### Pins
`DIR.Lib 6.0.*` / `Console.Lib 3.3.*` / `SdlVulkan.Renderer 6.7.*`.

### Namespace adoption
All layout references qualified as `Layout.X` against the new `DIR.Lib.Layout` namespace, via a per-project `global using Layout = DIR.Lib.Layout;` (UI.Abstractions + Lib.Tests). No bareword imports, no collisions.

### DSL dogfood
The two heaviest hand-written tree-builders are rewritten with the new `Layout.Builder` DSL:

- `FormRowLayout` (StepperControl / InsetPillButton / ToggleHeaderRow / LabeledInputRow / StepperRow)
- `EquipmentPanelLayout` (Header / SlotRow / FilterTable / the data-driven OTA flow)

e.g. `Layout.Builder.HStack(...).RowH(28).Bg(c).Clickable(hit, h)`. `EquipmentPanelLayoutTests` assert exact arranged geometry, so the DSL-built panel is provably identical to the prior hand-built records.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
