### PR TITLE
ci: exclude work dirs from Defender on the Windows publish legs

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -280,6 +280,16 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     steps:
+    # Defender real-time scanning in-lines every file write; on the compile-heavy
+    # AOT publish legs (ILC + MSVC link churn thousands of objects) that made the
+    # two Windows legs the slowest in the matrix (~6.5-7 min vs ~4-5 min Linux on
+    # identical work) -- and the release job gates on the whole matrix, so the
+    # Windows legs ARE the release wall time. Excluding the workspace + temp +
+    # NuGet cache BEFORE checkout lands any files is the cheap, well-known fix.
+    - name: Exclude work dirs from Defender (Windows CI speedup)
+      if: runner.os == 'Windows'
+      shell: pwsh
+      run: Add-MpPreference -ExclusionPath "$env:GITHUB_WORKSPACE", "$env:RUNNER_TEMP", "$env:USERPROFILE\.nuget"
     - uses: actions/checkout@v6
       with:
         submodules: recursive


### PR DESCRIPTION
## Summary

Windows Defender real-time scanning in-lines every file write. The two `windows-latest` AOT publish legs (ILC + MSVC link, thousands of object writes) are the slowest jobs in the `publish-apps` matrix — **6m51s (win-x64) / 6m25s (win-arm64) vs 5m08s/4m26s Linux and ~3m50s macOS** on identical work (run 28069577411) — and the `release` job gates on the whole matrix, so the Windows legs ARE the release wall time.

This adds the well-known fix as the first step of `publish-apps`, guarded to Windows runners and placed **before checkout** so the exclusion covers every file the job ever writes:

```yaml
- name: Exclude work dirs from Defender (Windows CI speedup)
  if: runner.os == 'Windows'
  shell: pwsh
  run: Add-MpPreference -ExclusionPath "$env:GITHUB_WORKSPACE", "$env:RUNNER_TEMP", "$env:USERPROFILE\.nuget"
```

No-op on non-Windows legs and harmless if the runner image already excludes any of these paths.

## Test plan

- [x] YAML parses (`yaml.safe_load`) with the new step first in `publish-apps`, correctly guarded
- [x] PR CI (build/test jobs) proves the workflow file is still valid
- [ ] Real timing validation happens on the next `workflow_dispatch` release (`/release-tianwen`) — compare the Windows leg durations against the 6m25s-6m51s baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015gjj4rpffkaXa9X3aF5ZxV