### PR TITLE
fix(hosting): make the minimal API native-AOT correct (server 132 -> 2 warnings)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -455,6 +455,36 @@ to `PhaseChanged` / `FrameWritten` / `PlateSolveCompleted` and pushes through `E
 
 Run: `dotnet run --project TianWen.Server` or `tianwen-server [--port 1888]`.
 
+**Native-AOT correctness (the `tianwen-server` binary is `PublishAot=true`).** Three things keep the
+minimal API working under AOT — none are optional, and a normal `dotnet build` will NOT flag a
+regression (the IL2026/IL3050 trim/AOT warnings only surface on `dotnet publish -r <rid>`):
+
+1. **RDG runs in `TianWen.Hosting`, not just the server.** The Request Delegate Generator only
+   intercepts `Map*` call sites in the project where it is enabled, and all the endpoints live in the
+   `TianWen.Hosting` *library*. So `TianWen.Hosting.csproj` sets `<IsAotCompatible>true</IsAotCompatible>`
+   + `<EnableRequestDelegateGenerator>true</EnableRequestDelegateGenerator>`. Without this the AOT
+   publish emitted ~130 IL2026/IL3050 warnings (one pair per `Map*`) and the endpoints fell back to
+   reflection-based delegates. `IsAotCompatible` also turns the trim/AOT analyzers on for the Hosting
+   code itself, catching regressions at library-build time.
+2. **Both JSON source-gen contexts are registered via `ConfigureHttpJsonOptions`** (in
+   `AddHostedSession`): `HostingJsonContext` (camelCase) then `NinaApiJsonContext` (PascalCase) on the
+   `TypeInfoResolverChain`. This is what makes **request-body binding** AOT-safe — the POST/PUT
+   endpoints that take a complex body (`CreateProfileRequest`, `PendingTarget`, `SetProfileRequest`)
+   would otherwise throw `NotSupportedException` at runtime. Responses don't depend on it — every
+   `Results.Json(...)` passes an explicit `JsonTypeInfo`.
+3. **No `ResponseEnvelope<object>` payloads.** A polymorphic `object` payload can't be resolved by a
+   source-gen context under AOT (it needs the runtime type's metadata). The two offenders were replaced
+   with concrete types: `GET /api/v1/session/targets` → `ResponseEnvelope<PendingTarget[]>`, and the
+   ninaAPI `list-devices`/`rescan` anonymous types → `NinaDeviceListItemDto[]`. **Never reintroduce a
+   `ResponseEnvelope<object>` or an anonymous-type payload** — register a concrete DTO in the relevant
+   `JsonSerializerContext` instead.
+
+Verify after any endpoint change by *publishing* (not just building) and smoke-testing the binary:
+`dotnet publish TianWen.Server -c Release -r win-arm64` then run `tianwen-server.exe --port <p>` and
+`curl` a GET, a complex-body POST, and a previously-`object` endpoint. The only expected publish
+warnings are 2 third-party rollups (IL2104/IL3053) from `LibUsbDotNet` (optional Canon-over-USB
+discovery; the lib ships no AOT annotations and we don't mask the warning).
+
 ### Image Pipeline & Buffer Lifecycle
 
 Camera → `ChannelBuffer` → `Image` → consumer → `image.Release()` → camera recycles. See

--- a/src/TianWen.Hosting/Api/NinaV2/NinaEquipmentEndpoints.cs
+++ b/src/TianWen.Hosting/Api/NinaV2/NinaEquipmentEndpoints.cs
@@ -534,31 +534,29 @@ internal static class NinaEquipmentEndpoints
         {
             group.MapGet($"/{device}/list-devices", (IHostedSession hosted) =>
             {
-                var name = GetDeviceName(hosted, device);
-                var devices = name is not null
-                    ? new[] { new { Id = name, DisplayName = name } }
-                    : Array.Empty<object>();
-
                 return Results.Json(
-                    ResponseEnvelope<object>.Ok(devices),
-                    NinaApiJsonContext.Default.ResponseEnvelopeObject);
+                    ResponseEnvelope<NinaDeviceListItemDto[]>.Ok(ListDevices(hosted, device)),
+                    NinaApiJsonContext.Default.ResponseEnvelopeNinaDeviceListItemDtoArray);
             });
 
             group.MapGet($"/{device}/rescan", (IHostedSession hosted) =>
             {
-                var name = GetDeviceName(hosted, device);
-                var devices = name is not null
-                    ? new[] { new { Id = name, DisplayName = name } }
-                    : Array.Empty<object>();
-
                 return Results.Json(
-                    ResponseEnvelope<object>.Ok(devices),
-                    NinaApiJsonContext.Default.ResponseEnvelopeObject);
+                    ResponseEnvelope<NinaDeviceListItemDto[]>.Ok(ListDevices(hosted, device)),
+                    NinaApiJsonContext.Default.ResponseEnvelopeNinaDeviceListItemDtoArray);
             });
 
             group.MapGet($"/{device}/connect", () => NinaOk("Connected"));
             group.MapGet($"/{device}/disconnect", () => NinaOk("Disconnected"));
         }
+    }
+
+    private static NinaDeviceListItemDto[] ListDevices(IHostedSession hosted, string device)
+    {
+        var name = GetDeviceName(hosted, device);
+        return name is not null
+            ? [new NinaDeviceListItemDto { Id = name, DisplayName = name }]
+            : [];
     }
 
     private static string? GetDeviceName(IHostedSession hosted, string device)

--- a/src/TianWen.Hosting/Api/SessionEndpoints.cs
+++ b/src/TianWen.Hosting/Api/SessionEndpoints.cs
@@ -163,12 +163,14 @@ internal static class SessionEndpoints
 
         // --- Target management (pre-session) ---
 
-        // GET /api/v1/session/targets — list pending targets
+        // GET /api/v1/session/targets — list pending targets.
+        // Concrete PendingTarget[] (not ResponseEnvelope<object>) so the source-gen JSON context
+        // can resolve the payload statically -- a polymorphic object payload throws under AOT.
         group.MapGet("/targets", (IHostedSession hosted) =>
         {
             return Results.Json(
-                ResponseEnvelope<object>.Ok(hosted.PendingTargets),
-                HostingJsonContext.Default.ResponseEnvelopeObject);
+                ResponseEnvelope<PendingTarget[]>.Ok([.. hosted.PendingTargets]),
+                HostingJsonContext.Default.ResponseEnvelopePendingTargetArray);
         });
 
         // POST /api/v1/session/targets — add a target

--- a/src/TianWen.Hosting/Dto/HostingJsonContext.cs
+++ b/src/TianWen.Hosting/Dto/HostingJsonContext.cs
@@ -15,7 +15,7 @@ namespace TianWen.Hosting.Dto;
 [JsonSerializable(typeof(ResponseEnvelope<OtaInfoDto[]>))]
 [JsonSerializable(typeof(ResponseEnvelope<string>))]
 [JsonSerializable(typeof(ResponseEnvelope<string[]>))]
-[JsonSerializable(typeof(ResponseEnvelope<object>))]
+[JsonSerializable(typeof(ResponseEnvelope<PendingTarget[]>))]
 [JsonSerializable(typeof(ResponseEnvelope<ProfileDetailDto>))]
 [JsonSerializable(typeof(ResponseEnvelope<Api.ProfileSummaryDto[]>))]
 [JsonSerializable(typeof(ResponseEnvelope<SessionConfigApiDto>))]

--- a/src/TianWen.Hosting/Dto/NinaApiJsonContext.cs
+++ b/src/TianWen.Hosting/Dto/NinaApiJsonContext.cs
@@ -21,7 +21,7 @@ namespace TianWen.Hosting.Dto;
 [JsonSerializable(typeof(ResponseEnvelope<NinaEventDto[]>))]
 [JsonSerializable(typeof(ResponseEnvelope<NinaImageHistoryDto[]>))]
 [JsonSerializable(typeof(ResponseEnvelope<NinaGuideStepDto[]>))]
-[JsonSerializable(typeof(ResponseEnvelope<object>))]
+[JsonSerializable(typeof(ResponseEnvelope<NinaDeviceListItemDto[]>))]
 [JsonSerializable(typeof(ResponseEnvelope<Api.ProfileSummaryDto[]>))]
 [JsonSerializable(typeof(ResponseEnvelope<WebSocketEventDto>))]
 [JsonSourceGenerationOptions(DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]

--- a/src/TianWen.Hosting/Dto/NinaV2/NinaDeviceListItemDto.cs
+++ b/src/TianWen.Hosting/Dto/NinaV2/NinaDeviceListItemDto.cs
@@ -1,0 +1,13 @@
+namespace TianWen.Hosting.Dto.NinaV2;
+
+/// <summary>
+/// One entry in a ninaAPI v2 <c>list-devices</c> / <c>rescan</c> response. TNS uses this to
+/// populate its device-selection dropdown. Concrete (not an anonymous type) so the source-gen
+/// JSON context can serialize it under native AOT.
+/// </summary>
+public sealed class NinaDeviceListItemDto
+{
+    public required string Id { get; init; }
+
+    public required string DisplayName { get; init; }
+}

--- a/src/TianWen.Hosting/Extensions/HostedSessionServiceCollectionExtensions.cs
+++ b/src/TianWen.Hosting/Extensions/HostedSessionServiceCollectionExtensions.cs
@@ -8,6 +8,7 @@ using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
 using TianWen.Hosting.Api;
 using TianWen.Hosting.Api.NinaV2;
+using TianWen.Hosting.Dto;
 using TianWen.Hosting.WebSocket;
 using TianWen.Lib.Devices;
 
@@ -24,6 +25,21 @@ public static class HostedSessionServiceCollectionExtensions
         services.AddSingleton<IHostedSession>(sp => sp.GetRequiredService<HostedSession>());
         services.AddSingleton<EventHub>();
         services.AddHostedService<EventBroadcaster>();
+
+        // Register the source-gen JSON contexts with the HTTP JSON options so minimal-API
+        // request-body binding (the POST/PUT endpoints that take a complex body --
+        // CreateProfileRequest, PendingTarget, SetProfileRequest) resolves type metadata
+        // statically instead of via reflection. Required for the native-AOT tianwen-server:
+        // without it, body binding throws NotSupportedException at runtime under AOT.
+        // Responses already pass an explicit JsonTypeInfo to Results.Json, so they don't rely
+        // on this chain. Hosting (camelCase) is inserted first; Nina (PascalCase) second -- the
+        // only implicitly-bound types are the three Hosting request DTOs, so there is no clash.
+        services.ConfigureHttpJsonOptions(options =>
+        {
+            options.SerializerOptions.TypeInfoResolverChain.Insert(0, HostingJsonContext.Default);
+            options.SerializerOptions.TypeInfoResolverChain.Insert(1, NinaApiJsonContext.Default);
+        });
+
         return services;
     }
 

--- a/src/TianWen.Hosting/TianWen.Hosting.csproj
+++ b/src/TianWen.Hosting/TianWen.Hosting.csproj
@@ -5,6 +5,14 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <Platforms>AnyCPU</Platforms>
+    <!-- This library is consumed by the AOT-published tianwen-server. Declaring it AOT-compatible
+         turns on the trim/AOT analyzers for our own code AND, together with the explicit switch
+         below, runs the Request Delegate Generator HERE so the minimal-API Map* call sites are
+         intercepted in this assembly. Without it the RDG (which only runs in the project where it
+         is enabled) never sees these endpoints, and the AOT publish of TianWen.Server falls back to
+         reflection-based request delegates -> IL2026/IL3050 + runtime NotSupportedException risk. -->
+    <IsAotCompatible>true</IsAotCompatible>
+    <EnableRequestDelegateGenerator>true</EnableRequestDelegateGenerator>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/TianWen.Lib.Tests.Functional/HostingApiTests.cs
+++ b/src/TianWen.Lib.Tests.Functional/HostingApiTests.cs
@@ -212,4 +212,54 @@ public class HostingApiTests(ITestOutputHelper outputHelper) : IAsyncLifetime
         var doc = JsonDocument.Parse(json);
         doc.RootElement.GetProperty("success").GetBoolean().ShouldBeFalse();
     }
+
+    // --- Native-AOT-fragile paths ---
+    // These guard the wiring that the AOT publish needs but a plain `dotnet build` cannot flag:
+    // complex JSON request-body binding (source-gen JsonSerializerContext via ConfigureHttpJsonOptions)
+    // and concrete-DTO payloads (no ResponseEnvelope<object>). Since AddHostedSession registers the
+    // source-gen contexts, the test host serializes through the same path as the native binary.
+
+    [Fact(Timeout = 10_000)]
+    public async Task SessionTargets_PostJsonBody_AddsAndRoundTrips()
+    {
+        var ct = TestContext.Current.CancellationToken;
+
+        // POST a PendingTarget as a JSON body (not query params) -- this is the body-binding path
+        // that throws NotSupportedException under AOT when the JSON context isn't registered.
+        var body = new StringContent(
+            """{"name":"Vega","ra":18.6156,"dec":38.7837,"durationMinutes":45}""",
+            System.Text.Encoding.UTF8, "application/json");
+        var post = await _client.PostAsync("/api/v1/session/targets", body, ct);
+        post.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var postDoc = JsonDocument.Parse(await post.Content.ReadAsStringAsync(ct));
+        postDoc.RootElement.GetProperty("success").GetBoolean().ShouldBeTrue();
+
+        // GET returns a concrete PendingTarget[] payload (was ResponseEnvelope<object>) and must
+        // round-trip the bound values.
+        var get = await _client.GetAsync("/api/v1/session/targets", ct);
+        get.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var arr = JsonDocument.Parse(await get.Content.ReadAsStringAsync(ct)).RootElement.GetProperty("response");
+        arr.GetArrayLength().ShouldBe(1);
+        var target = arr[0];
+        target.GetProperty("name").GetString().ShouldBe("Vega");
+        target.GetProperty("ra").GetDouble().ShouldBe(18.6156, 1e-6);
+        target.GetProperty("dec").GetDouble().ShouldBe(38.7837, 1e-6);
+        target.GetProperty("durationMinutes").GetDouble().ShouldBe(45.0, 1e-6);
+    }
+
+    [Fact(Timeout = 10_000)]
+    public async Task NinaListDevices_ReturnsSuccessEnvelopeWithArray()
+    {
+        var ct = TestContext.Current.CancellationToken;
+
+        // ninaAPI list-devices returns a concrete NinaDeviceListItemDto[] payload (was an
+        // anonymous-type ResponseEnvelope<object>, which can't be serialized under AOT).
+        var response = await _client.GetAsync("/v2/api/equipment/camera/list-devices", ct);
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        var doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync(ct));
+        // ninaAPI v2 uses PascalCase.
+        doc.RootElement.GetProperty("Success").GetBoolean().ShouldBeTrue();
+        doc.RootElement.GetProperty("Response").ValueKind.ShouldBe(JsonValueKind.Array);
+    }
 }


### PR DESCRIPTION
## Problem

The native-AOT publish of `tianwen-server` emitted **132 IL warnings** — flagged on a recent release run. Categorised on win-arm64 (identical on linux-x64, so **not** Windows-specific):

| Count | Code | Source |
|------:|------|--------|
| 65 | IL3050 (RequiresDynamicCode) | `Map*` call sites |
| 65 | IL2026 (RequiresUnreferencedCode) | `Map*` call sites |
| 1 | IL3053 | `LibUsbDotNet` third-party rollup |
| 1 | IL2104 | `LibUsbDotNet` third-party rollup |

**Root cause:** every minimal-API endpoint lives in the **`TianWen.Hosting` library**, but the Request Delegate Generator only intercepts `Map*` calls in the project where it is enabled (previously only `TianWen.Server`, via `PublishAot`). So the RDG never saw the library's endpoints, and the publish fell back to reflection-based request delegates — which throw `NotSupportedException` at runtime under AOT. Two endpoints also returned polymorphic `ResponseEnvelope<object>` payloads (incl. anonymous types), which a source-gen `JsonSerializerContext` cannot resolve under AOT.

These were a genuine runtime risk for `tianwen-server`'s REST + ninaAPI endpoints in the published binary (functional tests only ran under JIT).

## Fix

1. **`TianWen.Hosting.csproj`** — `IsAotCompatible` + `EnableRequestDelegateGenerator` so the RDG intercepts the `Map*` call sites *in this assembly*, and the trim/AOT analyzers run over the Hosting code (catching future regressions at library-build time).
2. **`AddHostedSession`** — register `HostingJsonContext` (camelCase) + `NinaApiJsonContext` (PascalCase) via `ConfigureHttpJsonOptions` so complex **request-body binding** (`CreateProfileRequest`, `PendingTarget`, `SetProfileRequest`) resolves type metadata statically.
3. **No more `ResponseEnvelope<object>`** — `GET /api/v1/session/targets` → `ResponseEnvelope<PendingTarget[]>`; ninaAPI `list-devices`/`rescan` anonymous types → new `NinaDeviceListItemDto[]`.

## Verification

Published `tianwen-server` (win-arm64) and **smoke-tested the native binary** — all endpoints return `200` with correct JSON:

- `GET /v2/api/version` (RDG delegate) ✓
- `GET …/camera/list-devices` → concrete `NinaDeviceListItemDto[]` (was anon-type `object`) ✓
- `GET /api/v1/session/targets` → concrete `PendingTarget[]` (was `object`) ✓
- `POST /api/v1/session/targets` with a JSON body → **body binding under AOT** ✓
- round-trip GET returns `[{"name":"Vega","ra":18.6156,"dec":38.7837,"durationMinutes":45}]` ✓

Server AOT warnings: **132 → 2**. The remaining 2 are third-party `LibUsbDotNet` rollups (optional Canon-over-USB discovery; the lib ships no AOT annotations) — left **visible** rather than masked, since suppressing real AOT warnings from a P/Invoke USB lib would hide a genuine runtime risk.

**Repo-wide AOT survey** (win-arm64): `tianwen-mcp` and `tianwen-fits` are **0 warnings**; `tianwen` (Cli) and `tianwen-gui` have only the same 2 LibUsbDotNet rollups. So after this change, the only AOT warnings anywhere are those 2 third-party rollups.

Added 2 functional guard tests (body-binding + concrete-DTO round-trips). All 14 `HostingApiTests` pass; normal Release build is clean (0 warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)