### PR TITLE
feat(alpaca): ImageBytes binary image transfer + wire AddAlpaca

### DIFF
--- a/src/TianWen.Cli/Program.cs
+++ b/src/TianWen.Cli/Program.cs
@@ -42,6 +42,7 @@ builder.Services
     .AddZWO()
     .AddQHY()
     .AddAscom()
+    .AddAlpaca()
     .AddMeade()
     .AddOnStep()
     .AddIOptron()

--- a/src/TianWen.Lib.Tests/AlpacaImageBytesTests.cs
+++ b/src/TianWen.Lib.Tests/AlpacaImageBytesTests.cs
@@ -1,0 +1,137 @@
+using System;
+using System.Buffers.Binary;
+using System.Text;
+using Shouldly;
+using TianWen.Lib.Devices.Alpaca;
+using Xunit;
+
+namespace TianWen.Lib.Tests;
+
+public class AlpacaImageBytesTests
+{
+    // ASCOM ImageArrayElementTypes wire values used in these payloads.
+    private const int Int16 = 1, Int32 = 2, UInt16 = 8;
+
+    /// <summary>
+    /// Builds an ImageBytes payload (44-byte ArrayMetadataV1 header + pixels) the way an Alpaca
+    /// server would: pixels in ASCOM column-major order, flat index of (x, y) = y + x*height.
+    /// </summary>
+    private static byte[] BuildPayload(int width, int height, int transmissionType, Func<int, int, long> valueAt,
+        int imageType = -1, int errorNumber = 0, int rank = 2, string errorMessage = "")
+    {
+        if (imageType < 0) imageType = transmissionType;
+        var elemSize = transmissionType switch { Int16 or UInt16 => 2, Int32 => 4, _ => throw new ArgumentException("unsupported", nameof(transmissionType)) };
+
+        byte[] body;
+        if (errorNumber != 0)
+        {
+            body = Encoding.UTF8.GetBytes(errorMessage);
+        }
+        else
+        {
+            body = new byte[width * height * elemSize];
+            for (var x = 0; x < width; x++)
+            {
+                for (var y = 0; y < height; y++)
+                {
+                    var off = (y + x * height) * elemSize; // ASCOM flat order, Y fastest
+                    var v = valueAt(x, y);
+                    switch (transmissionType)
+                    {
+                        case Int16: BinaryPrimitives.WriteInt16LittleEndian(body.AsSpan(off), (short)v); break;
+                        case UInt16: BinaryPrimitives.WriteUInt16LittleEndian(body.AsSpan(off), (ushort)v); break;
+                        case Int32: BinaryPrimitives.WriteInt32LittleEndian(body.AsSpan(off), (int)v); break;
+                    }
+                }
+            }
+        }
+
+        var payload = new byte[44 + body.Length];
+        var h = payload.AsSpan();
+        BinaryPrimitives.WriteInt32LittleEndian(h[0..], 1);                 // MetadataVersion
+        BinaryPrimitives.WriteInt32LittleEndian(h[4..], errorNumber);       // ErrorNumber
+        BinaryPrimitives.WriteInt32LittleEndian(h[8..], 1);                 // ClientTransactionID
+        BinaryPrimitives.WriteInt32LittleEndian(h[12..], 1);                // ServerTransactionID
+        BinaryPrimitives.WriteInt32LittleEndian(h[16..], 44);              // DataStart
+        BinaryPrimitives.WriteInt32LittleEndian(h[20..], imageType);        // ImageElementType
+        BinaryPrimitives.WriteInt32LittleEndian(h[24..], transmissionType); // TransmissionElementType
+        BinaryPrimitives.WriteInt32LittleEndian(h[28..], rank);             // Rank
+        BinaryPrimitives.WriteInt32LittleEndian(h[32..], width);            // Dimension1 = X / width
+        BinaryPrimitives.WriteInt32LittleEndian(h[36..], height);           // Dimension2 = Y / height
+        BinaryPrimitives.WriteInt32LittleEndian(h[40..], 0);               // Dimension3
+        body.CopyTo(payload, 44);
+        return payload;
+    }
+
+    [Fact]
+    public void DecodeChannel_TransposesAscomColumnMajorIntoRowMajorHeightWidth()
+    {
+        // 3 wide x 2 high, asymmetric pattern so a transpose bug can't pass: value = x*10 + y.
+        var payload = BuildPayload(width: 3, height: 2, transmissionType: Int16, valueAt: (x, y) => x * 10 + y);
+
+        var channel = AlpacaImageBytes.DecodeChannel(payload);
+
+        channel.Width.ShouldBe(3);
+        channel.Height.ShouldBe(2);
+        for (var x = 0; x < 3; x++)
+        {
+            for (var y = 0; y < 2; y++)
+            {
+                channel[y, x].ShouldBe((float)(x * 10 + y)); // pixel (x, y) must land at [y, x]
+            }
+        }
+        channel.MinValue.ShouldBe(0f);
+        channel.MaxValue.ShouldBe(21f);
+    }
+
+    [Fact]
+    public void DecodeChannel_UInt16_DecodesFullRange()
+    {
+        var payload = BuildPayload(2, 2, UInt16, (x, y) => x == 1 && y == 1 ? 60000 : 100);
+
+        var channel = AlpacaImageBytes.DecodeChannel(payload);
+
+        channel[1, 1].ShouldBe(60000f);
+        channel.MaxValue.ShouldBe(60000f);
+        channel.MinValue.ShouldBe(100f);
+    }
+
+    [Fact]
+    public void DecodeChannel_TransmissionTypeSmallerThanImageType_DecodesViaTransmissionType()
+    {
+        // Server declares an Int32 image but transmits Int16 to save bandwidth.
+        var payload = BuildPayload(2, 2, transmissionType: Int16, valueAt: (x, y) => x + y, imageType: Int32);
+
+        var channel = AlpacaImageBytes.DecodeChannel(payload);
+
+        channel.Width.ShouldBe(2);
+        channel[1, 1].ShouldBe(2f);
+    }
+
+    [Fact]
+    public void DecodeChannel_NonZeroErrorNumber_ThrowsAlpacaExceptionWithMessage()
+    {
+        var payload = BuildPayload(0, 0, Int16, (_, _) => 0, errorNumber: 1025, errorMessage: "Camera not connected");
+
+        var ex = Should.Throw<AlpacaException>(() => AlpacaImageBytes.DecodeChannel(payload));
+        ex.ErrorNumber.ShouldBe(1025);
+        ex.Message.ShouldBe("Camera not connected");
+    }
+
+    [Fact]
+    public void DecodeChannel_Rank3_ThrowsNotSupported()
+        => Should.Throw<NotSupportedException>(() => AlpacaImageBytes.DecodeChannel(BuildPayload(2, 2, Int16, (_, _) => 1, rank: 3)));
+
+    [Fact]
+    public void DecodeChannel_TruncatedHeader_ThrowsNotSupported()
+        => Should.Throw<NotSupportedException>(() => AlpacaImageBytes.DecodeChannel(new byte[10]));
+
+    [Fact]
+    public void DecodeChannel_PixelDataTooShort_ThrowsNotSupported()
+    {
+        var full = BuildPayload(4, 4, Int16, (_, _) => 1);
+        var truncated = full.AsSpan(0, 44 + 8).ToArray(); // only 4 of 16 pixels present
+
+        Should.Throw<NotSupportedException>(() => AlpacaImageBytes.DecodeChannel(truncated));
+    }
+}

--- a/src/TianWen.Lib/Devices/Alpaca/AlpacaCameraDriver.cs
+++ b/src/TianWen.Lib/Devices/Alpaca/AlpacaCameraDriver.cs
@@ -273,8 +273,21 @@ internal class AlpacaCameraDriver(AlpacaDevice device, IServiceProvider serviceP
         return ValueTask.CompletedTask;
     }
 
-    public Imaging.Channel? ImageData => null; // TODO: Alpaca imagearray endpoint requires special binary handling
-public void ReleaseImageData() { }
+    // Frame downloaded + decoded once when the server first reports the image ready
+    // (see GetImageReadyAsync), then read by the default ICameraDriver.GetImageAsync via the
+    // sync ImageData property. No buffer recycling — the float[,] is GC-managed per frame.
+    private Imaging.Channel? _imageData;
+    private Imaging.ChannelBuffer? _channelBuffer;
+
+    public Imaging.Channel? ImageData => _imageData;
+
+    Imaging.ChannelBuffer? ICameraDriver.ChannelBuffer => _channelBuffer;
+
+    public void ReleaseImageData()
+    {
+        _imageData = null;
+        _channelBuffer = null;
+    }
 
     public DateTimeOffset? LastExposureStartTime { get; private set; }
 
@@ -295,7 +308,23 @@ public void ReleaseImageData() { }
 
     // Async-primary members — native async HTTP calls
     public async ValueTask<bool> GetImageReadyAsync(CancellationToken cancellationToken = default)
-        => await Client.GetBoolAsync(BaseUrl, AlpacaDeviceType, AlpacaDeviceNumber, "imageready", cancellationToken);
+    {
+        var ready = await Client.GetBoolAsync(BaseUrl, AlpacaDeviceType, AlpacaDeviceNumber, "imageready", cancellationToken);
+
+        // Download + decode the frame once, when the server first reports it ready, so the
+        // synchronous ImageData property (read by the default GetImageAsync) is populated.
+        // Uses the binary ImageBytes transfer; a failed fetch leaves _imageData null so a
+        // later poll/retry re-downloads.
+        if (ready && _imageData is null)
+        {
+            var bytes = await Client.GetImageArrayBytesAsync(BaseUrl, AlpacaDeviceType, AlpacaDeviceNumber, "imagearray", cancellationToken);
+            var channel = AlpacaImageBytes.DecodeChannel(bytes);
+            _channelBuffer = new Imaging.ChannelBuffer(channel.Data, onRelease: static _ => { });
+            _imageData = channel;
+        }
+
+        return ready;
+    }
 
     public async ValueTask<CameraState> GetCameraStateAsync(CancellationToken cancellationToken = default)
         => (CameraState)await Client.GetIntAsync(BaseUrl, AlpacaDeviceType, AlpacaDeviceNumber, "camerastate", cancellationToken);
@@ -335,6 +364,10 @@ public void ReleaseImageData() { }
 
     public async ValueTask<DateTimeOffset> StartExposureAsync(TimeSpan duration, FrameType frameType = FrameType.Light, CancellationToken cancellationToken = default)
     {
+        // Drop any previous frame so GetImageReadyAsync re-downloads when this one is ready.
+        _imageData = null;
+        _channelBuffer = null;
+
         await PutMethodAsync("startexposure",
         [
             new("Duration", duration.TotalSeconds.ToString(CultureInfo.InvariantCulture)),

--- a/src/TianWen.Lib/Devices/Alpaca/AlpacaClient.cs
+++ b/src/TianWen.Lib/Devices/Alpaca/AlpacaClient.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Net.Http;
+using System.Net.Http.Headers;
 using System.Text.Json;
 using System.Text.Json.Serialization.Metadata;
 using System.Threading;
@@ -147,6 +148,35 @@ internal sealed class AlpacaClient(HttpClient httpClient)
         using var response = await httpClient.PutAsync(url, content, cancellationToken);
         var result = await DeserializeResponseAsync(response, AlpacaJsonSerializerContext.Default.AlpacaMethodResponse, cancellationToken);
         ThrowOnError(result.ErrorNumber, result.ErrorMessage);
+    }
+
+    /// <summary>
+    /// GET an image array endpoint using the binary ImageBytes transfer. Offers
+    /// <c>application/imagebytes</c> first (then <c>application/json</c>) via the
+    /// <c>Accept</c> header and returns the raw ImageBytes payload when the server honours it.
+    /// Throws <see cref="NotSupportedException"/> if the server responds with JSON instead —
+    /// the legacy (slow) JSON ImageArray decode is intentionally not implemented, since
+    /// effectively all current Alpaca camera servers support ImageBytes. Decode the returned
+    /// payload via <see cref="AlpacaImageBytes.DecodeChannel"/>.
+    /// </summary>
+    public async Task<byte[]> GetImageArrayBytesAsync(string baseUrl, string deviceType, int deviceNumber, string endpoint, CancellationToken cancellationToken = default)
+    {
+        var url = BuildGetUrl(baseUrl, deviceType, deviceNumber, endpoint);
+        using var request = new HttpRequestMessage(HttpMethod.Get, url);
+        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue(AlpacaImageBytes.MimeType));
+        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+
+        using var response = await httpClient.SendAsync(request, cancellationToken);
+        response.EnsureSuccessStatusCode();
+
+        var mediaType = response.Content.Headers.ContentType?.MediaType;
+        if (!string.Equals(mediaType, AlpacaImageBytes.MimeType, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new NotSupportedException(
+                $"Alpaca server returned '{mediaType ?? "(none)"}' for '{endpoint}'; only the binary '{AlpacaImageBytes.MimeType}' transfer is supported (the JSON ImageArray fallback is not implemented).");
+        }
+
+        return await response.Content.ReadAsByteArrayAsync(cancellationToken);
     }
 
     /// <summary>

--- a/src/TianWen.Lib/Devices/Alpaca/AlpacaImageBytes.cs
+++ b/src/TianWen.Lib/Devices/Alpaca/AlpacaImageBytes.cs
@@ -1,0 +1,160 @@
+using System;
+using System.Buffers.Binary;
+using System.Numerics;
+using System.Runtime.InteropServices;
+using System.Text;
+using TianWen.Lib.Imaging;
+
+namespace TianWen.Lib.Devices.Alpaca;
+
+/// <summary>
+/// Decoder for the ASCOM Alpaca "ImageBytes" binary image-array transfer
+/// (<c>application/imagebytes</c>). The payload is a 44-byte little-endian metadata
+/// header (ArrayMetadataV1) followed by the raw pixel data. This replaces the legacy
+/// JSON <c>imagearray</c> transfer, which encodes every pixel as a decimal-ASCII integer
+/// and is an order of magnitude slower for full-frame images.
+///
+/// Header layout (all <see cref="int"/>, little-endian) per ASCOMInitiative/ASCOMLibrary
+/// <c>ArrayMetadataV1</c>: 0 MetadataVersion, 4 ErrorNumber, 8 ClientTransactionID,
+/// 12 ServerTransactionID, 16 DataStart, 20 ImageElementType, 24 TransmissionElementType,
+/// 28 Rank, 32 Dimension1, 36 Dimension2, 40 Dimension3.
+/// </summary>
+internal static class AlpacaImageBytes
+{
+    /// <summary>MIME type negotiated via the HTTP <c>Accept</c> header and returned in <c>Content-Type</c>.</summary>
+    public const string MimeType = "application/imagebytes";
+
+    internal const int MetadataV1Length = 44;
+    private const int SupportedMetadataVersion = 1;
+
+    /// <summary>
+    /// ASCOM <c>ImageArrayElementTypes</c>. Used for both the image element type and the
+    /// (possibly smaller) transmission element type actually sent over the wire.
+    /// </summary>
+    internal enum ElementType
+    {
+        Unknown = 0,
+        Int16 = 1,
+        Int32 = 2,
+        Double = 3,
+        Single = 4,
+        UInt64 = 5,
+        Byte = 6,
+        Int64 = 7,
+        UInt16 = 8,
+        UInt32 = 9,
+    }
+
+    /// <summary>
+    /// Decodes an ImageBytes payload into a single monochrome/Bayer <see cref="Channel"/> in
+    /// row-major <c>[Height, Width]</c> layout holding raw ADU values.
+    ///
+    /// ImageBytes transmits a 2D image as <c>[Dimension1 = Width(X), Dimension2 = Height(Y)]</c>
+    /// in row-major order (last index fastest) — i.e. column-major in image terms, so the flat
+    /// index of pixel <c>(x, y)</c> is <c>y + x*Height</c>. This method transposes that into
+    /// <see cref="Channel"/>'s <c>[y, x]</c> layout. Pixels are read host-endian (all supported
+    /// targets are little-endian, matching ASCOM's own transfer assumption).
+    /// </summary>
+    /// <exception cref="AlpacaException">The server reported a non-zero error number; the body carries a UTF-8 message.</exception>
+    /// <exception cref="NotSupportedException">Unsupported metadata version, rank, element type, or malformed dimensions.</exception>
+    public static Channel DecodeChannel(ReadOnlySpan<byte> payload)
+    {
+        if (payload.Length < MetadataV1Length)
+        {
+            throw new NotSupportedException($"ImageBytes payload too small ({payload.Length} bytes; need at least {MetadataV1Length}).");
+        }
+
+        var metadataVersion = BinaryPrimitives.ReadInt32LittleEndian(payload[0..]);
+        if (metadataVersion != SupportedMetadataVersion)
+        {
+            throw new NotSupportedException($"Unsupported ImageBytes metadata version {metadataVersion} (expected {SupportedMetadataVersion}).");
+        }
+
+        var errorNumber = BinaryPrimitives.ReadInt32LittleEndian(payload[4..]);
+        var dataStart = BinaryPrimitives.ReadInt32LittleEndian(payload[16..]);
+
+        if (errorNumber != 0)
+        {
+            // On error the bytes from DataStart (>= the 44-byte header) are a UTF-8 encoded
+            // message rather than pixels; null falls back to a generic message.
+            var message = dataStart >= MetadataV1Length && dataStart < payload.Length
+                ? Encoding.UTF8.GetString(payload[dataStart..])
+                : null;
+            throw new AlpacaException(errorNumber, message);
+        }
+
+        var transmissionElementType = (ElementType)BinaryPrimitives.ReadInt32LittleEndian(payload[24..]);
+        var rank = BinaryPrimitives.ReadInt32LittleEndian(payload[28..]);
+        var width = BinaryPrimitives.ReadInt32LittleEndian(payload[32..]);  // Dimension1 = X
+        var height = BinaryPrimitives.ReadInt32LittleEndian(payload[36..]); // Dimension2 = Y
+
+        if (rank != 2)
+        {
+            // 3D (colour-plane) frames are out of scope: the session treats raw frames as mono/Bayer.
+            throw new NotSupportedException($"ImageBytes rank {rank} is not supported (only 2D monochrome/Bayer frames).");
+        }
+
+        if (width <= 0 || height <= 0)
+        {
+            throw new NotSupportedException($"ImageBytes reported non-positive dimensions {width}x{height}.");
+        }
+
+        if (dataStart < MetadataV1Length || dataStart > payload.Length)
+        {
+            throw new NotSupportedException($"ImageBytes DataStart {dataStart} is out of range (payload {payload.Length} bytes).");
+        }
+
+        var pixels = payload[dataStart..];
+        var channel = new float[height, width];
+        float min, max;
+
+        switch (transmissionElementType)
+        {
+            case ElementType.Byte: (min, max) = FillTransposed<byte>(pixels, width, height, channel); break;
+            case ElementType.Int16: (min, max) = FillTransposed<short>(pixels, width, height, channel); break;
+            case ElementType.UInt16: (min, max) = FillTransposed<ushort>(pixels, width, height, channel); break;
+            case ElementType.Int32: (min, max) = FillTransposed<int>(pixels, width, height, channel); break;
+            case ElementType.UInt32: (min, max) = FillTransposed<uint>(pixels, width, height, channel); break;
+            case ElementType.Int64: (min, max) = FillTransposed<long>(pixels, width, height, channel); break;
+            case ElementType.UInt64: (min, max) = FillTransposed<ulong>(pixels, width, height, channel); break;
+            case ElementType.Single: (min, max) = FillTransposed<float>(pixels, width, height, channel); break;
+            case ElementType.Double: (min, max) = FillTransposed<double>(pixels, width, height, channel); break;
+            default: throw new NotSupportedException($"Unsupported ImageBytes transmission element type {transmissionElementType}.");
+        }
+
+        return new Channel(channel, default, min, max, 0);
+    }
+
+    /// <summary>
+    /// Reads <paramref name="pixels"/> as little-endian <typeparamref name="T"/> elements in the
+    /// ASCOM column-major order and writes them transposed into <paramref name="channel"/>
+    /// (<c>[y, x]</c>), returning the (min, max) sample values.
+    /// </summary>
+    private static (float Min, float Max) FillTransposed<T>(ReadOnlySpan<byte> pixels, int width, int height, float[,] channel)
+        where T : unmanaged, INumber<T>
+    {
+        var typed = MemoryMarshal.Cast<byte, T>(pixels);
+        var expected = checked(width * height);
+        if (typed.Length < expected)
+        {
+            throw new NotSupportedException($"ImageBytes pixel data too short: {typed.Length} {typeof(T).Name} elements for a {width}x{height} image (need {expected}).");
+        }
+
+        var min = float.MaxValue;
+        var max = float.MinValue;
+        for (var x = 0; x < width; x++)
+        {
+            // Flat index of pixel (x, 0); Y is the fastest-varying dimension.
+            var columnBase = x * height;
+            for (var y = 0; y < height; y++)
+            {
+                var value = float.CreateTruncating(typed[columnBase + y]);
+                channel[y, x] = value;
+                if (value < min) min = value;
+                if (value > max) max = value;
+            }
+        }
+
+        return (min, max);
+    }
+}

--- a/src/TianWen.Server/Program.cs
+++ b/src/TianWen.Server/Program.cs
@@ -22,6 +22,7 @@ builder.Services
     .AddZWO()
     .AddQHY()
     .AddAscom()
+    .AddAlpaca()
     .AddMeade()
     .AddOnStep()
     .AddIOptron()

--- a/src/TianWen.UI.Gui/Program.cs
+++ b/src/TianWen.UI.Gui/Program.cs
@@ -30,6 +30,7 @@ services
     .AddZWO()
     .AddQHY()
     .AddAscom()
+    .AddAlpaca()
     .AddMeade()
     .AddOnStep()
     .AddIOptron()


### PR DESCRIPTION
## Why

`AlpacaCameraDriver.ImageData` was a `=> null` stub (*"imagearray endpoint requires special binary handling"*), so an Alpaca camera could connect but never return a frame — which is why `AddAlpaca()` was **never wired into any composition root**. This implements the ASCOM **ImageBytes** binary transfer and wires Alpaca in.

The legacy JSON `imagearray` encodes every pixel as a decimal-ASCII integer (tens of MB of text per full frame, ~10–50× slower) — unusable for a session loop. ImageBytes (`application/imagebytes`) sends a 44-byte header + raw pixels.

## What

- **`AlpacaImageBytes`** (new, pure/unit-tested) — decodes the 44-byte `ArrayMetadataV1` header + little-endian pixels. All `ImageArrayElementTypes` via a generic `INumber<T>` + `MemoryMarshal.Cast` reader; **transposes** ASCOM's column-major `[Dim1=width, Dim2=height]` flat order (`index = y + x*height`) into `Channel`'s row-major `[height, width]`; non-zero error number → `AlpacaException` (UTF-8 body message); guards for version/rank/dimensions/length.
- **`AlpacaClient.GetImageArrayBytesAsync`** — content-negotiated GET (`Accept: application/imagebytes`, then `application/json`). Returns the binary payload; throws a clear `NotSupportedException` if a server only offers JSON (the slow JSON-array path is intentionally not built — effectively all current Alpaca camera servers support ImageBytes).
- **`AlpacaCameraDriver`** — downloads + decodes once when the server first reports the frame ready (cached `Channel` + `ChannelBuffer` so the default `GetImageAsync` does a clean one-shot handoff), cleared on each `StartExposure`/release.
- **Wiring** — `.AddAlpaca()` into CLI, Server, GUI. Unlocks the whole Alpaca device family (camera, mount, focuser, filter wheel, switch, cover calibrator), notably for **headless Linux/Raspberry Pi**, where there was otherwise no vendor path beyond ZWO/QHY/Canon-native + the serial mounts.

## Spec provenance
Header layout / element-type enum / array ordering verified byte-exact against ASCOM's own source: [`ArrayMetadataV1.cs`](https://github.com/ASCOMInitiative/ASCOMLibrary/blob/main/ASCOM.Common/ASCOM.Common.Alpaca/Structs/ArrayMetadataV1.cs), [`AlpacaTools.cs`](https://github.com/ASCOMInitiative/ASCOMLibrary/blob/main/ASCOM.Common/ASCOM.Common.Alpaca/AlpacaTools.cs), [`AlpacaConstants.cs`](https://github.com/ASCOMInitiative/ASCOMLibrary/blob/main/ASCOM.Common/ASCOM.Common.Alpaca/Constants/AlpacaConstants.cs).

## Tests
`AlpacaImageBytesTests` — 7 cases: transpose correctness (asymmetric pattern), UInt16 full range, transmission-type-smaller-than-image-type, error-number message, rank-3 reject, truncation guards. Full unit suite green (2733 passing, 0 failed).

## Remaining validation (not done here)
- End-to-end against the **ASCOM Omni/Alpaca Simulator** (live `imageready` → download → decode round-trip, real `Content-Type` negotiation). The decoder is byte-exact + unit-pinned, but the live HTTP round-trip is unverified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)