### PR TITLE
fix(alpaca): mono camera connect + filter-wheel slots (caught by the sim suite)

### DIFF
--- a/src/TianWen.Lib.Tests.Simulators/AlpacaSimulatorTests.cs
+++ b/src/TianWen.Lib.Tests.Simulators/AlpacaSimulatorTests.cs
@@ -115,15 +115,17 @@ public class AlpacaSimulatorTests(ITestOutputHelper testOutputHelper)
                 var ready = await WaitAsync(async () => await cam.GetImageReadyAsync(ct), TimeSpan.FromSeconds(30), ct);
                 ready.ShouldBeTrue();
 
-                // The payoff: GetImageAsync downloads via GetImageArrayBytesAsync (Accept:
-                // application/imagebytes) and decodes with AlpacaImageBytes.DecodeChannel -- the
-                // binary transfer that was unit-pinned but never round-tripped against a live server.
+                // The payoff: GetImageReadyAsync downloads via GetImageArrayBytesAsync (Accept:
+                // application/imagebytes) and decodes with AlpacaImageBytes.DecodeChannel into
+                // ImageData -- the binary transfer that was unit-pinned but never round-tripped
+                // against a live server. Capture ImageData now: GetImageAsync transfers the buffer
+                // to the Image and nulls it.
+                var channel = cam.ImageData.ShouldNotBeNull();
+
                 var image = (await cam.GetImageAsync(ct)).ShouldNotBeNull();
                 image.Width.ShouldBeGreaterThan(0);
                 image.Height.ShouldBeGreaterThan(0);
                 image.MaxValue.ShouldBeGreaterThan(0f);
-
-                var channel = cam.ImageData.ShouldNotBeNull();
                 channel.Data.GetLength(1).ShouldBe(image.Width);
                 channel.Data.GetLength(0).ShouldBe(image.Height);
 

--- a/src/TianWen.Lib/Devices/Alpaca/AlpacaCameraDriver.cs
+++ b/src/TianWen.Lib/Devices/Alpaca/AlpacaCameraDriver.cs
@@ -66,8 +66,16 @@ internal class AlpacaCameraDriver(AlpacaDevice device, IServiceProvider serviceP
         _electronsPerADU = await Client.GetDoubleAsync(BaseUrl, AlpacaDeviceType, AlpacaDeviceNumber, "electronsperadu", cancellationToken);
         _exposureResolution = await Client.GetDoubleAsync(BaseUrl, AlpacaDeviceType, AlpacaDeviceNumber, "exposureresolution", cancellationToken);
         _sensorType = (SensorType)await Client.GetIntAsync(BaseUrl, AlpacaDeviceType, AlpacaDeviceNumber, "sensortype", cancellationToken);
-        _bayerOffsetX = await Client.GetIntAsync(BaseUrl, AlpacaDeviceType, AlpacaDeviceNumber, "bayeroffsetx", cancellationToken);
-        _bayerOffsetY = await Client.GetIntAsync(BaseUrl, AlpacaDeviceType, AlpacaDeviceNumber, "bayeroffsety", cancellationToken);
+
+        // BayerOffsetX/Y exist only for Bayer-matrix sensors; monochrome and direct-colour sensors
+        // throw PropertyNotImplemented per the ASCOM ICameraV3 spec (an unconditional read here
+        // failed connect against a mono Alpaca camera), so read them only when applicable. The
+        // fields default to 0.
+        if (_sensorType is not SensorType.Monochrome and not SensorType.Color)
+        {
+            _bayerOffsetX = await Client.GetIntAsync(BaseUrl, AlpacaDeviceType, AlpacaDeviceNumber, "bayeroffsetx", cancellationToken);
+            _bayerOffsetY = await Client.GetIntAsync(BaseUrl, AlpacaDeviceType, AlpacaDeviceNumber, "bayeroffsety", cancellationToken);
+        }
 
         // Cache initial write-through values
         _binX = await Client.GetIntAsync(BaseUrl, AlpacaDeviceType, AlpacaDeviceNumber, "binx", cancellationToken);

--- a/src/TianWen.Lib/Devices/Alpaca/AlpacaFilterWheelDriver.cs
+++ b/src/TianWen.Lib/Devices/Alpaca/AlpacaFilterWheelDriver.cs
@@ -58,6 +58,17 @@ internal class AlpacaFilterWheelDriver(AlpacaDevice device, IServiceProvider ser
     }
 
     /// <summary>
+    /// Populates the filter slot config on connect. Without this, <see cref="Filters"/> stays empty
+    /// (so <see cref="BeginMoveAsync"/> always throws) -- the base <see cref="DeviceDriverBase{TDevice,TDeviceInfo}.InitDeviceAsync"/>
+    /// is a no-op, and every other Alpaca driver overrides it, so the filter wheel must too.
+    /// </summary>
+    protected override async ValueTask<bool> InitDeviceAsync(CancellationToken cancellationToken)
+    {
+        await ReadFilterConfigAsync(cancellationToken);
+        return true;
+    }
+
+    /// <summary>
     /// Reads filter names and focus offsets from the Alpaca API after connecting.
     /// </summary>
     internal async Task ReadFilterConfigAsync(CancellationToken cancellationToken)


### PR DESCRIPTION
## What

Two Alpaca **driver** bugs + one **test**-ordering bug, all caught by the new Alpaca simulator suite (#72) running against a live OmniSim. With these, the suite is fully green against OmniSim v0.4.0: **Passed 7, Skipped 6, Failed 0** (run [28660594740](https://github.com/SharpAstro/tianwen/actions/runs/28660594740)), incl. the camera **ImageBytes round-trip** -- the transfer that was byte-pinned but never verified against a real server.

### Driver fixes (production code)

- **Camera: mono cameras could not connect.** `AlpacaCameraDriver.InitDeviceAsync` read `BayerOffsetX/Y` unconditionally, but the ASCOM ICameraV3 spec has monochrome / direct-colour sensors throw `PropertyNotImplemented` for them -- so connecting *any* mono Alpaca camera failed with "Property read BayerOffsetX is not implemented". Now read only for Bayer-matrix sensor types (`_sensorType` is already known one line up); the fields default to 0.
- **FilterWheel: `Filters` was always empty.** The driver never overrode the base (no-op) `InitDeviceAsync`, so `ReadFilterConfigAsync` was never called -- `_names` stayed null, `Filters` was always empty, and `BeginMoveAsync` always threw "Cannot change filter wheel position". Every other Alpaca driver overrides `InitDeviceAsync`; the filter wheel now does too.

### Test fix

- `Camera_ExposesAndDownloadsViaImageBytes` asserted `cam.ImageData` non-null **after** `GetImageAsync`, which by design transfers the channel buffer to the `Image` and calls `ReleaseImageData()` (nulling it). Capture `ImageData` right after readiness instead (mirroring `AscomDeviceTests`) and cross-check dims against the returned `Image`.

## Why no new tests

The `#72` Alpaca simulator suite **is** the regression test for the two driver bugs -- both were red before this change and are green after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015gjj4rpffkaXa9X3aF5ZxV
