### PR TITLE
feat(guider): adaptive image-ready poll cadence

### DIFF
--- a/src/TianWen.Lib.Tests/CameraDriverExtensionsTests.cs
+++ b/src/TianWen.Lib.Tests/CameraDriverExtensionsTests.cs
@@ -1,0 +1,41 @@
+using System;
+using Shouldly;
+using TianWen.Lib.Devices;
+using Xunit;
+
+namespace TianWen.Lib.Tests;
+
+public class CameraDriverExtensionsTests
+{
+    [Theory]
+    // remainingMs, leadMs, expectedMs
+    [InlineData(2000, 50, 1950)]  // far from end: one long sleep landing leadMargin before the end
+    [InlineData(60, 50, 10)]      // inside the lead window (> fine window): coarse 10 ms cadence
+    [InlineData(50, 50, 10)]      // exactly at the lead boundary: coarse cadence (not the long sleep)
+    [InlineData(11, 50, 10)]      // just above the fine window: still coarse
+    [InlineData(10, 50, 1)]       // at the fine window: switch to 1 ms cadence
+    [InlineData(3, 50, 1)]        // final stretch: 1 ms cadence
+    [InlineData(0, 50, 1)]        // predicted end reached, not yet ready: 1 ms cadence
+    [InlineData(-25, 50, 1)]      // exposure overran (negative remaining): still 1 ms, never <= 0
+    public void NextImageReadyPollDelay_FollowsAdaptiveCadence(int remainingMs, int leadMs, int expectedMs)
+    {
+        var delay = CameraDriverExtensions.NextImageReadyPollDelay(
+            TimeSpan.FromMilliseconds(remainingMs), TimeSpan.FromMilliseconds(leadMs));
+
+        delay.ShouldBe(TimeSpan.FromMilliseconds(expectedMs));
+    }
+
+    [Theory]
+    [InlineData(5000, 50)]
+    [InlineData(50, 50)]
+    [InlineData(10, 50)]
+    [InlineData(0, 50)]
+    [InlineData(-100, 50)]
+    public void NextImageReadyPollDelay_IsAlwaysStrictlyPositive(int remainingMs, int leadMs)
+    {
+        var delay = CameraDriverExtensions.NextImageReadyPollDelay(
+            TimeSpan.FromMilliseconds(remainingMs), TimeSpan.FromMilliseconds(leadMs));
+
+        delay.ShouldBeGreaterThan(TimeSpan.Zero);
+    }
+}

--- a/src/TianWen.Lib/Devices/CameraDriverExtensions.cs
+++ b/src/TianWen.Lib/Devices/CameraDriverExtensions.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace TianWen.Lib.Devices;
+
+/// <summary>
+/// Shared polling helpers for <see cref="ICameraDriver"/>.
+/// </summary>
+internal static class CameraDriverExtensions
+{
+    // Adaptive image-ready poll cadence. During the bulk of an exposure the frame
+    // cannot possibly be ready, so we sleep straight through that dead time in one
+    // chunk (zero polls); only once we are within the lead margin of the predicted
+    // end do we start polling, coarse first and then a 1 ms cadence for the final
+    // stretch so pickup latency at exposure end stays near-minimal. GetImageReadyAsync
+    // is a network round-trip on ASCOM/Alpaca cameras, so the long dead time is
+    // exactly where naive fixed-interval polling wastes effort.
+    private static readonly TimeSpan _coarsePollInterval = TimeSpan.FromMilliseconds(10);
+    private static readonly TimeSpan _finePollInterval = TimeSpan.FromMilliseconds(1);
+    private static readonly TimeSpan _finePollWindow = TimeSpan.FromMilliseconds(10);
+
+    /// <summary>
+    /// Computes the next image-ready poll delay from the time <paramref name="remaining"/>
+    /// until the exposure's predicted end. More than <paramref name="leadMargin"/> remaining
+    /// returns a single long sleep that lands <paramref name="leadMargin"/> before the end
+    /// (so the dead time costs no polls); inside the lead window it returns a coarse 10 ms
+    /// cadence; in the final ~10 ms — and on overrun, where <paramref name="remaining"/> is
+    /// &lt;= zero — it returns a 1 ms cadence. The result is always strictly positive, so a
+    /// caller loop can never busy-spin.
+    /// </summary>
+    internal static TimeSpan NextImageReadyPollDelay(TimeSpan remaining, TimeSpan leadMargin)
+    {
+        if (remaining > leadMargin)
+        {
+            return remaining - leadMargin;
+        }
+
+        if (remaining > _finePollWindow)
+        {
+            return _coarsePollInterval;
+        }
+
+        return _finePollInterval;
+    }
+
+    extension(ICameraDriver camera)
+    {
+        /// <summary>
+        /// Waits until the camera reports image-ready, polling with an adaptive cadence
+        /// (see <see cref="NextImageReadyPollDelay"/>): one long sleep through the exposure's
+        /// dead time, then a coarse cadence through the final <paramref name="pollLeadMargin"/>,
+        /// then 1 ms polls in the final window (and on overrun) until ready. Assumes an
+        /// exposure of <paramref name="exposure"/> was just started — the caller owns the
+        /// preceding <c>StartExposureAsync</c>.
+        /// </summary>
+        /// <param name="exposure">The exposure duration just started; used to predict the ready time.</param>
+        /// <param name="timeProvider">Clock for elapsed-time measurement and sleeping (fake-time testable).</param>
+        /// <param name="pollLeadMargin">How far before the predicted end to switch from one long sleep to active polling.</param>
+        /// <param name="timeout">Optional overall budget measured from entry; when it elapses the method returns <c>false</c> without the image being ready. <c>null</c> waits indefinitely (bounded only by <paramref name="cancellationToken"/>).</param>
+        /// <param name="cancellationToken">Cancels the wait (surfaces as <see cref="OperationCanceledException"/> from the sleep).</param>
+        /// <returns><c>true</c> once image-ready; <c>false</c> if <paramref name="timeout"/> elapsed first.</returns>
+        public async ValueTask<bool> WaitForImageReadyAsync(TimeSpan exposure, ITimeProvider timeProvider, TimeSpan pollLeadMargin, TimeSpan? timeout = null, CancellationToken cancellationToken = default)
+        {
+            var startedAt = timeProvider.GetTimestamp();
+
+            while (!await camera.GetImageReadyAsync(cancellationToken))
+            {
+                var elapsed = timeProvider.GetElapsedTime(startedAt);
+                if (timeout is { } budget && elapsed >= budget)
+                {
+                    return false;
+                }
+
+                await timeProvider.SleepAsync(NextImageReadyPollDelay(exposure - elapsed, pollLeadMargin), cancellationToken);
+            }
+
+            return true;
+        }
+    }
+}

--- a/src/TianWen.Lib/Devices/Guider/BuiltInGuiderDriver.cs
+++ b/src/TianWen.Lib/Devices/Guider/BuiltInGuiderDriver.cs
@@ -775,11 +775,11 @@ internal sealed class BuiltInGuiderDriver : IDeviceDependentGuider
     {
         await camera.StartExposureAsync(exposure, FrameType.Light, ct);
 
-        // Poll until image is ready
-        while (!await camera.GetImageReadyAsync(ct))
-        {
-            await timeProvider.SleepAsync(imageReadyPollInterval, ct);
-        }
+        // Adaptive wait: sleep through the exposure's dead time in one chunk, then
+        // tighten the poll cadence as the predicted end approaches (coarse, then 1 ms
+        // in the final window) so pickup latency stays minimal without burning poll
+        // round-trips. No overall timeout — the guide loop's own token bounds this.
+        await camera.WaitForImageReadyAsync(exposure, timeProvider, imageReadyPollInterval, timeout: null, ct);
 
         return await camera.GetImageAsync(ct) ?? throw new GuiderException("Failed to capture guide frame — no image data");
     }

--- a/src/TianWen.Lib/Devices/IExternal.cs
+++ b/src/TianWen.Lib/Devices/IExternal.cs
@@ -124,8 +124,11 @@ public interface IExternal
     }
 
     /// <summary>
-    /// Interval between polls when waiting for camera image readiness.
-    /// Default is 50ms. Override for testing or low-latency hardware.
+    /// Lead margin for adaptive camera image-ready polling (see
+    /// <see cref="CameraDriverExtensions.WaitForImageReadyAsync"/>): how far before the
+    /// predicted exposure end to switch from one long sleep through the dead time to
+    /// active polling (which then tightens to a 10ms then 1ms cadence). Default is 50ms.
+    /// Override for testing or low-latency hardware.
     /// </summary>
     TimeSpan ImageReadyPollInterval => TimeSpan.FromMilliseconds(50);
 

--- a/src/TianWen.Lib/Sequencing/PolarAlignment/MainCameraCaptureSource.cs
+++ b/src/TianWen.Lib/Sequencing/PolarAlignment/MainCameraCaptureSource.cs
@@ -173,18 +173,13 @@ namespace TianWen.Lib.Sequencing.PolarAlignment
 
             await _camera.StartExposureAsync(exposure, FrameType.Light, ct);
 
-            // Poll for image-ready. Time budget is exposure + 5s for download/digest.
-            // The driver may extend the actual exposure (e.g. CMOS rolling shutter),
-            // so we pad rather than fail strictly at exposure end.
+            // Adaptive poll for image-ready: sleep through the exposure's dead time, then
+            // tighten the cadence near the predicted end (coarse, then 1 ms). Time budget is
+            // exposure + 5s for download/digest -- the driver may extend the actual exposure
+            // (e.g. CMOS rolling shutter), so we pad rather than fail strictly at exposure end.
             var pollStart = System.Diagnostics.Stopwatch.GetTimestamp();
             var timeout = exposure + TimeSpan.FromSeconds(5);
-            var deadline = _timeProvider.GetTimestamp() + (long)(timeout.TotalSeconds * _timeProvider.TimestampFrequency);
-            while (_timeProvider.GetTimestamp() < deadline)
-            {
-                ct.ThrowIfCancellationRequested();
-                if (await _camera.GetImageReadyAsync(ct)) break;
-                await _timeProvider.SleepAsync(_imageReadyPollInterval, ct);
-            }
+            await _camera.WaitForImageReadyAsync(exposure, _timeProvider, _imageReadyPollInterval, timeout, ct);
             var pollElapsed = System.Diagnostics.Stopwatch.GetElapsedTime(pollStart);
 
             var getImageStart = System.Diagnostics.Stopwatch.GetTimestamp();


### PR DESCRIPTION
## Adaptive image-ready poll cadence

Replaces the fixed-interval `GetImageReadyAsync` poll in the guide hot path with a coarse-to-fine adaptive schedule:

- one long sleep through the exposure's dead time (zero polls),
- 10 ms coarse polls through the final lead margin (`External.ImageReadyPollInterval`, 50 ms),
- 1 ms polls in the final ~10 ms and on overrun, until ready.

For a 2 s guide sub this cuts ~40 `GetImageReadyAsync` round-trips to a handful (matters on networked ASCOM/Alpaca cameras) while dropping pickup latency from up to 50 ms to ~1 ms.

### Shape
- New shared `ICameraDriver.WaitForImageReadyAsync` extension over a pure `NextImageReadyPollDelay(remaining, leadMargin)` cadence (`CameraDriverExtensions.cs`).
- Routed both `GetImageReadyAsync` poll loops through it: `BuiltInGuiderDriver.CaptureGuideFrameAsync` (no timeout; guide-loop token bounds it) and `MainCameraCaptureSource` (polar-align; keeps its `exposure + 5 s` budget).
- The session main capture loop is tick-scheduled (not a naive fixed-interval poll), so it's intentionally out of scope.

### Tests
- `CameraDriverExtensionsTests` — 13 cases over all regimes (far / lead-boundary / coarse / fine / overrun + always-positive).
- Existing guide-loop + camera-coupling + polar-align integration tests (31) drive the refactored loop end-to-end under fake time, all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)