### PR TITLE
fix(guider+skywatcher): correctness audit — Dec-pulse guard, meridian-flip convergence test, hardening

### DIFF
--- a/src/TianWen.Lib.Tests.Functional/FakeSkywatcherMountDriverTests.cs
+++ b/src/TianWen.Lib.Tests.Functional/FakeSkywatcherMountDriverTests.cs
@@ -328,6 +328,42 @@ public class FakeSkywatcherMountDriverTests(ITestOutputHelper output)
     }
 
     /// <summary>
+    /// Regression (fix-sw): the DEFAULT constant-speed DEC pulse (decPulseGoTo=false) must query the
+    /// axis status (:f2) BEFORE the motion-mode command (:G2). Real firmware rejects :G on a
+    /// still-running axis with !2 (which <c>SendCommandAsync</c> would otherwise discard, silently
+    /// dropping the pulse); the guard checks status and stops a decelerating axis first, matching the
+    /// micro-GOTO / slew paths and the GSS client contract (stop running axis before :G).
+    /// </summary>
+    [Theory(Timeout = 60_000)]
+    [InlineData(GuideDirection.North)]
+    [InlineData(GuideDirection.South)]
+    public async Task GivenConstantSpeedDecPulseThenAxisStatusCheckedBeforeMotionMode(GuideDirection direction)
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var (mount, _) = await CreateConnectedMountAsync(ct); // decPulseGoTo defaults false -> rate mode
+        await mount.SyncRaDecAsync(6.0, 45.0, ct);
+        await mount.SetTrackingAsync(true, ct);
+
+        var serial = mount.SerialConnection.ShouldBeOfType<FakeSkywatcherSerialDevice>();
+        var before = serial.CommandLogSnapshot.Length;
+
+        await mount.PulseGuideAsync(direction, TimeSpan.FromSeconds(2), ct);
+
+        var decCmds = serial.CommandLogSnapshot.Skip(before)
+            .Where(c => c.Length > 2 && c[2] == '2')
+            .ToList();
+        output.WriteLine(string.Join(" ", decCmds));
+
+        var gIdx = decCmds.FindIndex(c => c.StartsWith(":G2", StringComparison.Ordinal));
+        var statusIdx = decCmds.FindIndex(c => c.StartsWith(":f2", StringComparison.Ordinal));
+        gIdx.ShouldBeGreaterThanOrEqualTo(0, "a constant-speed Dec pulse must command a motion mode (:G2)");
+        decCmds[gIdx].StartsWith(":G21", StringComparison.Ordinal)
+            .ShouldBeTrue("constant-speed pulse uses the low-speed SLEW func, not the GOTO func (:G22)");
+        statusIdx.ShouldBeGreaterThanOrEqualTo(0, "the Dec pulse must query axis status (:f2) before :G2");
+        statusIdx.ShouldBeLessThan(gIdx, "status must be checked BEFORE :G2 so a still-decelerating axis is stopped first");
+    }
+
+    /// <summary>
     /// Regression: after an away-from-pole sync the misalignment model anchors TRUE
     /// pointing to the sync reference plus time-based drift — and used to FREEZE OUT the
     /// live encoder entirely, making guide pulses invisible in pointing reads (the

--- a/src/TianWen.Lib.Tests.Functional/GuiderCalibrationTests.cs
+++ b/src/TianWen.Lib.Tests.Functional/GuiderCalibrationTests.cs
@@ -610,6 +610,76 @@ public class GuiderCalibrationTests(ITestOutputHelper output)
         corr.DecPulseMs.ShouldBeLessThan(0, "a drift toward North must be corrected toward South -- not amplified");
     }
 
+    [Theory(Timeout = 60_000)]
+    [InlineData(-1.0)] // northern-style sensor: North is CCW from West (North sweep = -Y)
+    [InlineData(1.0)]  // southern-style / flipped sensor: North is CW from West (North sweep = +Y)
+    public async Task GivenCalibratedGuiderWhenMeridianFlipThenCorrectionsStillConverge(double northDy)
+    {
+        // A GEM meridian flip reverses the DEC axis relative to the sky (the PHD2 "reverse Dec after
+        // flip" convention BuiltInGuiderDriver implements via GuiderCalibrationResult.WithMeridianFlip):
+        // on the post-flip pier side the DEC guide RESPONSE on the sensor inverts while RA is unchanged.
+        // This pins that the flipped calibration drives a post-flip error back to the lock point AND --
+        // the load-bearing negative check -- that WITHOUT the flip the same DEC error runs away. It must
+        // be a pure-math test: the fake guide camera does NOT model the flip's 180deg field change, so an
+        // end-to-end fake session could not catch a flip sign error here.
+        var ct = TestContext.Current.CancellationToken;
+        var timeProvider = new FakeTimeProviderWrapper(new DateTimeOffset(2025, 6, 15, 22, 0, 0, TimeSpan.Zero));
+
+        var tracker = new GuiderCentroidTracker(maxStars: 1);
+        var rig = new DirectionalStarRig { WestResponse = (-1.0, 0.0), NorthResponse = (0.0, northDy) };
+
+        ValueTask<Image> Render(CancellationToken token)
+        {
+            ReadOnlySpan<ProjectedStar> stars = [new ProjectedStar(160 + rig.X, 120 + rig.Y, Magnitude: 5.0)];
+            return ValueTask.FromResult(Image.FromChannel(SyntheticStarFieldRenderer.Render(
+                320, 240, 0, stars, offsetX: 0, offsetY: 0, exposureSeconds: 2.0, pixelScaleArcsec: PixelScaleArcsec)));
+        }
+
+        tracker.ProcessFrame((await Render(ct)).GetChannelArray(0));
+        tracker.IsAcquired.ShouldBeTrue();
+
+        var calibration = new GuiderCalibration { CalibrationPulseDuration = TimeSpan.FromSeconds(1), CalibrationSteps = 3 };
+        var cal = (await calibration.CalibrateAsync(rig, tracker, Render, timeProvider, ct)).ShouldNotBeNull();
+
+        var flipped = cal.WithMeridianFlip();
+
+        // Post-flip rig: the DEC sweep response inverts, RA unchanged (the established GEM-flip behavior).
+        DirectionalStarRig PostFlipRig() => new()
+        {
+            RatePxPerSec = rig.RatePxPerSec,
+            WestResponse = (-1.0, 0.0),
+            NorthResponse = (0.0, -northDy),
+        };
+
+        var controller = new ProportionalGuideController { MinPulseMs = 0 };
+
+        // With the flip applied, a combined RA+DEC offset on the post-flip sensor is driven to ~zero.
+        var converging = PostFlipRig();
+        converging.X = 4.0;
+        converging.Y = 5.0;
+        var startErr = Math.Sqrt(converging.X * converging.X + converging.Y * converging.Y);
+        for (var i = 0; i < 8; i++)
+        {
+            await ApplyCorrectionAsync(converging, controller.Compute(flipped, converging.X, converging.Y), ct);
+        }
+        var flippedErr = Math.Sqrt(converging.X * converging.X + converging.Y * converging.Y);
+        output.WriteLine($"northDy={northDy} flipped: |err| {startErr:F2} -> {flippedErr:F2}px");
+        flippedErr.ShouldBeLessThan(startErr * 0.2,
+            "WithMeridianFlip must keep the loop converging on the post-flip pier side");
+
+        // Negative check: WITHOUT the flip the same DEC error runs away (the classic post-flip Dec runaway).
+        var diverging = PostFlipRig();
+        diverging.X = 4.0;
+        diverging.Y = 5.0;
+        for (var i = 0; i < 4; i++)
+        {
+            await ApplyCorrectionAsync(diverging, controller.Compute(cal, diverging.X, diverging.Y), ct);
+        }
+        output.WriteLine($"northDy={northDy} no-flip: DEC {5.0:F2} -> {diverging.Y:F2}px");
+        Math.Abs(diverging.Y).ShouldBeGreaterThan(5.0,
+            "without WithMeridianFlip the DEC error must diverge on the flipped pier side");
+    }
+
     [Fact]
     public void SweepLinearityScoresMonotonicHighAndWanderingLow()
     {
@@ -626,6 +696,22 @@ public class GuiderCalibrationTests(ITestOutputHelper output)
             new CalibrationStep(8, 0), new CalibrationStep(2, 0), new CalibrationStep(9, 0));
         GuiderCalibration.SweepLinearity(origin, wandering, netDisplacementPx: 9.0)
             .ShouldBeLessThan(0.6, "a wandering sweep (unstable rate) must score below the reject threshold");
+    }
+
+    /// <summary>Applies a controller correction to the rig, mapping signed pulse-ms to guide directions
+    /// exactly as <c>GuideLoop</c> does (positive RA pulse = West, positive Dec pulse = North).</summary>
+    private static async ValueTask ApplyCorrectionAsync(DirectionalStarRig rig, GuideCorrection correction, CancellationToken ct)
+    {
+        if (correction.RaPulseMs != 0)
+        {
+            await rig.PulseGuideAsync(correction.RaPulseMs > 0 ? GuideDirection.West : GuideDirection.East,
+                TimeSpan.FromMilliseconds(Math.Abs(correction.RaPulseMs)), ct);
+        }
+        if (correction.DecPulseMs != 0)
+        {
+            await rig.PulseGuideAsync(correction.DecPulseMs > 0 ? GuideDirection.North : GuideDirection.South,
+                TimeSpan.FromMilliseconds(Math.Abs(correction.DecPulseMs)), ct);
+        }
     }
 
     /// <summary>Pulse target that moves a single tracked star by a per-axis response vector (camera px).</summary>

--- a/src/TianWen.Lib/Devices/Guider/BuiltInGuiderDriver.cs
+++ b/src/TianWen.Lib/Devices/Guider/BuiltInGuiderDriver.cs
@@ -23,7 +23,7 @@ internal sealed class BuiltInGuiderDriver : IDeviceDependentGuider
     private ICameraDriver? _camera;
     private IPulseGuideTarget? _pulseTarget;
 
-    private GuideLoop? _guideLoop;
+    private volatile GuideLoop? _guideLoop;
     private CancellationTokenSource? _guideCts;
     private Task? _guideLoopTask;
     private GuiderCalibrationResult? _lastCalibration;
@@ -369,11 +369,7 @@ internal sealed class BuiltInGuiderDriver : IDeviceDependentGuider
         // Reverse DEC direction in existing calibration data
         if (_lastCalibration is { } cal)
         {
-            _lastCalibration = cal with
-            {
-                DecRatePixPerSec = -cal.DecRatePixPerSec,
-                DecDisplacementPx = -cal.DecDisplacementPx
-            };
+            _lastCalibration = cal.WithMeridianFlip();
             // Toggle pier side so a subsequent auto-detect doesn't double-flip
             _calibrationPierSide = _calibrationPierSide?.Flipped;
         }
@@ -601,11 +597,7 @@ internal sealed class BuiltInGuiderDriver : IDeviceDependentGuider
                 var currentPierSide = await mount.GetSideOfPierAsync(ct);
                 if (_calibrationPierSide is { } calPier && calPier != currentPierSide)
                 {
-                    var flipped = calResult.Value with
-                    {
-                        DecRatePixPerSec = -calResult.Value.DecRatePixPerSec,
-                        DecDisplacementPx = -calResult.Value.DecDisplacementPx
-                    };
+                    var flipped = calResult.Value.WithMeridianFlip();
                     calResult = flipped;
                     _lastCalibration = flipped;
                     _calibrationPierSide = currentPierSide;
@@ -792,8 +784,6 @@ internal sealed class BuiltInGuiderDriver : IDeviceDependentGuider
         return await camera.GetImageAsync(ct) ?? throw new GuiderException("Failed to capture guide frame — no image data");
     }
 
-    private static readonly Random _ditherRng = new Random();
-
     public ValueTask DitherAsync(double ditherPixels, double settlePixels, double settleTime, double settleTimeout, bool raOnly = false, CancellationToken cancellationToken = default)
     {
         var current = CurrentState;
@@ -807,8 +797,10 @@ internal sealed class BuiltInGuiderDriver : IDeviceDependentGuider
         // creating the dither offset on the imaging camera.
         if (_guideLoop is { } loop)
         {
-            var angle = _ditherRng.NextDouble() * 2 * Math.PI;
-            var distance = ditherPixels * (0.5 + 0.5 * _ditherRng.NextDouble()); // 50-100% of requested
+            // Random.Shared is thread-safe (unlike a shared Random instance); dither direction
+            // does not need determinism, so no per-driver seeded RNG is required.
+            var angle = Random.Shared.NextDouble() * 2 * Math.PI;
+            var distance = ditherPixels * (0.5 + 0.5 * Random.Shared.NextDouble()); // 50-100% of requested
             var dx = distance * Math.Cos(angle);
             var dy = raOnly ? 0 : distance * Math.Sin(angle);
             loop.Tracker.OffsetLockPosition(dx, dy);
@@ -818,8 +810,10 @@ internal sealed class BuiltInGuiderDriver : IDeviceDependentGuider
         _settleTime = settleTime;
         _settleTimeout = settleTimeout;
 
-        ForceState(GuiderState.Settling);
+        // Record the settle-phase timestamps BEFORE flipping to Settling, so a poll that observes
+        // the Settling state never reads a stale phase-start tick (mirrors GuideAsync's ordering).
         RecordSettlePhaseStart();
+        ForceState(GuiderState.Settling);
 
         return ValueTask.CompletedTask;
     }

--- a/src/TianWen.Lib/Devices/Guider/GuiderCalibration.cs
+++ b/src/TianWen.Lib/Devices/Guider/GuiderCalibration.cs
@@ -672,6 +672,24 @@ internal readonly record struct GuiderCalibrationResult(
     public readonly double DecAngleDeg => DecAngleRad * 180.0 / Math.PI;
 
     /// <summary>
+    /// Returns the calibration with the DEC sense reversed for a German-mount meridian flip
+    /// (PHD2's "reverse Dec output after meridian flip"). Across a GEM flip the Dec axis mechanically
+    /// reverses relative to the sky while RA tracks the same way, so the Dec guide RESPONSE on the
+    /// sensor inverts but the RA response does not. Only the Dec rate/displacement sign flips here —
+    /// the measured axis ANGLES still describe where the motor axes point on the sensor and are left
+    /// unchanged. Negating <see cref="DecRatePixPerSec"/> inverts the Dec correction direction the
+    /// <see cref="ProportionalGuideController"/> derives, which is exactly what keeps the loop
+    /// converging on the post-flip pier side. Single source of truth for both flip sites in
+    /// <c>BuiltInGuiderDriver</c>; pinned by the post-flip convergence test in GuiderCalibrationTests.
+    /// </summary>
+    public readonly GuiderCalibrationResult WithMeridianFlip()
+        => this with
+        {
+            DecRatePixPerSec = -DecRatePixPerSec,
+            DecDisplacementPx = -DecDisplacementPx,
+        };
+
+    /// <summary>
     /// Decomposes a pixel-space error (dX, dY) onto the two MEASURED mount-axis directions
     /// (RA-West at <see cref="CameraAngleRad"/>, Dec-North at <see cref="DecAngleRad"/>) by solving
     /// the 2x2 basis. This honours the measured Dec SENSE (so a sensor whose North is clockwise from

--- a/src/TianWen.Lib/Devices/Guider/IGuider.cs
+++ b/src/TianWen.Lib/Devices/Guider/IGuider.cs
@@ -320,7 +320,7 @@ public interface IGuider : IDeviceDriver
         var settleTimeout = settleTime * SETTLE_TIMEOUT_FACTOR;
 
         Logger.LogInformation("Start dithering pixel={DitherPixel} settlePixel={SettlePixel} settleTime={SettleTime}, timeout={SettleTimeout}",
-            ditherPixel, settlePixel, settlePixel, settleTimeout);
+            ditherPixel, settlePixel, settleTime, settleTimeout);
 
         await DitherAsync(ditherPixel, settlePixel, settleTime.TotalSeconds, settleTimeout.TotalSeconds, cancellationToken: cancellationToken);
 

--- a/src/TianWen.Lib/Devices/Skywatcher/SkywatcherMountDriverBase.cs
+++ b/src/TianWen.Lib/Devices/Skywatcher/SkywatcherMountDriverBase.cs
@@ -659,6 +659,15 @@ internal abstract class SkywatcherMountDriverBase<TDevice>(TDevice device, IServ
                 return;
             }
 
+            // Real firmware rejects :G while the axis is still decelerating from the previous
+            // pulse's :K2 (error !2, silently discarded by SendCommandAsync) — the pulse is then
+            // lost. Mirror the decPulseGoTo / slew paths: ensure a full stop before :G2. Cheap
+            // when already stopped (one status round-trip).
+            if ((await QueryAxisStatusAsync('2', cancellationToken)).IsRunning)
+            {
+                await StopAxisAndWaitAsync('2', cancellationToken);
+            }
+
             await SendCommandAsync('G', '2', SkywatcherProtocol.EncodeMotionMode(SkywatcherMotionFunc.LowSpeedSlew, forward, IsSouthernHemisphere), cancellationToken);
             var t1 = SkywatcherProtocol.ComputeT1Preset(_tmrFreq, _cprDec, guideSpeed, false, _highSpeedRatio);
             await SendCommandAsync('I', '2', SkywatcherProtocol.EncodeUInt24(t1), cancellationToken);
@@ -1128,8 +1137,15 @@ internal abstract class SkywatcherMountDriverBase<TDevice>(TDevice device, IServ
         {
             throw new InvalidOperationException($"Failed to write command :{cmd}{axis}");
         }
-        // Read and discard acknowledgment
-        await port.TryReadTerminatedAsync(CrTerminator, cancellationToken);
+        // Read the acknowledgment. A response beginning with '!' is a firmware error (e.g. !2 =
+        // motor not stopped / :G on a running axis, !0 = unknown command). These were previously
+        // discarded silently, which hid dropped commands: a rejected :G no-ops the whole
+        // G/H/M/J goto/pulse sequence with no exception. Surface them so the gap is diagnosable.
+        var ack = await port.TryReadTerminatedAsync(CrTerminator, cancellationToken);
+        if (ack is { Length: > 0 } && ack[0] == '!')
+        {
+            Logger.LogWarning("Skywatcher command :{Cmd}{Axis} rejected with error response {Ack}", cmd, axis, ack);
+        }
     }
 
     private record struct AxisStatus(bool IsRunning, bool IsTracking, bool IsForward, bool IsInitDone);


### PR DESCRIPTION
## What

A correctness audit of the **built-in guider** and the **SkyWatcher mount driver** (the two surfaces we'd just changed at the session level for the meridian-flip work). Two real fixes, one previously-untested-but-correct path now pinned, and concurrency hardening.

### SkyWatcher (`d6f8e9a`)
- **Dec-pulse stop guard.** The *default* constant-speed Dec pulse (`decPulseGoTo=false`) issued `:G2` with no stop-and-wait — unlike the micro-GOTO and slew paths. Real firmware rejects `:G` on a still-decelerating axis with `!2`, so a Dec pulse arriving while the prior pulse's `:K2` was still halting the axis got silently dropped. Now queries `:f2` and `StopAxisAndWait` before `:G2` (cheap when already stopped).
- **Surface `!`-acks.** `SendCommandAsync` discarded the ack, so a rejected `:G`/`:H`/`:M`/`:J` no-op'd the whole sequence silently. Now logs a warning on any `!` response.
- Regression test: constant-speed Dec pulse checks status (`:f2`) before the low-speed-slew motion mode (`:G21…`).

### Guider (`9569971`)
- **Meridian-flip calibration: correct, now pinned.** Audit flagged a suspected "Dec runaway after flip" bug; I re-derived it (and an independent agent did too, after one false start) — the transform **is correct**: a GEM flip mechanically reverses Dec while RA tracks the same way, so negating only `DecRatePixPerSec`/`DecDisplacementPx` (PHD2's "reverse Dec after flip") is right. But it had **zero test coverage** and the fake camera can't catch a flip sign error (no 180° field model). Extracted the duplicated transform into a single `GuiderCalibrationResult.WithMeridianFlip()` and added a **both-hemisphere convergence test** with a load-bearing **negative check** (without the flip, Dec diverges).
- **Concurrency hardening.** `_guideLoop` → `volatile` (its siblings `_lastFrame`/`_calibrationTracker` already are; read cross-thread); `_ditherRng` static `Random` → `Random.Shared` (thread-safe); `DitherAsync` records settle timestamps before flipping to `Settling` (mirrors `GuideAsync`, avoids a stale-phase-start read).
- Fixed `DitherWaitAsync` log passing `settlePixel` twice (`settleTime` was never logged).

> Note: I deliberately did **not** churn the `double` fields (`_settlePixels/Time/Timeout`, `_gotoTargetRa/Dec`) to `Volatile.Read/Write` — the `volatile` keyword is illegal on `double`, and a torn read of an aligned 64-bit field doesn't occur on the x64/arm64 targets; wrapping every hot-path access was not worth the risk.

## Verification
- `dotnet build TianWen.Lib` — 0 warnings.
- Functional: 60/60 (incl. 2 new flip-convergence + 2 new Dec-pulse-guard tests) + 12/12 `FakeCameraMountCoupling`.
- Unit: 132 SkyWatcher (GSS oracle replay) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)