### PR TITLE
feat(tools): de-externalize lzip -- managed build decode + regeneration encode (P3)

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -21,13 +21,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     # The PreprocessCatalogs MSBuild target produces the *.gs.gz embedded
-    # resources from *.json.lz / *.csv.lz sources. The pwsh script shells out
-    # to `lzip -dc` to decompress the .lz inputs, then writes the .gs.gz output
-    # via .NET GZipStream. *.gs.gz is gitignored, so a fresh checkout must
-    # regenerate it during build. lzip is tiny (~80 KB) so a direct apt install
-    # is simpler than caching.
-    - name: Install lzip
-      run: sudo apt-get update && sudo apt-get install -y lzip
+    # resources from *.json.lz / *.csv.lz sources, decoding the .lz inputs with
+    # the managed lzip decoder (Lzip.Lib) and writing the .gs.gz output via .NET
+    # GZipStream -- no external `lzip` binary is needed. *.gs.gz is gitignored,
+    # so a fresh checkout regenerates it during build.
     - uses: actions/checkout@v6
       with:
         submodules: recursive
@@ -63,10 +60,10 @@ jobs:
     - name: Build
       run: dotnet build -c $BUILD_CONF --no-restore -p:Version=${VERSION_PREFIX}${VERSION_REV}${VERSION_HASH} -p:FileVersion=${VERSION_PREFIX}.${VERSION_REV} -p:ContinuousIntegrationBuild=true
       working-directory: src
-    # Share the preprocessed catalog .gs.gz files with the test + publish jobs
-    # so they don't need lzip installed (esp. publish-apps, which runs on a
-    # cross-platform matrix). Downstream jobs download into the same path and
-    # rely on file mtime > *.json.lz mtime to skip the PreprocessCatalogs target.
+    # Share the preprocessed catalog .gs.gz files with the test + publish jobs so
+    # they skip re-running PreprocessCatalogs (and the catalog LFS pull), esp.
+    # publish-apps on its cross-platform matrix. Downstream jobs download into the
+    # same path and rely on file mtime > *.json.lz mtime to skip the target.
     - name: Upload preprocessed catalogs
       uses: actions/upload-artifact@v7
       with:

--- a/.github/workflows/simulators.yml
+++ b/.github/workflows/simulators.yml
@@ -35,14 +35,13 @@ env:
   ASCOM_PLATFORM_INSTALLER: ASCOMPlatform713.4851.exe
 
 jobs:
-  # Produce the *.gs.gz preprocessed catalogs once (the only step needing lzip + the *.lz LFS
-  # objects) and share them with the sim jobs, mirroring how dotnet.yml's build job feeds its
-  # test jobs. This is what lets the Windows leg build TianWen.Lib without lzip.
+  # Produce the *.gs.gz preprocessed catalogs once (needs the *.lz LFS objects) and share them
+  # with the sim jobs, mirroring how dotnet.yml's build job feeds its test jobs. The .lz inputs are
+  # decoded by the managed lzip decoder (Lzip.Lib), so no external `lzip` binary is installed; this
+  # also spares the Windows leg from pulling the catalog LFS objects itself.
   catalogs:
     runs-on: ubuntu-latest
     steps:
-    - name: Install lzip
-      run: sudo apt-get update && sudo apt-get install -y lzip
     - uses: actions/checkout@v6
       with:
         submodules: recursive

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,7 +161,8 @@ install is too heavy for every push). Two entry points on `.github/workflows/sim
 `workflow_dispatch` (`gh workflow run simulators.yml [-f suite=alpaca|ascom|both]`) and a **weekly
 `schedule`** that runs the **Alpaca leg only** as an unattended regression guard (the Windows ASCOM
 leg stays dispatch-only). A shared `catalogs` job feeds the `*.gs.gz` artifact so the Windows leg
-needs no `lzip`. The PR `dotnet.yml` loop only *compiles* the project; the live-sim run is the
+skips the catalog LFS pull + preprocess (the `.lz` decode is managed via `Lzip.Lib`, so no leg needs
+an external `lzip` binary). The PR `dotnet.yml` loop only *compiles* the project; the live-sim run is the
 dispatch/schedule. **This suite earned its keep on the first run** -- it caught two real Alpaca driver
 bugs (mono camera couldn't connect; filter wheel never populated slots) plus a stub audit
 (`Gains`/`Offsets`/`ReadoutMode`/`LastExposureDuration`). Real-time settle waits go through a real

--- a/docs/plans/sharpastro-lzip.md
+++ b/docs/plans/sharpastro-lzip.md
@@ -1,8 +1,10 @@
 # Lzip.Lib — managed lzip codec sibling repo (plan)
 
-**Status:** P1 **DONE** (repo `SharpAstro/Lzip.Lib`, decoder-only, published `Lzip.Lib 1.0.21`).
-P1.5 **DONE** (TianWen re-pointed at the package; in-tree `LzipDecoder` deleted; branch
-`feat/lzip-lib-repoint`). P2 (encoder) + P3 (de-externalize build/regeneration) remain.
+**Status: COMPLETE.** P1 **DONE** (repo `SharpAstro/Lzip.Lib`, decoder, published `Lzip.Lib 1.0.21`).
+P1.5 **DONE** (TianWen runtime re-pointed; in-tree `LzipDecoder` deleted; PR #75). P2 **DONE**
+(managed encoder via vendored PD 7-Zip LZMA SDK, published `Lzip.Lib 1.1.41`; Lzip.Lib PR #1).
+P3 **DONE** (tianwen build decode + milkyway encode swapped to managed; external `lzip` installs
+dropped from CI). The external `lzip` binary is fully retired.
 
 Extract the managed lzip codec into its own SharpAstro sibling repo (like `SharpAstro.Jpeg` /
 `SER.Lib` / `DIR.Lib`), published to NuGet, and have TianWen depend on it -- so we drop the external
@@ -115,12 +117,18 @@ Never push TianWen referencing an unpublished package version -- publish to NuGe
 2. **DONE (P1.5).** Deleted `src/TianWen.Lib/Astrometry/Catalogs/LzipDecoder.cs`; the only two callers
    (`CelestialObjectDB`, `SkyMapTab`) now `using SharpAstro.Lzip;` (SkyMapTab gets the package
    transitively through TianWen.Lib). 349 catalog tests green against the extracted decoder.
-3. Replace external `lzip -dc` in `tools/preprocess-catalog.ps1` with a tiny `dotnet` decode step (or
-   port the whole preprocess to a small `tools/` .NET tool) using `SharpAstro.Lzip`.
-4. Replace `Compress-WithLzip` (`Get-Tycho2Catalogs.ps1`) and `generate_milkyway.cs`'s `lzip -9` with
-   the `SharpAstro.Lzip` encoder.
-5. Drop the `lzip` install from `dotnet.yml` + `simulators.yml` (`catalogs` job) once nothing shells
-   out to it. Update the CLAUDE.md / preprocess-catalog.ps1 docstrings that mention "lzip on PATH".
+3. **DONE (P3).** Replaced the `lzip -dc` shell-out in `tools/preprocess-catalog.ps1` with a managed
+   decode (`Initialize-Lzip` loads `Lzip.Lib.dll` via `Add-Type`; MSBuild's `PreprocessCatalogs` target
+   passes the resolved reference as `-LzipAssembly`, with a sibling/NuGet-cache probe fallback for
+   standalone runs). Verified: all 15 `.gs.gz` regenerate **byte-identically** to the lzip-produced
+   ones, with `lzip` stripped from PATH.
+4. **DONE (P3).** `generate_milkyway.cs` now encodes via `LzipEncoder.Compress(raw, { Level = 9,
+   MemberSize = 2<<20 })` instead of `lzip -9 -b 2MiB`. (There was no `Compress-WithLzip` in
+   `Get-Tycho2Catalogs.ps1` -- the milkyway blob was the only encode touchpoint in `tools/`.) Verified:
+   a real bake's multi-member output passes real `lzip -t`.
+5. **DONE (P3).** Dropped the `lzip` `apt install` from `dotnet.yml` + `simulators.yml` (`catalogs`
+   job); updated the CLAUDE.md + `preprocess-catalog.ps1` docstrings. Bumped the tianwen pin to
+   `Lzip.Lib 1.1.*`.
 
 ## Phasing
 
@@ -128,11 +136,11 @@ Never push TianWen referencing an unpublished package version -- publish to NuGe
 |---|---|---|---|
 | P1 | New repo skeleton + conventions; move `LzipDecoder` (+ tests) verbatim; publish decoder-only | `Lzip.Lib` 1.0 | **DONE** (1.0.21) |
 | P1.5 | Re-point TianWen to the package; delete the local decoder (integration steps 1-2) | TianWen consuming it | **DONE** (`feat/lzip-lib-repoint`) |
-| P2 | Add `LzipEncoder` (vendor LZMA SDK + framing + chunking) + tests | `Lzip.Lib` 1.1 | TODO |
-| P3 | TianWen: swap build decode + regeneration encode to managed; remove all external `lzip` (steps 3-5) | zero external lzip | TODO |
+| P2 | Add `LzipEncoder` (vendor LZMA SDK + framing + chunking) + tests | `Lzip.Lib` 1.1 | **DONE** (1.1.41, PR #1) |
+| P3 | TianWen: swap build decode + regeneration encode to managed; remove all external `lzip` (steps 3-5) | zero external lzip | **DONE** (`feat/lzip-p3-deexternalize`) |
 
-P1/P1.5 are low-risk and immediately give the sibling structure + a NuGet package; P2 is the big lift
-(the encoder); P3 finishes the de-externalization.
+All phases complete: the sibling ships both codec halves (1.1.41), TianWen consumes it at runtime + build
++ regeneration, and no external `lzip` binary is installed or shelled out to anywhere.
 
 ## Decisions (resolved)
 

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -20,11 +20,12 @@
          to pick up CI patch publishes. TianWen.Lib's SerImageBridge consumes it; the FITS
          viewer's SerPreviewSource gets it transitively. -->
     <PackageVersion Include="SER.Lib" Version="1.0.*" />
-    <!-- Lzip.Lib: pure-managed lzip (LZMA1) codec (SharpAstro.Lzip). Decompresses the .gs.gz
-         catalog snapshots (CelestialObjectDB) + the baked Milky Way blob (SkyMapTab); replaces
-         the in-tree LzipDecoder that used to live under Astrometry/Catalogs. Sibling-tracked;
-         floats 1.0.* to pick up CI patch publishes. Decoder-only in 1.0 (an encoder follows). -->
-    <PackageVersion Include="Lzip.Lib" Version="1.0.*" />
+    <!-- Lzip.Lib: pure-managed lzip (LZMA1) codec (SharpAstro.Lzip). Runtime decode of the
+         tyc2.bin.lz + baked Milky Way blob (CelestialObjectDB / SkyMapTab); build-time decode of
+         the .json.lz/.csv.lz catalog inputs (tools/preprocess-catalog.ps1); and encode of the
+         milkyway .bgra.lz (tools/generate_milkyway.cs), so no external lzip binary is needed.
+         1.1 added the encoder; floats 1.1.* to pick up CI patch publishes. -->
+    <PackageVersion Include="Lzip.Lib" Version="1.1.*" />
     <PackageVersion Include="GeoTimeZone" Version="6.1.0" />
     <!-- Microsoft packages -->
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.5" />

--- a/src/TianWen.Lib/TianWen.Lib.csproj
+++ b/src/TianWen.Lib/TianWen.Lib.csproj
@@ -123,12 +123,20 @@
 
   <!-- Convert source .json.lz catalogs to the ASCII-separated .gs.gz format consumed
        by AsciiRecordReader at runtime. Re-runs only when an input is newer than its
-       output. See tools/preprocess-catalog.ps1 + docs/plans/catalog-binary-format.md. -->
+       output. See tools/preprocess-catalog.ps1 + docs/plans/catalog-binary-format.md.
+       DependsOnTargets="ResolveReferences" ensures the Lzip.Lib reference (the managed
+       lzip decoder that replaced the external `lzip -dc`) is resolved + copied, so we can
+       hand its dll path to the script via -LzipAssembly (works for both the sibling
+       ProjectReference and the NuGet PackageReference). -->
   <Target Name="PreprocessCatalogs"
           BeforeTargets="AssignTargetPaths"
+          DependsOnTargets="ResolveReferences"
           Inputs="@(CatalogPreprocess)"
           Outputs="@(CatalogPreprocess->'%(OutputPath)')">
-    <Exec Command="pwsh -NoProfile -File &quot;$(MSBuildThisFileDirectory)..\..\tools\preprocess-catalog.ps1&quot; -Input &quot;%(CatalogPreprocess.FullPath)&quot; -Output &quot;$(MSBuildThisFileDirectory)%(CatalogPreprocess.OutputPath)&quot;" />
+    <PropertyGroup>
+      <_LzipLibDll>@(ReferenceCopyLocalPaths->WithMetadataValue('FileName','Lzip.Lib')->WithMetadataValue('Extension','.dll'))</_LzipLibDll>
+    </PropertyGroup>
+    <Exec Command="pwsh -NoProfile -File &quot;$(MSBuildThisFileDirectory)..\..\tools\preprocess-catalog.ps1&quot; -Input &quot;%(CatalogPreprocess.FullPath)&quot; -Output &quot;$(MSBuildThisFileDirectory)%(CatalogPreprocess.OutputPath)&quot; -LzipAssembly &quot;$(_LzipLibDll)&quot;" />
   </Target>
 
   <!-- Register the generated .gs.gz outputs as EmbeddedResource items.

--- a/tools/generate_milkyway.cs
+++ b/tools/generate_milkyway.cs
@@ -27,7 +27,8 @@
 //
 // Options map 1:1 to MilkyWayBakerOptions fields (see its XML docs for defaults).
 //
-// Requires: `lzip` CLI on PATH.
+// Compresses the output with the managed lzip encoder (SharpAstro.Lzip) -- no external
+// `lzip` binary required.
 
 using System;
 using System.Diagnostics;
@@ -35,6 +36,7 @@ using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
+using SharpAstro.Lzip;
 using TianWen.Lib.Astrometry.Catalogs;
 using TianWen.Lib.Extensions;
 
@@ -114,25 +116,14 @@ var rawPath = output.EndsWith(".lz") ? output[..^3] : output + ".raw";
 MilkyWayTextureBaker.WriteRaw(rawPath, width, height, bgra);
 Console.WriteLine($"Raw size: {new FileInfo(rawPath).Length:N0} bytes");
 
-Console.WriteLine("Compressing with lzip -9 -b 2MiB ...");
-var lzip = Process.Start(new ProcessStartInfo("lzip", $"-9 -b 2MiB -f \"{rawPath}\"")
-{
-    UseShellExecute = false,
-    RedirectStandardError = true
-}) ?? throw new InvalidOperationException("failed to start lzip");
-await lzip.WaitForExitAsync();
-if (lzip.ExitCode != 0)
-{
-    Console.Error.WriteLine(await lzip.StandardError.ReadToEndAsync());
-    return lzip.ExitCode;
-}
-
-var finalPath = rawPath + ".lz";
-if (finalPath != output)
-{
-    if (File.Exists(output)) File.Delete(output);
-    File.Move(finalPath, output);
-}
+// Compress with the managed lzip encoder (SharpAstro.Lzip) -- no external `lzip` binary.
+// Level 9 + 2 MiB members mirrors the former `lzip -9 -b 2MiB`; the multi-member layout lets
+// SkyMapTab's loader decode the blob across cores.
+Console.WriteLine("Compressing with managed Lzip.Lib (level 9, 2 MiB members) ...");
+var raw = await File.ReadAllBytesAsync(rawPath);
+var compressed = LzipEncoder.Compress(raw, new LzipOptions { Level = 9, MemberSize = 2 << 20 });
+await File.WriteAllBytesAsync(output, compressed);
+File.Delete(rawPath);
 Console.WriteLine($"Compressed: {new FileInfo(output).Length:N0} bytes -> {output}");
 return 0;
 

--- a/tools/preprocess-catalog.ps1
+++ b/tools/preprocess-catalog.ps1
@@ -36,9 +36,10 @@ decoder runs ~7-8x faster than the managed LzipDecoder for ~30% larger
 compressed bytes. On a ~1 MB total payload that's +344 KB on disk for ~35 ms
 saved at cold start.
 
-Note the *input* .lz files are still decompressed by shelling out to `lzip -dc`,
-so a working `lzip` binary must be on PATH at build time. Local Windows boxes
-get this via the lzip CLI; CI installs it via SharpAstro/cache-apt-pkgs-action.
+The *input* .lz files are decompressed with the managed lzip decoder
+(SharpAstro.Lzip / Lzip.Lib) via Initialize-Lzip -- no external `lzip` binary
+is required. MSBuild passes the resolved Lzip.Lib.dll as -LzipAssembly; a
+standalone run falls back to a sibling-build / NuGet-cache probe.
 
 .EXAMPLE
 pwsh -NoProfile -File tools/preprocess-catalog.ps1 `
@@ -48,10 +49,59 @@ pwsh -NoProfile -File tools/preprocess-catalog.ps1 `
 [CmdletBinding()]
 param(
     [Parameter(Mandatory)] [Alias('Input')] [string] $InputPath,
-    [Parameter(Mandatory)] [Alias('Output')] [string] $OutputPath
+    [Parameter(Mandatory)] [Alias('Output')] [string] $OutputPath,
+    # Path to Lzip.Lib.dll (the managed lzip decoder). MSBuild passes the resolved reference;
+    # standalone runs fall back to a sibling-build / NuGet-cache probe. See Initialize-Lzip.
+    [string] $LzipAssembly
 )
 
 $ErrorActionPreference = 'Stop'
+
+# Load the managed lzip decoder (SharpAstro.Lzip / Lzip.Lib) once. This replaces the former
+# `lzip -dc` shell-out so the build needs no external `lzip` binary on PATH.
+$script:LzipLoaded = $false
+function Initialize-Lzip {
+    if ($script:LzipLoaded) { return }
+
+    $dll = $null
+    if ($LzipAssembly -and (Test-Path -LiteralPath $LzipAssembly)) {
+        $dll = $LzipAssembly
+    }
+    else {
+        # Fallbacks for standalone invocation (MSBuild normally supplies -LzipAssembly).
+        $candidates = @()
+        # 1. Local sibling build output (UseLocalSiblings dev boxes): ../../Lzip.Lib/src/Lzip.Lib/bin.
+        $siblingBin = Join-Path $PSScriptRoot '..\..\Lzip.Lib\src\Lzip.Lib\bin'
+        if (Test-Path -LiteralPath $siblingBin) {
+            $candidates += Get-ChildItem -LiteralPath $siblingBin -Recurse -Filter 'Lzip.Lib.dll' -ErrorAction SilentlyContinue |
+                Sort-Object LastWriteTime -Descending
+        }
+        # 2. NuGet global-packages cache (CI + package consumers): lzip.lib/<ver>/lib/netX/Lzip.Lib.dll.
+        $nugetRoot = if ($env:NUGET_PACKAGES) { $env:NUGET_PACKAGES } else { Join-Path $HOME '.nuget\packages' }
+        $lzipPkg = Join-Path $nugetRoot 'lzip.lib'
+        if (Test-Path -LiteralPath $lzipPkg) {
+            $candidates += Get-ChildItem -LiteralPath $lzipPkg -Recurse -Filter 'Lzip.Lib.dll' -ErrorAction SilentlyContinue |
+                Where-Object { $_.FullName -match '[\\/]lib[\\/]net' } | Sort-Object FullName -Descending
+        }
+        $dll = ($candidates | Select-Object -First 1).FullName
+    }
+
+    if (-not $dll -or -not (Test-Path -LiteralPath $dll)) {
+        throw "Could not locate Lzip.Lib.dll. Pass -LzipAssembly <path>, build the Lzip.Lib sibling, or restore the Lzip.Lib package."
+    }
+
+    Add-Type -LiteralPath $dll
+    $script:LzipLoaded = $true
+}
+
+# Decompress an lzip (.lz) file to $OutPath using the managed decoder. Writes the decoded bytes
+# verbatim (the payload is already UTF-8 JSON/CSV), so there is no encoding round-trip.
+function Expand-LzToFile([string] $LzPath, [string] $OutPath) {
+    Initialize-Lzip
+    $compressed = [System.IO.File]::ReadAllBytes($LzPath)
+    $plain = [SharpAstro.Lzip.LzipDecoder]::Decompress($compressed)
+    [System.IO.File]::WriteAllBytes($OutPath, $plain)
+}
 
 # ASCII control codes used as separators. These bytes do not appear in any
 # SIMBAD/NGC field value, so no escaping is ever needed.
@@ -89,8 +139,7 @@ function Append-Record([System.Text.StringBuilder] $sb, [bool] $isFirst, [string
 function Encode-Simbad([string] $InputPath, [System.Text.StringBuilder] $sb) {
     $tempJson = [System.IO.Path]::GetTempFileName() + '.json'
     try {
-        & lzip -dc -- $InputPath | Set-Content -LiteralPath $tempJson -Encoding utf8NoBOM
-        if ($LASTEXITCODE -ne 0) { throw "lzip -dc failed for $InputPath (exit $LASTEXITCODE)" }
+        Expand-LzToFile $InputPath $tempJson
 
         $jsonText = [System.IO.File]::ReadAllText($tempJson)
         $records = $jsonText | ConvertFrom-Json
@@ -138,8 +187,7 @@ function Encode-Simbad([string] $InputPath, [System.Text.StringBuilder] $sb) {
 function Encode-Ngc([string] $InputPath, [System.Text.StringBuilder] $sb) {
     $tempCsv = [System.IO.Path]::GetTempFileName() + '.csv'
     try {
-        & lzip -dc -- $InputPath | Set-Content -LiteralPath $tempCsv -Encoding utf8NoBOM
-        if ($LASTEXITCODE -ne 0) { throw "lzip -dc failed for $InputPath (exit $LASTEXITCODE)" }
+        Expand-LzToFile $InputPath $tempCsv
 
         $csvText = [System.IO.File]::ReadAllText($tempCsv)
         # Import-Csv handles ';' delimiter and "..."-quoted fields with embedded ';' or commas.
@@ -220,8 +268,8 @@ $summary =
 
 # Compress raw UTF-8 bytes straight into $OutputPath via .NET GZipStream. No
 # temp file -- the runtime reads back through System.IO.Compression.GZipStream,
-# so encoder + decoder match one-to-one. (Input .lz decompression above does
-# still shell out to `lzip -dc`; output .gs.gz emission stays managed.)
+# so encoder + decoder match one-to-one. (Input .lz decompression above uses the
+# managed SharpAstro.Lzip decoder; the whole preprocess is now external-lzip-free.)
 $bytes = [System.Text.Encoding]::UTF8.GetBytes($sb.ToString())
 
 $outDir = Split-Path -Parent $OutputPath


### PR DESCRIPTION
## What

Retires the external **`lzip`** binary from TianWen entirely (P3, final phase of [`docs/plans/sharpastro-lzip.md`](docs/plans/sharpastro-lzip.md)). Runtime decode was already managed (P1.5, #75); this swaps the last two touchpoints to `Lzip.Lib` and drops the CI installs.

## Changes

- **`tools/preprocess-catalog.ps1`** (build-time decode): `lzip -dc` → managed `LzipDecoder`. `Initialize-Lzip` loads `Lzip.Lib.dll` via `Add-Type`; the `PreprocessCatalogs` MSBuild target passes the resolved reference as `-LzipAssembly` (works for both the sibling `ProjectReference` and the NuGet `PackageReference`), with a sibling-build / NuGet-cache probe fallback for standalone runs.
- **`tools/generate_milkyway.cs`** (regeneration encode): `lzip -9 -b 2MiB` → `LzipEncoder.Compress(raw, { Level = 9, MemberSize = 2<<20 })`.
- **`.github/workflows/{dotnet,simulators}.yml`**: dropped the `apt install lzip` steps.
- **`Directory.Packages.props`**: `Lzip.Lib` `1.0.*` → `1.1.*` (for the encoder API; `1.1.41` is live on nuget).
- **Docs**: `CLAUDE.md`, the `.ps1` docstring, and the plan doc (all phases now marked done).

## Verification

- With **`lzip` stripped from PATH**, the build regenerates all **15 catalog `.gs.gz` byte-identically** to the old lzip path (managed decode yields the same decompressed bytes; embedded catalog data unchanged).
- A full 2048×1024 milkyway bake's multi-member, managed-encoded output **passes real `lzip -t`** (76.7% saved, comparable to `lzip -9`).
- **349** `CelestialObjectDBTests` green in a consumer build (new MSBuild target + runtime decode healthy).

## Result

No external `lzip` binary is installed or shelled out to anywhere — build, runtime, or regeneration. The whole lzip-de-externalization initiative (P1 → P3) is complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015gjj4rpffkaXa9X3aF5ZxV