### PR TITLE
feat(skywatcher): alignment-mode setting; alt-az report-only (refused) + full-support plan

### DIFF
--- a/docs/plans/altaz-mount-support.md
+++ b/docs/plans/altaz-mount-support.md
@@ -1,0 +1,131 @@
+# Alt-Az (and fork) mount support
+
+Status legend: ✅ shipped · 🔜 next · ⛔ blocked/deferred
+
+## Summary
+
+SkyWatcher mounts like the **AZ-GTi** are dual-mode: the *same* hardware runs equatorial (EQ, on a
+wedge) or alt-azimuth (AZ, flat). TianWen's SkyWatcher driver is **equatorial-only** today. This plan
+covers (a) what already ships to make alt-az *safe*, and (b) the full work to make alt-az actually
+*usable*.
+
+**Shipped (Phase 0):** a user-selectable `?alignment=GermanPolar|Polar|AltAz` setting on the SkyWatcher
+device (default `GermanPolar`). `AltAz` is **report-only**: `GetAlignmentAsync` returns it, pier-side
+reads return `Unknown`, and the session's GEM-only meridian-flip gate skips the mount — but coordinate
+slews, sidereal tracking, and RA/Dec sync are **refused** with `NotSupportedException`, so an alt-az
+mount can never be driven with the equatorial transforms and silently mis-point. See
+`SkywatcherMountDriverBase.EnsureEquatorialAlignment`. The meridian-flip gate itself is GEM-only as of
+the `AlignmentMode.GermanPolar` check in `Session.Imaging.cs` (`ImagingLoopAsync`).
+
+**Not done:** everything needed to actually *point, track, guide, and image* in alt-az (Phases 1–3).
+
+## Why alignment is a user setting, not auto-detected
+
+The SkyWatcher motor-controller protocol **cannot report whether the mount is in AZ or EQ mode** —
+it's the same hardware either way:
+
+- `:e` (firmware/model) returns the same model code (AZ-GTi = `0xA5`/`0xC5`) regardless of how the
+  mount is physically set up.
+- `:q` capabilities exposes a `CanAzEq` bit, but that only means "supports both modes", not "currently
+  in AZ".
+
+This is why the SynScan app *asks* at connect and GSServer makes `AlignmentMode` a persisted user
+setting. We mirror GSServer: a setting, defaulting to `GermanPolar`.
+
+**Home position:** in alt-az the SkyWatcher home is the raw encoder zero — **az 0 (north), alt 0
+(horizontal)** — not the equatorial pole (`HomeAxisX/Y = 0/0` in GSS's AltAz profile vs `90/90` for
+GermanPolar). The driver's `MaybeSyncToPoleAfterSiteSetAsync` is skipped in alt-az for this reason.
+
+## Reference: how GSServer handles AZ vs EQ
+
+GSS uses ASCOM's standard `AlignmentModes` (`algAltAz` / `algPolar` / `algGermanPolar`) as a user
+setting (`SkySettings.AlignmentMode`) with a separate settings profile per mode. In `algAltAz`:
+
+| Concern | GSS behavior (`Axes.cs` / `SkyServer.cs`) |
+|---|---|
+| Axis transforms | **Identity** — the two motor axes *are* Az/Alt (no through-pole / hemisphere fold) |
+| RA/Dec ↔ axes | `RaDec2AltAz(lst, latitude)` / `AltAz2RaDec` |
+| Meridian flip | `IsFlipRequired → false`; `DetermineSideOfPier → pierUnknown`; `CanSetPierSide → false` |
+| Tracking | Dual-axis predictor: a timer recomputes **both** Az and Alt rates (vs EQ single-axis sidereal `:I`) |
+| Pulse guiding | Mini-GOTO in Az/Alt space; Dec sense is a plain South sign-flip (no pier side) |
+| ASCOM reporting | `AlignmentMode=algAltAz`, `CanSetPierSide=false`, `DestinationSideOfPier=pierUnknown` |
+
+## Gap analysis — what full alt-az support needs
+
+Each item lists the concrete TianWen touchpoint.
+
+### 1. Az/Alt ↔ encoder-step transforms 🔜
+`SkywatcherMountDriverBase.RaToSteps` / `StepsToRa` / `DecToSteps` / `StepsToDec` are equatorial
+(HA/Dec, south-mirror, through-pole). Alt-az needs a parallel path: target RA/Dec → Az/Alt (via LST +
+site latitude) → axis steps (≈identity, home = az0/alt0), and the inverse for position reads. The
+shared transform helper `IMountDriver.TryTransformJ2000ToMountNativeAsync` already yields `Az`/`Alt`
+alongside `RaMount`/`DecMount`, so the input is available — the SkyWatcher step math is what's missing.
+
+### 2. `BeginSlewToTargetAsync` pier-side gate 🔜 (shared, affects all drivers)
+`IMountDriver.BeginSlewToTargetAsync` refuses the slew when `DestinationSideOfPierAsync == Unknown`.
+For an alt-az mount that *legitimately* has no pier side, this is a hard block (today it's exactly
+what makes Phase-0 reject work). Full support must bypass the pier-side gate when alignment is alt-az.
+This is an `IMountDriver`-layer change, so it also unblocks **ASCOM/Alpaca** alt-az mounts (which
+already report `algAltAz` natively).
+
+### 3. Dual-axis alt-az tracking 🔜
+`SkywatcherMountDriverBase.SetTrackingAsync` runs a single RA axis at sidereal. Alt-az tracking needs
+both axes driven at continuously-recomputed rates (a predictor + periodic re-rate, like GSS's
+`AltAzTrackingTimerEvent`). New subsystem in the driver.
+
+### 4. Alt-az guiding ⛔ (after 1–3)
+`PulseGuideCoreAsync` maps N/S/E/W to the Dec/RA axes (equatorial). In alt-az, corrections map to
+Alt/Az and the field **rotates continuously**, so:
+- the built-in guider's calibration would drift as the field rotates (calibration assumes a fixed
+  camera-to-axis angle);
+- the pier-side Dec-sense invariant (`CalibrateGuiderAsync` slews to HA −0.5h; see CLAUDE.md "Guider
+  calibration pier-side invariant") is meaningless for alt-az and needs an alt-az calibration pose.
+
+Likely outcome: short unguided subs for alt-az, or a substantially different guiding model.
+
+### 5. Field rotation / derotator ⛔ (the imaging blocker)
+Alt-az mounts rotate the field while tracking, smearing long exposures. Real imaging needs **one** of:
+- a mechanical **derotator** — `IRotatorDriver` / `DeviceType.Rotator`, which **does not exist yet**
+  (it's a backlog item: TODO.md "Rotator device type"); or
+- short subs + **software derotation** in the stacker; or
+- accept alt-az for EAA / plate-solve / visual only (no long-exposure imaging).
+
+This gates alt-az *imaging* independently of the mount-driver work.
+
+### 6. Position reads in alt-az 🔜
+`GetRightAscensionAsync` / `GetDeclinationAsync` run the equatorial `StepsToRa`/`StepsToDec` on the
+encoder, so at the alt-az home `(0,0)` they report a nonsense RA/Dec. Full support converts the Az/Alt
+encoder position → RA/Dec via site + time. `EquatorialSystem` stays `Topocentric`.
+
+### 7. `Polar` (fork-on-wedge equatorial) — minor, separate
+`Polar` is equatorial (RA/Dec) with no flip; the `#47` gate already skips flips for non-`GermanPolar`.
+Our equatorial transforms are GermanPolar-shaped (south mirror / through-pole); whether a fork-Polar
+mount needs different handling (GSS distinguishes Polar Left/Right) is unverified. Low priority — the
+AZ-GTi is not a fork mount. For now `Polar` rides the equatorial path and skips the flip.
+
+## Phasing
+
+| Phase | Scope | Enables | Status |
+|---|---|---|---|
+| 0 | Alignment setting + report-only + reject; GEM-only flip gate | Safe: never mis-points an alt-az mount | ✅ |
+| 1 | Items 1, 2, 3, 6 | Correct alt-az **GOTO + tracking + position** (visual / EAA / plate-solve & sync) — no imaging | 🔜 |
+| 2 | Item 4 | Alt-az guiding (or a documented "unguided short subs" stance) | ⛔ after 1 |
+| 3 | Item 5 | Long-exposure alt-az **imaging** (gated on rotator support, itself a TODO) | ⛔ |
+
+## Testing
+
+- `FakeSkywatcherSerialDevice` already models the motor controller; a fake alt-az path would interpret
+  the two axes as Az/Alt. Phase-1 tests: a GOTO lands at the correct az/alt; tracking keeps a target's
+  az/alt converging over fake time; position reads round-trip RA/Dec ↔ Az/Alt.
+- Phase-0 (shipped) is covered by `FakeSkywatcherMountDriverTests`:
+  `GivenAltAzAlignmentThenReportedButCoordinateOpsRefused` (report + reject) and
+  `GivenNoAlignmentQueryThenDefaultsToGermanPolar` (default unchanged), plus the GEM-only flip
+  `[Theory]` in `SessionObservationLoopTests`.
+
+## Recommendation
+
+Most AZ-GTi *imagers* run the mount on an equatorial wedge (EQ mode) precisely to avoid field rotation
+— and that path already works as `GermanPolar`. Phase 0 makes the alt-az case **safe** rather than
+silently wrong. Pursue **Phase 1** if there's demand for visual / EAA / plate-solve use of an alt-az
+mount; **defer Phase 3 (imaging)** until `IRotatorDriver` support lands, since long-exposure alt-az
+imaging is impossible without derotation regardless of how good the mount driver is.

--- a/src/TianWen.Lib.Tests.Functional/FakeSkywatcherMountDriverTests.cs
+++ b/src/TianWen.Lib.Tests.Functional/FakeSkywatcherMountDriverTests.cs
@@ -20,7 +20,8 @@ public class FakeSkywatcherMountDriverTests(ITestOutputHelper output)
         double azMisalignmentArcmin = 0.0,
         double altMisalignmentArcmin = 0.0,
         DateTimeOffset? now = null,
-        bool decPulseGoTo = false)
+        bool decPulseGoTo = false,
+        string? alignment = null)
     {
         var external = new FakeExternal(output, now: now ?? new DateTimeOffset(2025, 6, 15, 22, 0, 0, TimeSpan.Zero));
         var query = new NameValueCollection
@@ -35,6 +36,10 @@ public class FakeSkywatcherMountDriverTests(ITestOutputHelper output)
         {
             query.Add("decPulseGoto", "true");
         }
+        if (alignment is not null)
+        {
+            query.Add("alignment", alignment);
+        }
         var device = new FakeDevice(DeviceType.Mount, 1, query);
         var mount = new FakeSkywatcherMountDriver(device, external.BuildServiceProvider());
         return (mount, external);
@@ -47,9 +52,10 @@ public class FakeSkywatcherMountDriverTests(ITestOutputHelper output)
         double azMisalignmentArcmin = 0.0,
         double altMisalignmentArcmin = 0.0,
         DateTimeOffset? now = null,
-        bool decPulseGoTo = false)
+        bool decPulseGoTo = false,
+        string? alignment = null)
     {
-        var (mount, external) = CreateMount(latitude, longitude, azMisalignmentArcmin, altMisalignmentArcmin, now, decPulseGoTo);
+        var (mount, external) = CreateMount(latitude, longitude, azMisalignmentArcmin, altMisalignmentArcmin, now, decPulseGoTo, alignment);
         await mount.ConnectAsync(ct);
         await mount.SetSiteLatitudeAsync(latitude, ct);
         await mount.SetSiteLongitudeAsync(longitude, ct);
@@ -361,6 +367,42 @@ public class FakeSkywatcherMountDriverTests(ITestOutputHelper output)
             .ShouldBeTrue("constant-speed pulse uses the low-speed SLEW func, not the GOTO func (:G22)");
         statusIdx.ShouldBeGreaterThanOrEqualTo(0, "the Dec pulse must query axis status (:f2) before :G2");
         statusIdx.ShouldBeLessThan(gIdx, "status must be checked BEFORE :G2 so a still-decelerating axis is stopped first");
+    }
+
+    /// <summary>Default (no ?alignment query) is German equatorial — the existing behaviour is unchanged.</summary>
+    [Fact(Timeout = 60_000)]
+    public async Task GivenNoAlignmentQueryThenDefaultsToGermanPolar()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var (mount, _) = await CreateConnectedMountAsync(ct);
+        (await mount.GetAlignmentAsync(ct)).ShouldBe(AlignmentMode.GermanPolar);
+    }
+
+    /// <summary>
+    /// Alt-az alignment (e.g. an AZ-GTi off its equatorial wedge) is REPORT-ONLY in this driver:
+    /// GetAlignment returns AltAz and both pier-side reads are Unknown (so the session's GEM-only flip
+    /// gate skips this mount), but coordinate slews / sidereal tracking / RA-Dec sync are REFUSED with
+    /// NotSupported — the encoder transforms here are equatorial, so honouring an alt-az target would
+    /// silently point the mount wrong. Stopping tracking stays allowed. See docs/plans/altaz-mount-support.md.
+    /// </summary>
+    [Fact(Timeout = 60_000)]
+    public async Task GivenAltAzAlignmentThenReportedButCoordinateOpsRefused()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var (mount, _) = await CreateConnectedMountAsync(ct, alignment: "AltAz");
+
+        (await mount.GetAlignmentAsync(ct)).ShouldBe(AlignmentMode.AltAz);
+        mount.CanSetSideOfPier.ShouldBeFalse();
+        (await mount.GetSideOfPierAsync(ct)).ShouldBe(PointingState.Unknown);
+        (await mount.DestinationSideOfPierAsync(6.0, 45.0, ct)).ShouldBe(PointingState.Unknown);
+
+        // Coordinate operations are refused — never silently point an equatorial transform at alt-az.
+        await Should.ThrowAsync<NotSupportedException>(async () => await mount.BeginSlewRaDecAsync(6.0, 45.0, ct));
+        await Should.ThrowAsync<NotSupportedException>(async () => await mount.SyncRaDecAsync(6.0, 45.0, ct));
+        await Should.ThrowAsync<NotSupportedException>(async () => await mount.SetTrackingAsync(true, ct));
+
+        // Stopping tracking is always safe and must not throw.
+        await Should.NotThrowAsync(async () => await mount.SetTrackingAsync(false, ct));
     }
 
     /// <summary>

--- a/src/TianWen.Lib/Devices/DeviceQueryKey.cs
+++ b/src/TianWen.Lib/Devices/DeviceQueryKey.cs
@@ -37,6 +37,7 @@ public enum DeviceQueryKey
     PolarMisalignmentAzArcmin,
     PolarMisalignmentAltArcmin,
     DecPulseGoTo,
+    Alignment,
 }
 
 public static class DeviceQueryKeyExtensions
@@ -91,6 +92,7 @@ public static class DeviceQueryKeyExtensions
             DeviceQueryKey.PolarMisalignmentAzArcmin => "polarMisalignmentAzArcmin",
             DeviceQueryKey.PolarMisalignmentAltArcmin => "polarMisalignmentAltArcmin",
             DeviceQueryKey.DecPulseGoTo => "decPulseGoto",
+            DeviceQueryKey.Alignment => "alignment",
             _ => key.ToString().ToLowerInvariant()
         };
     }

--- a/src/TianWen.Lib/Devices/Skywatcher/SkywatcherDevice.cs
+++ b/src/TianWen.Lib/Devices/Skywatcher/SkywatcherDevice.cs
@@ -26,6 +26,12 @@ public record SkywatcherDevice(Uri DeviceUri) : DeviceBase(DeviceUri)
 
     private static readonly ImmutableArray<DeviceSettingDescriptor> MountSettings =
     [
+        // Alignment is a user choice (the AZ/EQ-capable hardware reports the same model code either
+        // way, so it cannot be auto-detected). AltAz is currently REPORT-ONLY — the driver refuses
+        // coordinate slews/tracking in alt-az; see docs/plans/altaz-mount-support.md.
+        DeviceSettingHelper.EnumSetting<AlignmentMode>(
+            DeviceQueryKey.Alignment.Key, "Alignment",
+            defaultValue: AlignmentMode.GermanPolar),
         DeviceSettingHelper.BoolSetting(
             DeviceQueryKey.DecPulseGoTo.Key, "Dec Pulse as GOTO",
             defaultValue: false,

--- a/src/TianWen.Lib/Devices/Skywatcher/SkywatcherMountDriverBase.cs
+++ b/src/TianWen.Lib/Devices/Skywatcher/SkywatcherMountDriverBase.cs
@@ -80,6 +80,41 @@ internal abstract class SkywatcherMountDriverBase<TDevice>(TDevice device, IServ
     private readonly bool _decPulseGoTo =
         bool.TryParse(device.Query.QueryValue(DeviceQueryKey.DecPulseGoTo), out var decPulseGoTo) && decPulseGoTo;
 
+    /// <summary>
+    /// Mount alignment mode (<c>?alignment=GermanPolar|Polar|AltAz</c>; default German equatorial).
+    /// This is a USER setting, mirroring GSServer: the same AZ/EQ hardware (e.g. a SkyWatcher AZ-GTi
+    /// on a wedge vs flat) reports the identical motor-controller model code, so the protocol cannot
+    /// tell which way it is mounted — the SynScan app asks at connect; we make it configurable.
+    /// <para>
+    /// German/Polar drive the equatorial HA/Dec encoder-step transforms in this class. <b>Alt-az is
+    /// REPORTED</b> (so the session skips meridian-flip + pier-side logic) but coordinate slews,
+    /// sidereal tracking, and RA/Dec sync are <b>REFUSED</b>: the step transforms here are equatorial,
+    /// so honouring an alt-az target would silently point the mount wrong. Full alt-az support is
+    /// scoped in <c>docs/plans/altaz-mount-support.md</c>.
+    /// </para>
+    /// </summary>
+    private readonly AlignmentMode _alignmentMode =
+        Enum.TryParse<AlignmentMode>(device.Query.QueryValue(DeviceQueryKey.Alignment), ignoreCase: true, out var alignment)
+            ? alignment
+            : AlignmentMode.GermanPolar;
+
+    /// <summary>
+    /// Fails loudly for a coordinate operation we cannot yet perform in a non-equatorial alignment.
+    /// The SkyWatcher transforms in this driver are equatorial (HA/Dec -&gt; encoder steps); an RA/Dec
+    /// slew, sidereal tracking, or sync issued in alt-az mode would point the mount wrong, so we throw
+    /// rather than execute it silently. See <c>docs/plans/altaz-mount-support.md</c>.
+    /// </summary>
+    private void EnsureEquatorialAlignment(string operation)
+    {
+        if (_alignmentMode == AlignmentMode.AltAz)
+        {
+            throw new NotSupportedException(
+                $"{operation} is not supported in alt-azimuth alignment mode. The TianWen SkyWatcher driver " +
+                "drives equatorial mounts only — put the mount on an equatorial wedge and set alignment=GermanPolar. " +
+                "Full alt-az support is tracked in docs/plans/altaz-mount-support.md.");
+        }
+    }
+
     // Site
     private double _siteLatitude = double.NaN;
     private double _siteLongitude = double.NaN;
@@ -174,7 +209,7 @@ internal abstract class SkywatcherMountDriverBase<TDevice>(TDevice device, IServ
     public EquatorialCoordinateType EquatorialSystem => EquatorialCoordinateType.Topocentric;
 
     public ValueTask<AlignmentMode> GetAlignmentAsync(CancellationToken cancellationToken)
-        => ValueTask.FromResult(AlignmentMode.GermanPolar);
+        => ValueTask.FromResult(_alignmentMode);
 
     public ValueTask<TrackingSpeed> GetTrackingSpeedAsync(CancellationToken cancellationToken)
         => ValueTask.FromResult(TrackingSpeed.Sidereal); // Skywatcher only supports sidereal tracking natively
@@ -199,6 +234,9 @@ internal abstract class SkywatcherMountDriverBase<TDevice>(TDevice device, IServ
     {
         if (tracking)
         {
+            // Sidereal single-axis tracking is equatorial-only; alt-az needs a dual-axis predictor.
+            EnsureEquatorialAlignment("Tracking");
+
             if (_cprRa == 0 || _tmrFreq == 0)
             {
                 return;
@@ -387,6 +425,8 @@ internal abstract class SkywatcherMountDriverBase<TDevice>(TDevice device, IServ
 
     public virtual async ValueTask BeginSlewRaDecAsync(double ra, double dec, CancellationToken cancellationToken)
     {
+        EnsureEquatorialAlignment("Slewing to RA/Dec");
+
         if (_cprRa == 0 || _cprDec == 0)
         {
             throw new InvalidOperationException("Mount not initialized");
@@ -489,6 +529,8 @@ internal abstract class SkywatcherMountDriverBase<TDevice>(TDevice device, IServ
 
     public virtual async ValueTask SyncRaDecAsync(double ra, double dec, CancellationToken cancellationToken)
     {
+        EnsureEquatorialAlignment("Sync to RA/Dec");
+
         var raSteps = RaToSteps(ra);
         var decSteps = DecToSteps(dec);
 
@@ -789,6 +831,13 @@ internal abstract class SkywatcherMountDriverBase<TDevice>(TDevice device, IServ
 
     public async ValueTask<PointingState> GetSideOfPierAsync(CancellationToken cancellationToken)
     {
+        // Alt-az mounts have no pier side. Reporting Unknown also makes the session's GEM-only flip
+        // gate skip meridian-flip handling for this mount.
+        if (_alignmentMode == AlignmentMode.AltAz)
+        {
+            return PointingState.Unknown;
+        }
+
         // Pier side is determined from the Dec encoder position (the physical orientation of
         // the telescope), not from HA (which only tells you where the target is in the sky).
         // Following GSServer GermanPolar convention:
@@ -810,6 +859,13 @@ internal abstract class SkywatcherMountDriverBase<TDevice>(TDevice device, IServ
 
     public ValueTask<PointingState> DestinationSideOfPierAsync(double ra, double dec, CancellationToken cancellationToken)
     {
+        // Alt-az has no pier side; returning Unknown also makes BeginSlewToTargetAsync refuse the
+        // (equatorial) slew for an alt-az mount instead of pointing it wrong.
+        if (_alignmentMode == AlignmentMode.AltAz)
+        {
+            return ValueTask.FromResult(PointingState.Unknown);
+        }
+
         // Determine pier side based on hour angle
         var transform = new Transform(TimeProvider);
         transform.RefreshDateTimeFromTimeProvider();
@@ -852,6 +908,10 @@ internal abstract class SkywatcherMountDriverBase<TDevice>(TDevice device, IServ
     private async ValueTask MaybeSyncToPoleAfterSiteSetAsync(CancellationToken cancellationToken)
     {
         if (!Connected) return;
+        // "Parked at the pole" is an equatorial reporting convenience. In alt-az the home IS the raw
+        // encoder zero (az 0 = north, alt 0 = horizontal), so there is nothing to sync — and an RA/Dec
+        // sync is refused in alt-az anyway. Skip it so setting the site never fails for an alt-az mount.
+        if (_alignmentMode == AlignmentMode.AltAz) return;
         if (_cprRa == 0 || _cprDec == 0) return;
         if (double.IsNaN(_siteLatitude) || double.IsNaN(_siteLongitude)) return;
         if (_posRa != 0 || _posDec != 0) return;


### PR DESCRIPTION
## What

SkyWatcher mounts like the **AZ-GTi** run either equatorial (on a wedge) or alt-azimuth (flat) — the *same* hardware. The motor-controller protocol **cannot detect which** (the `:e` model code is identical in both modes; `:q CanAzEq` only means "supports both"), so — mirroring GSServer — the mode is now a **user setting**: `?alignment=GermanPolar|Polar|AltAz` (default `GermanPolar`), surfaced as an `EnumCycle` in the equipment UI.

Our SkyWatcher coordinate transforms are equatorial (HA/Dec → encoder steps), so this PR makes alt-az **safe, not silently wrong** — it does *not* yet make alt-az drivable.

## Behavior

- `GetAlignmentAsync` reports the configured mode → the session's GEM-only meridian-flip gate (#47) skips an alt-az mount.
- `GetSideOfPier` / `DestinationSideOfPier` → `Unknown` for AltAz (no pier side; also makes `BeginSlewToTargetAsync` refuse the equatorial slew).
- `BeginSlewRaDec` / `SyncRaDec` / `SetTracking(true)` throw `NotSupportedException` in AltAz (`EnsureEquatorialAlignment`) — never point an equatorial transform at an alt-az target. Stopping tracking stays allowed; the "park at pole" site-set convenience is skipped (alt-az home is the raw encoder zero: **az 0 = north, alt 0 = horizontal**).

## Analysis doc

`docs/plans/altaz-mount-support.md` lays out what **full** alt-az support needs beyond this setting, with TianWen touchpoints and a phasing table:
- Az/Alt ↔ encoder-step transforms
- the shared `BeginSlewToTargetAsync` pier-side bypass (also unblocks ASCOM/Alpaca alt-az)
- dual-axis alt-az tracking (predictor, like GSS)
- alt-az guiding (continuous field rotation breaks the fixed-angle calibration)
- **field rotation** — the imaging blocker, gated on a derotator / `IRotatorDriver` that doesn't exist yet
- Recommendation: keep report-only as the safe default (wedge/EQ already works and serves most imagers); pursue correct alt-az pointing/tracking (Phase 1) only on demand; defer alt-az *imaging* until rotator support lands.

## Verification
- `dotnet build TianWen.Lib` — 0 warnings.
- `FakeSkywatcherMountDriver` functional: 47/47 (incl. `GivenAltAzAlignmentThenReportedButCoordinateOpsRefused`, `GivenNoAlignmentQueryThenDefaultsToGermanPolar`).
- SkyWatcher unit + GSS oracle: 132/132 (default `GermanPolar` path unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)