### PR TITLE
Retire the stb_image port + standardise nuget.org key

### DIFF
--- a/docs/todo/infra.md
+++ b/docs/todo/infra.md
@@ -69,23 +69,30 @@ Part of the TianWen TODO set. See [TODO.md](../../TODO.md) for the index and the
 
 ## Build / dev environment (local siblings)
 
-- [x] **NuGet graph-restore source-key alignment** (DONE 2026-07-04, `src/NuGet.config`). With all
-      sibling repos cloned, `UseLocalSiblings` project-references them, so a restore builds a graph
-      spanning `../DIR.Lib`, `../StbImageSharp`, `../FITS.Lib`, `../SER.Lib`, … and MSBuild merges
-      *their* `nuget.config`s into the settings. `packageSourceMapping` matches by source **key**, so
-      the key mismatch (`api.nuget.org` in tianwen/siblings vs the user-wide `nuget.org`) made the
-      winning mapping point at a source that didn't survive the merge → spurious NU1100
-      "PackageSourceMapping is enabled … nuget.org not considered" for FC.SDK / ZWOptical.SDK /
-      TianWen.DAL / SharpAstro.LALR.CC / FC.SDK.Raw. Fix: `src/NuGet.config` uses key `nuget.org`
-      (same URL) so a plain `dotnet restore` / VS restore is deterministic regardless of which
-      siblings are checked out. `RestoreConfigFile` in `Directory.Build.props` does **not** work here
-      — it only applies to tianwen projects, not the sibling projects in the graph; a CLI
-      `-p:RestoreConfigFile=` (global property) does, but isn't automatic for VS. CI is unaffected
-      (PackageReference from nuget.org, single consistent key).
-- [ ] **`TianWen.DAL/NuGet.config` has an empty `<packageSourceMapping><clear/></packageSourceMapping>`**
-      (maps nothing → breaks restore for anything using that config). Fixed locally 2026-07-04 to map
-      `*`→`nuget.org`, but that lives in the **sibling repo**, not tianwen — the fix must be committed
-      + pushed in the TianWen.DAL repo to be durable (a fresh clone reintroduces the broken config).
+- [x] **NuGet graph-restore source-key alignment — standardized on `nuget.org`** (DONE 2026-07-04,
+      re-diagnosed + fixed properly). With all sibling repos cloned, `UseLocalSiblings`
+      project-references them, so a restore builds a graph spanning `../DIR.Lib`, `../StbImageSharp`,
+      `../FITS.Lib`, `../SER.Lib`, … and MSBuild merges *their* `nuget.config`s into one settings
+      object. `packageSourceMapping` matches by source **key**, so a key mismatch across the merged
+      configs makes the winning mapping point at a source that didn't survive the merge → NU1100
+      "PackageSourceMapping is enabled … not considered" for FC.SDK / FC.SDK.Raw / ZWOptical.SDK /
+      TianWen.DAL / SharpAstro.LALR.CC. **The correct key is `nuget.org`** — proven to be the
+      NuGet fresh-install default (an empty user config auto-writes `<add key="nuget.org"
+      value="https://api.nuget.org/v3/index.json" protocolVersion="3" />`). The earlier note here had
+      the premise **inverted** (it claimed the user-wide key was `nuget.org` and briefly flipped
+      `src/NuGet.config` to `api.nuget.org`); in fact the user-wide config on the arm64 box had drifted
+      to a non-standard `api.nuget.org` key **and** a `packageSourceMapping` routing `*` there — that
+      mapping was the real root cause. Fix: renamed the `api.nuget.org` **key** → `nuget.org` (URL
+      unchanged) in the user-wide config **and** `FITS.Lib` / `SER.Lib` / `zwo-sdk-nuget` configs, and
+      kept `src/NuGet.config` on `nuget.org`. `TianWen.DAL` was already on `nuget.org`. After that,
+      `dotnet build TianWen.Lib` restores clean. CI is unaffected (fresh runners = `nuget.org` default).
+      `RestoreConfigFile` in `Directory.Build.props` does **not** help — it only applies to tianwen
+      projects, not the sibling projects in the graph.
+- [x] **`TianWen.DAL/NuGet.config`** — now maps `*`→`nuget.org` (fixed in the sibling repo). Was an
+      empty `<packageSourceMapping><clear/></packageSourceMapping>` that mapped nothing. NB: TianWen.DAL
+      is consumed by tianwen as a **package**, not a project ref, so its config was never actually in
+      tianwen's restore graph — the graph-poisoning configs were `FITS.Lib` / `SER.Lib` (project refs)
+      plus the user-wide config, all now on `nuget.org`.
 - [ ] **Keep `open-vs.ps1`'s "Siblings" folder in sync with `Directory.Build.props`'
       `UseLocalSiblings` set** (currently: DIR.Lib, Console.Lib, SdlVulkan.Renderer, StbImageSharp
       family, QHYCCD.SDK, FITS.Lib, SER.Lib, Lzip.Lib, + transitive Fonts.Lib for

--- a/open-vs.ps1
+++ b/open-vs.ps1
@@ -2,8 +2,10 @@
 # Generates TianWen.local.slnx at the repo root with sibling project references,
 # then opens it in Visual Studio. This gives Go To Definition into every sibling
 # that Directory.Build.props' UseLocalSiblings switch project-references (DIR.Lib,
-# Console.Lib, SdlVulkan.Renderer, the StbImageSharp family, QHYCCD.SDK, FITS.Lib,
-# SER.Lib, Lzip.Lib). Keep this list in sync with Directory.Build.props.
+# Console.Lib, SdlVulkan.Renderer, the SharpAstro codec projects in the StbImageSharp
+# repo, QHYCCD.SDK, FITS.Lib, SER.Lib, Lzip.Lib). Keep this list in sync with
+# Directory.Build.props. NB: the stb_image port itself (StbImageSharp.csproj) is not
+# listed — TianWen consumes only the SharpAstro.* codecs, not the port.
 #
 # The base TianWen.slnx in src/ stays untouched (used by CI and dotnet build).
 
@@ -32,7 +34,9 @@ $siblings = @"
     <Project Path="../Fonts.Lib/src/SharpAstro.Fonts/SharpAstro.Fonts.csproj" />
     <Project Path="../Console.Lib/src/Console.Lib/Console.Lib.csproj" />
     <Project Path="../SdlVulkan.Renderer/src/SdlVulkan.Renderer/SdlVulkan.Renderer.csproj" />
-    <Project Path="../StbImageSharp/src/StbImageSharp/StbImageSharp.csproj" />
+    <!-- SharpAstro.* codec projects from the StbImageSharp repo. The stb_image
+         port (StbImageSharp.csproj) is intentionally omitted: nothing in the
+         solution references it (Fonts decodes CBDT PNGs via SharpAstro.Png). -->
     <Project Path="../StbImageSharp/src/SharpAstro.Tiff/SharpAstro.Tiff.csproj" />
     <Project Path="../StbImageSharp/src/SharpAstro.Exif/SharpAstro.Exif.csproj" />
     <Project Path="../StbImageSharp/src/SharpAstro.Png/SharpAstro.Png.csproj" />

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -13,7 +13,6 @@
       AND Exists('$(MSBuildThisFileDirectory)..\..\DIR.Lib\src\DIR.Lib\DIR.Lib.csproj')
       AND Exists('$(MSBuildThisFileDirectory)..\..\Console.Lib\src\Console.Lib\Console.Lib.csproj')
       AND Exists('$(MSBuildThisFileDirectory)..\..\SdlVulkan.Renderer\src\SdlVulkan.Renderer\SdlVulkan.Renderer.csproj')
-      AND Exists('$(MSBuildThisFileDirectory)..\..\StbImageSharp\src\StbImageSharp\StbImageSharp.csproj')
       AND Exists('$(MSBuildThisFileDirectory)..\..\StbImageSharp\src\SharpAstro.Tiff\SharpAstro.Tiff.csproj')
       AND Exists('$(MSBuildThisFileDirectory)..\..\StbImageSharp\src\SharpAstro.Exif\SharpAstro.Exif.csproj')
       AND Exists('$(MSBuildThisFileDirectory)..\..\StbImageSharp\src\SharpAstro.Png\SharpAstro.Png.csproj')

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -94,7 +94,7 @@
          `using Layout = DIR.Lib.Layout;` and write Layout.Node / Layout.Builder / Layout.Sizing. Lockstep
          with Console.Lib 3.3 + SdlVulkan.Renderer 6.7.
          6.3 bumped alongside SdlVulkan.Renderer 6.10 (which requires DIR.Lib >= 6.3.1201). -->
-    <PackageVersion Include="DIR.Lib" Version="6.3.*" />
+    <PackageVersion Include="DIR.Lib" Version="6.4.*" />
     <!-- DIR.Lib 3.0 extracted its codec layer to these sibling packages, which
          ship as a lockstep family from the StbImageSharp repo. 3.0 brought a
          binary-breaking SharpAstro.Tiff change (TiffPageOptions.IccProfile is
@@ -108,17 +108,20 @@
          matched set.
          The whole family floats to 3.3.* in lockstep so all members resolve to the
          matched set (mixing minors across a lockstep break is a runtime hazard). -->
-    <PackageVersion Include="SharpAstro.Tiff" Version="3.3.*" />
-    <PackageVersion Include="SharpAstro.Exif" Version="3.3.*" />
-    <PackageVersion Include="SharpAstro.Png" Version="3.3.*" />
-    <PackageVersion Include="SharpAstro.Color.Icc" Version="3.3.*" />
-    <PackageVersion Include="SharpAstro.Jpeg.IccInjector" Version="3.3.*" />
+    <PackageVersion Include="SharpAstro.Tiff" Version="3.4.*" />
+    <PackageVersion Include="SharpAstro.Exif" Version="3.4.*" />
+    <PackageVersion Include="SharpAstro.Png" Version="3.4.*" />
+    <PackageVersion Include="SharpAstro.Color.Icc" Version="3.4.*" />
+    <PackageVersion Include="SharpAstro.Jpeg.IccInjector" Version="3.4.*" />
+    <!-- SharpAstro.Jpeg (SOF3 lossless + baseline decoder): consumed transitively
+         (FC.SDK.Raw / Console.Lib) and directly by TianWen.UI.Benchmarks' LosslessJpeg bench. -->
+    <PackageVersion Include="SharpAstro.Jpeg" Version="3.4.*" />
     <!-- Pure-managed JPEG XR (T.832) + OpenEXR codecs. Image.WriteJxrAsync emits
          HDR float pixels (BD32F mono / BD16F RGB); Image.WriteExrAsync emits OpenEXR
          (FLOAT mono / HALF RGB). Same StbImageSharp repo + 3.3.* lockstep as the
          other SharpAstro codec siblings. -->
-    <PackageVersion Include="SharpAstro.Jxr" Version="3.3.*" />
-    <PackageVersion Include="SharpAstro.Exr" Version="3.3.*" />
+    <PackageVersion Include="SharpAstro.Jxr" Version="3.4.*" />
+    <PackageVersion Include="SharpAstro.Exr" Version="3.4.*" />
     <!-- Console.Lib 2.17 adds ScrollableList + TreeView opt-in auto wheel routing
          (on top of 2.13-2.16 widget work). 2.18 is a no-code lockstep rebuild against
          DIR.Lib 4.5, same sibling family as SdlVulkan.Renderer 6.1.
@@ -128,7 +131,7 @@
          DIR.Lib 5.1 (lockstep with SdlVulkan.Renderer 6.5).
          3.2 is a no-code lockstep rebuild against DIR.Lib 5.2.
          3.3 is a no-code lockstep rebuild against DIR.Lib 6.0 (layout namespace + Layout.Builder DSL). -->
-    <PackageVersion Include="Console.Lib" Version="3.3.*" />
+    <PackageVersion Include="Console.Lib" Version="3.5.*" />
     <!-- SdlVulkan.Renderer 5.0 adds a multi-page SDF glyph atlas (no more grow
          stall / Adreno submit-wedge) on top of 4.1's SetSystemCursor + anisotropic
          glyph xScale. 5.1 implements DIR.Lib 4.4's PushClip/PopClip via Vulkan
@@ -155,13 +158,13 @@
          (ArrangedNode.Depth + PixelWidgetBase.GetCapturedLayout + LayoutInspection).
          6.10 adds DebugSignalArgs (JsonElement OptInt/OptDouble/OptBool/OptString extension members) used by
          Program.cs's DebugInspector SignalFactories; without this bump the GUI DEBUG build fails CS1061. -->
-    <PackageVersion Include="SdlVulkan.Renderer" Version="6.10.*" />
+    <PackageVersion Include="SdlVulkan.Renderer" Version="6.11.*" />
     <PackageVersion Include="SDL3-CS" Version="3.5.0-preview.20260213-150035" />
     <PackageVersion Include="SDL3-CS.Native" Version="3.5.0-preview.20260205-174353" />
     <!-- Canon DSLR -->
-    <PackageVersion Include="FC.SDK" Version="1.3.*" />
+    <PackageVersion Include="FC.SDK" Version="1.4.*" />
     <!-- Floating: Canon raw decoder (.cr2/.cr3 -> mosaic). Tracks FC.SDK repo CI (1.3.x). -->
-    <PackageVersion Include="FC.SDK.Raw" Version="1.3.*" />
+    <PackageVersion Include="FC.SDK.Raw" Version="1.4.*" />
     <!-- Image encoding -->
     <PackageVersion Include="StbImageWriteSharp" Version="1.16.7" />
     <!-- Other packages -->

--- a/src/NuGet.config
+++ b/src/NuGet.config
@@ -2,12 +2,14 @@
 <configuration>
   <packageSources>
     <clear />
-    <!-- Source key MUST match the user-wide config's key ("nuget.org"). A static graph
-         restore that spans the cloned sibling repos merges their nuget.configs together;
-         packageSourceMapping matches by source KEY, so a key mismatch (e.g. "api.nuget.org"
-         here vs "nuget.org" user-wide) makes the mapping reference a source that didn't
-         survive the merge -> NU1100 "PackageSourceMapping is enabled ... nuget.org not
-         considered" for FC.SDK / ZWOptical.SDK / TianWen.DAL / SharpAstro.LALR.CC / FC.SDK.Raw. -->
+    <!-- Source key MUST be "nuget.org" — the NuGet fresh-install default (an empty user
+         config auto-writes exactly this key). A static graph restore that spans the cloned
+         sibling repos (DIR.Lib, StbImageSharp, FITS.Lib, SER.Lib, ...) merges their
+         nuget.configs together; packageSourceMapping matches by source KEY, so any key
+         mismatch across the merged configs makes the winning mapping reference a source that
+         didn't survive the merge -> NU1100 "PackageSourceMapping is enabled ... not
+         considered" for FC.SDK / FC.SDK.Raw / ZWOptical.SDK / TianWen.DAL. Keep every
+         nuget.config in the sibling set (and the user-wide config) on "nuget.org". -->
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
   <packageSourceMapping>

--- a/src/TianWen.UI.Benchmarks/LosslessJpegBenchmarks.cs
+++ b/src/TianWen.UI.Benchmarks/LosslessJpegBenchmarks.cs
@@ -2,7 +2,7 @@ using System;
 using System.Buffers.Binary;
 using System.IO;
 using BenchmarkDotNet.Attributes;
-using StbImageSharp;
+using SharpAstro.Jpeg;
 
 namespace TianWen.UI.Benchmarks;
 

--- a/src/TianWen.UI.Benchmarks/Profiling.cs
+++ b/src/TianWen.UI.Benchmarks/Profiling.cs
@@ -2,7 +2,7 @@ using System;
 using System.Diagnostics;
 using System.IO;
 using System.Threading.Tasks;
-using StbImageSharp;
+using SharpAstro.Jpeg;
 using TianWen.Lib.Imaging;
 
 namespace TianWen.UI.Benchmarks;

--- a/src/TianWen.UI.Benchmarks/TianWen.UI.Benchmarks.csproj
+++ b/src/TianWen.UI.Benchmarks/TianWen.UI.Benchmarks.csproj
@@ -16,22 +16,23 @@
     <ProjectReference Include="..\TianWen.UI.Abstractions\TianWen.UI.Abstractions.csproj" />
   </ItemGroup>
 
-  <!-- LosslessJpegBenchmarks measures StbImageSharp's lossless JPEG decoder
-       directly. The package would arrive transitively from FC.SDK.Raw, but
-       when the StbImageSharp sibling is checked out locally we want to
-       benchmark against the sibling source so iteration on the decoder
-       (Huffman fast-paths, predictor tweaks, etc.) is visible without a
-       NuGet republish round-trip. ProjectReference here overrides the
-       transitive PackageReference for this benchmark project only.
-       NU1605 is suppressed here because the sibling source version
-       (e.g. 2.30.0) can be lower than the transitive constraint pinned by
-       SharpAstro.Fonts (2.30.11+); for a benchmark project this trade-off
-       is acceptable. -->
+  <!-- LosslessJpegBenchmarks measures SharpAstro.Jpeg's SOF3 lossless JPEG decoder
+       directly. The package arrives transitively (FC.SDK.Raw), but when the
+       StbImageSharp repo (which hosts SharpAstro.Jpeg) is checked out locally we
+       want to benchmark against the sibling source so iteration on the decoder
+       (Huffman fast-paths, predictor tweaks, etc.) is visible without a NuGet
+       republish round-trip. ProjectReference here overrides the transitive/direct
+       PackageReference for this benchmark project only. NU1605 is suppressed
+       because the sibling source version (3.4.0) can be lower than the transitive
+       constraint (3.4.x from FC.SDK.Raw); for a benchmark project that's fine. -->
   <PropertyGroup Condition="'$(UseLocalSiblings)' == 'true'">
     <NoWarn>$(NoWarn);NU1605</NoWarn>
   </PropertyGroup>
   <ItemGroup Condition="'$(UseLocalSiblings)' == 'true'">
-    <ProjectReference Include="..\..\..\StbImageSharp\src\StbImageSharp\StbImageSharp.csproj" />
+    <ProjectReference Include="..\..\..\StbImageSharp\src\SharpAstro.Jpeg\SharpAstro.Jpeg.csproj" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(UseLocalSiblings)' != 'true'">
+    <PackageReference Include="SharpAstro.Jpeg" />
   </ItemGroup>
 
   <!-- Re-use the LFS-tracked Canon raw fixtures from TianWen.Lib.Tests so the


### PR DESCRIPTION
## What
- **Re-pin siblings to the StbImage-free chain**: `DIR.Lib 6.4.*`, `Console.Lib 3.5.*`, `SdlVulkan.Renderer 6.11.*`, `FC.SDK`/`FC.SDK.Raw 1.4.*`, SharpAstro codec family `3.4.*`.
- **Drop the phantom stb-port refs** from `Directory.Build.props` (UseLocalSiblings gate) + `open-vs.ps1` — TianWen consumes only the SharpAstro.* codecs, never the port.
- **Standardise the NuGet source key on `nuget.org`** (the fresh-install default) + corrected the inverted `infra.md` note.

## Why
The stb_image port (`SharpAstro.StbImage`) reached TianWen only transitively — via `SharpAstro.Fonts` (CBDT glyph PNGs) and `FC.SDK.Raw` (CR2 lossless JPEG), with `Console.Lib` (markdown images) also leaning on the Fonts-transitive copy. Each was moved onto a focused codec (`SharpAstro.Png` / `SharpAstro.Jpeg`, incl. a SOF3 lossless decoder ported into `SharpAstro.Jpeg` and indexed-PNG support added to `SharpAstro.Png`).

## Verified
`dotnet build TianWen.Lib -p:UseLocalSiblings=false` (full package-mode restore) resolves `DIR.Lib 6.4.1231` + `FC.SDK.Raw 1.4.501` + `Fonts 1.5.291` + `Jpeg/Png/Tiff 3.4.411` — **no `SharpAstro.StbImage`** anywhere in the graph. The NU1100 restore failure (from the source-key mismatch) is also gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015gjj4rpffkaXa9X3aF5ZxV