### PR TITLE
fix(session): only meridian-flip German equatorial mounts

### DIFF
--- a/src/TianWen.Lib.Tests.Functional/SessionObservationLoopTests.cs
+++ b/src/TianWen.Lib.Tests.Functional/SessionObservationLoopTests.cs
@@ -353,12 +353,62 @@ public class SessionObservationLoopTests(ITestOutputHelper output)
         // Should have produced frames (some before the flip, some after)
         ctx.Session.TotalFramesWritten.ShouldBeGreaterThan(0, "should have written frames across meridian flip");
 
+        // A German equatorial mount MUST flip here (contrast: the non-German theory below asserts 0).
+        ctx.Session.MeridianFlipCount.ShouldBeGreaterThan(0,
+            "a GEM crossing the meridian must perform a flip");
+
         // Observation should have advanced (completed its scheduled duration)
         ctx.Session.CurrentObservationIndex.ShouldBeGreaterThanOrEqualTo(1,
             "observation should have advanced after completing duration");
 
         output.WriteLine($"Frames written: {ctx.Session.TotalFramesWritten}");
         output.WriteLine($"Total exposure: {ctx.Session.TotalExposureTime}");
+    }
+
+    /// <summary>
+    /// A fork/equatorial (<see cref="AlignmentMode.Polar"/>) or Alt-Az mount never meridian-flips —
+    /// only a German equatorial mount's counterweight bar would collide with the pier past the meridian.
+    /// Same geometry as <see cref="GivenAcrossMeridianTargetWhenHACrossesDeadbandThenFlipAndContinueImaging"/>
+    /// (a target that crosses the meridian mid-observation), but the mount reports a non-German alignment,
+    /// so the imaging loop must track straight across: frames keep being written and ZERO flips occur.
+    /// </summary>
+    [Theory(Timeout = 120_000)]
+    [InlineData(AlignmentMode.Polar)] // fork on an equatorial wedge
+    [InlineData(AlignmentMode.AltAz)] // alt-azimuth
+    public async Task GivenNonGermanMountWhenTargetCrossesMeridianThenImagesWithoutFlipping(AlignmentMode alignment)
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var subExposure = TimeSpan.FromSeconds(30);
+
+        // Same crossing geometry as the GEM flip test: HA starts ~-0.15h, crosses to +0.1h after ~15 min.
+        var observations = new[]
+        {
+            new ScheduledObservation(
+                new Target(4.89, 20.0, "MeridianCrosser", null),
+                WinterNightStart,
+                TimeSpan.FromMinutes(30),
+                AcrossMeridian: true,
+                FilterPlan: FilterPlanBuilder.BuildSingleFilterPlan(subExposure),
+                Gain: 0,
+                Offset: 0
+            )
+        };
+
+        using var ctx = await CreateWinterSessionAsync(observations, mountPort: null, cancellationToken: ct);
+
+        // Make the (otherwise German) fake report a non-German alignment — a fork or Alt-Az mount.
+        ((FakeMountDriver)ctx.Mount).Alignment = alignment;
+
+        await RunObservationLoopWithTimePumpAsync(ctx, subExposure, ct);
+
+        ctx.Session.MeridianFlipCount.ShouldBe(0,
+            "a fork / Alt-Az mount tracks across the meridian and must never flip");
+        ctx.Session.TotalFramesWritten.ShouldBeGreaterThan(0,
+            "imaging must continue straight across the meridian");
+        ctx.Session.CurrentObservationIndex.ShouldBeGreaterThanOrEqualTo(1,
+            "observation should advance after completing its duration");
+
+        output.WriteLine($"alignment={alignment} frames={ctx.Session.TotalFramesWritten} flips={ctx.Session.MeridianFlipCount}");
     }
 
     /// <summary>

--- a/src/TianWen.Lib/Devices/Fake/FakeMountDriver.cs
+++ b/src/TianWen.Lib/Devices/Fake/FakeMountDriver.cs
@@ -226,8 +226,15 @@ internal sealed class FakeMountDriver(FakeDevice fakeDevice, IServiceProvider se
 
     public bool TimeIsSetByUs { get; private set; }
 
+    /// <summary>
+    /// Alignment mode this fake reports. Defaults to German equatorial (the mount type that
+    /// meridian-flips). Settable so tests can simulate a fork/equatorial (<see cref="AlignmentMode.Polar"/>)
+    /// or Alt-Az mount, which track across the meridian without flipping.
+    /// </summary>
+    internal AlignmentMode Alignment { get; set; } = AlignmentMode.GermanPolar;
+
     public ValueTask<AlignmentMode> GetAlignmentAsync(CancellationToken cancellationToken)
-        => ValueTask.FromResult(AlignmentMode.GermanPolar);
+        => ValueTask.FromResult(Alignment);
 
     public ValueTask<bool> IsTrackingAsync(CancellationToken cancellationToken)
         => ValueTask.FromResult(_isTracking);

--- a/src/TianWen.Lib/Sequencing/Session.Imaging.cs
+++ b/src/TianWen.Lib/Sequencing/Session.Imaging.cs
@@ -325,6 +325,15 @@ internal partial record Session
         // A GEM flips at most once per target. Set after a successful (or detected) flip so the HA-window
         // decision can never re-fire for this observation — the backstop behind the destination-side gate.
         var hasFlipped = false;
+
+        // The meridian flip + pre-meridian obstruction pause are a GERMAN-equatorial concern ONLY: the GEM's
+        // counterweight bar would collide with the pier if it tracked past the meridian on the same side.
+        // Fork/equatorial (AlignmentMode.Polar — OTA rides between the fork arms) and Alt-Az mounts track
+        // straight across the meridian and never flip, so the entire detection block below is skipped for
+        // them. Read once (cheap, effectively constant per session); default to GermanPolar on a read failure
+        // so a transient glitch can never stop a real GEM from flipping.
+        var isGermanEquatorial =
+            await CatchAsync(mount.Driver.GetAlignmentAsync, cancellationToken, AlignmentMode.GermanPolar) == AlignmentMode.GermanPolar;
         var currentSubExposuresSec = new int[scopes];
 
         for (var i = 0; i < scopes; i++)
@@ -705,7 +714,7 @@ internal partial record Session
             // For non-AcrossMeridian targets: keep the legacy HA-jump detection — if the pier side
             //   changes unexpectedly, abort the target.
             var flipAction = FlipAction.Continue;
-            if (!await CatchAsync(mount.Driver.IsSlewingAsync, cancellationToken))
+            if (isGermanEquatorial && !await CatchAsync(mount.Driver.IsSlewingAsync, cancellationToken))
             {
                 if (observation.AcrossMeridian)
                 {
@@ -805,6 +814,7 @@ internal partial record Session
                         hourAngleAtSlewTime = flipResult.HourAngle;
                         // A flip happened (commanded or detected) — never flip again for this target.
                         hasFlipped = true;
+                        MeridianFlipCount++;
                         // Update the pier-side baseline so the next out-of-band-flip detection
                         // compares against where we are now, not where we were three flips ago.
                         if (flipResult.PierSide != PointingState.Unknown)

--- a/src/TianWen.Lib/Sequencing/Session.cs
+++ b/src/TianWen.Lib/Sequencing/Session.cs
@@ -143,6 +143,9 @@ internal partial record Session(
     public int TotalFramesWritten => Volatile.Read(ref _totalFramesWritten);
     public TimeSpan TotalExposureTime => TimeSpan.FromTicks(Interlocked.Read(ref _totalExposureTimeTicks));
     public int CurrentObservationIndex => _activeObservation;
+    /// <summary>Number of meridian flips actually performed or detected this session. Test seam used to
+    /// assert that a non-German mount (fork / Alt-Az) images across the meridian without ever flipping.</summary>
+    internal int MeridianFlipCount { get; private set; }
     public ImmutableArray<FocusRunRecord> FocusHistory => [.. _focusHistory];
     public ImmutableArray<(int Position, float Hfd)> ActiveFocusSamples => _activeFocusSamples;
     public ImmutableArray<GuideErrorSample> GuideSamples => [.. _guideSamples];


### PR DESCRIPTION
## What

Meridian flips (and the pre-meridian obstruction pause) are a **GEM-only** concern — the counterweight bar collides with the pier if a German mount tracks past the meridian on the same side. **Fork/equatorial** (`AlignmentMode.Polar` — OTA rides between the fork arms) and **Alt-Az** mounts track straight across the meridian and never flip.

## The gap

`ObservationScheduler` sets `AcrossMeridian` purely from the target's transit geometry (mount-agnostic), and the imaging loop keyed *only* on that flag. `GetAlignmentAsync()` was implemented on every driver but **never consulted in `Sequencing`**. So a fork/Alt-Az mount imaging a transiting target would perform one unnecessary, disruptive flip cycle — stop guider → re-slew → re-center → restart guider — at the meridian, plus the obstruction-zone exposure pause. (Not a runaway: the re-slew lands at `HA > 0` immediately and `hasFlipped` stops further attempts — but it's lost integration time on a mount that should just keep tracking.)

In practice this only bit **ASCOM/Alpaca/Meade fork or Alt-Az mounts** (the built-in serial drivers are all GermanPolar) — narrow, but real.

## Fix

Read `GetAlignmentAsync()` once at the top of `ImagingLoopAsync` and gate the whole flip/obstruction detection block on `AlignmentMode.GermanPolar`. Non-German mounts fall through to normal imaging. Defaults to `GermanPolar` on a read failure, so a transient glitch can never stop a real GEM from flipping.

## Tests

- New internal `Session.MeridianFlipCount` seam + settable `FakeMountDriver.Alignment`.
- `[Theory]` (`Polar`, `AltAz`): a mount crossing the meridian images with **0 flips** while frames are written.
- The existing GEM crossing test now also asserts **flips > 0**, so the counter is a proven discriminator (the non-GEM `== 0` assertion isn't vacuous).

## Verification
- `dotnet build TianWen.Lib` — 0 warnings.
- `SessionObservationLoop` functional suite: 12/12 (incl. 2 new non-GEM cases + strengthened GEM test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)