### PR TITLE
refactor(ui): migrate all UI builders to the Layout.Builder DSL + document it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -479,6 +479,30 @@ range + AutoLevel quantum-range assertions to all four legacy stretch test files
 Pattern when extending tests: assert per-channel byte/float means stay inside `(epsilon, max-epsilon)`
 to catch the channel-collapse regressions we hit during the WB+shadow coordinate-space refactor.
 
+### Layout DSL (`DIR.Lib.Layout`)
+
+GUI/TUI panels are built from a surface-agnostic declarative layout engine in DIR.Lib (`DIR.Lib.Layout`):
+author a tree of immutable `Layout.Node` records, `Layout.Engine.Arrange` measures + arranges it, and
+`PixelWidgetBase.PaintLayout` draws + binds clicks **from the same arranged rect** (draw == hit by
+construction — no second hit-rect arithmetic that can drift). See
+[`docs/architecture/layout-dsl.md`](docs/architecture/layout-dsl.md).
+
+- **Build trees with the `Layout.Builder` DSL, never `new Layout.Node.X { }` initializers or `cursor += h`
+  placement.** Factories: `Layout.Builder.VStack/HStack/Text/Box/Fill/Spacer/Grid/Overlay/Split/Dock(...)`.
+  Chrome via fluent **instance methods** on `Layout.Node`: `.WFixed/.WStar/.RowH/.ColW/.Stretch/.Bg/.Pad/
+  .Clickable/.WithGap`. Each is a pure `this with { ... }` transform emitting the same records.
+- **Alias, don't import.** Keep `using DIR.Lib;` and add a per-project `global using Layout =
+  DIR.Lib.Layout;` (or csproj `<Using ... Alias="Layout"/>`); write the qualified `Layout.Node` /
+  `Layout.Builder`. Do NOT `using DIR.Lib.Layout;` — it drops the collision-prone barewords (`Node`,
+  `Content`, `Size<T>`) into scope. A consumer owning its own `Layout` type must rename it (PTV did:
+  `Layout` -> `ElementGrid`).
+- **Conditional background:** `.Bg(color)` always sets a value, so for a nullable bg build the base then
+  `if (cond) n = n.Bg(color);` — never `.Bg(default)` (paints transparent, not null).
+- **Interactive sub-widgets** (text inputs, charts, sky map) emit a `Layout.Builder.Fill(key: "...")` leaf
+  and draw into its rect via `PaintLayout`'s `drawFill` callback.
+- Engine geometry is headless-testable (stub `Layout.IMeasureContext`); `EquipmentPanelLayoutTests` /
+  `SessionConfigLayoutTests` pin arranged rects. Shipped DIR.Lib 6.0 / Console.Lib 3.3 / SdlVulkan.Renderer 6.7.
+
 ### Signal Handler Pattern — Route, Don't Implement
 
 The lightweight `SignalBus` is our alternative to MediatR/MVVM. `AppSignalHandler.cs` subscribe

--- a/docs/architecture/layout-dsl.md
+++ b/docs/architecture/layout-dsl.md
@@ -1,0 +1,142 @@
+# Layout engine + the `Layout.Builder` DSL
+
+TianWen's GUI/TUI panels are built from a **surface-agnostic declarative layout engine** that lives in
+DIR.Lib (`DIR.Lib.Layout`). You describe a tree of immutable records; the engine measures + arranges it
+into rects; a per-surface painter walks the arranged tree to **draw and bind clicks from the same rect**
+(draw == hit by construction). The `Layout.Builder` DSL is the ergonomic front-end for authoring that tree.
+
+This doc is the "how to build a panel" reference. The engine itself is in
+`../../../DIR.Lib/src/DIR.Lib/Layout/`.
+
+## Pipeline
+
+```
+Layout.Builder.VStack(...)        // 1. author a tree (records)
+   -> Layout.Node tree
+Layout.Engine.Arrange(root, rect, ctx)   // 2. measure + arrange (two-pass)
+   -> ImmutableArray<Layout.ArrangedNode>  (pre-order: parent before children)
+PixelWidgetBase.PaintLayout(arranged)     // 3. paint + auto-bind clicks
+   -> FillRect(Background) + DrawText/Box/Fill + RegisterClickable(Hit) per node
+```
+
+Step 3 is the load-bearing guarantee: a node's **background fill, its drawn content, and its click region
+all come from the one arranged rect** — there is no second "hit rect" arithmetic that can drift from the
+drawn position. Inner nodes register later, so a button inside a clickable row still wins the hit.
+
+## The namespace + the `Layout` alias
+
+The engine + DSL live in `DIR.Lib.Layout`, with the redundant prefix dropped: `Layout.Node`,
+`Layout.Engine`, `Layout.Content`, `Layout.Axis`, `Layout.Sizing`, `Layout.Size<T>`, `Layout.DockChild`,
+`Layout.DockSide`, `Layout.ArrangedNode`, `Layout.IMeasureContext`, `Layout.Builder`.
+
+**Consumer convention** — keep `using DIR.Lib;` and add a per-project alias:
+
+```csharp
+global using Layout = DIR.Lib.Layout;   // GlobalUsings.cs, or a csproj <Using Include="DIR.Lib.Layout" Alias="Layout" />
+```
+
+Then write the qualified form everywhere: `Layout.Builder.VStack(...)`, `Layout.Node`, `Layout.Sizing`.
+
+- **Do not** `using DIR.Lib.Layout;` directly — that drops the collision-prone barewords (`Node`,
+  `Content`, `Size<T>`, `Builder`) into the file's scope.
+- A `using DIR.Lib;` alone does **not** make the nested `Layout` namespace referenceable (a using-directive
+  imports types, not nested namespaces) — that's why the alias is required. (Inside DIR.Lib's own code the
+  alias is unnecessary: `Layout.X` resolves via enclosing-namespace lookup.)
+- A consumer that already owns a `Layout` type can't alias it. (periodic-table-viewer renamed its
+  `PeriodicTable.Layout` element-grid helper to `ElementGrid` to free the name.)
+
+## Authoring: `Layout.Builder` + fluent `Layout.Node` modifiers
+
+**Build a tree, never `cursor += h`.** The DSL is pure sugar — `Layout.Builder.Text("x")` is exactly
+`new Layout.Node.Leaf(new Layout.Content.Text("x"))`. Two halves:
+
+### Factories (`Layout.Builder`)
+
+| Factory | Produces |
+|---------|----------|
+| `Text(value, fontSize=14, color=white, hAlign=Near, vAlign=Center)` | text leaf (styling is intrinsic, set here) |
+| `Box(w, h, color=transparent)` | fixed box / swatch / separator |
+| `Fill(minW=0, minH=0, key=null)` | app-drawn escape hatch (chart, image, text input); route multiple via `key` |
+| `Spacer()` | transparent `Box(0,0)` |
+| `VStack(...)` / `HStack(...)` | stacked children (`params ReadOnlySpan<Node>`; pass `arr.AsSpan()` for a dynamic list) |
+| `Grid(cols, ...)` | uniform N-column grid |
+| `Overlay(layer, top)` | modal / dropdown / popup |
+| `Split(first, second, axis, firstExtent, dividerThickness, dividerHit, dividerColor)` | two resizable panes + a draggable divider |
+| `Dock(fill, Right(child, w), Top(child, h), ...)` | edge-pinned strips + a fill remainder |
+
+### Fluent modifiers (instance methods on `Layout.Node`)
+
+Chrome that would otherwise be an object-initializer block. They are **instance methods** (we own `Node`),
+each a pure `this with { ... }` transform, so chaining needs no `using`:
+
+| Modifier | Sets |
+|----------|------|
+| `.W(Sizing)` / `.H(Sizing)` | explicit sizing |
+| `.WFixed(u)` / `.WStar(w=1)` / `.WAuto()` (+ `H*`) | single-axis shorthand |
+| `.RowH(u)` | `Width=Star, Height=Fixed(u)` — the dominant full-width row |
+| `.ColW(u)` | `Width=Fixed(u), Height=Star` — fixed column that stretches vertically |
+| `.Stretch()` | `Star` on both axes — fill the cell |
+| `.Bg(color)` | background fill |
+| `.Pad(u)` | inner padding |
+| `.Clickable(hit, onClick=null)` | bind `Hit` (+ optional handler) to the whole rect |
+| `.WithGap(g)` / `.WithGaps(r, c)` | stack gap / grid gaps (no-op on the wrong node kind) |
+
+> `.WithGap` (not `.Gap`) because `Node.Stack` already exposes a `Gap` property — a method + property of the
+> same name collide. This is also why the modifiers are instance methods rather than extension methods on a
+> type we don't own: extensions would need their declaring namespace imported, which reintroduces the
+> bareword-collision problem the alias avoids.
+
+### Before / after
+
+```csharp
+// before -- object-initializer, chrome as a block, double-wrapped leaves
+var pad   = new Layout.Node.Leaf(new Layout.Content.Box(0f,0f)) { Width = Layout.Sizing.Fixed(8f), Height = Layout.Sizing.Star() };
+var label = new Layout.Node.Leaf(new Layout.Content.Text(slot.Label, 14f) { Color = dim }) { Width = Layout.Sizing.Star(0.35f), Height = Layout.Sizing.Star() };
+return new Layout.Node.Stack([pad, label, ...], Layout.Axis.Horizontal)
+{
+    Height = Layout.Sizing.Fixed(28f), Width = Layout.Sizing.Star(),
+    Background = active ? activeBg : normalBg,
+    Hit = new HitResult.SlotHit<AssignTarget>(slot.Slot), OnClick = onClick,
+};
+
+// after -- DSL
+return Layout.Builder.HStack(
+        Layout.Builder.Spacer().ColW(8f),
+        Layout.Builder.Text(slot.Label, 14f, dim).WStar(0.35f).HStar(),
+        /* ... */)
+    .RowH(28f)
+    .Bg(active ? activeBg : normalBg)
+    .Clickable(new HitResult.SlotHit<AssignTarget>(slot.Slot), onClick);
+```
+
+**Conditional background:** the fluent `.Bg(color)` always sets a value, so for a nullable/conditional
+background build the base node then `if (cond) n = n.Bg(color);` — never `.Bg(default)` (that paints
+transparent rather than leaving `Background` null).
+
+**Interactive sub-widgets** (text inputs, telemetry graphs, the sky map, custom charts) stay as imperative
+helpers: emit a `Layout.Builder.Fill(key: "...")` leaf and draw into its arranged rect via `PaintLayout`'s
+`drawFill` callback, keyed when a tree has several.
+
+## Where the builders live
+
+- **Generic shared rows** -> `FormRowLayout` (StepperControl, InsetPillButton, ToggleHeaderRow,
+  LabeledInputRow, StepperRow).
+- **Equipment-panel structure** -> `EquipmentPanelLayout` (data-driven OTA flow, SlotRow, FilterTable).
+- **Per-tab trees** -> the tab files (`EquipmentTab`, `SessionTab`, `LiveSessionTab`, `PlannerTab`,
+  `SkyMapTab.Search`, `NotificationsTab`, `SessionConfigLayout`, `ImageRendererBase`).
+
+All of them author via `Layout.Builder`. New panels should too — never reach for `new Layout.Node.X { }`
+object-initializers or imperative `cursor += h` placement.
+
+## Testing
+
+`Layout.Engine.Arrange` is headless (a stub `Layout.IMeasureContext` supplies glyph metrics), so panel
+geometry is unit-testable with no renderer. `EquipmentPanelLayoutTests` / `SessionConfigLayoutTests` assert
+exact arranged rects; the DIR.Lib `LayoutBuilderTests` prove a DSL-built tree arranges identically to the
+hand-built records. For tabs without geometry tests, verify via the SDL inspector (`tw_inspect.py regions`)
+that elements are present with the right footprint — see the UI-refactor verification bar.
+
+## Shipped
+
+DIR.Lib 6.0 / Console.Lib 3.3 / SdlVulkan.Renderer 6.7 (lockstep). All TianWen UI builders author via the
+DSL; `DIR.Lib.Layout` is the single home for the engine + Builder.

--- a/src/TianWen.UI.Abstractions/EquipmentTab.cs
+++ b/src/TianWen.UI.Abstractions/EquipmentTab.cs
@@ -547,20 +547,12 @@ namespace TianWen.UI.Abstractions
                 var siteStr = $"  Site: {latStr}, {lonStr}{elevStr}";
 
                 var siteBtnW = w - padding * 2f;
-                var siteRow = new Layout.Node.Stack(
-                [
-                    new Layout.Node.Leaf(new Layout.Content.Text(siteStr, BaseFontSize * 0.9f) { Color = SiteText, HAlign = TextAlign.Near, VAlign = TextAlign.Center })
-                        { Width = Layout.Sizing.Star(), Height = Layout.Sizing.Star() },
-                    new Layout.Node.Leaf(new Layout.Content.Text("[>]", BaseFontSize * 0.85f) { Color = DimText, HAlign = TextAlign.Center, VAlign = TextAlign.Center })
-                        { Width = Layout.Sizing.Fixed(arrowW), Height = Layout.Sizing.Star() },
-                ], Layout.Axis.Horizontal)
-                {
-                    Width = Layout.Sizing.Fixed(siteBtnW),
-                    Height = Layout.Sizing.Fixed(itemH),
-                    Background = SlotNormal,
-                    Hit = new HitResult.ButtonHit("EditSite"),
-                    OnClick = _ => PostSignal(new EditSiteSignal()),
-                };
+                var siteRow = Layout.Builder.HStack(
+                    Layout.Builder.Text(siteStr, BaseFontSize * 0.9f, SiteText).Stretch(),
+                    Layout.Builder.Text("[>]", BaseFontSize * 0.85f, DimText, TextAlign.Center, TextAlign.Center).WFixed(arrowW).HStar())
+                    .WFixed(siteBtnW).HFixed(itemH)
+                    .Bg(SlotNormal)
+                    .Clickable(new HitResult.ButtonHit("EditSite"), _ => PostSignal(new EditSiteSignal()));
                 RenderLayout(siteRow, new RectF32(x + padding, cursor, siteBtnW, itemH), fontPath, dpiScale);
                 cursor += itemH;
             }
@@ -568,14 +560,10 @@ namespace TianWen.UI.Abstractions
             {
                 // No site configured -- show "Set Site" button
                 var setSiteBtnW = Renderer.MeasureText("Set Site".AsSpan(), fontPath, fontSize).Width + padding * 4f;
-                var setSiteLeaf = new Layout.Node.Leaf(new Layout.Content.Text("Set Site", BaseFontSize) { Color = BodyText, HAlign = TextAlign.Center, VAlign = TextAlign.Center })
-                {
-                    Width = Layout.Sizing.Fixed(setSiteBtnW),
-                    Height = Layout.Sizing.Fixed(buttonH),
-                    Background = CreateButton,
-                    Hit = new HitResult.ButtonHit("EditSite"),
-                    OnClick = _ => PostSignal(new EditSiteSignal()),
-                };
+                var setSiteLeaf = Layout.Builder.Text("Set Site", BaseFontSize, BodyText, TextAlign.Center, TextAlign.Center)
+                    .WFixed(setSiteBtnW).HFixed(buttonH)
+                    .Bg(CreateButton)
+                    .Clickable(new HitResult.ButtonHit("EditSite"), _ => PostSignal(new EditSiteSignal()));
                 RenderLayout(setSiteLeaf, new RectF32(x + padding, cursor, setSiteBtnW, buttonH), fontPath, dpiScale);
                 cursor += buttonH;
             }
@@ -623,37 +611,24 @@ namespace TianWen.UI.Abstractions
                 || OtaDeviceConnected(ota.FilterWheel) || OtaDeviceConnected(ota.Cover);
 
             // Title leaf (left, takes remaining width after the two buttons)
-            var titleLeaf = new Layout.Node.Leaf(
-                new Layout.Content.Text($"Telescope #{index}: {ota.Name}", BaseFontSize) { Color = HeaderText, HAlign = TextAlign.Near, VAlign = TextAlign.Center })
-            {
-                Width = Layout.Sizing.Star(),
-                Height = Layout.Sizing.Star(),
-            };
+            var titleLeaf = Layout.Builder.Text($"Telescope #{index}: {ota.Name}", BaseFontSize, HeaderText).Stretch();
 
             // [Remove] button leaf -- disabled grey when a device is connected; armed/normal otherwise
             Layout.Node removeLeaf;
             if (otaHasConnectedDevice)
             {
-                removeLeaf = new Layout.Node.Leaf(
-                    new Layout.Content.Text("Remove", BaseFontSize * 0.85f) { Color = DimmedText, HAlign = TextAlign.Center, VAlign = TextAlign.Center })
-                {
-                    Width = Layout.Sizing.Fixed(removeBtnW),
-                    Height = Layout.Sizing.Star(),
-                    Background = SegmentDisabled,
+                removeLeaf = Layout.Builder.Text("Remove", BaseFontSize * 0.85f, DimmedText, TextAlign.Center, TextAlign.Center)
+                    .WFixed(removeBtnW).HStar()
+                    .Bg(SegmentDisabled);
                     // No Hit, no OnClick -- disabled
-                };
             }
             else
             {
                 var armed = State.PendingRemoveOtaIndex == index;
-                removeLeaf = new Layout.Node.Leaf(
-                    new Layout.Content.Text(armed ? "Confirm?" : "Remove", BaseFontSize * 0.85f) { Color = BodyText, HAlign = TextAlign.Center, VAlign = TextAlign.Center })
-                {
-                    Width = Layout.Sizing.Fixed(removeBtnW),
-                    Height = Layout.Sizing.Star(),
-                    Background = armed ? ConfirmDangerBg : RemoveButtonBg,
-                    Hit = new HitResult.ButtonHit($"RemoveOta{index}"),
-                    OnClick = _ =>
+                removeLeaf = Layout.Builder.Text(armed ? "Confirm?" : "Remove", BaseFontSize * 0.85f, BodyText, TextAlign.Center, TextAlign.Center)
+                    .WFixed(removeBtnW).HStar()
+                    .Bg(armed ? ConfirmDangerBg : RemoveButtonBg)
+                    .Clickable(new HitResult.ButtonHit($"RemoveOta{index}"), _ =>
                     {
                         if (State.PendingRemoveOtaIndex == capturedI)
                         {
@@ -668,27 +643,18 @@ namespace TianWen.UI.Abstractions
                             State.PendingRemoveOtaIndex = capturedI;
                             appState.NeedsRedraw = true;
                         }
-                    },
-                };
+                    });
             }
 
             // Gap leaf between Remove and Edit
-            var gapLeaf = new Layout.Node.Leaf(new Layout.Content.Box(0f, 0f))
-            {
-                Width = Layout.Sizing.Fixed(btnGap),
-                Height = Layout.Sizing.Star(),
-            };
+            var gapLeaf = Layout.Builder.Spacer().WFixed(btnGap).HStar();
 
             // [Edit]/[Save] toggle button leaf
             var editLabel = isEditingOta ? "Save" : "Edit";
-            var editLeaf = new Layout.Node.Leaf(
-                new Layout.Content.Text(editLabel, BaseFontSize * 0.85f) { Color = BodyText, HAlign = TextAlign.Center, VAlign = TextAlign.Center })
-            {
-                Width = Layout.Sizing.Fixed(editBtnW),
-                Height = Layout.Sizing.Star(),
-                Background = EditButtonBg,
-                Hit = new HitResult.ButtonHit($"EditOta{index}"),
-                OnClick = _ =>
+            var editLeaf = Layout.Builder.Text(editLabel, BaseFontSize * 0.85f, BodyText, TextAlign.Center, TextAlign.Center)
+                .WFixed(editBtnW).HStar()
+                .Bg(EditButtonBg)
+                .Clickable(new HitResult.ButtonHit($"EditOta{index}"), _ =>
                 {
                     if (isEditingOta)
                     {
@@ -708,16 +674,12 @@ namespace TianWen.UI.Abstractions
                     {
                         State.BeginEditingOta(capturedI, ota);
                     }
-                },
-            };
+                });
 
             // Build the full header row as a horizontal Stack
-            var headerRow = new Layout.Node.Stack([titleLeaf, removeLeaf, gapLeaf, editLeaf], Layout.Axis.Horizontal)
-            {
-                Width = Layout.Sizing.Fixed(w),
-                Height = Layout.Sizing.Fixed(itemH),
-                Background = OtaHeaderBg,
-            };
+            var headerRow = Layout.Builder.HStack(titleLeaf, removeLeaf, gapLeaf, editLeaf)
+                .WFixed(w).HFixed(itemH)
+                .Bg(OtaHeaderBg);
             RenderLayout(headerRow, new RectF32(x, cursor, w, itemH), fontPath, dpiScale);
             return cursor + itemH;
         }
@@ -906,12 +868,9 @@ namespace TianWen.UI.Abstractions
                 var capturedIdx = i;
                 // Row background + whole-row select hit as one draw==hit leaf; the badge/name/status/segment
                 // content draws on top below (later registrations win, so the segment beats the row hit).
-                var rowLeaf = new Layout.Node.Leaf(new Layout.Content.Box(0f, 0f))
-                {
-                    Background = isCurrentForSlot ? SlotActive : baseBg,
-                    Hit = new HitResult.ListItemHit("Devices", i),
-                    OnClick = _ => PostSignal(new AssignDeviceSignal(capturedIdx)),
-                };
+                var rowLeaf = Layout.Builder.Spacer()
+                    .Bg(isCurrentForSlot ? SlotActive : baseBg)
+                    .Clickable(new HitResult.ListItemHit("Devices", i), _ => PostSignal(new AssignDeviceSignal(capturedIdx)));
                 RenderLayout(rowLeaf, new RectF32(x, rowY, rowW, itemH), fontPath, dpiScale);
                 FillRect(x, rowY + itemH - 1f, rowW, 1f, SeparatorColor);
 
@@ -1107,8 +1066,7 @@ namespace TianWen.UI.Abstractions
             var capUri = cameraUri;
             const float font = 0.78f;
             // Three equal inset pills; gap is a design unit (2 du) so it scales with DPI.
-            var strip = new Layout.Node.Stack(
-            [
+            var strip = Layout.Builder.HStack(
                 FormRowLayout.InsetPillButton("Warm up & Off", BaseFontSize * font, ConfirmWarmBg, BodyText,
                     new HitResult.ButtonHit("WarmCoolerOff"), _ => PostSignal(new WarmAndCoolerOffSignal(capUri))),
                 FormRowLayout.InsetPillButton("Force", BaseFontSize * font, ConfirmForceBg, BodyText,
@@ -1124,8 +1082,8 @@ namespace TianWen.UI.Abstractions
                     {
                         State.PendingCoolerOffConfirm = null;
                         State.PendingCoolerOffForceConfirm = null;
-                    }),
-            ], Layout.Axis.Horizontal, 2f);
+                    }))
+                .WithGap(2f);
             RenderLayout(strip, new RectF32(x, y, w, h), fontPath, dpiScale);
 
             return y + h;
@@ -1140,8 +1098,7 @@ namespace TianWen.UI.Abstractions
         {
             var capUri = cameraUri;
             // [Cancel] LEFT, destructive [REALLY FORCE] RIGHT (anti-double-click position swap); two pills, gap 4 du.
-            var strip = new Layout.Node.Stack(
-            [
+            var strip = Layout.Builder.HStack(
                 FormRowLayout.InsetPillButton("Cancel", BaseFontSize * 0.8f, ConfirmCancelBg, BodyText,
                     new HitResult.ButtonHit("CancelForceCoolerOff"),
                     _ =>
@@ -1155,8 +1112,8 @@ namespace TianWen.UI.Abstractions
                     {
                         State.PendingCoolerOffForceConfirm = null;
                         PostSignal(new SetCoolerOffSignal(capUri));
-                    }),
-            ], Layout.Axis.Horizontal, 4f);
+                    }))
+                .WithGap(4f);
             RenderLayout(strip, new RectF32(x, y, w, h), fontPath, dpiScale);
 
             return y + h;
@@ -1184,8 +1141,7 @@ namespace TianWen.UI.Abstractions
             var capUri = deviceUri;
             const float font = 0.75f;
             // Order: [Warm/Wait & Off] [Force Off -> escalates to stage 2] [Cancel]; three equal inset pills, gap 2 du.
-            var strip = new Layout.Node.Stack(
-            [
+            var strip = Layout.Builder.HStack(
                 FormRowLayout.InsetPillButton(safetyLabel, BaseFontSize * font, ConfirmWarmBg, BodyText,
                     new HitResult.ButtonHit("WarmDisconnect"), _ => PostSignal(new WarmAndDisconnectDeviceSignal(capUri))),
                 FormRowLayout.InsetPillButton("Force", BaseFontSize * font, ConfirmForceBg, BodyText,
@@ -1201,8 +1157,8 @@ namespace TianWen.UI.Abstractions
                     {
                         State.PendingDisconnectConfirm = null;
                         State.PendingForceConfirm = null;
-                    }),
-            ], Layout.Axis.Horizontal, 2f);
+                    }))
+                .WithGap(2f);
             RenderLayout(strip, new RectF32(x, y, w, h), fontPath, dpiScale);
         }
 
@@ -1219,8 +1175,7 @@ namespace TianWen.UI.Abstractions
             // [Cancel] LEFT (where [Warm & Off] was), destructive [REALLY FORCE] RIGHT (where [Cancel] was):
             // the reversed pairing means a double-click that started on [Force Off] (middle of stage 1) lands
             // on the [Cancel] half, never the destructive button. Two equal inset pills, gap 4 du.
-            var strip = new Layout.Node.Stack(
-            [
+            var strip = Layout.Builder.HStack(
                 FormRowLayout.InsetPillButton("Cancel", BaseFontSize * 0.8f, ConfirmCancelBg, BodyText,
                     new HitResult.ButtonHit("CancelForce"),
                     _ =>
@@ -1234,8 +1189,8 @@ namespace TianWen.UI.Abstractions
                     {
                         State.PendingForceConfirm = null;
                         PostSignal(new ForceDisconnectDeviceSignal(capUri));
-                    }),
-            ], Layout.Axis.Horizontal, 4f);
+                    }))
+                .WithGap(4f);
             RenderLayout(strip, new RectF32(x, y, w, h), fontPath, dpiScale);
         }
 
@@ -1273,13 +1228,12 @@ namespace TianWen.UI.Abstractions
             var capturedUri = deviceUri;
             Action<InputModifier> onAction = _ => { if (!isConnected) PostSignal(new ConnectDeviceSignal(capturedUri)); };
             Action<InputModifier> offAction = _ => { if (isConnected) PostSignal(new DisconnectDeviceSignal(capturedUri)); };
-            var seg = new Layout.Node.Stack(
-            [
+            var seg = Layout.Builder.HStack(
                 FormRowLayout.InsetPillButton(onLabel, BaseFontSize * 0.85f, onBg, BodyText,
                     pending ? null : new HitResult.ButtonHit("Connect"), pending ? null : onAction),
                 FormRowLayout.InsetPillButton(offLabel, BaseFontSize * 0.85f, offBg, BodyText,
-                    pending ? null : new HitResult.ButtonHit("Disconnect"), pending ? null : offAction),
-            ], Layout.Axis.Horizontal, 1f);
+                    pending ? null : new HitResult.ButtonHit("Disconnect"), pending ? null : offAction))
+                .WithGap(1f);
             RenderLayout(seg, new RectF32(x, y, w, h), fontPath, dpiScale);
         }
 
@@ -1821,12 +1775,10 @@ namespace TianWen.UI.Abstractions
             var btnW = Math.Max(measured, minBtnW);
             var btnX = x + w - padding - btnW;
             // Background + label + (enabled-only) hit as one draw==hit leaf.
-            var connectAllBtn = new Layout.Node.Leaf(new Layout.Content.Text(label, BaseFontSize * 0.95f) { Color = BodyText, HAlign = TextAlign.Center, VAlign = TextAlign.Center })
-            {
-                Background = bg,
-                Hit = enabled ? new HitResult.ButtonHit("ConnectAll") : null,
-                OnClick = enabled ? (Action<InputModifier>)(_ => PostSignal(new ConnectAllDevicesSignal())) : null,
-            };
+            var connectAllBtn = Layout.Builder.Text(label, BaseFontSize * 0.95f, BodyText, TextAlign.Center, TextAlign.Center)
+                .Bg(bg)
+                .Clickable(enabled ? new HitResult.ButtonHit("ConnectAll") : null,
+                    enabled ? (Action<InputModifier>)(_ => PostSignal(new ConnectAllDevicesSignal())) : null);
             RenderLayout(connectAllBtn, new RectF32(btnX, btnY, btnW, buttonH), fontPath, dpiScale);
         }
 

--- a/src/TianWen.UI.Abstractions/ImageRendererBase.cs
+++ b/src/TianWen.UI.Abstractions/ImageRendererBase.cs
@@ -329,20 +329,20 @@ namespace TianWen.UI.Abstractions
             var below = new RectF32(0f, ToolbarHeight, Width, Height - ToolbarHeight - StatusBarHeight);
 
             Layout.Node content = state.ShowInfoPanel
-                ? new Layout.Node.Dock(
-                    [new Layout.DockChild(Layout.DockSide.Right, new Layout.Node.Leaf(new Layout.Content.Fill(Key: "infoPanel")), Layout.Sizing.Fixed(BaseInfoPanelWidth))],
-                    new Layout.Node.Leaf(new Layout.Content.Fill(Key: "image")))
-                : new Layout.Node.Leaf(new Layout.Content.Fill(Key: "image"));
+                ? Layout.Builder.Dock(
+                    Layout.Builder.Fill(key: "image"),
+                    Layout.Builder.Right(Layout.Builder.Fill(key: "infoPanel"), BaseInfoPanelWidth))
+                : Layout.Builder.Fill(key: "image");
 
             Layout.Node root = state.ShowFileList
-                ? new Layout.Node.Split(
-                    new Layout.Node.Leaf(new Layout.Content.Fill(Key: "fileList")),
+                ? Layout.Builder.Split(
+                    Layout.Builder.Fill(key: "fileList"),
                     content,
                     Layout.Axis.Horizontal,
-                    FirstExtent: state.FileListWidthBase,
-                    DividerThickness: BaseFileListDividerWidth,
-                    DividerHit: new ResizeHandleHit("FileList"),
-                    DividerColor: state.IsResizingFileList ? ResizeHandleActiveColor : ResizeHandleIdleColor)
+                    firstExtent: state.FileListWidthBase,
+                    dividerThickness: BaseFileListDividerWidth,
+                    dividerHit: new ResizeHandleHit("FileList"),
+                    dividerColor: state.IsResizingFileList ? ResizeHandleActiveColor : ResizeHandleIdleColor)
                 : content;
 
             _layoutArranged = ArrangeLayout(root, below, fontPath, DpiScale);

--- a/src/TianWen.UI.Abstractions/LiveSessionTab.cs
+++ b/src/TianWen.UI.Abstractions/LiveSessionTab.cs
@@ -570,14 +570,9 @@ namespace TianWen.UI.Abstractions
                 // draw==hit leaf -- background, label, and click region all bind to one node's rect
                 // (rendered via the layout engine) so the hit target can never drift from the paint.
                 var dropdown = state.ModeDropdown;
-                var modeLeaf = new Layout.Node.Leaf(
-                    new Layout.Content.Text(pillLabel, fontSize * 0.9f / dpiScale) { Color = AbortText, HAlign = TextAlign.Center, VAlign = TextAlign.Center })
-                {
-                    Width = Layout.Sizing.Star(),
-                    Height = Layout.Sizing.Star(),
-                    Background = modePillColor,
-                    Hit = new HitResult.ButtonHit("ModePill"),
-                    OnClick = _ =>
+                var modeLeaf = Layout.Builder.Text(pillLabel, fontSize * 0.9f / dpiScale, AbortText, TextAlign.Center, TextAlign.Center)
+                    .Stretch().Bg(modePillColor)
+                    .Clickable(new HitResult.ButtonHit("ModePill"), _ =>
                     {
                         if (dropdown.IsOpen)
                         {
@@ -639,8 +634,7 @@ namespace TianWen.UI.Abstractions
                                 }
                             });
                         state.NeedsRedraw = true;
-                    },
-                };
+                    });
                 RenderLayout(modeLeaf, new RectF32(pillX, pillY, pillW, pillH), fontPath, dpiScale);
 
                 // Current time is shown by the global status-bar clock (top-right on every
@@ -2319,14 +2313,9 @@ namespace TianWen.UI.Abstractions
                 _ => "?"
             };
             DrawText("On done", fontPath, x0, y, labelW, rowH, smallFs, DimText, TextAlign.Near, TextAlign.Center);
-            var onDoneBtn = new Layout.Node.Leaf(
-                new Layout.Content.Text(onDoneLabel, smallFs / dpiScale) { Color = BodyText, HAlign = TextAlign.Center, VAlign = TextAlign.Center })
-            {
-                Width = Layout.Sizing.Star(),
-                Height = Layout.Sizing.Star(),
-                Background = new RGBAColor32(0x44, 0x66, 0x99, 0xff),
-                Hit = new HitResult.ButtonHit("PolarSetupOnDone"),
-                OnClick = _ =>
+            var onDoneBtn = Layout.Builder.Text(onDoneLabel, smallFs / dpiScale, BodyText, TextAlign.Center, TextAlign.Center)
+                .Stretch().Bg(new RGBAColor32(0x44, 0x66, 0x99, 0xff))
+                .Clickable(new HitResult.ButtonHit("PolarSetupOnDone"), _ =>
                 {
                     var next = state.PolarSetupConfig.OnDone switch
                     {
@@ -2336,8 +2325,7 @@ namespace TianWen.UI.Abstractions
                     };
                     state.PolarSetupConfig = state.PolarSetupConfig with { OnDone = next };
                     state.NeedsRedraw = true;
-                },
-            };
+                });
             RenderLayout(onDoneBtn, new RectF32(x0 + labelW, y, w - labelW, rowH), fontPath, dpiScale);
             y += rowH;
 
@@ -2347,19 +2335,13 @@ namespace TianWen.UI.Abstractions
                 ? new RGBAColor32(0x44, 0x66, 0x99, 0xff)
                 : new RGBAColor32(0x2a, 0x2a, 0x35, 0xff);
             DrawText("Save frames", fontPath, x0, y, labelW, rowH, smallFs, DimText, TextAlign.Near, TextAlign.Center);
-            var saveBtn = new Layout.Node.Leaf(
-                new Layout.Content.Text(saveLabel, smallFs / dpiScale) { Color = BodyText, HAlign = TextAlign.Center, VAlign = TextAlign.Center })
-            {
-                Width = Layout.Sizing.Star(),
-                Height = Layout.Sizing.Star(),
-                Background = saveBg,
-                Hit = new HitResult.ButtonHit("PolarSetupSaveFrames"),
-                OnClick = _ =>
+            var saveBtn = Layout.Builder.Text(saveLabel, smallFs / dpiScale, BodyText, TextAlign.Center, TextAlign.Center)
+                .Stretch().Bg(saveBg)
+                .Clickable(new HitResult.ButtonHit("PolarSetupSaveFrames"), _ =>
                 {
                     state.PolarSetupConfig = state.PolarSetupConfig with { SaveFrames = !state.PolarSetupConfig.SaveFrames };
                     state.NeedsRedraw = true;
-                },
-            };
+                });
             RenderLayout(saveBtn, new RectF32(x0 + labelW, y, w - labelW, rowH), fontPath, dpiScale);
             y += rowH;
 
@@ -2369,19 +2351,13 @@ namespace TianWen.UI.Abstractions
                 ? new RGBAColor32(0x44, 0x66, 0x99, 0xff)
                 : new RGBAColor32(0x2a, 0x2a, 0x35, 0xff);
             DrawText("Incremental", fontPath, x0, y, labelW, rowH, smallFs, DimText, TextAlign.Near, TextAlign.Center);
-            var incBtn = new Layout.Node.Leaf(
-                new Layout.Content.Text(incLabel, smallFs / dpiScale) { Color = BodyText, HAlign = TextAlign.Center, VAlign = TextAlign.Center })
-            {
-                Width = Layout.Sizing.Star(),
-                Height = Layout.Sizing.Star(),
-                Background = incBg,
-                Hit = new HitResult.ButtonHit("PolarSetupUseIncremental"),
-                OnClick = _ =>
+            var incBtn = Layout.Builder.Text(incLabel, smallFs / dpiScale, BodyText, TextAlign.Center, TextAlign.Center)
+                .Stretch().Bg(incBg)
+                .Clickable(new HitResult.ButtonHit("PolarSetupUseIncremental"), _ =>
                 {
                     state.PolarSetupConfig = state.PolarSetupConfig with { UseIncrementalSolver = !state.PolarSetupConfig.UseIncrementalSolver };
                     state.NeedsRedraw = true;
-                },
-            };
+                });
             RenderLayout(incBtn, new RectF32(x0 + labelW, y, w - labelW, rowH), fontPath, dpiScale);
 
             // ---- Start button (anchored at panel bottom, full width) ---------

--- a/src/TianWen.UI.Abstractions/NotificationsTab.cs
+++ b/src/TianWen.UI.Abstractions/NotificationsTab.cs
@@ -65,19 +65,14 @@ namespace TianWen.UI.Abstractions
                 // Clear button as one draw==hit Layout.Node leaf instead of separate FillRect +
                 // DrawText + RegisterClickable (which can drift). Font is a raw design unit --
                 // PaintLayout re-applies dpiScale.
-                var clearBtn = new Layout.Node.Leaf(
-                    new Layout.Content.Text("Clear", BaseFontSize * 0.95f) { Color = BodyText, HAlign = TextAlign.Center, VAlign = TextAlign.Center })
-                {
-                    Width = Layout.Sizing.Star(),
-                    Height = Layout.Sizing.Star(),
-                    Background = new RGBAColor32(0x3a, 0x3a, 0x46, 0xff),
-                    Hit = new HitResult.ButtonHit("NotificationsClear"),
-                    OnClick = _ =>
+                var clearBtn = Layout.Builder.Text("Clear", BaseFontSize * 0.95f, BodyText, TextAlign.Center, TextAlign.Center)
+                    .Stretch()
+                    .Bg(new RGBAColor32(0x3a, 0x3a, 0x46, 0xff))
+                    .Clickable(new HitResult.ButtonHit("NotificationsClear"), _ =>
                     {
                         appState.ClearNotifications();
                         appState.NeedsRedraw = true;
-                    },
-                };
+                    });
                 RenderLayout(clearBtn, new RectF32(btnX, btnY, btnW, btnH), fontPath, dpiScale);
             }
 

--- a/src/TianWen.UI.Abstractions/PlannerTab.cs
+++ b/src/TianWen.UI.Abstractions/PlannerTab.cs
@@ -330,59 +330,44 @@ namespace TianWen.UI.Abstractions
                 if (isPinned)
                 {
                     var capturedPinIdx = PlannerActions.FindProposalIndex(state.Proposals, scored.Target);
-                    pinLeaf = new Layout.Node.Leaf(new Layout.Content.Text("\u2212", BaseFontSize) { Color = RemoveBtnText, HAlign = TextAlign.Center, VAlign = TextAlign.Center })
-                    {
-                        Width = Layout.Sizing.Fixed(BaseFontSize * 1.5f),
-                        Height = Layout.Sizing.Star(),
-                        Background = RemoveBtnBg,
-                        Hit = capturedPinIdx >= 0 ? new HitResult.ButtonHit("RemoveProposal") : null,
-                        OnClick = capturedPinIdx >= 0 ? (Action<InputModifier>)(_ =>
-                        {
-                            PlannerActions.RemoveProposal(state, capturedPinIdx);
-                            if (state.SelectedTargetIndex >= state.PinnedCount)
+                    pinLeaf = Layout.Builder.Text("\u2212", BaseFontSize, RemoveBtnText, TextAlign.Center, TextAlign.Center)
+                        .WFixed(BaseFontSize * 1.5f).HStar().Bg(RemoveBtnBg)
+                        .Clickable(
+                            capturedPinIdx >= 0 ? new HitResult.ButtonHit("RemoveProposal") : null,
+                            capturedPinIdx >= 0 ? (Action<InputModifier>)(_ =>
                             {
-                                state.SelectedTargetIndex = Math.Max(0, state.SelectedTargetIndex - 1);
-                            }
-                        }) : null,
-                    };
+                                PlannerActions.RemoveProposal(state, capturedPinIdx);
+                                if (state.SelectedTargetIndex >= state.PinnedCount)
+                                {
+                                    state.SelectedTargetIndex = Math.Max(0, state.SelectedTargetIndex - 1);
+                                }
+                            }) : null);
                 }
                 else
                 {
                     var capturedTarget = scored.Target;
-                    pinLeaf = new Layout.Node.Leaf(new Layout.Content.Text("+", BaseFontSize) { Color = PinnedText, HAlign = TextAlign.Center, VAlign = TextAlign.Center })
-                    {
-                        Width = Layout.Sizing.Fixed(BaseFontSize * 1.5f),
-                        Height = Layout.Sizing.Star(),
-                        Background = PinnedBg,
-                        Hit = new HitResult.ButtonHit("AddProposal"),
-                        OnClick = _ => PlannerActions.ToggleProposal(state, capturedTarget),
-                    };
+                    pinLeaf = Layout.Builder.Text("+", BaseFontSize, PinnedText, TextAlign.Center, TextAlign.Center)
+                        .WFixed(BaseFontSize * 1.5f).HStar().Bg(PinnedBg)
+                        .Clickable(new HitResult.ButtonHit("AddProposal"), _ => PlannerActions.ToggleProposal(state, capturedTarget));
                 }
 
                 // Whole row: [pad | name * | type | info | pad | pin]. Column widths + fonts are raw design
                 // units (the engine applies dpiScale); the bounds rect is listW px wide so the Star name cell
                 // fills exactly what the old nameW computed. The row carries the select hit; pinLeaf its own.
-                Layout.Node Spacer() => new Layout.Node.Leaf(new Layout.Content.Box(0f, 0f)) { Width = Layout.Sizing.Fixed(BasePadding), Height = Layout.Sizing.Star() };
+                Layout.Node Spacer() => Layout.Builder.Spacer().ColW(BasePadding);
                 Layout.Node Cell(string text, float fontMul, RGBAColor32 color, TextAlign halign, float widthDesign) =>
-                    new Layout.Node.Leaf(new Layout.Content.Text(text, BaseFontSize * fontMul) { Color = color, HAlign = halign, VAlign = TextAlign.Center })
-                    {
-                        Width = widthDesign > 0f ? Layout.Sizing.Fixed(widthDesign) : Layout.Sizing.Star(),
-                        Height = Layout.Sizing.Star(),
-                    };
-                var row = new Layout.Node.Stack(
-                [
+                    widthDesign > 0f
+                        ? Layout.Builder.Text(text, BaseFontSize * fontMul, color, halign, TextAlign.Center).WFixed(widthDesign).HStar()
+                        : Layout.Builder.Text(text, BaseFontSize * fontMul, color, halign, TextAlign.Center).Stretch();
+                var row = Layout.Builder.HStack(
                     Spacer(),
                     Cell(scored.Target.Name, 1f, rowTextColor, TextAlign.Near, 0f),
                     Cell(scored.ObjectType.ToAbbreviation(), 0.85f, DimText, TextAlign.Near, BaseFontSize * 3.2f),
                     Cell(infoStr, 1f, isSelected ? SelectedText : DimText, TextAlign.Far, BaseFontSize * 3.5f),
                     Spacer(),
-                    pinLeaf,
-                ], Layout.Axis.Horizontal)
-                {
-                    Background = rowBg,
-                    Hit = new HitResult.ListItemHit("TargetList", i),
-                    OnClick = _ => { state.SelectedTargetIndex = capturedIdx; state.NeedsRedraw = true; },
-                };
+                    pinLeaf)
+                    .Bg(rowBg)
+                    .Clickable(new HitResult.ListItemHit("TargetList", i), _ => { state.SelectedTargetIndex = capturedIdx; state.NeedsRedraw = true; });
                 RenderLayout(row, new RectF32(rect.X, rowY, listW, itemHeight), fontPath, dpiScale);
             }
 

--- a/src/TianWen.UI.Abstractions/SessionConfigLayout.cs
+++ b/src/TianWen.UI.Abstractions/SessionConfigLayout.cs
@@ -97,36 +97,23 @@ namespace TianWen.UI.Abstractions
                 children.Add(GroupGap(style.Padding * 0.5f));
             }
 
-            return new Layout.Node.Stack(children.ToImmutable(), Layout.Axis.Vertical)
-            {
-                Width = Layout.Sizing.Star(),
-                Height = Layout.Sizing.Auto,
-            };
+            return Layout.Builder.VStack(children.ToImmutable().AsSpan())
+                .WStar();
         }
 
         // Section header: inset label over a header-coloured band. A Text leaf cannot carry padding (the
         // painter draws it at the node's full rect), so the left inset is a fixed pad cell in a Stack.
         private static Layout.Node Header(string name, in SessionConfigStyle style) =>
-            new Layout.Node.Stack(
-            [
+            Layout.Builder.HStack(
                 Pad(style.Padding),
-                new Layout.Node.Leaf(new Layout.Content.Text(name, style.FontSize) { Color = style.HeaderText, HAlign = TextAlign.Near, VAlign = TextAlign.Center })
-                {
-                    Width = Layout.Sizing.Star(),
-                    Height = Layout.Sizing.Star(),
-                },
-            ], Layout.Axis.Horizontal)
-            {
-                Width = Layout.Sizing.Star(),
-                Height = Layout.Sizing.Fixed(style.HeaderHeight),
-                Background = style.HeaderBg,
-            };
+                Layout.Builder.Text(name, style.FontSize, style.HeaderText).Stretch())
+            .RowH(style.HeaderHeight).Bg(style.HeaderBg);
 
         private static Layout.Node GroupGap(float height) =>
-            new Layout.Node.Leaf(new Layout.Content.Box(0f, 0f)) { Width = Layout.Sizing.Star(), Height = Layout.Sizing.Fixed(height) };
+            Layout.Builder.Spacer().RowH(height);
 
         private static Layout.Node Pad(float width) =>
-            new Layout.Node.Leaf(new Layout.Content.Box(0f, 0f)) { Width = Layout.Sizing.Fixed(width), Height = Layout.Sizing.Star() };
+            Layout.Builder.Spacer().ColW(width);
 
         // One field row: [ pad | label ]  [ control ]  over a full-width row background.
         private static Layout.Node FieldRow(
@@ -139,29 +126,16 @@ namespace TianWen.UI.Abstractions
             // pad + label = the select-clickable region. Height = Star so the whole-row-height hit matches
             // the old RegisterClickable(rect.X, cursor, labelW + padding, itemH) exactly -- the control
             // buttons register later (children win), so dec/inc still get their own clicks.
-            var selectCell = new Layout.Node.Stack(
-            [
+            var selectCell = Layout.Builder.HStack(
                 Pad(style.Padding),
-                new Layout.Node.Leaf(new Layout.Content.Text(field.Label, style.FontSize) { Color = style.BodyText, HAlign = TextAlign.Near, VAlign = TextAlign.Center })
-                {
-                    Width = Layout.Sizing.Fixed(style.LabelWidth),
-                    Height = Layout.Sizing.Star(),
-                },
-            ], Layout.Axis.Horizontal)
-            {
-                Height = Layout.Sizing.Star(),
-                Hit = new HitResult.ListItemHit("ConfigField", idx),
-                OnClick = onSelectField?.Invoke(idx),
-            };
+                Layout.Builder.Text(field.Label, style.FontSize, style.BodyText).WFixed(style.LabelWidth).HStar())
+            .HStar()
+            .Clickable(new HitResult.ListItemHit("ConfigField", idx), onSelectField?.Invoke(idx));
 
             var control = Control(field, config, valueWidth, btnW, running, style, onDecrement, onIncrement);
 
-            return new Layout.Node.Stack([selectCell, control], Layout.Axis.Horizontal)
-            {
-                Width = Layout.Sizing.Star(),
-                Height = Layout.Sizing.Fixed(style.ItemHeight),
-                Background = rowBg,
-            };
+            return Layout.Builder.HStack(selectCell, control)
+                .RowH(style.ItemHeight).Bg(rowBg);
         }
 
         private static Layout.Node Control(
@@ -176,27 +150,19 @@ namespace TianWen.UI.Abstractions
                 {
                     var valueStr = field.FormatValue(config);
                     var isOn = valueStr == "ON";
-                    return new Layout.Node.Leaf(new Layout.Content.Text(valueStr, style.FontSize) { Color = running ? style.DimText : style.BodyText, HAlign = TextAlign.Center, VAlign = TextAlign.Center })
-                    {
-                        Width = Layout.Sizing.Fixed(style.ToggleButtonWidth),
-                        Height = Layout.Sizing.Star(),
-                        Background = running ? style.DisabledBg : (isOn ? style.ToggleOnBg : style.ToggleOffBg),
-                        Hit = new HitResult.ButtonHit($"Toggle:{field.Label}"),
-                        OnClick = running ? null : onIncrement?.Invoke(field),
-                    };
+                    return Layout.Builder.Text(valueStr, style.FontSize, running ? style.DimText : style.BodyText, TextAlign.Center, TextAlign.Center)
+                        .WFixed(style.ToggleButtonWidth).HStar()
+                        .Bg(running ? style.DisabledBg : (isOn ? style.ToggleOnBg : style.ToggleOffBg))
+                        .Clickable(new HitResult.ButtonHit($"Toggle:{field.Label}"), running ? null : onIncrement?.Invoke(field));
                 }
 
                 case ConfigFieldKind.EnumCycle:
                 {
                     var valueStr = field.FormatValue(config);
-                    return new Layout.Node.Leaf(new Layout.Content.Text($"{valueStr} \u25B6", style.FontSize * 0.9f) { Color = running ? style.DimText : style.BodyText, HAlign = TextAlign.Center, VAlign = TextAlign.Center })
-                    {
-                        Width = Layout.Sizing.Fixed(style.CycleButtonWidth),
-                        Height = Layout.Sizing.Star(),
-                        Background = running ? style.DisabledBg : style.CycleBg,
-                        Hit = new HitResult.ButtonHit($"Cycle:{field.Label}"),
-                        OnClick = running ? null : onIncrement?.Invoke(field),
-                    };
+                    return Layout.Builder.Text($"{valueStr} \u25B6", style.FontSize * 0.9f, running ? style.DimText : style.BodyText, TextAlign.Center, TextAlign.Center)
+                        .WFixed(style.CycleButtonWidth).HStar()
+                        .Bg(running ? style.DisabledBg : style.CycleBg)
+                        .Clickable(new HitResult.ButtonHit($"Cycle:{field.Label}"), running ? null : onIncrement?.Invoke(field));
                 }
 
                 default:

--- a/src/TianWen.UI.Abstractions/SessionTab.cs
+++ b/src/TianWen.UI.Abstractions/SessionTab.cs
@@ -597,17 +597,11 @@ namespace TianWen.UI.Abstractions
                 var expValW = colExpW - expBtnW * 2;
 
                 Layout.Node ExpButton(string glyph, string hit, Action<InputModifier> onClick) =>
-                    new Layout.Node.Leaf(new Layout.Content.Text(glyph, BaseFontSize * 0.85f) { Color = BodyText, HAlign = TextAlign.Center, VAlign = TextAlign.Center })
-                    {
-                        Width = Layout.Sizing.Fixed(BaseStepperBtnW * 0.85f),
-                        Height = Layout.Sizing.Star(),
-                        Background = StepperBg,
-                        Hit = new HitResult.ButtonHit(hit),
-                        OnClick = onClick,
-                    };
+                    Layout.Builder.Text(glyph, BaseFontSize * 0.85f, BodyText, TextAlign.Center, TextAlign.Center)
+                        .WFixed(BaseStepperBtnW * 0.85f).HStar().Bg(StepperBg)
+                        .Clickable(new HitResult.ButtonHit(hit), onClick);
 
-                var expRow = new Layout.Node.Stack(
-                [
+                var expRow = Layout.Builder.HStack(
                     ExpButton("\u2212", $"Dec:Exp:{i}",
                         _ =>
                         {
@@ -617,7 +611,7 @@ namespace TianWen.UI.Abstractions
                                 capturedI, p with { SubExposure = SessionTabState.StepExposure(cur, false) });
                             State.NeedsRedraw = true;
                         }),
-                    new Layout.Node.Leaf(new Layout.Content.Fill(Key: "exp")) { Width = Layout.Sizing.Star(), Height = Layout.Sizing.Star() },
+                    Layout.Builder.Fill(key: "exp").Stretch(),
                     ExpButton("+", $"Inc:Exp:{i}",
                         _ =>
                         {
@@ -626,8 +620,7 @@ namespace TianWen.UI.Abstractions
                             plannerState.Proposals = plannerState.Proposals.SetItem(
                                 capturedI, p with { SubExposure = SessionTabState.StepExposure(cur, true) });
                             State.NeedsRedraw = true;
-                        }),
-                ], Layout.Axis.Horizontal);
+                        }));
 
                 RenderLayout(expRow, new RectF32(colExpX, cursor, expBtnW + expValW + expBtnW, rowH), fontPath, dpiScale,
                     drawFill: (_, r) =>

--- a/src/TianWen.UI.Abstractions/SkyMapTab.Search.cs
+++ b/src/TianWen.UI.Abstractions/SkyMapTab.Search.cs
@@ -85,14 +85,8 @@ namespace TianWen.UI.Abstractions
             // leaf (fill and hit are the same arranged rect) instead of a FillRect +
             // RegisterClickable pair whose rects could silently drift apart.
             RenderLayout(
-                new Layout.Node.Leaf(new Layout.Content.Box(0f, 0f))
-                {
-                    Width = Layout.Sizing.Star(),
-                    Height = Layout.Sizing.Star(),
-                    Background = SearchBackdrop,
-                    Hit = new HitResult.ButtonHit("SearchBackdrop"),
-                    OnClick = _ => PostSignal(new CloseSkyMapSearchSignal()),
-                },
+                Layout.Builder.Spacer().Stretch().Bg(SearchBackdrop)
+                    .Clickable(new HitResult.ButtonHit("SearchBackdrop"), _ => PostSignal(new CloseSkyMapSearchSignal())),
                 contentRect, fontPath, dpiScale);
 
             var pw = SearchPanelWidth * dpiScale;
@@ -115,13 +109,9 @@ namespace TianWen.UI.Abstractions
             // (fontSize / dpiScale); RenderLayout re-applies dpiScale.
             var closeW = headerH;
             RenderLayout(
-                new Layout.Node.Leaf(new Layout.Content.Text("X", fontSize / dpiScale) { Color = SearchText, HAlign = TextAlign.Center, VAlign = TextAlign.Center })
-                {
-                    Width = Layout.Sizing.Star(),
-                    Height = Layout.Sizing.Star(),
-                    Hit = new HitResult.ButtonHit("SearchClose"),
-                    OnClick = _ => PostSignal(new CloseSkyMapSearchSignal()),
-                },
+                Layout.Builder.Text("X", fontSize / dpiScale, SearchText, TextAlign.Center, TextAlign.Center)
+                    .Stretch()
+                    .Clickable(new HitResult.ButtonHit("SearchClose"), _ => PostSignal(new CloseSkyMapSearchSignal())),
                 new RectF32(px + pw - closeW, py, closeW, headerH), fontPath, dpiScale);
 
             // Search input
@@ -179,34 +169,22 @@ namespace TianWen.UI.Abstractions
                 // optional V-mag text, and the click surface are all the same arranged rect,
                 // so the hit region can no longer drift away from what's drawn.
                 var rowChildren = ImmutableArray.CreateBuilder<Layout.Node>();
-                rowChildren.Add(new Layout.Node.Leaf(new Layout.Content.Box(0f, 0f)) { Width = Layout.Sizing.Fixed(12f), Height = Layout.Sizing.Star() });
-                rowChildren.Add(new Layout.Node.Leaf(new Layout.Content.Text(entry.Display, nameFont) { Color = isSelected ? selectedTextColor : SearchText, HAlign = TextAlign.Near, VAlign = TextAlign.Center })
-                {
-                    Width = Layout.Sizing.Star(),
-                    Height = Layout.Sizing.Star(),
-                });
+                rowChildren.Add(Layout.Builder.Spacer().ColW(12f).HStar());
+                rowChildren.Add(Layout.Builder.Text(entry.Display, nameFont, isSelected ? selectedTextColor : SearchText).Stretch());
                 if (!float.IsNaN(entry.VMag))
                 {
-                    rowChildren.Add(new Layout.Node.Leaf(new Layout.Content.Text($"{entry.VMag:F1}m", magFont) { Color = isSelected ? selectedTextColor : SearchDimText, HAlign = TextAlign.Far, VAlign = TextAlign.Center })
-                    {
-                        Width = Layout.Sizing.Fixed(52f),
-                        Height = Layout.Sizing.Star(),
-                    });
+                    rowChildren.Add(Layout.Builder.Text($"{entry.VMag:F1}m", magFont, isSelected ? selectedTextColor : SearchDimText, TextAlign.Far).WFixed(52f).HStar());
                 }
-                rowChildren.Add(new Layout.Node.Leaf(new Layout.Content.Box(0f, 0f)) { Width = Layout.Sizing.Fixed(10f), Height = Layout.Sizing.Star() });
+                rowChildren.Add(Layout.Builder.Spacer().ColW(10f).HStar());
 
-                var rowNode = new Layout.Node.Stack(rowChildren.ToImmutable(), Layout.Axis.Horizontal)
-                {
-                    Width = Layout.Sizing.Star(),
-                    Height = Layout.Sizing.Star(),
-                    Background = isSelected ? SearchRowHover : (RGBAColor32?)null,
-                    Hit = new HitResult.ListItemHit("SearchResult", capturedIndex),
-                    OnClick = _ =>
+                var rowNode = Layout.Builder.HStack(rowChildren.ToImmutable().AsSpan())
+                    .Stretch()
+                    .Clickable(new HitResult.ListItemHit("SearchResult", capturedIndex), _ =>
                     {
                         State.Search.SelectedResultIndex = capturedIndex;
                         PostSignal(new SkyMapSearchCommitSignal());
-                    },
-                };
+                    });
+                if (isSelected) rowNode = rowNode.Bg(SearchRowHover);
                 RenderLayout(rowNode, new RectF32(x, rowY, w, rowH), fontPath, dpiScale);
             }
         }
@@ -368,17 +346,13 @@ namespace TianWen.UI.Abstractions
             // glyph box and the click surface are the same arranged rect.
             var closeSize = 20f * dpiScale;
             RenderLayout(
-                new Layout.Node.Leaf(new Layout.Content.Text("X", fontSize / dpiScale * 0.9f) { Color = SearchDimText, HAlign = TextAlign.Center, VAlign = TextAlign.Center })
-                {
-                    Width = Layout.Sizing.Star(),
-                    Height = Layout.Sizing.Star(),
-                    Hit = new HitResult.ButtonHit("InfoPanelClose"),
-                    OnClick = _ =>
+                Layout.Builder.Text("X", fontSize / dpiScale * 0.9f, SearchDimText, TextAlign.Center, TextAlign.Center)
+                    .Stretch()
+                    .Clickable(new HitResult.ButtonHit("InfoPanelClose"), _ =>
                     {
                         State.Search.InfoPanel = null;
                         State.NeedsRedraw = true;
-                    },
-                },
+                    }),
                 new RectF32(px + pw - closeSize, py, closeSize, closeSize), fontPath, dpiScale);
 
             // Selection marker on the map itself. For objects with a known shape


### PR DESCRIPTION
Completes the layout-DSL adoption: every TianWen UI builder now authors via `Layout.Builder` (the rename/release shipped the DSL + migrated the 2 shared builders; this finishes the remaining 8).

## Migration (36 sites, strictly semantics-preserving)
Converted from object-initializer `new Layout.Node{…}` construction to the fluent DSL:
`EquipmentTab` (15), `SessionConfigLayout` (8), `SkyMapTab.Search` (8), `LiveSessionTab` (4), `ImageRendererBase` (4, incl. the FITS Split/Dock — divider args preserved exactly), `PlannerTab` (5), `SessionTab` (3), `NotificationsTab` (1).

**Zero `new Layout.Node` / `new Layout.Content` remain** in TianWen.UI.Abstractions. Verification:
- `EquipmentPanelLayoutTests` + `SessionConfigLayoutTests` assert exact arranged geometry → unchanged.
- Live SDL-inspector spot-check: Planner, **Equipment** (biggest), and Session tabs render with correct draw==hit regions, no stderr exceptions.

## Docs
- `CLAUDE.md` → new **Layout DSL** section (build-with-Builder, the `using Layout = DIR.Lib.Layout;` alias rule, conditional-bg gotcha).
- `docs/architecture/layout-dsl.md` → deep-dive (pipeline, namespace/alias rationale, factory + modifier tables, before/after, testing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
