### PR TITLE
ASCOM out-of-process CET-off host + native-driver blacklist

### DIFF
--- a/docs/plans/ascom-com-sta-message-pump.md
+++ b/docs/plans/ascom-com-sta-message-pump.md
@@ -1,5 +1,13 @@
 # ASCOM COM drivers: STA + message-pump host (plan)
 
+> **⚠️ SUPERSEDED (2026-07-04) by [ascom-oop-host.md](ascom-oop-host.md).** The STA message-pump
+> mitigation proposed below is the **wrong fix**: the `0xC0000409` crash is a **CET (hardware
+> shadow-stack) violation** of the in-proc .NET Framework CLR, a native `RtlFailFast` that **no
+> client-side message pump can catch** (four pump/no-pump experiments all crashed identically). The
+> correct fix is `<CETCompat>false</CETCompat>` on the executable that loads the driver, delivered via a
+> tiny out-of-process CET-off helper so the main app keeps CET on. This doc is kept only for the
+> root-cause investigation + driver survey below; **do not implement the STA-pump mitigation.**
+
 **Status: NOT STARTED (design + finding captured).** Found during the Gemini FlatPanel Lite bring-up
 (branch `fix/gemini-flat-panel`) while trying to cross-check the panel via the vendor ASCOM driver.
 TianWen's ASCOM-over-COM path (`AscomDevice` / `AscomDispatchDevice`) cannot reliably **connect** an

--- a/docs/plans/ascom-oop-host.md
+++ b/docs/plans/ascom-oop-host.md
@@ -1,8 +1,10 @@
 # ASCOM COM drivers: out-of-process CET-off host (plan)
 
-**Status: Phases 1–4.5 DONE, Phase 5 PARTIAL** (branch `feat/ascom-oop-host`, 2026-07-04). The real
-0xC0000409 driver (`ASCOM.GeminiFPLite.CoverCalibrator`) now connects through the helper without
-fastfailing the process (see Phase 5 below). Supersedes the mitigation in
+**Status: Phases 1–4.5 DONE, Phase 5 PARTIAL, native-driver blacklist DONE** (branch
+`feat/ascom-oop-host`, 2026-07-05). The real 0xC0000409 driver (`ASCOM.GeminiFPLite.CoverCalibrator`)
+now connects through the helper without fastfailing the process (see Phase 5 below), and ASCOM drivers
+we reimplement natively are hidden from discovery when the native family is present (see "Native-driver
+blacklist"). Supersedes the mitigation in
 [ascom-com-sta-message-pump.md](ascom-com-sta-message-pump.md) — the STA message pump was the **wrong
 fix** (see "Corrected root cause" below).
 
@@ -126,6 +128,61 @@ object (`AscomOutOfProcessConnectTests`):
 
 Still hardware-gated: verifying the panel actually illuminates + meters a flat (needs the physical
 Gemini panel), the mount sub-dispatch path (`AxisRates`), and the win-arm64 publish / ship-beside-app.
+
+#### Why the ASCOM Gemini won't illuminate through the helper (decompiled, 2026-07-05)
+
+With the physical panel on COM3 the transport is proven fully working (identity reads, `get_Connected`,
+`set_Connected` all round-trip cleanly through the CET-off helper) — but `Connected` stays `False` after
+the connect. Decompiling `ASCOM.GeminiFPLite.CoverCalibrator` (v6.6, `[ClassInterface(None)] :
+ICoverCalibratorV1`) settled two things:
+
+- **There was never a `Connected`-getter fault.** The getter is a trivial `return connectedState`. The
+  `DISP_E_UNKNOWNNAME` (0x80020006) seen while polling was `Connecting` (a Platform-7 member absent on
+  this V1 driver) being evaluated *first* in an interpolated log line — a diagnostic artifact, not a
+  transport or dispid-stability problem. Typelib dispids are stable per the COM contract; no re-resolve
+  workaround is warranted.
+- **The driver connects against an empty COM port when hosted by us.** Its `Connected=true` setter opens
+  `Settings.Default.MyComPort` — a **user-scoped `.NET ApplicationSettingsBase` (`user.config`) setting**,
+  whose on-disk location is keyed to the *hosting process's* assembly identity. The COM port the user
+  picked in the driver's SetupDialog (or NINA, or Device Hub) lives in *those* hosts' `user.config`; our
+  `tianwen-ascomhost` has never written one, so `MyComPort` reads its `[DefaultSettingValue("")]` empty
+  default, `SerialPort.Open("")` throws, the driver swallows it, and `connectedState` stays false. (The
+  driver *does* read the global ASCOM Profile `"COM Port"` into a field during `ReadProfile()`, but never
+  uses it to connect — a driver bug.) Confirmed empirically: four different hosts on this box hold four
+  different `MyComPort` values (COM3/COM5/COM7). This is the general hazard of hosting any legacy .NET
+  COM driver out-of-process — anything persisted via `user.config` does not travel between hosts.
+
+The practical answer is the **native-driver blacklist** below: steer users to TianWen's own serial
+`GeminiFlatPanelDriver`, which has neither the CET crash nor the per-host-port bug. Seeding the helper's
+`user.config` from the global ASCOM Profile is a possible future refinement for *other* `user.config`-
+based CET-incompatible drivers, but is not needed for Gemini.
+
+## Native-driver blacklist — hide ASCOM twins of native backends
+
+`NativeDriverBlacklist` (`TianWen.Lib/Devices/`) drops an ASCOM COM driver from discovery when TianWen
+ships a first-class native backend for it, so the picker shows one entry per physical device instead of
+the native driver plus its redundant (often buggier) ASCOM twin. Gemini is the motivating case (CET
+crash **and** the per-host `MyComPort` bug above); the native serial path has neither problem.
+
+- **Conditional on native availability.** The hide fires only when the discovery pass actually surfaced a
+  native device of the superseding family, matched by `DeviceBase.DeviceClass` (the URI host, e.g.
+  `ZWODevice`/`QHYDevice`/`GeminiDevice`). If the native SDK can't load or no device is present, no native
+  device is discovered and the ASCOM twin passes through as the fallback — the user is never stranded.
+- **Zero coupling / no cycles.** The correlation is pure data (ASCOM ProgID → native `DeviceClass`
+  string) matched against already-discovered devices in the neutral `DeviceDiscovery.RegisteredDevices`
+  aggregation. No device family references another, no per-source vendor interface was added, and the
+  ASCOM subsystem stays ignorant of the native ones. (`DeviceClass` comes from `Uri.Host`, which URI
+  normalisation lower-cases, so the match is case-insensitive — pinned by a test that caught this.)
+- **Scope (curated, exact ProgID match).** Gemini FlatPanel Lite (`ASCOM.GeminiFPLite.CoverCalibrator` →
+  `GeminiDevice`); ZWO ASI/EAF/EFW (`ASCOM.ASICamera2[_2].Camera`, `ASCOM.EAF[_2].Focuser`,
+  `ASCOM.EFW2[_2].FilterWheel` → `ZWODevice`); QHYCCD cam/CFW/qfoc (`ASCOM.QHYCCD[_CAM2|_GUIDER].Camera`,
+  `ASCOM.QHYCFW[2st]`/`ASCOM.QHYFWRS232.FilterWheel`, `ASCOM.qfoc.Focuser` → `QHYDevice`).
+- **Deliberately excluded:** `ASCOM.GeminiFocuserPro` (a different Gemini product, no native impl) and the
+  mount drivers (`ASCOM.iOptron2017`/`OnStep`/`SkyWatcher`), whose native equivalents cover only a vendor
+  subset — e.g. native iOptron is the SkyGuider Pro, not the CEM/GEM/HEM range `ASCOM.iOptron2017.Telescope`
+  drives — so hiding them would remove mounts we can't otherwise control.
+- Pinned by `NativeDriverBlacklistTests` (hidden-when-native-present, kept-as-fallback, non-blacklisted
+  kept, GeminiFocuserPro survives, case-insensitive ProgID + DeviceClass).
 
 ### Phase 4 design notes
 

--- a/docs/plans/ascom-oop-host.md
+++ b/docs/plans/ascom-oop-host.md
@@ -1,6 +1,8 @@
 # ASCOM COM drivers: out-of-process CET-off host (plan)
 
-**Status: Phases 1–4.5 DONE** (branch `feat/ascom-oop-host`, 2026-07-04). Supersedes the mitigation in
+**Status: Phases 1–4.5 DONE, Phase 5 PARTIAL** (branch `feat/ascom-oop-host`, 2026-07-04). The real
+0xC0000409 driver (`ASCOM.GeminiFPLite.CoverCalibrator`) now connects through the helper without
+fastfailing the process (see Phase 5 below). Supersedes the mitigation in
 [ascom-com-sta-message-pump.md](ascom-com-sta-message-pump.md) — the STA message pump was the **wrong
 fix** (see "Corrected root cause" below).
 
@@ -100,7 +102,30 @@ Phase 4 when generalizing to the mount.
 | P3 | `tianwen-ascomhost` exe = `JsonRpcServer` + `AscomComHost` handler over `DispatchObject`; port handshake; STA thread; E2E test (spawn exe → handshake → drive real COM); AOT-publish + verify `CETCompat=false` in the PE header | **DONE** (this commit; E2E test green against `Scripting.Dictionary`; PE header confirmed CET-off) |
 | P4 | Parent side: `IDispatchTransport` seam (in-proc `DispatchObject` / out-of-proc `RemoteDispatchTransport`); `mscoree` registry detection (`AscomComServerClassifier`); helper process lifecycle (`AscomHostProcess` spawn + connect + `AscomHostJob` kill-on-close); wire so the 8 `AscomXxxDriver` classes stay unchanged | **DONE** |
 | P4.5 | Replace loopback TCP with a per-user **named pipe**: transport-agnostic `JsonRpcServer.ServeAsync(IUtf8TextBasedConnection)`, `NamedPipeConnection`, parent-owns-server + GUID-name launch arg (drops the stdout `PORT` handshake). AOT-publish re-verified. | **DONE** (this commit) |
-| P5 | Prove cover-first on the **real Gemini FlatPanel Lite** through the helper (the actual 0xC0000409 driver); generalize to the mount (adds sub-dispatch handles — telescope `AxisRates`/`Item`, currently `NotSupported` on the remote transport); confirm win-arm64 publish + ship the helper beside the app | NOT STARTED |
+| P5 | Prove cover-first on the **real Gemini FlatPanel Lite** through the helper (the actual 0xC0000409 driver); generalize to the mount (adds sub-dispatch handles — telescope `AxisRates`/`Item`, currently `NotSupported` on the remote transport); confirm win-arm64 publish + ship the helper beside the app | **PARTIAL** — real-driver survival proven (below); panel illumination (needs hardware) + mount sub-dispatch + win-arm64/packaging pending |
+
+### Phase 5 — enemy contact (2026-07-04, dev box)
+
+Tested against the **real ASCOM drivers registered on the bring-up machine**, not just a synthetic COM
+object (`AscomOutOfProcessConnectTests`):
+
+- **Classification is correct on real drivers (7/7).** `AscomComServerClassifier` routes
+  `ASCOM.GeminiFPLite.CoverCalibrator`, `ASCOM.GeminiFocuserPro.Focuser`, `ASCOM.DeepSkyDad.FP.*`,
+  `ASCOM.iOptron2017.*` (all `mscoree.dll`) **out-of-process**, and leaves `ASCOM.Simulator.*` /
+  `ASCOM.GS.Sky.Telescope` (`LocalServer32`) **and** `CCDSimulator.Camera` (native in-proc
+  `CCDSimulator.dll`, *not* mscoree) **in-proc**. The native-in-proc negative case is the subtle one and
+  it passed.
+- **The actual 0xC0000409 driver survives through the helper.** Connecting
+  `ASCOM.GeminiFPLite.CoverCalibrator` via `AscomDispatchDevice` (→ factory → helper) runs its
+  `Connected=true` `Application.DoEvents()` busy-spin — the exact CET shadow-stack tripwire — inside the
+  CET-off helper and returns cleanly (`Connected=False`, no panel attached, **no exception, no fastfail**).
+  In-proc this would have `RtlFailFast`'d the process before returning. The ~3 s runtime confirms the
+  busy-spin actually executed rather than being a no-op, and a helper crash would have surfaced as a
+  pipe-break `IOException` (test would fail) rather than the clean null result observed. No helper
+  processes leaked.
+
+Still hardware-gated: verifying the panel actually illuminates + meters a flat (needs the physical
+Gemini panel), the mount sub-dispatch path (`AxisRates`), and the win-arm64 publish / ship-beside-app.
 
 ### Phase 4 design notes
 

--- a/docs/plans/ascom-oop-host.md
+++ b/docs/plans/ascom-oop-host.md
@@ -1,6 +1,6 @@
 # ASCOM COM drivers: out-of-process CET-off host (plan)
 
-**Status: Phases 1–4 DONE** (branch `feat/ascom-oop-host`, 2026-07-04). Supersedes the mitigation in
+**Status: Phases 1–4.5 DONE** (branch `feat/ascom-oop-host`, 2026-07-04). Supersedes the mitigation in
 [ascom-com-sta-message-pump.md](ascom-com-sta-message-pump.md) — the STA message pump was the **wrong
 fix** (see "Corrected root cause" below).
 
@@ -35,7 +35,7 @@ Evidence that settled it:
 We do **not** want to disable CET for the whole TianWen product (CET is a real exploit-mitigation, and
 we don't ship .NET Framework with the product). Instead: **one small out-of-process helper hosts the
 CET-incompatible driver with CET off**, and the CET-on main app drives it remotely over the **same
-JSON-RPC-over-TCP protocol PHD2 already uses** (loopback only).
+JSON-RPC protocol PHD2 already uses**, carried on a per-user named pipe (local only).
 
 - **`tianwen-ascomhost`** (`src/TianWen.AscomHost/`): AOT-native, `<CETCompat>false</CETCompat>`,
   Windows-only. Hosts a `DispatchObject` (the AOT-safe raw-vtable IDispatch wrapper) and exposes its
@@ -46,12 +46,22 @@ JSON-RPC-over-TCP protocol PHD2 already uses** (loopback only).
 - **Cameras stay in-proc** — the `ImageArray` SAFEARRAY is too big to marshal per frame, and no camera
   driver in the crash cluster is one we can't already reach natively.
 
-### Port handshake (ephemeral, helper → parent)
+### Named-pipe transport (Phase 4.5 — replaced loopback TCP)
 
-`JsonRpcServer` binds `TcpListener(IPAddress.Loopback, 0)` — the OS assigns a free port. The helper
-prints `PORT <n>` as its **first stdout line** once the socket is bound; the parent reads that line,
-then connects a `JsonRpcClient` to `127.0.0.1:<n>`. The port flows **helper → parent** (not
-parent-picks-and-passes), so there is no TOCTOU race between probing a free port and binding it.
+The transport is a **per-user named pipe**, not a loopback TCP socket. Rationale: a loopback port is
+connectable by any local process, shows up in `netstat`, and goes through the full TCP stack where
+corporate AV/firewall/EDR products routinely inspect, delay, or block loopback connections — all real
+liabilities on the managed Windows boxes this runs on. A named pipe has none of that: no network stack,
+no port, no firewall involvement, and an ACL scoped to the current user (`PipeOptions.CurrentUserOnly`).
+
+To avoid a create-vs-connect race, the **parent owns the pipe server**: it creates a
+`NamedPipeServerStream` with a GUID name, passes that name to the helper as `argv[0]`, spawns it, then
+waits for the helper (the pipe **client**, `NamedPipeClientStream`) to connect. No stdout handshake —
+the name is a launch argument, and the server pipe exists before the child starts, so there is no race
+and no TOCTOU. `JsonRpcServer` is transport-agnostic (`ServeAsync(IUtf8TextBasedConnection, ct)`); the
+helper serves over a `NamedPipeConnection`, and PHD2 keeps its own TCP `JsonRpcOverTcpConnection` (it is
+a real network client). Lifetime: when the parent exits the pipe breaks and the helper's serve loop ends
+(the job object is the hard backstop).
 
 ### STA affinity
 
@@ -88,7 +98,8 @@ Phase 4 when generalizing to the mount.
 | P1 | Extract the JSON-RPC client buried in the PHD2 driver into a shared `JsonRpcClient` (spine for both PHD2 and the host); refactor `OpenPHD2GuiderDriver` onto it | **DONE** (`d1471d58`; unit + live-PHD2 smoke tests) |
 | P2 | `JsonRpcServer` + server-side `JsonRpcOverTcpConnection`; loopback round-trip test | **DONE** (`8ffe2254`) |
 | P3 | `tianwen-ascomhost` exe = `JsonRpcServer` + `AscomComHost` handler over `DispatchObject`; port handshake; STA thread; E2E test (spawn exe → handshake → drive real COM); AOT-publish + verify `CETCompat=false` in the PE header | **DONE** (this commit; E2E test green against `Scripting.Dictionary`; PE header confirmed CET-off) |
-| P4 | Parent side: `IDispatchTransport` seam (in-proc `DispatchObject` / out-of-proc `RemoteDispatchTransport`); `mscoree` registry detection (`AscomComServerClassifier`); helper process lifecycle (`AscomHostProcess` spawn + PORT handshake + `AscomHostJob` kill-on-close); wire so the 8 `AscomXxxDriver` classes stay unchanged | **DONE** (this commit) |
+| P4 | Parent side: `IDispatchTransport` seam (in-proc `DispatchObject` / out-of-proc `RemoteDispatchTransport`); `mscoree` registry detection (`AscomComServerClassifier`); helper process lifecycle (`AscomHostProcess` spawn + connect + `AscomHostJob` kill-on-close); wire so the 8 `AscomXxxDriver` classes stay unchanged | **DONE** |
+| P4.5 | Replace loopback TCP with a per-user **named pipe**: transport-agnostic `JsonRpcServer.ServeAsync(IUtf8TextBasedConnection)`, `NamedPipeConnection`, parent-owns-server + GUID-name launch arg (drops the stdout `PORT` handshake). AOT-publish re-verified. | **DONE** (this commit) |
 | P5 | Prove cover-first on the **real Gemini FlatPanel Lite** through the helper (the actual 0xC0000409 driver); generalize to the mount (adds sub-dispatch handles — telescope `AxisRates`/`Item`, currently `NotSupported` on the remote transport); confirm win-arm64 publish + ship the helper beside the app | NOT STARTED |
 
 ### Phase 4 design notes
@@ -102,8 +113,8 @@ Phase 4 when generalizing to the mount.
   warning** (no worse than pre-Phase-4). The factory resolves an `ILoggerFactory` from the DI
   `serviceProvider` (a base primary-ctor param, in scope for the field initializer) to log the decision.
 - **Synchronous transport.** The ASCOM COM surface is inherently synchronous/single-apartment, so
-  `RemoteDispatchTransport` does a **synchronous, single-flight** loopback round-trip (a blocking COM call
-  becomes a blocking loopback call) — it does *not* reuse the async `JsonRpcClient` (that exists for
+  `RemoteDispatchTransport` does a **synchronous, single-flight** pipe round-trip (a blocking COM call
+  becomes a blocking pipe call) — it does *not* reuse the async `JsonRpcClient` (that exists for
   PHD2's event-pushing stream). The helper serves sequentially and never pushes, so the reply to request
   N is the next line; a `System.Threading.Lock` serializes the write/read pair.
 - **HResult fidelity.** A COM failure on the helper is re-thrown as `JsonRpcException(msg, HResult)`; the

--- a/docs/plans/ascom-oop-host.md
+++ b/docs/plans/ascom-oop-host.md
@@ -1,6 +1,6 @@
 # ASCOM COM drivers: out-of-process CET-off host (plan)
 
-**Status: Phases 1–3 DONE** (branch `feat/ascom-oop-host`, 2026-07-04). Supersedes the mitigation in
+**Status: Phases 1–4 DONE** (branch `feat/ascom-oop-host`, 2026-07-04). Supersedes the mitigation in
 [ascom-com-sta-message-pump.md](ascom-com-sta-message-pump.md) — the STA message pump was the **wrong
 fix** (see "Corrected root cause" below).
 
@@ -88,8 +88,36 @@ Phase 4 when generalizing to the mount.
 | P1 | Extract the JSON-RPC client buried in the PHD2 driver into a shared `JsonRpcClient` (spine for both PHD2 and the host); refactor `OpenPHD2GuiderDriver` onto it | **DONE** (`d1471d58`; unit + live-PHD2 smoke tests) |
 | P2 | `JsonRpcServer` + server-side `JsonRpcOverTcpConnection`; loopback round-trip test | **DONE** (`8ffe2254`) |
 | P3 | `tianwen-ascomhost` exe = `JsonRpcServer` + `AscomComHost` handler over `DispatchObject`; port handshake; STA thread; E2E test (spawn exe → handshake → drive real COM); AOT-publish + verify `CETCompat=false` in the PE header | **DONE** (this commit; E2E test green against `Scripting.Dictionary`; PE header confirmed CET-off) |
-| P4 | Parent side: `IDispatchTransport` seam (`LocalDispatchTransport` in-proc / `RemoteDispatchTransport` over `JsonRpcClient`); `mscoree` registry detection at `AscomDevice.NewInstanceFromDevice`; helper process lifecycle (spawn + JobObject to tie lifetime); wire so the 8 `AscomXxxDriver` classes stay unchanged | NOT STARTED |
-| P5 | Prove cover-first on the **real Gemini FlatPanel Lite** through the helper (the actual 0xC0000409 driver); generalize to mount/focuser/FW/switch (adds sub-dispatch handles); confirm win-arm64 publish | NOT STARTED |
+| P4 | Parent side: `IDispatchTransport` seam (in-proc `DispatchObject` / out-of-proc `RemoteDispatchTransport`); `mscoree` registry detection (`AscomComServerClassifier`); helper process lifecycle (`AscomHostProcess` spawn + PORT handshake + `AscomHostJob` kill-on-close); wire so the 8 `AscomXxxDriver` classes stay unchanged | **DONE** (this commit) |
+| P5 | Prove cover-first on the **real Gemini FlatPanel Lite** through the helper (the actual 0xC0000409 driver); generalize to the mount (adds sub-dispatch handles — telescope `AxisRates`/`Item`, currently `NotSupported` on the remote transport); confirm win-arm64 publish + ship the helper beside the app | NOT STARTED |
+
+### Phase 4 design notes
+
+- **`DispatchObject` *is* the local transport.** `IDispatchTransport` was extracted from its exact public
+  surface, so `DispatchObject : IDispatchTransport` with no wrapper class. The `[DispatchInterface]`
+  generator now emits an `IDispatchTransport _dispatch` field, so every wrapper is transport-agnostic.
+- **Routing** happens in `AscomDispatchDevice`'s ctor via `DispatchTransportFactory.Create(progId, sp)`:
+  classify → if `mscoree` in-proc and the helper is locatable, spawn `RemoteDispatchTransport`; else
+  `new DispatchObject`. If the helper is needed but missing/unstartable, it **falls back to in-proc with a
+  warning** (no worse than pre-Phase-4). The factory resolves an `ILoggerFactory` from the DI
+  `serviceProvider` (a base primary-ctor param, in scope for the field initializer) to log the decision.
+- **Synchronous transport.** The ASCOM COM surface is inherently synchronous/single-apartment, so
+  `RemoteDispatchTransport` does a **synchronous, single-flight** loopback round-trip (a blocking COM call
+  becomes a blocking loopback call) — it does *not* reuse the async `JsonRpcClient` (that exists for
+  PHD2's event-pushing stream). The helper serves sequentially and never pushes, so the reply to request
+  N is the next line; a `System.Threading.Lock` serializes the write/read pair.
+- **HResult fidelity.** A COM failure on the helper is re-thrown as `JsonRpcException(msg, HResult)`; the
+  transport reconstructs `COMException(msg, HResult)`. This keeps the driver's Platform-6 fallback
+  (`catch (COMException) when (HResult == DISP_E_UNKNOWNNAME)`) working across the wire.
+- **Helper location:** `TIANWEN_ASCOMHOST` env override → beside the running app → sibling build output
+  (dev/test).
+- **Not yet supported over the wire:** opaque `GetObject`/`InvokeMethodObject` VARIANTs and sub-dispatch
+  (`InvokeMethodDispatch`/`GetPropertyDispatch`, i.e. telescope `AxisRates`) throw `NotSupportedException`
+  — none of the crash-cluster devices (cover/focuser/FW/switch) use them; the mount is Phase 5.
+- **Validated:** `RemoteDispatchTransportTests` drives the typed transport against the real helper +
+  `Scripting.Dictionary` (get/set/invoke round-trip + a `COMException`-with-HResult on an illegal call);
+  `AscomComServerClassifier` correctly leaves a native in-proc server in-proc. Full E2E against the real
+  Gemini panel is Phase 5 (needs the hardware).
 
 ## Notes
 

--- a/docs/plans/ascom-oop-host.md
+++ b/docs/plans/ascom-oop-host.md
@@ -1,0 +1,100 @@
+# ASCOM COM drivers: out-of-process CET-off host (plan)
+
+**Status: Phases 1–3 DONE** (branch `feat/ascom-oop-host`, 2026-07-04). Supersedes the mitigation in
+[ascom-com-sta-message-pump.md](ascom-com-sta-message-pump.md) — the STA message pump was the **wrong
+fix** (see "Corrected root cause" below).
+
+## The problem (recap)
+
+A cluster of vendor ASCOM COM drivers (Gemini FlatPanel Lite, Gemini Focuser Pro, iOptron, some QHY)
+busy-spin `Application.DoEvents()` in their `Connected = true` setter. Driving them from TianWen
+(`AscomDevice` / `AscomDispatchDevice`) **hard-crashes the process on connect** with exit `0xC0000409`
+(STATUS_STACK_BUFFER_OVERRUN, `ntdll+0x11f1e6`) — no catchable managed exception. NINA connects the
+same drivers cleanly.
+
+## Corrected root cause — CET, not the missing message pump
+
+The crash is a **CET (Control-flow Enforcement Technology / hardware shadow-stack) violation**. The
+legacy in-proc **.NET Framework 4.x CLR** (`mscoree.dll`, `RuntimeVersion v4.0.30319`) that these
+drivers load in-process is **not CET-compatible**; when the driver's `DoEvents` unwinds through the
+CLR's JIT-emitted frames, the shadow-stack check trips a native `RtlFailFast`. Windows 10 20H1+/Win11
+enforce CET for a process whose main image opts in — and .NET AOT/modern binaries opt in **by
+default**, which is why `tianwen-*` crash but NINA (a .NET Framework WPF app, CET off) does not.
+
+Evidence that settled it:
+- Four client-side experiments (raw IDispatch, WinForms `Application.Run` pump, `ASCOM.Com.DriverAccess`
+  console, a bare-COM pwsh repro) **all crashed** the same way — proving no client-side message pump can
+  catch it. The STA-pump plan cannot work.
+- The fix is `<CETCompat>false</CETCompat>` on the **executable that loads the driver** — it removes
+  shadow-stack enforcement for that process only. Confirmed: NINA ships CET off.
+- Drivers that don't crash are either out-of-proc (`LocalServer32`, e.g. GS Server), native-inproc, or
+  simply don't `DoEvents` — none load the CET-incompatible inproc Framework CLR on our hot path.
+
+## Chosen architecture — a tiny CET-off helper, main app keeps CET
+
+We do **not** want to disable CET for the whole TianWen product (CET is a real exploit-mitigation, and
+we don't ship .NET Framework with the product). Instead: **one small out-of-process helper hosts the
+CET-incompatible driver with CET off**, and the CET-on main app drives it remotely over the **same
+JSON-RPC-over-TCP protocol PHD2 already uses** (loopback only).
+
+- **`tianwen-ascomhost`** (`src/TianWen.AscomHost/`): AOT-native, `<CETCompat>false</CETCompat>`,
+  Windows-only. Hosts a `DispatchObject` (the AOT-safe raw-vtable IDispatch wrapper) and exposes its
+  typed surface over JSON-RPC. ~2.2 MB native, ships no .NET runtime.
+- **Detection** (Phase 4): route a device to the helper only when its `InprocServer32` default value
+  ends with `mscoree.dll` (a .NET Framework inproc COM server); native/comhost inproc and
+  `LocalServer32` drivers stay in-proc, unchanged. Read the registry in the process (x64) bitness view.
+- **Cameras stay in-proc** — the `ImageArray` SAFEARRAY is too big to marshal per frame, and no camera
+  driver in the crash cluster is one we can't already reach natively.
+
+### Port handshake (ephemeral, helper → parent)
+
+`JsonRpcServer` binds `TcpListener(IPAddress.Loopback, 0)` — the OS assigns a free port. The helper
+prints `PORT <n>` as its **first stdout line** once the socket is bound; the parent reads that line,
+then connects a `JsonRpcClient` to `127.0.0.1:<n>`. The port flows **helper → parent** (not
+parent-picks-and-passes), so there is no TOCTOU race between probing a free port and binding it.
+
+### STA affinity
+
+`JsonRpcServer` uses `ConfigureAwait(false)`, so handler continuations land on arbitrary thread-pool
+(MTA) threads. A legacy COM driver's hidden window has thread affinity, so **every** call to one COM
+object must come from **one** thread. The helper therefore owns a single dedicated **STA** thread
+(`StaComThread`) and marshals every `DispatchObject` op onto it — the handle table needs no locking
+because it is only ever touched there. (The STA thread is the *correct apartment for legacy COM*, not a
+crash workaround; the crash fix is CET-off.)
+
+## Wire vocabulary (`AscomComHost`)
+
+Mirrors `DispatchObject`'s typed surface 1:1 so the parent's remote transport (Phase 4) is a mechanical
+projection:
+
+| Method | Params | Result |
+|---|---|---|
+| `create` | `[progId]` | handle (int) |
+| `release` | `[handle]` | void |
+| `get{Bool,Int,Short,Double,String,DateTime,StringArray,IntArray,Int2DArray}` | `[handle, name]` | value |
+| `set{Bool,Int,Short,Double,String,DateTime}` | `[handle, name, value]` | void |
+| `invoke{,Bool,Int,Double}` | `[handle, name, ...args]` | void / value |
+
+`DateTime` is ISO-8601 round-trip (`"o"`). Method args are inferred from JSON kind (bool / integral→int
+/ real→double / string); a tagged `DateTime` arg encoding is deferred (no crash-cluster driver needs
+one). Sub-dispatch returns (`InvokeMethodDispatch` / `GetPropertyDispatch`, e.g. mount `AxisRates`) are
+**not yet** wired — cover/calibrator/focuser/FW/switch don't need them; add handle-returning variants in
+Phase 4 when generalizing to the mount.
+
+## Phasing
+
+| Phase | Scope | Status |
+|---|---|---|
+| P1 | Extract the JSON-RPC client buried in the PHD2 driver into a shared `JsonRpcClient` (spine for both PHD2 and the host); refactor `OpenPHD2GuiderDriver` onto it | **DONE** (`d1471d58`; unit + live-PHD2 smoke tests) |
+| P2 | `JsonRpcServer` + server-side `JsonRpcOverTcpConnection`; loopback round-trip test | **DONE** (`8ffe2254`) |
+| P3 | `tianwen-ascomhost` exe = `JsonRpcServer` + `AscomComHost` handler over `DispatchObject`; port handshake; STA thread; E2E test (spawn exe → handshake → drive real COM); AOT-publish + verify `CETCompat=false` in the PE header | **DONE** (this commit; E2E test green against `Scripting.Dictionary`; PE header confirmed CET-off) |
+| P4 | Parent side: `IDispatchTransport` seam (`LocalDispatchTransport` in-proc / `RemoteDispatchTransport` over `JsonRpcClient`); `mscoree` registry detection at `AscomDevice.NewInstanceFromDevice`; helper process lifecycle (spawn + JobObject to tie lifetime); wire so the 8 `AscomXxxDriver` classes stay unchanged | NOT STARTED |
+| P5 | Prove cover-first on the **real Gemini FlatPanel Lite** through the helper (the actual 0xC0000409 driver); generalize to mount/focuser/FW/switch (adds sub-dispatch handles); confirm win-arm64 publish | NOT STARTED |
+
+## Notes
+
+- **The native driver still dodges all of this.** TianWen's own serial `GeminiFlatPanelDriver`
+  (`AddGemini()`) connects clean, headless, cross-platform — no COM, no `DoEvents`, no helper. This plan
+  makes the *ASCOM-COM fallback* robust, not the primary Gemini path.
+- The interim GUI freeze mitigation (`AppSignalHandler.RunDeviceOpOffRenderThreadAsync`, merged via
+  PR #77) keeps the render loop live during the busy-spin but does **not** fix the crash — this host does.

--- a/src/TianWen.AscomHost/AscomComHost.cs
+++ b/src/TianWen.AscomHost/AscomComHost.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 using System.Text.Json;
 using System.Threading;
@@ -33,6 +34,20 @@ internal sealed class AscomComHost(StaComThread sta) : IDisposable
 
     /// <summary>The <see cref="JsonRpcRequestHandler"/> passed to <see cref="JsonRpcServer"/>.</summary>
     public async ValueTask HandleAsync(string method, JsonElement p, Utf8JsonWriter result, CancellationToken cancellationToken)
+    {
+        try
+        {
+            await DispatchAsync(method, p, result).ConfigureAwait(false);
+        }
+        catch (COMException ce)
+        {
+            // Carry the COM HResult across as the JSON-RPC error code so the parent's driver can still do
+            // `catch (COMException) when (HResult == DISP_E_UNKNOWNNAME)` -- the Platform-6 fallback path.
+            throw new JsonRpcException(ce.Message, ce.HResult);
+        }
+    }
+
+    private async ValueTask DispatchAsync(string method, JsonElement p, Utf8JsonWriter result)
     {
         switch (method)
         {

--- a/src/TianWen.AscomHost/AscomComHost.cs
+++ b/src/TianWen.AscomHost/AscomComHost.cs
@@ -1,0 +1,242 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Runtime.Versioning;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using TianWen.Lib.Connections;
+using TianWen.Lib.Devices.Ascom.ComInterop;
+
+namespace TianWen.AscomHost;
+
+/// <summary>
+/// The JSON-RPC request handler that exposes <see cref="DispatchObject"/> over the wire, so a CET-enabled
+/// parent process can drive a CET-incompatible in-proc ASCOM COM driver hosted here (CET off) as if it
+/// were local. The vocabulary mirrors <see cref="DispatchObject"/>'s typed surface one-for-one, so the
+/// parent's remote transport (Phase 4) is a mechanical projection of it:
+/// <list type="bullet">
+///   <item><c>create [progId]</c> -&gt; handle (int)</item>
+///   <item><c>release [handle]</c> -&gt; void</item>
+///   <item><c>get{Bool,Int,Short,Double,String,DateTime,StringArray,IntArray,Int2DArray} [handle, name]</c> -&gt; value</item>
+///   <item><c>set{Bool,Int,Short,Double,String,DateTime} [handle, name, value]</c> -&gt; void</item>
+///   <item><c>invoke{,Bool,Int,Double} [handle, name, ...args]</c> -&gt; void|value</item>
+/// </list>
+/// Every COM-touching operation is marshalled onto the single <see cref="StaComThread"/>, so the handle
+/// table needs no synchronization (see that type's remarks).
+/// </summary>
+[SupportedOSPlatform("windows")]
+internal sealed class AscomComHost(StaComThread sta) : IDisposable
+{
+    private readonly Dictionary<int, DispatchObject> _objects = new();
+    private int _nextHandle = 1;
+
+    /// <summary>The <see cref="JsonRpcRequestHandler"/> passed to <see cref="JsonRpcServer"/>.</summary>
+    public async ValueTask HandleAsync(string method, JsonElement p, Utf8JsonWriter result, CancellationToken cancellationToken)
+    {
+        switch (method)
+        {
+            case "create":
+            {
+                var progId = Str(p, 0);
+                var handle = await sta.InvokeAsync(() =>
+                {
+                    var obj = new DispatchObject(progId);
+                    var h = _nextHandle++;
+                    _objects[h] = obj;
+                    return h;
+                }).ConfigureAwait(false);
+                result.WriteNumberValue(handle);
+                break;
+            }
+
+            case "release":
+            {
+                var handle = Int(p, 0);
+                await sta.InvokeAsync(() =>
+                {
+                    if (_objects.Remove(handle, out var obj))
+                    {
+                        obj.Dispose();
+                    }
+                }).ConfigureAwait(false);
+                break;
+            }
+
+            // ---- getters: [handle, name] ----
+            case "getBool":
+                result.WriteBooleanValue(await On(p, o => o.GetBool(Name(p))).ConfigureAwait(false));
+                break;
+            case "getInt":
+                result.WriteNumberValue(await On(p, o => o.GetInt(Name(p))).ConfigureAwait(false));
+                break;
+            case "getShort":
+                result.WriteNumberValue(await On(p, o => o.GetShort(Name(p))).ConfigureAwait(false));
+                break;
+            case "getDouble":
+                result.WriteNumberValue(await On(p, o => o.GetDouble(Name(p))).ConfigureAwait(false));
+                break;
+            case "getString":
+                result.WriteStringValue(await On(p, o => o.GetString(Name(p))).ConfigureAwait(false));
+                break;
+            case "getDateTime":
+                result.WriteStringValue((await On(p, o => o.GetDateTime(Name(p))).ConfigureAwait(false)).ToString("o", CultureInfo.InvariantCulture));
+                break;
+            case "getStringArray":
+                WriteStringArray(result, await On(p, o => o.GetStringArray(Name(p))).ConfigureAwait(false));
+                break;
+            case "getIntArray":
+                WriteIntArray(result, await On(p, o => o.GetIntArray(Name(p))).ConfigureAwait(false));
+                break;
+            case "getInt2DArray":
+                WriteInt2DArray(result, await On(p, o => o.GetInt2DArray(Name(p))).ConfigureAwait(false));
+                break;
+
+            // ---- setters: [handle, name, value] ----
+            case "setBool":
+                await OnVoid(p, o => o.Set(Name(p), p[2].GetBoolean())).ConfigureAwait(false);
+                break;
+            case "setInt":
+                await OnVoid(p, o => o.Set(Name(p), p[2].GetInt32())).ConfigureAwait(false);
+                break;
+            case "setShort":
+                await OnVoid(p, o => o.Set(Name(p), p[2].GetInt16())).ConfigureAwait(false);
+                break;
+            case "setDouble":
+                await OnVoid(p, o => o.Set(Name(p), p[2].GetDouble())).ConfigureAwait(false);
+                break;
+            case "setString":
+                await OnVoid(p, o => o.Set(Name(p), p[2].GetString() ?? string.Empty)).ConfigureAwait(false);
+                break;
+            case "setDateTime":
+            {
+                var value = DateTime.Parse(Str(p, 2), CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind);
+                await OnVoid(p, o => o.Set(Name(p), value)).ConfigureAwait(false);
+                break;
+            }
+
+            // ---- method invocation: [handle, name, ...args] ----
+            case "invoke":
+                await OnVoid(p, o => o.InvokeMethod(Name(p), Args(p))).ConfigureAwait(false);
+                break;
+            case "invokeBool":
+                result.WriteBooleanValue(await On(p, o => o.InvokeMethodBool(Name(p), Args(p))).ConfigureAwait(false));
+                break;
+            case "invokeInt":
+                result.WriteNumberValue(await On(p, o => o.InvokeMethodInt(Name(p), Args(p))).ConfigureAwait(false));
+                break;
+            case "invokeDouble":
+                result.WriteNumberValue(await On(p, o => o.InvokeMethodDouble(Name(p), Args(p))).ConfigureAwait(false));
+                break;
+
+            default:
+                throw new JsonRpcException($"unknown method '{method}'");
+        }
+    }
+
+    // Marshal a value-returning COM op onto the STA thread; the closure resolves the handle there too so
+    // the handle table is only ever touched on that one thread.
+    private Task<T> On<T>(JsonElement p, Func<DispatchObject, T> op)
+    {
+        var handle = Int(p, 0);
+        return sta.InvokeAsync(() => op(Resolve(handle)));
+    }
+
+    private Task OnVoid(JsonElement p, Action<DispatchObject> op)
+    {
+        var handle = Int(p, 0);
+        return sta.InvokeAsync(() => op(Resolve(handle)));
+    }
+
+    private DispatchObject Resolve(int handle)
+        => _objects.TryGetValue(handle, out var obj) ? obj : throw new JsonRpcException($"unknown handle {handle}");
+
+    private static int Int(JsonElement p, int i) => p[i].GetInt32();
+
+    private static string Str(JsonElement p, int i)
+        => p[i].GetString() ?? throw new JsonRpcException($"argument {i} must be a string");
+
+    private static string Name(JsonElement p) => Str(p, 1);
+
+    // ASCOM method arguments are almost always numeric/bool. JSON loses the int-vs-double distinction, so
+    // integral numbers map to int and fractional ones to double (DispatchObject.ArgsToVariants accepts
+    // bool/int/short/double/string/DateTime). Rare DateTime args would need a tagged encoding -- deferred.
+    private static object[] Args(JsonElement p)
+    {
+        var len = p.GetArrayLength();
+        if (len <= 2)
+        {
+            return [];
+        }
+
+        var args = new object[len - 2];
+        for (var i = 2; i < len; i++)
+        {
+            args[i - 2] = ToArg(p[i]);
+        }
+        return args;
+    }
+
+    private static object ToArg(JsonElement e) => e.ValueKind switch
+    {
+        JsonValueKind.True => true,
+        JsonValueKind.False => false,
+        JsonValueKind.String => e.GetString() ?? string.Empty,
+        JsonValueKind.Number => e.TryGetInt32(out var i) ? i : e.GetDouble(),
+        _ => throw new JsonRpcException($"unsupported argument kind {e.ValueKind}"),
+    };
+
+    private static void WriteStringArray(Utf8JsonWriter w, string[] arr)
+    {
+        w.WriteStartArray();
+        foreach (var s in arr)
+        {
+            w.WriteStringValue(s);
+        }
+        w.WriteEndArray();
+    }
+
+    private static void WriteIntArray(Utf8JsonWriter w, int[] arr)
+    {
+        w.WriteStartArray();
+        foreach (var n in arr)
+        {
+            w.WriteNumberValue(n);
+        }
+        w.WriteEndArray();
+    }
+
+    // Emitted as an array-of-rows [[...],[...]] preserving the native [dim1, dim2] shape.
+    private static void WriteInt2DArray(Utf8JsonWriter w, int[,] arr)
+    {
+        var d0 = arr.GetLength(0);
+        var d1 = arr.GetLength(1);
+        w.WriteStartArray();
+        for (var i = 0; i < d0; i++)
+        {
+            w.WriteStartArray();
+            for (var j = 0; j < d1; j++)
+            {
+                w.WriteNumberValue(arr[i, j]);
+            }
+            w.WriteEndArray();
+        }
+        w.WriteEndArray();
+    }
+
+    public void Dispose()
+    {
+        // Best-effort release on the STA thread the objects were created on, fire-and-forget: the process
+        // is shutting down and the STA thread is a background thread, so we don't block on it (and mustn't
+        // sync-over-async). Explicit per-object lifetime goes through the "release" RPC; this is the net
+        // for anything still open at shutdown. StaComThread.Dispose() drains this queued item before exit.
+        _ = sta.InvokeAsync(() =>
+        {
+            foreach (var obj in _objects.Values)
+            {
+                obj.Dispose();
+            }
+            _objects.Clear();
+        });
+    }
+}

--- a/src/TianWen.AscomHost/Program.cs
+++ b/src/TianWen.AscomHost/Program.cs
@@ -1,4 +1,5 @@
 using System;
+using System.IO.Pipes;
 using System.Threading;
 using System.Threading.Tasks;
 using TianWen.AscomHost;
@@ -9,12 +10,20 @@ using TianWen.Lib.Connections;
 // A tiny, AOT-native, CET-off helper that hosts a legacy in-proc .NET Framework ASCOM COM driver -- the
 // kind whose Connected=true DoEvents pump trips a native fastfail (0xC0000409) under the CET shadow stack
 // the main TianWen app runs with. The main app keeps CET on and drives the driver from here over the
-// same JSON-RPC-over-TCP protocol PHD2 uses (loopback only).
+// same JSON-RPC protocol PHD2 uses, carried on a per-user named pipe (no network stack, no loopback port,
+// no firewall/AV involvement).
 //
-// Port handshake: the OS assigns the loopback port (JsonRpcServer binds port 0), and we report it back to
-// the parent by printing "PORT <n>" as the first stdout line. The parent reads that line, then connects a
-// JsonRpcClient to 127.0.0.1:<n>. Reporting the port after the socket is already bound avoids the TOCTOU
-// race a "parent picks a free port and passes it in" scheme would have.
+// Transport: the PARENT creates the named-pipe server (before spawning us, so there is no race) and
+// passes its GUID pipe name as argv[0]; we connect as the pipe client and serve. When the parent exits,
+// the pipe breaks and our serve loop ends -- we exit on our own (the job object is the hard backstop).
+
+if (args.Length < 1 || string.IsNullOrWhiteSpace(args[0]))
+{
+    await Console.Error.WriteLineAsync("usage: tianwen-ascomhost <pipe-name>");
+    return 2;
+}
+
+var pipeName = args[0];
 
 using var cancellation = new CancellationTokenSource();
 Console.CancelKeyPress += (_, e) =>
@@ -25,17 +34,31 @@ Console.CancelKeyPress += (_, e) =>
 
 using var sta = new StaComThread();
 using var host = new AscomComHost(sta);
-using var server = new JsonRpcServer(
+var server = new JsonRpcServer(
     host.HandleAsync,
     onError: (ex, context) => Console.Error.WriteLine($"[tianwen-ascomhost] {context}: {ex.Message}"));
 
-var port = server.Start();
-Console.Out.WriteLine($"PORT {port}");
-Console.Out.Flush();
+using var pipe = new NamedPipeClientStream(
+    ".",
+    pipeName,
+    PipeDirection.InOut,
+    PipeOptions.Asynchronous | PipeOptions.CurrentUserOnly);
 
 try
 {
-    await server.RunAsync(cancellation.Token);
+    pipe.Connect(timeout: 15_000);
+}
+catch (Exception ex)
+{
+    await Console.Error.WriteLineAsync($"[tianwen-ascomhost] could not connect to pipe '{pipeName}': {ex.Message}");
+    return 3;
+}
+
+using var connection = new NamedPipeConnection(pipe);
+
+try
+{
+    await server.ServeAsync(connection, cancellation.Token);
 }
 catch (OperationCanceledException)
 {

--- a/src/TianWen.AscomHost/Program.cs
+++ b/src/TianWen.AscomHost/Program.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using TianWen.AscomHost;
+using TianWen.Lib.Connections;
+
+// TianWen out-of-process ASCOM COM host (tianwen-ascomhost).
+//
+// A tiny, AOT-native, CET-off helper that hosts a legacy in-proc .NET Framework ASCOM COM driver -- the
+// kind whose Connected=true DoEvents pump trips a native fastfail (0xC0000409) under the CET shadow stack
+// the main TianWen app runs with. The main app keeps CET on and drives the driver from here over the
+// same JSON-RPC-over-TCP protocol PHD2 uses (loopback only).
+//
+// Port handshake: the OS assigns the loopback port (JsonRpcServer binds port 0), and we report it back to
+// the parent by printing "PORT <n>" as the first stdout line. The parent reads that line, then connects a
+// JsonRpcClient to 127.0.0.1:<n>. Reporting the port after the socket is already bound avoids the TOCTOU
+// race a "parent picks a free port and passes it in" scheme would have.
+
+using var cancellation = new CancellationTokenSource();
+Console.CancelKeyPress += (_, e) =>
+{
+    e.Cancel = true;
+    cancellation.Cancel();
+};
+
+using var sta = new StaComThread();
+using var host = new AscomComHost(sta);
+using var server = new JsonRpcServer(
+    host.HandleAsync,
+    onError: (ex, context) => Console.Error.WriteLine($"[tianwen-ascomhost] {context}: {ex.Message}"));
+
+var port = server.Start();
+Console.Out.WriteLine($"PORT {port}");
+Console.Out.Flush();
+
+try
+{
+    await server.RunAsync(cancellation.Token);
+}
+catch (OperationCanceledException)
+{
+    // shutdown requested
+}
+
+return 0;

--- a/src/TianWen.AscomHost/StaComThread.cs
+++ b/src/TianWen.AscomHost/StaComThread.cs
@@ -1,0 +1,80 @@
+using System;
+using System.Collections.Concurrent;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace TianWen.AscomHost;
+
+/// <summary>
+/// A single dedicated STA thread that serves as the one-and-only apartment for every hosted COM object.
+/// <para>
+/// This is load-bearing, not decoration. Legacy in-proc ASCOM COM drivers create a hidden window (their
+/// <c>Connected=true</c> setter pumps it via <c>Application.DoEvents()</c>), and a window has thread
+/// affinity: every call to that object must arrive on the thread that created it, or the pump runs on the
+/// wrong message queue and the driver hangs / misbehaves. <see cref="JsonRpcServer"/> deliberately uses
+/// <c>ConfigureAwait(false)</c>, so its request-handler continuations land on arbitrary thread-pool (MTA)
+/// threads -- we therefore marshal each COM operation onto this one STA thread via <see cref="InvokeAsync{T}"/>
+/// rather than relying on a synchronization context the server would ignore.
+/// </para>
+/// <para>Work items run strictly sequentially (one COM object wants exactly that), so state the ops touch
+/// -- the handle table in <see cref="AscomComHost"/> -- needs no locking: it is only ever read/written on
+/// this thread.</para>
+/// </summary>
+internal sealed class StaComThread : IDisposable
+{
+    private readonly BlockingCollection<Action> _queue = new();
+    private readonly Thread _thread;
+
+    public StaComThread()
+    {
+        _thread = new Thread(Loop)
+        {
+            IsBackground = true,
+            Name = "ascom-com-sta",
+        };
+        _thread.SetApartmentState(ApartmentState.STA);
+        _thread.Start();
+    }
+
+    private void Loop()
+    {
+        foreach (var action in _queue.GetConsumingEnumerable())
+        {
+            action();
+        }
+    }
+
+    /// <summary>Runs <paramref name="func"/> on the STA thread and completes the returned task with its result.</summary>
+    public Task<T> InvokeAsync<T>(Func<T> func)
+    {
+        var tcs = new TaskCompletionSource<T>(TaskCreationOptions.RunContinuationsAsynchronously);
+        try
+        {
+            _queue.Add(() =>
+            {
+                try
+                {
+                    tcs.SetResult(func());
+                }
+                catch (Exception ex)
+                {
+                    tcs.SetException(ex);
+                }
+            });
+        }
+        catch (InvalidOperationException) // queue completed (shutting down)
+        {
+            tcs.SetCanceled();
+        }
+        return tcs.Task;
+    }
+
+    /// <summary>Runs a void <paramref name="action"/> on the STA thread.</summary>
+    public Task InvokeAsync(Action action) => InvokeAsync<object?>(() =>
+    {
+        action();
+        return null;
+    });
+
+    public void Dispose() => _queue.CompleteAdding();
+}

--- a/src/TianWen.AscomHost/TianWen.AscomHost.csproj
+++ b/src/TianWen.AscomHost/TianWen.AscomHost.csproj
@@ -32,7 +32,7 @@
     <Compile Include="..\TianWen.Lib\Connections\CommunicationProtocol.cs" Link="Connections\CommunicationProtocol.cs" />
     <Compile Include="..\TianWen.Lib\Connections\IUtf8TextBasedConnection.cs" Link="Connections\IUtf8TextBasedConnection.cs" />
     <Compile Include="..\TianWen.Lib\Connections\JsonRpcException.cs" Link="Connections\JsonRpcException.cs" />
-    <Compile Include="..\TianWen.Lib\Connections\JsonRpcOverTcpConnection.cs" Link="Connections\JsonRpcOverTcpConnection.cs" />
+    <Compile Include="..\TianWen.Lib\Connections\NamedPipeConnection.cs" Link="Connections\NamedPipeConnection.cs" />
     <Compile Include="..\TianWen.Lib\Connections\JsonRpcServer.cs" Link="Connections\JsonRpcServer.cs" />
     <Compile Include="..\TianWen.Lib\Devices\Ascom\ComInterop\IDispatchTransport.cs" Link="ComInterop\IDispatchTransport.cs" />
     <Compile Include="..\TianWen.Lib\Devices\Ascom\ComInterop\NativeMethods.cs" Link="ComInterop\NativeMethods.cs" />

--- a/src/TianWen.AscomHost/TianWen.AscomHost.csproj
+++ b/src/TianWen.AscomHost/TianWen.AscomHost.csproj
@@ -34,6 +34,7 @@
     <Compile Include="..\TianWen.Lib\Connections\JsonRpcException.cs" Link="Connections\JsonRpcException.cs" />
     <Compile Include="..\TianWen.Lib\Connections\JsonRpcOverTcpConnection.cs" Link="Connections\JsonRpcOverTcpConnection.cs" />
     <Compile Include="..\TianWen.Lib\Connections\JsonRpcServer.cs" Link="Connections\JsonRpcServer.cs" />
+    <Compile Include="..\TianWen.Lib\Devices\Ascom\ComInterop\IDispatchTransport.cs" Link="ComInterop\IDispatchTransport.cs" />
     <Compile Include="..\TianWen.Lib\Devices\Ascom\ComInterop\NativeMethods.cs" Link="ComInterop\NativeMethods.cs" />
     <Compile Include="..\TianWen.Lib\Devices\Ascom\ComInterop\SafeArrayMarshal.cs" Link="ComInterop\SafeArrayMarshal.cs" />
     <Compile Include="..\TianWen.Lib\Devices\Ascom\ComInterop\DispatchObject.cs" Link="ComInterop\DispatchObject.cs" />

--- a/src/TianWen.AscomHost/TianWen.AscomHost.csproj
+++ b/src/TianWen.AscomHost/TianWen.AscomHost.csproj
@@ -1,0 +1,42 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <!-- net10.0-windows: this exe only ever runs on Windows (it hosts legacy in-proc COM ASCOM
+         drivers), so the -windows platform silences the CA1416 warnings the [SupportedOSPlatform]
+         DispatchObject members would otherwise raise, and it never runs anywhere else. -->
+    <TargetFramework>net10.0-windows</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <AssemblyName>tianwen-ascomhost</AssemblyName>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <Platforms>AnyCPU</Platforms>
+    <PublishAot>true</PublishAot>
+    <!-- THE POINT OF THIS PROCESS. Disabling CET (Control-flow Enforcement Technology / hardware
+         shadow stack) removes shadow-stack enforcement for this process only. The .NET Framework
+         4.x CLR that legacy ASCOM COM drivers load in-proc (mscoree.dll, v4.0.30319) is not
+         CET-compatible: a driver's Connected=true DoEvents pump trips a native RtlFailFast
+         (0xC0000409 STATUS_STACK_BUFFER_OVERRUN). The main TianWen app keeps CET on and offloads
+         those drivers to this helper over JSON-RPC. See docs/plans/ascom-oop-host.md. -->
+    <CETCompat>false</CETCompat>
+    <!-- We use only the low-level System.Text.Json reader/writer (no JsonSerializer reflection),
+         raw-vtable COM interop, and TCP: all AOT-safe and no XML doc consumers. -->
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+    <DebugType Condition="'$(Configuration)' == 'Release'">none</DebugType>
+  </PropertyGroup>
+
+  <!-- Bare-minimum shared sources LINKED (not a TianWen.Lib ProjectReference) so this helper stays
+       tiny and AOT-clean: it must not pull the whole library (catalogs, imaging, native camera SDKs)
+       into the native binary. These files are self-contained (BCL + raw COM interop only). -->
+  <ItemGroup>
+    <Compile Include="..\TianWen.Lib\Connections\CommunicationProtocol.cs" Link="Connections\CommunicationProtocol.cs" />
+    <Compile Include="..\TianWen.Lib\Connections\IUtf8TextBasedConnection.cs" Link="Connections\IUtf8TextBasedConnection.cs" />
+    <Compile Include="..\TianWen.Lib\Connections\JsonRpcException.cs" Link="Connections\JsonRpcException.cs" />
+    <Compile Include="..\TianWen.Lib\Connections\JsonRpcOverTcpConnection.cs" Link="Connections\JsonRpcOverTcpConnection.cs" />
+    <Compile Include="..\TianWen.Lib\Connections\JsonRpcServer.cs" Link="Connections\JsonRpcServer.cs" />
+    <Compile Include="..\TianWen.Lib\Devices\Ascom\ComInterop\NativeMethods.cs" Link="ComInterop\NativeMethods.cs" />
+    <Compile Include="..\TianWen.Lib\Devices\Ascom\ComInterop\SafeArrayMarshal.cs" Link="ComInterop\SafeArrayMarshal.cs" />
+    <Compile Include="..\TianWen.Lib\Devices\Ascom\ComInterop\DispatchObject.cs" Link="ComInterop\DispatchObject.cs" />
+  </ItemGroup>
+
+</Project>

--- a/src/TianWen.Lib.SourceGenerators/DispatchInterfaceGenerator.cs
+++ b/src/TianWen.Lib.SourceGenerators/DispatchInterfaceGenerator.cs
@@ -139,7 +139,7 @@ internal sealed class DispatchInterfaceAttribute : global::System.Attribute
 
         sb.AppendLine($"{accessibility} partial class {classInfo.ClassName}");
         sb.AppendLine("{");
-        sb.AppendLine("    private readonly global::TianWen.Lib.Devices.Ascom.ComInterop.DispatchObject _dispatch;");
+        sb.AppendLine("    private readonly global::TianWen.Lib.Devices.Ascom.ComInterop.IDispatchTransport _dispatch;");
         sb.AppendLine();
 
         // Generate property implementations

--- a/src/TianWen.Lib.Tests.Simulators/AscomHostProcessTests.cs
+++ b/src/TianWen.Lib.Tests.Simulators/AscomHostProcessTests.cs
@@ -1,117 +1,76 @@
 using Shouldly;
 using System;
-using System.Diagnostics;
-using System.IO;
-using System.Net;
+using System.Runtime.Versioning;
 using System.Text.Json;
-using System.Threading;
-using System.Threading.Tasks;
-using TianWen.Lib.Connections;
+using TianWen.Lib.Devices.Ascom.ComInterop;
 using Xunit;
 
 namespace TianWen.Lib.Tests.Simulators;
 
 /// <summary>
-/// End-to-end proof of the out-of-process ASCOM COM host (<c>tianwen-ascomhost.exe</c>): spawn the real
-/// helper, read its <c>PORT n</c> handshake line, connect the production <see cref="JsonRpcClient"/> over
-/// loopback TCP, and round-trip <c>create</c> / <c>getInt</c> / <c>setInt</c> / <c>release</c> against a
-/// real COM object. Uses <c>Scripting.Dictionary</c> (scrrun.dll, present on every Windows install) as a
+/// End-to-end proof of the out-of-process ASCOM COM host at the raw wire level: <see cref="AscomHostProcess"/>
+/// spawns the real <c>tianwen-ascomhost.exe</c>, creates the named-pipe server, waits for the helper to
+/// connect, and round-trips <c>create</c> / <c>getInt</c> / <c>setInt</c> / <c>release</c> against a real
+/// COM object. Uses <c>Scripting.Dictionary</c> (scrrun.dll, present on every Windows install) as a
 /// benign always-available <c>IDispatch</c>, so this exercises the whole transport + the raw-vtable
 /// <c>DispatchObject</c> against genuine COM without needing an ASCOM Platform install or hardware.
 /// <para>Auto-skips off Windows or when the helper exe hasn't been built, so a bare <c>dotnet test</c>
 /// stays green.</para>
 /// </summary>
+[SupportedOSPlatform("windows")] // AscomHostProcess is windows-only; the runtime SkipUnless guards execution
 public class AscomHostProcessTests
 {
     [Fact]
-    public async Task GivenTheBuiltHelperWhenDrivingARealComObjectThenCreateGetSetReleaseRoundTrip()
+    public void GivenTheBuiltHelperWhenDrivingRawJsonRpcThenCreateGetSetReleaseRoundTrip()
     {
         Assert.SkipUnless(OperatingSystem.IsWindows(), "The ASCOM COM host is Windows-only.");
+        Assert.SkipUnless(DispatchTransportFactory.TryLocateHelper(out var exe), "Skipped unless tianwen-ascomhost.exe has been built.");
 
-        var exe = LocateHelperExe();
-        Assert.SkipUnless(exe is not null, "Skipped unless tianwen-ascomhost.exe has been built.");
+        using var host = AscomHostProcess.Spawn(exe, TimeSpan.FromSeconds(10));
 
-        var ct = TestContext.Current.CancellationToken;
-
-        using var process = new Process
+        // create Scripting.Dictionary -> handle
+        int handle;
+        using (var r = host.Call("create", w =>
         {
-            StartInfo = new ProcessStartInfo(exe!)
-            {
-                UseShellExecute = false,
-                RedirectStandardOutput = true,
-                RedirectStandardError = true,
-                CreateNoWindow = true,
-            },
-        };
-        process.Start();
-
-        try
+            w.WriteStartArray();
+            w.WriteStringValue("Scripting.Dictionary");
+            w.WriteEndArray();
+        }))
         {
-            // Handshake: the helper prints "PORT <n>" as its first stdout line once the socket is bound.
-            var handshake = await process.StandardOutput.ReadLineAsync(ct);
-            handshake.ShouldNotBeNull();
-            handshake!.ShouldStartWith("PORT ");
-            var port = int.Parse(handshake.AsSpan("PORT ".Length));
-            port.ShouldBeGreaterThan(0);
-
-            var connection = new JsonRpcOverTcpConnection();
-            await connection.ConnectAsync(new IPEndPoint(IPAddress.Loopback, port), ct);
-            using var client = new JsonRpcClient(connection);
-            _ = client.ReceiveLoopAsync(ct);
-
-            // create Scripting.Dictionary -> handle
-            int handle;
-            using (var r = await client.CallAsync("create", w =>
-            {
-                w.WriteStartArray();
-                w.WriteStringValue("Scripting.Dictionary");
-                w.WriteEndArray();
-            }, ct))
-            {
-                handle = r.RootElement.GetProperty("result").GetInt32();
-            }
-            handle.ShouldBeGreaterThan(0);
-
-            // getInt Count -> 0 (a freshly created dictionary is empty)
-            using (var r = await client.CallAsync("getInt", w => WriteHandleName(w, handle, "Count"), ct))
-            {
-                r.RootElement.GetProperty("result").GetInt32().ShouldBe(0);
-            }
-
-            // setInt CompareMode = 1 then getInt CompareMode -> 1 (proves the set path round-trips)
-            using (await client.CallAsync("setInt", w =>
-            {
-                w.WriteStartArray();
-                w.WriteNumberValue(handle);
-                w.WriteStringValue("CompareMode");
-                w.WriteNumberValue(1);
-                w.WriteEndArray();
-            }, ct)) { }
-
-            using (var r = await client.CallAsync("getInt", w => WriteHandleName(w, handle, "CompareMode"), ct))
-            {
-                r.RootElement.GetProperty("result").GetInt32().ShouldBe(1);
-            }
-
-            // release -> void (result:null)
-            using (var r = await client.CallAsync("release", w =>
-            {
-                w.WriteStartArray();
-                w.WriteNumberValue(handle);
-                w.WriteEndArray();
-            }, ct))
-            {
-                r.RootElement.GetProperty("result").ValueKind.ShouldBe(JsonValueKind.Null);
-            }
-
-            connection.Dispose();
+            handle = r.RootElement.GetProperty("result").GetInt32();
         }
-        finally
+        handle.ShouldBeGreaterThan(0);
+
+        // getInt Count -> 0 (a freshly created dictionary is empty)
+        using (var r = host.Call("getInt", w => WriteHandleName(w, handle, "Count")))
         {
-            if (!process.HasExited)
-            {
-                process.Kill(entireProcessTree: true);
-            }
+            r.RootElement.GetProperty("result").GetInt32().ShouldBe(0);
+        }
+
+        // setInt CompareMode = 1 then getInt CompareMode -> 1 (settable while the dictionary is empty)
+        using (host.Call("setInt", w =>
+        {
+            w.WriteStartArray();
+            w.WriteNumberValue(handle);
+            w.WriteStringValue("CompareMode");
+            w.WriteNumberValue(1);
+            w.WriteEndArray();
+        })) { }
+
+        using (var r = host.Call("getInt", w => WriteHandleName(w, handle, "CompareMode")))
+        {
+            r.RootElement.GetProperty("result").GetInt32().ShouldBe(1);
+        }
+
+        // release -> void (result:null)
+        using (var r = host.Call("release", w =>
+        {
+            w.WriteStartArray();
+            w.WriteNumberValue(handle);
+            w.WriteEndArray();
+        }))
+        {
+            r.RootElement.GetProperty("result").ValueKind.ShouldBe(JsonValueKind.Null);
         }
     }
 
@@ -121,29 +80,5 @@ public class AscomHostProcessTests
         w.WriteNumberValue(handle);
         w.WriteStringValue(name);
         w.WriteEndArray();
-    }
-
-    /// <summary>
-    /// Resolves the sibling helper exe by walking up to the solution root (the dir with TianWen.slnx),
-    /// then into TianWen.AscomHost's build output for the same configuration as this test assembly.
-    /// </summary>
-    private static string? LocateHelperExe()
-    {
-        var baseDir = AppContext.BaseDirectory;
-        var dir = new DirectoryInfo(baseDir);
-        while (dir is not null && !File.Exists(Path.Combine(dir.FullName, "TianWen.slnx")))
-        {
-            dir = dir.Parent;
-        }
-        if (dir is null)
-        {
-            return null;
-        }
-
-        var config = baseDir.Contains($"{Path.DirectorySeparatorChar}Release{Path.DirectorySeparatorChar}", StringComparison.OrdinalIgnoreCase)
-            ? "Release"
-            : "Debug";
-        var exe = Path.Combine(dir.FullName, "TianWen.AscomHost", "bin", config, "net10.0-windows", "tianwen-ascomhost.exe");
-        return File.Exists(exe) ? exe : null;
     }
 }

--- a/src/TianWen.Lib.Tests.Simulators/AscomHostProcessTests.cs
+++ b/src/TianWen.Lib.Tests.Simulators/AscomHostProcessTests.cs
@@ -1,0 +1,149 @@
+using Shouldly;
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Net;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using TianWen.Lib.Connections;
+using Xunit;
+
+namespace TianWen.Lib.Tests.Simulators;
+
+/// <summary>
+/// End-to-end proof of the out-of-process ASCOM COM host (<c>tianwen-ascomhost.exe</c>): spawn the real
+/// helper, read its <c>PORT n</c> handshake line, connect the production <see cref="JsonRpcClient"/> over
+/// loopback TCP, and round-trip <c>create</c> / <c>getInt</c> / <c>setInt</c> / <c>release</c> against a
+/// real COM object. Uses <c>Scripting.Dictionary</c> (scrrun.dll, present on every Windows install) as a
+/// benign always-available <c>IDispatch</c>, so this exercises the whole transport + the raw-vtable
+/// <c>DispatchObject</c> against genuine COM without needing an ASCOM Platform install or hardware.
+/// <para>Auto-skips off Windows or when the helper exe hasn't been built, so a bare <c>dotnet test</c>
+/// stays green.</para>
+/// </summary>
+public class AscomHostProcessTests
+{
+    [Fact]
+    public async Task GivenTheBuiltHelperWhenDrivingARealComObjectThenCreateGetSetReleaseRoundTrip()
+    {
+        Assert.SkipUnless(OperatingSystem.IsWindows(), "The ASCOM COM host is Windows-only.");
+
+        var exe = LocateHelperExe();
+        Assert.SkipUnless(exe is not null, "Skipped unless tianwen-ascomhost.exe has been built.");
+
+        var ct = TestContext.Current.CancellationToken;
+
+        using var process = new Process
+        {
+            StartInfo = new ProcessStartInfo(exe!)
+            {
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                CreateNoWindow = true,
+            },
+        };
+        process.Start();
+
+        try
+        {
+            // Handshake: the helper prints "PORT <n>" as its first stdout line once the socket is bound.
+            var handshake = await process.StandardOutput.ReadLineAsync(ct);
+            handshake.ShouldNotBeNull();
+            handshake!.ShouldStartWith("PORT ");
+            var port = int.Parse(handshake.AsSpan("PORT ".Length));
+            port.ShouldBeGreaterThan(0);
+
+            var connection = new JsonRpcOverTcpConnection();
+            await connection.ConnectAsync(new IPEndPoint(IPAddress.Loopback, port), ct);
+            using var client = new JsonRpcClient(connection);
+            _ = client.ReceiveLoopAsync(ct);
+
+            // create Scripting.Dictionary -> handle
+            int handle;
+            using (var r = await client.CallAsync("create", w =>
+            {
+                w.WriteStartArray();
+                w.WriteStringValue("Scripting.Dictionary");
+                w.WriteEndArray();
+            }, ct))
+            {
+                handle = r.RootElement.GetProperty("result").GetInt32();
+            }
+            handle.ShouldBeGreaterThan(0);
+
+            // getInt Count -> 0 (a freshly created dictionary is empty)
+            using (var r = await client.CallAsync("getInt", w => WriteHandleName(w, handle, "Count"), ct))
+            {
+                r.RootElement.GetProperty("result").GetInt32().ShouldBe(0);
+            }
+
+            // setInt CompareMode = 1 then getInt CompareMode -> 1 (proves the set path round-trips)
+            using (await client.CallAsync("setInt", w =>
+            {
+                w.WriteStartArray();
+                w.WriteNumberValue(handle);
+                w.WriteStringValue("CompareMode");
+                w.WriteNumberValue(1);
+                w.WriteEndArray();
+            }, ct)) { }
+
+            using (var r = await client.CallAsync("getInt", w => WriteHandleName(w, handle, "CompareMode"), ct))
+            {
+                r.RootElement.GetProperty("result").GetInt32().ShouldBe(1);
+            }
+
+            // release -> void (result:null)
+            using (var r = await client.CallAsync("release", w =>
+            {
+                w.WriteStartArray();
+                w.WriteNumberValue(handle);
+                w.WriteEndArray();
+            }, ct))
+            {
+                r.RootElement.GetProperty("result").ValueKind.ShouldBe(JsonValueKind.Null);
+            }
+
+            connection.Dispose();
+        }
+        finally
+        {
+            if (!process.HasExited)
+            {
+                process.Kill(entireProcessTree: true);
+            }
+        }
+    }
+
+    private static void WriteHandleName(Utf8JsonWriter w, int handle, string name)
+    {
+        w.WriteStartArray();
+        w.WriteNumberValue(handle);
+        w.WriteStringValue(name);
+        w.WriteEndArray();
+    }
+
+    /// <summary>
+    /// Resolves the sibling helper exe by walking up to the solution root (the dir with TianWen.slnx),
+    /// then into TianWen.AscomHost's build output for the same configuration as this test assembly.
+    /// </summary>
+    private static string? LocateHelperExe()
+    {
+        var baseDir = AppContext.BaseDirectory;
+        var dir = new DirectoryInfo(baseDir);
+        while (dir is not null && !File.Exists(Path.Combine(dir.FullName, "TianWen.slnx")))
+        {
+            dir = dir.Parent;
+        }
+        if (dir is null)
+        {
+            return null;
+        }
+
+        var config = baseDir.Contains($"{Path.DirectorySeparatorChar}Release{Path.DirectorySeparatorChar}", StringComparison.OrdinalIgnoreCase)
+            ? "Release"
+            : "Debug";
+        var exe = Path.Combine(dir.FullName, "TianWen.AscomHost", "bin", config, "net10.0-windows", "tianwen-ascomhost.exe");
+        return File.Exists(exe) ? exe : null;
+    }
+}

--- a/src/TianWen.Lib.Tests.Simulators/AscomOutOfProcessConnectTests.cs
+++ b/src/TianWen.Lib.Tests.Simulators/AscomOutOfProcessConnectTests.cs
@@ -1,0 +1,96 @@
+using Shouldly;
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
+using TianWen.Lib.Devices.Ascom.ComInterop;
+using Xunit;
+
+namespace TianWen.Lib.Tests.Simulators;
+
+/// <summary>
+/// "No plan survives contact with the enemy." Drives the out-of-process host against the REAL ASCOM COM
+/// drivers registered on this machine -- most importantly <c>ASCOM.GeminiFPLite.CoverCalibrator</c>, the
+/// in-proc .NET Framework driver whose <c>Connected=true</c> DoEvents busy-spin fastfails our CET-on
+/// process (0xC0000409). The DoEvents spin runs during connect regardless of whether the panel hardware
+/// answers, so this reproduces the crash trigger without the physical panel.
+/// <para>All tests auto-skip when the relevant driver / the helper exe is absent, so they never break a
+/// bare <c>dotnet test</c> on a box without these drivers.</para>
+/// </summary>
+[SupportedOSPlatform("windows")]
+public class AscomOutOfProcessConnectTests(ITestOutputHelper output)
+{
+    private const int DISP_E_UNKNOWNNAME = unchecked((int)0x80020006);
+
+    private static bool Registered(string progId) => NativeMethods.CLSIDFromProgID(progId, out _) == 0;
+
+    [Theory]
+    [InlineData("ASCOM.GeminiFPLite.CoverCalibrator", true)]   // mscoree v4 -> out-of-process (the crasher)
+    [InlineData("ASCOM.GeminiFocuserPro.Focuser", true)]        // mscoree v4 -> out-of-process
+    [InlineData("ASCOM.DeepSkyDad.FP.CoverCalibrator1", true)]  // mscoree v4 -> out-of-process
+    [InlineData("ASCOM.iOptron2017.Telescope", true)]           // mscoree v4 -> out-of-process
+    [InlineData("ASCOM.Simulator.Telescope", false)]            // LocalServer32 (OmniSim proxy) -> in-proc
+    [InlineData("ASCOM.GS.Sky.Telescope", false)]               // LocalServer32 (GS Server) -> in-proc
+    [InlineData("CCDSimulator.Camera", false)]                  // native in-proc (CCDSimulator.dll) -> in-proc
+    public void GivenARealRegisteredDriverWhenClassifyingThenRoutesCorrectly(string progId, bool expectedOutOfProcess)
+    {
+        Assert.SkipUnless(OperatingSystem.IsWindows(), "Registry classification is Windows-only.");
+        Assert.SkipUnless(Registered(progId), $"Skipped unless {progId} is registered on this machine.");
+
+        var isOop = AscomComServerClassifier.RequiresOutOfProcessHost(progId, out var reason);
+        output.WriteLine($"{progId} -> out-of-process={isOop} ({reason})");
+
+        isOop.ShouldBe(expectedOutOfProcess);
+    }
+
+    [Fact(Timeout = 60_000)]
+    public void GivenTheRealGeminiFlatPanelWhenConnectedThroughTheHelperThenTheProcessSurvives()
+    {
+        Assert.SkipUnless(OperatingSystem.IsWindows(), "ASCOM COM is Windows-only.");
+        const string progId = "ASCOM.GeminiFPLite.CoverCalibrator";
+        Assert.SkipUnless(Registered(progId), $"Skipped unless {progId} is registered.");
+        Assert.SkipUnless(DispatchTransportFactory.TryLocateHelper(out _), "Skipped unless tianwen-ascomhost.exe has been built.");
+
+        // Sanity: this driver must route out-of-process, else the connect below would fastfail us in-proc.
+        AscomComServerClassifier.RequiresOutOfProcessHost(progId, out _).ShouldBeTrue();
+
+        // Ctor routes through DispatchTransportFactory -> spawns the CET-off helper and creates the COM
+        // object there. (sp=null: routing works without a logger; we just don't emit the routing line.)
+        using var device = new AscomDispatchDevice(progId, serviceProvider: null);
+
+        bool connected = false;
+        Exception? caught = null;
+        try
+        {
+            // The enemy: the Connected setter's ~1.1 s Application.DoEvents() busy-spin -- the exact CET
+            // shadow-stack tripwire. In-proc this fastfailed the process (0xC0000409); in the CET-off
+            // helper it must run to completion and return (or fail with a catchable COM/serial error,
+            // since the panel isn't attached).
+            try
+            {
+                device.Connect(); // Platform 7
+            }
+            catch (COMException ex) when (ex.HResult == DISP_E_UNKNOWNNAME)
+            {
+                device.Connected = true; // Platform 6 legacy path (this is what busy-spins DoEvents)
+            }
+
+            connected = device.Connected;
+        }
+        catch (Exception ex)
+        {
+            caught = ex; // a catchable failure (no hardware) is a PASS -- the point is we weren't fastfailed
+        }
+        finally
+        {
+            try { device.Connected = false; } catch { /* best effort */ }
+        }
+
+        output.WriteLine($"Gemini FlatPanel via helper: connected={connected}, caught={caught?.GetType().Name}: {caught?.Message}");
+
+        // Reaching here at all is the proof: the DoEvents busy-spin ran in the CET-off helper without
+        // fastfailing this process. A COMException (no panel) is expected and fine; a process crash would
+        // never have let this assertion run.
+        (connected || caught is COMException || caught is InvalidOperationException || caught is null)
+            .ShouldBeTrue($"unexpected failure mode: {caught}");
+    }
+}

--- a/src/TianWen.Lib.Tests.Simulators/Phd2SmokeTests.cs
+++ b/src/TianWen.Lib.Tests.Simulators/Phd2SmokeTests.cs
@@ -1,0 +1,96 @@
+using Shouldly;
+using System;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+using TianWen.Lib.Connections;
+using Xunit;
+
+namespace TianWen.Lib.Tests.Simulators;
+
+/// <summary>
+/// Live smoke test of the extracted <see cref="JsonRpcClient"/> against a real running PHD2
+/// (the JSON-RPC server on 127.0.0.1:4400 for instance 1). Exercises exactly the path the refactored
+/// <c>OpenPHD2GuiderDriver</c> now relies on -- TCP connect, the receive loop, and <c>CallAsync</c>
+/// id-correlation -- so it proves the generalization didn't break real PHD2 interop. Auto-skips when
+/// PHD2 isn't listening, so a bare <c>dotnet test</c> stays green.
+/// </summary>
+public class Phd2SmokeTests
+{
+    private const int Phd2Port = 4400; // instance 1
+
+    private static bool Phd2Reachable()
+    {
+        try
+        {
+            using var probe = new TcpClient();
+            return probe.ConnectAsync(IPAddress.Loopback, Phd2Port).Wait(TimeSpan.FromMilliseconds(500)) && probe.Connected;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    [Fact]
+    public async Task GivenARunningPhd2WhenCallingGetAppStateThenACorrelatedResultIsReturned()
+    {
+        Assert.SkipUnless(Phd2Reachable(), $"Skipped unless PHD2 is running (JSON-RPC on 127.0.0.1:{Phd2Port}).");
+
+        var ct = TestContext.Current.CancellationToken;
+
+        var connection = new JsonRpcOverTcpConnection();
+        await connection.ConnectAsync(new IPEndPoint(IPAddress.Loopback, Phd2Port), ct);
+
+        using var client = new JsonRpcClient(connection);
+        var loop = client.ReceiveLoopAsync(ct);
+
+        // get_app_state is read-only and valid even with no equipment connected; it returns a string
+        // like "Stopped" / "Looping" / "Guiding".
+        using (var response = await client.CallAsync("get_app_state", writeParams: null, ct))
+        {
+            var appState = response.RootElement.GetProperty("result").GetString();
+            appState.ShouldNotBeNullOrEmpty();
+        }
+
+        // A second call proves id-correlation advances (id 2 matched, not the cached id-1 response).
+        using (var version = await client.CallAsync("get_app_state", writeParams: null, ct))
+        {
+            version.RootElement.TryGetProperty("result", out _).ShouldBeTrue();
+        }
+
+        connection.Dispose();
+    }
+
+    [Fact]
+    public async Task GivenARunningPhd2WhenConnectedThenAServerNotificationIsRoutedToTheHandler()
+    {
+        Assert.SkipUnless(Phd2Reachable(), $"Skipped unless PHD2 is running (JSON-RPC on 127.0.0.1:{Phd2Port}).");
+
+        var ct = TestContext.Current.CancellationToken;
+        var firstEvent = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var connection = new JsonRpcOverTcpConnection();
+        await connection.ConnectAsync(new IPEndPoint(IPAddress.Loopback, Phd2Port), ct);
+
+        // PHD2 pushes a "Version" event (a notification: has "Event", no "id") to every client right
+        // after it connects -- exercising exactly the onNotification path the refactor added (+ the
+        // doc-disposal wrapper the driver uses).
+        using var client = new JsonRpcClient(connection, onNotification: (doc, _) =>
+        {
+            if (doc.RootElement.TryGetProperty("Event", out var ev))
+            {
+                firstEvent.TrySetResult(ev.GetString() ?? "");
+            }
+            doc.Dispose();
+            return ValueTask.CompletedTask;
+        });
+        _ = client.ReceiveLoopAsync(ct);
+
+        var eventName = await firstEvent.Task.WaitAsync(TimeSpan.FromSeconds(5), ct);
+        eventName.ShouldNotBeNullOrEmpty(); // typically "Version"
+
+        connection.Dispose();
+    }
+}

--- a/src/TianWen.Lib.Tests.Simulators/RemoteDispatchTransportTests.cs
+++ b/src/TianWen.Lib.Tests.Simulators/RemoteDispatchTransportTests.cs
@@ -1,0 +1,59 @@
+using Shouldly;
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
+using TianWen.Lib.Devices.Ascom.ComInterop;
+using Xunit;
+
+namespace TianWen.Lib.Tests.Simulators;
+
+/// <summary>
+/// Drives the typed <see cref="RemoteDispatchTransport"/> (the parent-side out-of-process transport)
+/// against the real <c>tianwen-ascomhost</c> helper and a live <c>Scripting.Dictionary</c> COM object.
+/// Proves the whole Phase-4 parent path: spawn + handshake + create + the typed get/set/invoke surface,
+/// and -- critically -- that a COM failure comes back as a <see cref="COMException"/> carrying the
+/// peer's HResult (the mechanism the driver's Platform-6 <c>catch (COMException) when (HResult == …)</c>
+/// fallback relies on). Auto-skips off Windows or when the helper isn't built.
+/// </summary>
+[SupportedOSPlatform("windows")] // call sites are windows-only; the runtime SkipUnless guards execution
+public class RemoteDispatchTransportTests
+{
+    private static readonly TimeSpan Handshake = TimeSpan.FromSeconds(10);
+
+    [Fact]
+    public void GivenScriptingDictionaryWhenDrivenViaRemoteTransportThenTypedCallsRoundTrip()
+    {
+        Assert.SkipUnless(OperatingSystem.IsWindows(), "The ASCOM COM host is Windows-only.");
+        Assert.SkipUnless(DispatchTransportFactory.TryLocateHelper(out var exe), "Skipped unless tianwen-ascomhost.exe has been built.");
+
+        using var transport = RemoteDispatchTransport.Create(exe, "Scripting.Dictionary", Handshake);
+
+        // getInt: a fresh dictionary is empty
+        transport.GetInt("Count").ShouldBe(0);
+
+        // invoke (void, with args): Add(key, item)
+        transport.InvokeMethod("Add", "alpha", 1);
+        transport.InvokeMethod("Add", "beta", 2);
+        transport.GetInt("Count").ShouldBe(2);
+
+        // invokeBool: Exists(key)
+        transport.InvokeMethodBool("Exists", "alpha").ShouldBeTrue();
+        transport.InvokeMethodBool("Exists", "missing").ShouldBeFalse();
+
+        // Error propagation: setting CompareMode once the dictionary holds items is an illegal COM call.
+        // It must surface as a COMException carrying the peer's HResult, not a generic error.
+        var ex = Should.Throw<COMException>(() => transport.Set("CompareMode", 1));
+        ex.HResult.ShouldNotBe(0);
+    }
+
+    [Fact]
+    public void GivenANativeInProcComServerWhenClassifyingThenItStaysInProc()
+    {
+        Assert.SkipUnless(OperatingSystem.IsWindows(), "Registry classification is Windows-only.");
+
+        // Scripting.Dictionary is a native (scrrun.dll) in-proc server -- CET-safe, must NOT be routed
+        // to the out-of-process host.
+        AscomComServerClassifier.RequiresOutOfProcessHost("Scripting.Dictionary", out var reason).ShouldBeFalse();
+        reason.ShouldNotBeNullOrEmpty();
+    }
+}

--- a/src/TianWen.Lib.Tests.Simulators/TianWen.Lib.Tests.Simulators.csproj
+++ b/src/TianWen.Lib.Tests.Simulators/TianWen.Lib.Tests.Simulators.csproj
@@ -40,6 +40,9 @@
     <ProjectReference Include="..\TianWen.Lib\TianWen.Lib.csproj" />
     <!-- FakeExternal + the xUnit logging helpers live here. -->
     <ProjectReference Include="..\TianWen.Lib.Tests\TianWen.Lib.Tests.csproj" />
+    <!-- Build-only: AscomHostProcessTests spawns the built tianwen-ascomhost.exe and locates it by
+         path, so we don't want its assembly referenced, only built before the tests run. -->
+    <ProjectReference Include="..\TianWen.AscomHost\TianWen.AscomHost.csproj" ReferenceOutputAssembly="false" Private="false" SkipGetTargetFrameworkProperties="true" />
   </ItemGroup>
 
 </Project>

--- a/src/TianWen.Lib.Tests/JsonRpcClientTests.cs
+++ b/src/TianWen.Lib.Tests/JsonRpcClientTests.cs
@@ -1,0 +1,119 @@
+using Shouldly;
+using System;
+using System.Collections.Concurrent;
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+using TianWen.Lib.Connections;
+using Xunit;
+
+namespace TianWen.Lib.Tests;
+
+/// <summary>
+/// Pins the shared <see cref="JsonRpcClient"/> (extracted from the PHD2 driver, reused by the
+/// out-of-process ASCOM COM host) against a fake line connection: id correlation on success,
+/// <see cref="JsonRpcException"/> on an <c>error</c> response, and notification routing.
+/// </summary>
+public class JsonRpcClientTests
+{
+    /// <summary>In-memory <see cref="IUtf8TextBasedConnection"/>: captures written requests, replays queued inbound lines.</summary>
+    private sealed class FakeLineConnection : IUtf8TextBasedConnection
+    {
+        private readonly Channel<string> _inbound = Channel.CreateUnbounded<string>();
+        public ConcurrentQueue<string> Written { get; } = new();
+
+        public void PushInbound(string line) => _inbound.Writer.TryWrite(line);
+
+        public CommunicationProtocol HighLevelProtocol => CommunicationProtocol.JsonRPC;
+        public bool IsConnected => true;
+        public ValueTask ConnectAsync(EndPoint endPoint, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+
+        public async ValueTask<string?> ReadLineAsync(CancellationToken cancellationToken = default)
+        {
+            try
+            {
+                return await _inbound.Reader.ReadAsync(cancellationToken);
+            }
+            catch (ChannelClosedException)
+            {
+                return null;
+            }
+        }
+
+        public ValueTask<bool> WriteLineAsync(ReadOnlyMemory<byte> message, CancellationToken cancellationToken = default)
+        {
+            Written.Enqueue(Encoding.UTF8.GetString(message.Span));
+            return ValueTask.FromResult(true);
+        }
+
+        public void Dispose() => _inbound.Writer.TryComplete();
+    }
+
+    [Fact]
+    public async Task GivenAResultResponseWhenCallingThenTheCorrelatedResultIsReturned()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var conn = new FakeLineConnection();
+        using var client = new JsonRpcClient(conn);
+        var loop = client.ReceiveLoopAsync(ct);
+
+        // First call gets id 1 (Interlocked.Increment from 0).
+        var callTask = client.CallAsync("get", w =>
+        {
+            w.WriteStartArray();
+            w.WriteStringValue("Connected");
+            w.WriteEndArray();
+        }, ct);
+
+        conn.PushInbound("""{"jsonrpc":"2.0","id":1,"result":true}""");
+
+        using var response = await callTask;
+        response.RootElement.GetProperty("result").GetBoolean().ShouldBeTrue();
+
+        // The request went out with method + id + params.
+        conn.Written.TryDequeue(out var req).ShouldBeTrue();
+        using var reqDoc = JsonDocument.Parse(req!);
+        reqDoc.RootElement.GetProperty("method").GetString().ShouldBe("get");
+        reqDoc.RootElement.GetProperty("id").GetInt64().ShouldBe(1);
+        reqDoc.RootElement.GetProperty("params")[0].GetString().ShouldBe("Connected");
+    }
+
+    [Fact]
+    public async Task GivenAnErrorResponseWhenCallingThenJsonRpcExceptionIsThrown()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var conn = new FakeLineConnection();
+        using var client = new JsonRpcClient(conn);
+        _ = client.ReceiveLoopAsync(ct);
+
+        var callTask = client.CallAsync("set", null, ct);
+        conn.PushInbound("""{"jsonrpc":"2.0","id":1,"error":{"code":-2146233088,"message":"boom"}}""");
+
+        var ex = await Should.ThrowAsync<JsonRpcException>(async () => await callTask);
+        ex.Message.ShouldBe("boom");
+        ex.Code.ShouldBe(-2146233088);
+    }
+
+    [Fact]
+    public async Task GivenAMessageWithoutIdWhenReceivedThenItIsRoutedAsANotification()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var conn = new FakeLineConnection();
+        var seen = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        using var client = new JsonRpcClient(conn, onNotification: (doc, _) =>
+        {
+            seen.TrySetResult(doc.RootElement.GetProperty("method").GetString() ?? "");
+            doc.Dispose();
+            return ValueTask.CompletedTask;
+        });
+        _ = client.ReceiveLoopAsync(ct);
+
+        conn.PushInbound("""{"jsonrpc":"2.0","method":"GuideStep","params":{"dx":1.0}}""");
+
+        (await seen.Task.WaitAsync(TimeSpan.FromSeconds(5), ct)).ShouldBe("GuideStep");
+    }
+}

--- a/src/TianWen.Lib.Tests/JsonRpcServerTests.cs
+++ b/src/TianWen.Lib.Tests/JsonRpcServerTests.cs
@@ -1,8 +1,7 @@
 using Shouldly;
 using System;
-using System.Net;
+using System.IO.Pipes;
 using System.Text.Json;
-using System.Threading;
 using System.Threading.Tasks;
 using TianWen.Lib.Connections;
 using Xunit;
@@ -11,9 +10,9 @@ namespace TianWen.Lib.Tests;
 
 /// <summary>
 /// Exercises <see cref="JsonRpcServer"/> against the real <see cref="JsonRpcClient"/> over an actual
-/// loopback TCP connection (no external process): result round-trip + id-correlation, a void method
-/// (<c>result:null</c>), and <see cref="JsonRpcException"/> propagation from a throwing handler. This
-/// is the pair the out-of-process ASCOM COM host runs on.
+/// named-pipe pair (no external process): result round-trip + id-correlation, a void method
+/// (<c>result:null</c>), and <see cref="JsonRpcException"/> propagation from a throwing handler. This is
+/// the transport (named pipe) + protocol the out-of-process ASCOM COM host runs on.
 /// </summary>
 public class JsonRpcServerTests
 {
@@ -38,17 +37,24 @@ public class JsonRpcServerTests
     };
 
     [Fact]
-    public async Task GivenServerAndClientOverLoopbackWhenCallingThenResultsErrorsAndVoidsRoundTrip()
+    public async Task GivenServerAndClientOverNamedPipeWhenCallingThenResultsErrorsAndVoidsRoundTrip()
     {
         var ct = TestContext.Current.CancellationToken;
+        var pipeName = $"tianwen-test-{Guid.NewGuid():N}";
 
-        using var server = new JsonRpcServer(MakeHandler());
-        var port = server.Start();
-        var serverTask = server.RunAsync(ct);
+        var serverPipe = new NamedPipeServerStream(pipeName, PipeDirection.InOut, 1, PipeTransmissionMode.Byte, PipeOptions.Asynchronous);
+        var clientPipe = new NamedPipeClientStream(".", pipeName, PipeDirection.InOut, PipeOptions.Asynchronous);
 
-        var connection = new JsonRpcOverTcpConnection();
-        await connection.ConnectAsync(new IPEndPoint(IPAddress.Loopback, port), ct);
-        using var client = new JsonRpcClient(connection);
+        var waitForConnect = serverPipe.WaitForConnectionAsync(ct);
+        await clientPipe.ConnectAsync(ct);
+        await waitForConnect;
+
+        var server = new JsonRpcServer(MakeHandler());
+        using var serverConnection = new NamedPipeConnection(serverPipe);
+        var serveTask = server.ServeAsync(serverConnection, ct);
+
+        using var clientConnection = new NamedPipeConnection(clientPipe);
+        using var client = new JsonRpcClient(clientConnection);
         _ = client.ReceiveLoopAsync(ct);
 
         // result round-trip + id correlation
@@ -78,7 +84,5 @@ public class JsonRpcServerTests
         var ex = await Should.ThrowAsync<JsonRpcException>(async () => await client.CallAsync("boom", null, ct));
         ex.Message.ShouldBe("kaboom");
         ex.Code.ShouldBe(-7);
-
-        connection.Dispose();
     }
 }

--- a/src/TianWen.Lib.Tests/JsonRpcServerTests.cs
+++ b/src/TianWen.Lib.Tests/JsonRpcServerTests.cs
@@ -1,0 +1,84 @@
+using Shouldly;
+using System;
+using System.Net;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using TianWen.Lib.Connections;
+using Xunit;
+
+namespace TianWen.Lib.Tests;
+
+/// <summary>
+/// Exercises <see cref="JsonRpcServer"/> against the real <see cref="JsonRpcClient"/> over an actual
+/// loopback TCP connection (no external process): result round-trip + id-correlation, a void method
+/// (<c>result:null</c>), and <see cref="JsonRpcException"/> propagation from a throwing handler. This
+/// is the pair the out-of-process ASCOM COM host runs on.
+/// </summary>
+public class JsonRpcServerTests
+{
+    private static JsonRpcRequestHandler MakeHandler() => (method, @params, result, _) =>
+    {
+        switch (method)
+        {
+            case "add":
+                result.WriteNumberValue(@params[0].GetInt32() + @params[1].GetInt32());
+                break;
+            case "ping":
+                result.WriteStringValue("pong");
+                break;
+            case "noop":
+                break; // writes nothing -> server emits result:null
+            case "boom":
+                throw new JsonRpcException("kaboom", -7);
+            default:
+                throw new JsonRpcException($"unknown method '{method}'");
+        }
+        return ValueTask.CompletedTask;
+    };
+
+    [Fact]
+    public async Task GivenServerAndClientOverLoopbackWhenCallingThenResultsErrorsAndVoidsRoundTrip()
+    {
+        var ct = TestContext.Current.CancellationToken;
+
+        using var server = new JsonRpcServer(MakeHandler());
+        var port = server.Start();
+        var serverTask = server.RunAsync(ct);
+
+        var connection = new JsonRpcOverTcpConnection();
+        await connection.ConnectAsync(new IPEndPoint(IPAddress.Loopback, port), ct);
+        using var client = new JsonRpcClient(connection);
+        _ = client.ReceiveLoopAsync(ct);
+
+        // result round-trip + id correlation
+        using (var r = await client.CallAsync("add", w =>
+        {
+            w.WriteStartArray();
+            w.WriteNumberValue(2);
+            w.WriteNumberValue(3);
+            w.WriteEndArray();
+        }, ct))
+        {
+            r.RootElement.GetProperty("result").GetInt32().ShouldBe(5);
+        }
+
+        using (var r = await client.CallAsync("ping", null, ct))
+        {
+            r.RootElement.GetProperty("result").GetString().ShouldBe("pong");
+        }
+
+        // void method -> result:null
+        using (var r = await client.CallAsync("noop", null, ct))
+        {
+            r.RootElement.GetProperty("result").ValueKind.ShouldBe(JsonValueKind.Null);
+        }
+
+        // throwing handler -> error object -> JsonRpcException on the client
+        var ex = await Should.ThrowAsync<JsonRpcException>(async () => await client.CallAsync("boom", null, ct));
+        ex.Message.ShouldBe("kaboom");
+        ex.Code.ShouldBe(-7);
+
+        connection.Dispose();
+    }
+}

--- a/src/TianWen.Lib.Tests/NativeDriverBlacklistTests.cs
+++ b/src/TianWen.Lib.Tests/NativeDriverBlacklistTests.cs
@@ -1,0 +1,96 @@
+using System;
+using System.Linq;
+using Microsoft.Extensions.Logging.Abstractions;
+using Shouldly;
+using TianWen.Lib.Devices;
+using TianWen.Lib.Devices.Ascom;
+using Xunit;
+
+namespace TianWen.Lib.Tests;
+
+public class NativeDriverBlacklistTests
+{
+    // A stand-in for a native device family. Its DeviceClass is the URI host, exactly as real devices
+    // (ZWODevice/QHYDevice/GeminiDevice) derive it -- so we don't need SDK-backed sources to test.
+    private sealed record TestNativeDevice(Uri DeviceUri) : DeviceBase(DeviceUri);
+
+    private static DeviceBase Native(string deviceClass, DeviceType type, string id)
+        => new TestNativeDevice(new Uri($"{type}://{deviceClass}/{id}#{id}"));
+
+    private static AscomDevice Ascom(DeviceType type, string progId)
+        => new(type, progId, progId);
+
+    private static string[] FilterIds(params DeviceBase[] devices)
+        => NativeDriverBlacklist.FilterSuperseded(devices, NullLogger.Instance).Select(d => d.DeviceId).ToArray();
+
+    [Fact]
+    public void GivenBlacklistedAscomAndItsNativeTwinPresentThenAscomIsHidden()
+    {
+        var ids = FilterIds(
+            Ascom(DeviceType.Camera, "ASCOM.ASICamera2.Camera"),
+            Native("ZWODevice", DeviceType.Camera, "0"));
+
+        ids.ShouldBe(["0"]); // the native ZWO camera survives, the ASCOM twin is dropped
+    }
+
+    [Fact]
+    public void GivenBlacklistedAscomButNoNativeTwinThenAscomIsKeptAsFallback()
+    {
+        // No native ZWODevice discovered (SDK absent / no camera) -> never strand the user.
+        var ids = FilterIds(Ascom(DeviceType.Camera, "ASCOM.ASICamera2.Camera"));
+
+        ids.ShouldBe(["ASCOM.ASICamera2.Camera"]);
+    }
+
+    [Fact]
+    public void GivenGeminiFlatPanelWithNativeSerialPresentThenAscomGeminiIsHidden()
+    {
+        var ids = FilterIds(
+            Ascom(DeviceType.CoverCalibrator, "ASCOM.GeminiFPLite.CoverCalibrator"),
+            Native("GeminiDevice", DeviceType.CoverCalibrator, "COM3"));
+
+        ids.ShouldBe(["COM3"]);
+    }
+
+    [Fact]
+    public void GivenNonBlacklistedAscomThenItIsKeptEvenAlongsideANativeDevice()
+    {
+        // ASCOM.PlayerOne isn't reimplemented natively; a ZWO native device must not hide it.
+        var ids = FilterIds(
+            Ascom(DeviceType.Camera, "ASCOM.PlayerOne.Camera"),
+            Native("ZWODevice", DeviceType.Camera, "0"));
+
+        ids.ShouldBe(["ASCOM.PlayerOne.Camera", "0"]);
+    }
+
+    [Fact]
+    public void GivenGeminiFocuserProThenItIsNotHiddenByTheNativeGeminiCoverFamily()
+    {
+        // GeminiFocuserPro is a different product with no native impl -- must survive even if a native
+        // GeminiDevice (the flat panel) is present.
+        var ids = FilterIds(
+            Ascom(DeviceType.Focuser, "ASCOM.GeminiFocuserPro.Focuser"),
+            Native("GeminiDevice", DeviceType.Focuser, "COM3"));
+
+        ids.ShouldBe(["ASCOM.GeminiFocuserPro.Focuser", "COM3"]);
+    }
+
+    [Theory]
+    [InlineData("ASCOM.GeminiFPLite.CoverCalibrator", "GeminiDevice")]
+    [InlineData("ascom.asicamera2.camera", "ZWODevice")] // case-insensitive ProgID match
+    [InlineData("ASCOM.EFW2_2.FilterWheel", "ZWODevice")]
+    [InlineData("ASCOM.qfoc.Focuser", "QHYDevice")]
+    [InlineData("ASCOM.QHYCFW.FilterWheel", "QHYDevice")]
+    public void GivenKnownProgIdThenMapsToExpectedNativeClass(string progId, string expected)
+    {
+        NativeDriverBlacklist.TryGetNativeClass(progId, out var nativeClass).ShouldBeTrue();
+        nativeClass.ShouldBe(expected);
+    }
+
+    [Theory]
+    [InlineData("ASCOM.PlayerOne.Camera")]
+    [InlineData("ASCOM.GeminiFocuserPro.Focuser")]
+    [InlineData("ASCOM.iOptron2017.Telescope")]
+    public void GivenUnlistedProgIdThenNoNativeClass(string progId)
+        => NativeDriverBlacklist.TryGetNativeClass(progId, out _).ShouldBeFalse();
+}

--- a/src/TianWen.Lib/Connections/JsonRpcClient.cs
+++ b/src/TianWen.Lib/Connections/JsonRpcClient.cs
@@ -1,0 +1,209 @@
+/*
+
+Portions derived from the phd2client (Andy Galasso), MIT License:
+
+Copyright (c) 2018 Andy Galasso
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+*/
+
+using DotNext.Threading;
+using System;
+using System.Buffers;
+using System.Collections.Concurrent;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace TianWen.Lib.Connections;
+
+/// <summary>Thrown when a JSON-RPC call fails to send, times out its correlation, or the peer returns an <c>error</c> object.</summary>
+internal sealed class JsonRpcException(string message, int? code = null) : Exception(message)
+{
+    /// <summary>The JSON-RPC <c>error.code</c>, when the peer supplied one.</summary>
+    public int? Code { get; } = code;
+}
+
+/// <summary>
+/// Generic JSON-RPC peer over an <see cref="IUtf8TextBasedConnection"/> (one line == one message).
+/// Owns request-<c>id</c> correlation, the receive loop, and response-vs-notification routing; the
+/// caller supplies message-specific concerns via delegates (parameter serialization, notification
+/// handling, error reporting). Extracted from the PHD2 guider driver so the same client backs PHD2
+/// and the out-of-process ASCOM COM host.
+/// <para>
+/// Wire shape (matches PHD2): a request is <c>{"method":…,"id":N,"params":…?}</c>; an inbound message
+/// carrying both a <c>jsonrpc</c> property and a numeric <c>id</c> is a <b>response</b> (correlated by
+/// id), anything else is a server <b>notification</b> handed to <c>onNotification</c>.
+/// </para>
+/// <para>
+/// One client wraps one connection for its whole lifetime; reconnect creates a new client. The caller
+/// runs <see cref="ReceiveLoopAsync"/> as a background task and awaits <see cref="CallAsync"/> from any
+/// number of callers concurrently (each is correlated by its own id).
+/// </para>
+/// </summary>
+internal sealed class JsonRpcClient(
+    IUtf8TextBasedConnection connection,
+    Func<JsonDocument, CancellationToken, ValueTask>? onNotification = null,
+    Action<Exception, string>? onError = null) : IDisposable
+{
+    private readonly ConcurrentDictionary<long, JsonDocument> _responses = [];
+    private readonly AsyncManualResetEvent _responseSignal = new(false);
+    private long _messageId;
+
+    /// <summary>
+    /// Reads and dispatches inbound messages until the connection closes (<c>ReadLineAsync</c> returns
+    /// null), <paramref name="cancellationToken"/> fires, or a read faults. Run as a background task.
+    /// </summary>
+    public async Task ReceiveLoopAsync(CancellationToken cancellationToken)
+    {
+        string? line = null;
+        try
+        {
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                try
+                {
+                    line = await connection.ReadLineAsync(cancellationToken).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException oce) when (oce.CancellationToken.IsCancellationRequested)
+                {
+                    break;
+                }
+                catch (Exception ex)
+                {
+                    // A read fault means the connection is unusable -- report and end the loop so the
+                    // owner can tear down / reconnect (the original PHD2 loop fell through here with a
+                    // stale `line` and could reprocess it; ending is both cleaner and reconnect-friendly).
+                    onError?.Invoke(ex, "reading from input stream");
+                    break;
+                }
+
+                if (line is null)
+                {
+                    break; // peer disconnected
+                }
+
+                JsonDocument message;
+                try
+                {
+                    message = JsonDocument.Parse(line);
+                }
+                catch (JsonException ex)
+                {
+                    onError?.Invoke(ex, $"ignoring invalid json: {line}");
+                    continue;
+                }
+
+                if (message.RootElement.TryGetProperty("jsonrpc", out _)
+                    && message.RootElement.TryGetProperty("id", out var idProp)
+                    && idProp.ValueKind is JsonValueKind.Number
+                    && idProp.TryGetInt64(out var id))
+                {
+                    // Response: store by id (disposing any superseded doc) and wake awaiting callers.
+                    _ = _responses.AddOrUpdate(id, message, (_, old) =>
+                    {
+                        old.Dispose();
+                        return message;
+                    });
+                    _responseSignal.Set(true);
+                }
+                else if (onNotification is { } handler)
+                {
+                    // Notification: the handler owns the document.
+                    await handler(message, cancellationToken).ConfigureAwait(false);
+                }
+                else
+                {
+                    message.Dispose();
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            onError?.Invoke(ex, $"processing: {line}");
+        }
+    }
+
+    /// <summary>
+    /// Sends <paramref name="method"/> with an auto-assigned id and awaits the correlated response.
+    /// <paramref name="writeParams"/>, when non-null, writes the <c>params</c> value (array or object);
+    /// pass null for a parameterless call. Throws <see cref="JsonRpcException"/> on a send failure or an
+    /// <c>error</c> response. The returned <see cref="JsonDocument"/> is owned by the caller (dispose it).
+    /// </summary>
+    public async ValueTask<JsonDocument> CallAsync(string method, Action<Utf8JsonWriter>? writeParams, CancellationToken cancellationToken)
+    {
+        var buffer = new ArrayBufferWriter<byte>(128);
+        long id;
+        using (var req = new Utf8JsonWriter(buffer, new JsonWriterOptions { Indented = false }))
+        {
+            id = Interlocked.Increment(ref _messageId);
+            req.WriteStartObject();
+            req.WriteString("method", method);
+            req.WriteNumber("id", id);
+            if (writeParams is not null)
+            {
+                req.WritePropertyName("params");
+                writeParams(req);
+            }
+            req.WriteEndObject();
+        }
+
+        if (!await connection.WriteLineAsync(buffer.WrittenMemory, cancellationToken).ConfigureAwait(false))
+        {
+            throw new JsonRpcException($"Failed to send request '{method}'");
+        }
+
+        JsonDocument? response;
+        while (!_responses.TryRemove(id, out response))
+        {
+            await _responseSignal.WaitAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        if (response.RootElement.TryGetProperty("error", out var errorEl))
+        {
+            var message = errorEl.ValueKind is JsonValueKind.Object && errorEl.TryGetProperty("message", out var m)
+                ? m.GetString()
+                : errorEl.ToString();
+            var code = errorEl.ValueKind is JsonValueKind.Object && errorEl.TryGetProperty("code", out var c) && c.TryGetInt32(out var ci)
+                ? ci
+                : (int?)null;
+            response.Dispose();
+            throw new JsonRpcException(message ?? "error response did not contain a message", code);
+        }
+
+        if (!response.RootElement.TryGetProperty("id", out var respId) || !respId.TryGetInt64(out var rid) || rid != id)
+        {
+            var actual = response.RootElement.ToString();
+            response.Dispose();
+            throw new JsonRpcException($"Response id was not {id}: {actual}");
+        }
+
+        return response;
+    }
+
+    public void Dispose()
+    {
+        foreach (var kv in _responses)
+        {
+            kv.Value.Dispose();
+        }
+        _responses.Clear();
+    }
+}

--- a/src/TianWen.Lib/Connections/JsonRpcClient.cs
+++ b/src/TianWen.Lib/Connections/JsonRpcClient.cs
@@ -34,13 +34,6 @@ using System.Threading.Tasks;
 
 namespace TianWen.Lib.Connections;
 
-/// <summary>Thrown when a JSON-RPC call fails to send, times out its correlation, or the peer returns an <c>error</c> object.</summary>
-internal sealed class JsonRpcException(string message, int? code = null) : Exception(message)
-{
-    /// <summary>The JSON-RPC <c>error.code</c>, when the peer supplied one.</summary>
-    public int? Code { get; } = code;
-}
-
 /// <summary>
 /// Generic JSON-RPC peer over an <see cref="IUtf8TextBasedConnection"/> (one line == one message).
 /// Owns request-<c>id</c> correlation, the receive loop, and response-vs-notification routing; the

--- a/src/TianWen.Lib/Connections/JsonRpcException.cs
+++ b/src/TianWen.Lib/Connections/JsonRpcException.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace TianWen.Lib.Connections;
+
+/// <summary>Thrown when a JSON-RPC call fails to send, times out its correlation, or the peer returns an <c>error</c> object.</summary>
+internal sealed class JsonRpcException(string message, int? code = null) : Exception(message)
+{
+    /// <summary>The JSON-RPC <c>error.code</c>, when the peer supplied one.</summary>
+    public int? Code { get; } = code;
+}

--- a/src/TianWen.Lib/Connections/JsonRpcOverTcpConnection.cs
+++ b/src/TianWen.Lib/Connections/JsonRpcOverTcpConnection.cs
@@ -38,6 +38,22 @@ internal class JsonRpcOverTcpConnection : IUtf8TextBasedConnection
     private TcpClient? _tcpClient;
     private StreamReader? _streamReader;
 
+    /// <summary>Client-side: call <see cref="ConnectAsync"/> to dial an endpoint.</summary>
+    public JsonRpcOverTcpConnection()
+    {
+    }
+
+    /// <summary>
+    /// Server-side: wrap a client already accepted by a listener. The read/write-line semantics are
+    /// identical to the dialled path; only setup differs (accept vs connect), so <see cref="ConnectAsync"/>
+    /// is not used in this mode.
+    /// </summary>
+    internal JsonRpcOverTcpConnection(TcpClient acceptedClient)
+    {
+        _tcpClient = acceptedClient;
+        _streamReader = new StreamReader(acceptedClient.GetStream());
+    }
+
     public async ValueTask ConnectAsync(EndPoint endPoint, CancellationToken cancellationToken = default)
     {
         _tcpClient = new TcpClient();

--- a/src/TianWen.Lib/Connections/JsonRpcOverTcpConnection.cs
+++ b/src/TianWen.Lib/Connections/JsonRpcOverTcpConnection.cs
@@ -38,22 +38,6 @@ internal class JsonRpcOverTcpConnection : IUtf8TextBasedConnection
     private TcpClient? _tcpClient;
     private StreamReader? _streamReader;
 
-    /// <summary>Client-side: call <see cref="ConnectAsync"/> to dial an endpoint.</summary>
-    public JsonRpcOverTcpConnection()
-    {
-    }
-
-    /// <summary>
-    /// Server-side: wrap a client already accepted by a listener. The read/write-line semantics are
-    /// identical to the dialled path; only setup differs (accept vs connect), so <see cref="ConnectAsync"/>
-    /// is not used in this mode.
-    /// </summary>
-    internal JsonRpcOverTcpConnection(TcpClient acceptedClient)
-    {
-        _tcpClient = acceptedClient;
-        _streamReader = new StreamReader(acceptedClient.GetStream());
-    }
-
     public async ValueTask ConnectAsync(EndPoint endPoint, CancellationToken cancellationToken = default)
     {
         _tcpClient = new TcpClient();

--- a/src/TianWen.Lib/Connections/JsonRpcServer.cs
+++ b/src/TianWen.Lib/Connections/JsonRpcServer.cs
@@ -1,7 +1,5 @@
 using System;
 using System.Buffers;
-using System.Net;
-using System.Net.Sockets;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
@@ -18,43 +16,21 @@ namespace TianWen.Lib.Connections;
 internal delegate ValueTask JsonRpcRequestHandler(string method, JsonElement @params, Utf8JsonWriter resultWriter, CancellationToken cancellationToken);
 
 /// <summary>
-/// Minimal JSON-RPC 2.0 server over loopback TCP: binds an auto-assigned loopback port, accepts a
-/// single client, and serves requests through a <see cref="JsonRpcRequestHandler"/> until the client
-/// disconnects or cancellation fires. The server side of the same wire format
-/// <see cref="JsonRpcClient"/> speaks, so the two interoperate directly (client's
-/// <c>{"method","id","params"?}</c> in, this server's <c>{"jsonrpc":"2.0","id",result|error}</c> out).
+/// Minimal JSON-RPC 2.0 server: serves requests on an already-connected
+/// <see cref="IUtf8TextBasedConnection"/> through a <see cref="JsonRpcRequestHandler"/> until the peer
+/// disconnects or cancellation fires. Transport-agnostic — the caller owns the listen/accept (a named
+/// pipe for the out-of-process ASCOM host, or a TCP accept) and hands the connected transport to
+/// <see cref="ServeAsync"/>. It speaks the server side of the same wire format <see cref="JsonRpcClient"/>
+/// speaks (client's <c>{"method","id","params"?}</c> in, this server's
+/// <c>{"jsonrpc":"2.0","id",result|error}</c> out).
 /// <para>
-/// Used by the out-of-process ASCOM COM host (one server per hosted device, on 127.0.0.1). Requests
-/// are served sequentially on the accept loop, which is exactly what a single COM object wants.
+/// Requests are served sequentially on the calling task, which is exactly what a single COM object wants.
 /// </para>
 /// </summary>
-internal sealed class JsonRpcServer(JsonRpcRequestHandler handler, Action<Exception, string>? onError = null) : IDisposable
+internal sealed class JsonRpcServer(JsonRpcRequestHandler handler, Action<Exception, string>? onError = null)
 {
-    private readonly TcpListener _listener = new(IPAddress.Loopback, 0);
-    private bool _started;
-
-    /// <summary>Binds and starts listening on an OS-assigned loopback port; returns that port.</summary>
-    public int Start()
-    {
-        _listener.Start();
-        _started = true;
-        return ((IPEndPoint)_listener.LocalEndpoint).Port;
-    }
-
-    /// <summary>Accepts one client and serves its requests until it disconnects or <paramref name="cancellationToken"/> fires.</summary>
-    public async Task RunAsync(CancellationToken cancellationToken)
-    {
-        if (!_started)
-        {
-            Start();
-        }
-
-        using var tcp = await _listener.AcceptTcpClientAsync(cancellationToken).ConfigureAwait(false);
-        using var connection = new JsonRpcOverTcpConnection(tcp);
-        await ServeAsync(connection, cancellationToken).ConfigureAwait(false);
-    }
-
-    private async Task ServeAsync(IUtf8TextBasedConnection connection, CancellationToken cancellationToken)
+    /// <summary>Serves requests on <paramref name="connection"/> until it disconnects or <paramref name="cancellationToken"/> fires.</summary>
+    public async Task ServeAsync(IUtf8TextBasedConnection connection, CancellationToken cancellationToken)
     {
         while (!cancellationToken.IsCancellationRequested)
         {
@@ -75,7 +51,7 @@ internal sealed class JsonRpcServer(JsonRpcRequestHandler handler, Action<Except
 
             if (line is null)
             {
-                break; // client disconnected
+                break; // peer disconnected
             }
 
             JsonDocument request;
@@ -153,6 +129,4 @@ internal sealed class JsonRpcServer(JsonRpcRequestHandler handler, Action<Except
             }
         }
     }
-
-    public void Dispose() => _listener.Stop();
 }

--- a/src/TianWen.Lib/Connections/JsonRpcServer.cs
+++ b/src/TianWen.Lib/Connections/JsonRpcServer.cs
@@ -1,0 +1,158 @@
+using System;
+using System.Buffers;
+using System.Net;
+using System.Net.Sockets;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace TianWen.Lib.Connections;
+
+/// <summary>
+/// Handles one JSON-RPC request. Writes the <c>result</c> <b>value</b> into <paramref name="resultWriter"/>
+/// (e.g. <c>resultWriter.WriteBooleanValue(true)</c>, or an object/array); write nothing for a void
+/// method (the server emits <c>"result":null</c>). Throw <see cref="JsonRpcException"/> (or any exception)
+/// to have the server emit an <c>error</c> object instead. <paramref name="params"/> is
+/// <see cref="JsonValueKind.Undefined"/> when the request carried no <c>params</c>.
+/// </summary>
+internal delegate ValueTask JsonRpcRequestHandler(string method, JsonElement @params, Utf8JsonWriter resultWriter, CancellationToken cancellationToken);
+
+/// <summary>
+/// Minimal JSON-RPC 2.0 server over loopback TCP: binds an auto-assigned loopback port, accepts a
+/// single client, and serves requests through a <see cref="JsonRpcRequestHandler"/> until the client
+/// disconnects or cancellation fires. The server side of the same wire format
+/// <see cref="JsonRpcClient"/> speaks, so the two interoperate directly (client's
+/// <c>{"method","id","params"?}</c> in, this server's <c>{"jsonrpc":"2.0","id",result|error}</c> out).
+/// <para>
+/// Used by the out-of-process ASCOM COM host (one server per hosted device, on 127.0.0.1). Requests
+/// are served sequentially on the accept loop, which is exactly what a single COM object wants.
+/// </para>
+/// </summary>
+internal sealed class JsonRpcServer(JsonRpcRequestHandler handler, Action<Exception, string>? onError = null) : IDisposable
+{
+    private readonly TcpListener _listener = new(IPAddress.Loopback, 0);
+    private bool _started;
+
+    /// <summary>Binds and starts listening on an OS-assigned loopback port; returns that port.</summary>
+    public int Start()
+    {
+        _listener.Start();
+        _started = true;
+        return ((IPEndPoint)_listener.LocalEndpoint).Port;
+    }
+
+    /// <summary>Accepts one client and serves its requests until it disconnects or <paramref name="cancellationToken"/> fires.</summary>
+    public async Task RunAsync(CancellationToken cancellationToken)
+    {
+        if (!_started)
+        {
+            Start();
+        }
+
+        using var tcp = await _listener.AcceptTcpClientAsync(cancellationToken).ConfigureAwait(false);
+        using var connection = new JsonRpcOverTcpConnection(tcp);
+        await ServeAsync(connection, cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task ServeAsync(IUtf8TextBasedConnection connection, CancellationToken cancellationToken)
+    {
+        while (!cancellationToken.IsCancellationRequested)
+        {
+            string? line;
+            try
+            {
+                line = await connection.ReadLineAsync(cancellationToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException oce) when (oce.CancellationToken.IsCancellationRequested)
+            {
+                break;
+            }
+            catch (Exception ex)
+            {
+                onError?.Invoke(ex, "reading request");
+                break;
+            }
+
+            if (line is null)
+            {
+                break; // client disconnected
+            }
+
+            JsonDocument request;
+            try
+            {
+                request = JsonDocument.Parse(line);
+            }
+            catch (JsonException ex)
+            {
+                onError?.Invoke(ex, $"ignoring invalid json: {line}");
+                continue;
+            }
+
+            using (request)
+            {
+                var root = request.RootElement;
+                var method = root.TryGetProperty("method", out var m) ? m.GetString() ?? "" : "";
+                var id = root.TryGetProperty("id", out var idEl) && idEl.TryGetInt64(out var i) ? i : 0L;
+                var @params = root.TryGetProperty("params", out var p) ? p : default;
+
+                // Dispatch into a scratch buffer so a mid-write fault can't corrupt the response frame.
+                var result = new ArrayBufferWriter<byte>(64);
+                string? errorMessage = null;
+                int? errorCode = null;
+                try
+                {
+                    using var resultWriter = new Utf8JsonWriter(result, new JsonWriterOptions { Indented = false });
+                    await handler(method, @params, resultWriter, cancellationToken).ConfigureAwait(false);
+                    resultWriter.Flush();
+                }
+                catch (JsonRpcException jre)
+                {
+                    errorMessage = jre.Message;
+                    errorCode = jre.Code;
+                }
+                catch (Exception ex)
+                {
+                    onError?.Invoke(ex, $"handling '{method}'");
+                    errorMessage = ex.Message;
+                }
+
+                var response = new ArrayBufferWriter<byte>(128);
+                using (var w = new Utf8JsonWriter(response, new JsonWriterOptions { Indented = false }))
+                {
+                    w.WriteStartObject();
+                    w.WriteString("jsonrpc", "2.0");
+                    w.WriteNumber("id", id);
+                    if (errorMessage is null)
+                    {
+                        w.WritePropertyName("result");
+                        if (result.WrittenCount > 0)
+                        {
+                            w.WriteRawValue(result.WrittenSpan, skipInputValidation: true);
+                        }
+                        else
+                        {
+                            w.WriteNullValue();
+                        }
+                    }
+                    else
+                    {
+                        w.WritePropertyName("error");
+                        w.WriteStartObject();
+                        if (errorCode is { } code)
+                        {
+                            w.WriteNumber("code", code);
+                        }
+                        w.WriteString("message", errorMessage);
+                        w.WriteEndObject();
+                    }
+                    w.WriteEndObject();
+                }
+
+                await connection.WriteLineAsync(response.WrittenMemory, cancellationToken).ConfigureAwait(false);
+            }
+        }
+    }
+
+    public void Dispose() => _listener.Stop();
+}

--- a/src/TianWen.Lib/Connections/NamedPipeConnection.cs
+++ b/src/TianWen.Lib/Connections/NamedPipeConnection.cs
@@ -1,0 +1,53 @@
+using System;
+using System.IO;
+using System.IO.Pipes;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace TianWen.Lib.Connections;
+
+/// <summary>
+/// An <see cref="IUtf8TextBasedConnection"/> over an already-connected duplex <see cref="PipeStream"/>
+/// (a named pipe). Same line framing (one CRLF-terminated JSON message per line) as
+/// <see cref="JsonRpcOverTcpConnection"/>, but over Windows local IPC — no network stack, no loopback
+/// port, no firewall/AV involvement, and an ACL scoped to the current user. The out-of-process ASCOM
+/// host (<c>tianwen-ascomhost</c>) serves over this. The pipe is connected by the caller (server-side
+/// <see cref="PipeStream.WaitForConnection"/> or client-side <see cref="NamedPipeClientStream.Connect(int)"/>),
+/// so <see cref="ConnectAsync"/> is not used.
+/// </summary>
+internal sealed class NamedPipeConnection(PipeStream pipe) : IUtf8TextBasedConnection
+{
+    private static readonly ReadOnlyMemory<byte> CRLF = "\r\n"u8.ToArray();
+
+    private readonly StreamReader _reader = new(pipe);
+
+    public CommunicationProtocol HighLevelProtocol => CommunicationProtocol.JsonRPC;
+
+    public bool IsConnected => pipe.IsConnected;
+
+    public ValueTask ConnectAsync(EndPoint endPoint, CancellationToken cancellationToken = default)
+        => throw new NotSupportedException("NamedPipeConnection wraps an already-connected pipe.");
+
+    public ValueTask<string?> ReadLineAsync(CancellationToken cancellationToken = default)
+        => _reader.ReadLineAsync(cancellationToken);
+
+    public async ValueTask<bool> WriteLineAsync(ReadOnlyMemory<byte> jsonlUtf8Bytes, CancellationToken cancellationToken = default)
+    {
+        if (!pipe.CanWrite)
+        {
+            return false;
+        }
+
+        await pipe.WriteAsync(jsonlUtf8Bytes, cancellationToken).ConfigureAwait(false);
+        await pipe.WriteAsync(CRLF, cancellationToken).ConfigureAwait(false);
+        await pipe.FlushAsync(cancellationToken).ConfigureAwait(false);
+        return true;
+    }
+
+    public void Dispose()
+    {
+        _reader.Dispose();
+        pipe.Dispose();
+    }
+}

--- a/src/TianWen.Lib/Devices/Ascom/AscomDeviceDriverBase.cs
+++ b/src/TianWen.Lib/Devices/Ascom/AscomDeviceDriverBase.cs
@@ -21,7 +21,9 @@ internal abstract class AscomDeviceDriverBase(AscomDevice device, IServiceProvid
     // and fall back.
     private const int DISP_E_UNKNOWNNAME = unchecked((int)0x80020006);
 
-    protected readonly AscomDispatchDevice _dispatchDevice = new(device.DeviceId);
+    // serviceProvider is the base primary-ctor parameter (in scope for field initializers); the factory
+    // resolves an ILoggerFactory from it to log the in-proc-vs-out-of-process routing decision.
+    protected readonly AscomDispatchDevice _dispatchDevice = new(device.DeviceId, serviceProvider);
 
     public override string Name => SafeGet(() => _dispatchDevice.Name, _device.DisplayName);
 

--- a/src/TianWen.Lib/Devices/Ascom/ComInterop/AscomComServerClassifier.cs
+++ b/src/TianWen.Lib/Devices/Ascom/ComInterop/AscomComServerClassifier.cs
@@ -1,0 +1,84 @@
+using Microsoft.Win32;
+using System;
+using System.IO;
+using System.Runtime.Versioning;
+
+namespace TianWen.Lib.Devices.Ascom.ComInterop;
+
+/// <summary>
+/// Decides whether an ASCOM driver must be hosted out-of-process (in the CET-off
+/// <c>tianwen-ascomhost</c>) or can run in-proc via <see cref="DispatchObject"/>.
+/// <para>
+/// The out-of-process host is needed <b>only</b> for the CET-incompatible in-proc .NET Framework CLR:
+/// a driver whose <c>InprocServer32</c> default value resolves to <c>mscoree.dll</c> (the Framework
+/// shim). Those drivers fastfail our CET-on process on connect (0xC0000409). Everything else is CET-safe
+/// and stays in-proc:
+/// </para>
+/// <list type="bullet">
+///   <item><c>LocalServer32</c> drivers (e.g. GS Server) already run out-of-proc; COM marshals to their
+///     own process, so their CLR never loads into ours.</item>
+///   <item>Native in-proc drivers (ZWO/ASI/PlayerOne/QHYCCD) and .NET Core comhost drivers
+///     (<c>&lt;name&gt;.comhost.dll</c>, not <c>mscoree.dll</c>) are CET-compatible.</item>
+/// </list>
+/// Reads both registry views (Platform 6 registers 32-bit, Platform 7 may be 64-bit-only), matching
+/// <see cref="AscomDeviceIterator"/>'s discovery walk.
+/// </summary>
+[SupportedOSPlatform("windows")]
+internal static class AscomComServerClassifier
+{
+    /// <summary>
+    /// True when <paramref name="progId"/> is an in-proc .NET Framework COM server
+    /// (<c>InprocServer32 = mscoree.dll</c>) with no out-of-proc <c>LocalServer32</c>, i.e. one that
+    /// must be hosted out-of-process. <paramref name="reason"/> carries a short human-readable
+    /// classification for logging either way.
+    /// </summary>
+    public static bool RequiresOutOfProcessHost(string progId, out string reason)
+    {
+        if (NativeMethods.CLSIDFromProgID(progId, out var clsid) != 0)
+        {
+            reason = "ProgID does not resolve to a CLSID";
+            return false;
+        }
+
+        var clsidString = $"{{{clsid.ToString().ToUpperInvariant()}}}";
+
+        foreach (var view in new[] { RegistryView.Registry64, RegistryView.Registry32 })
+        {
+            using var hklm = RegistryKey.OpenBaseKey(RegistryHive.LocalMachine, view);
+            using var clsidKey = hklm.OpenSubKey($@"SOFTWARE\Classes\CLSID\{clsidString}", false);
+            if (clsidKey is null)
+            {
+                continue;
+            }
+
+            // LocalServer32 => the driver runs out-of-proc already; its CLR never loads into ours, so it
+            // is CET-safe. Prefer in-proc DispatchObject (CoCreateInstance launches the local server).
+            using (var localServer = clsidKey.OpenSubKey("LocalServer32", false))
+            {
+                if (localServer?.GetValue(null) is string ls && !string.IsNullOrWhiteSpace(ls))
+                {
+                    reason = "LocalServer32 (out-of-proc already, CET-safe)";
+                    return false;
+                }
+            }
+
+            using var inproc = clsidKey.OpenSubKey("InprocServer32", false);
+            if (inproc?.GetValue(null) is string raw && !string.IsNullOrWhiteSpace(raw))
+            {
+                var fileName = Path.GetFileName(Environment.ExpandEnvironmentVariables(raw.Trim().Trim('"')));
+                if (string.Equals(fileName, "mscoree.dll", StringComparison.OrdinalIgnoreCase))
+                {
+                    var runtime = inproc.GetValue("RuntimeVersion") as string;
+                    reason = $"InprocServer32=mscoree.dll (in-proc .NET Framework CLR, RuntimeVersion={runtime ?? "?"})";
+                    return true;
+                }
+
+                reason = $"InprocServer32={fileName} (CET-safe in-proc)";
+                return false;
+            }
+        }
+
+        reason = "no usable InprocServer32/LocalServer32 found";
+        return false;
+    }
+}

--- a/src/TianWen.Lib/Devices/Ascom/ComInterop/AscomDispatchCamera.cs
+++ b/src/TianWen.Lib/Devices/Ascom/ComInterop/AscomDispatchCamera.cs
@@ -11,7 +11,7 @@ namespace TianWen.Lib.Devices.Ascom.ComInterop;
 [DispatchInterface]
 internal sealed partial class AscomDispatchCamera : IDisposable
 {
-    public AscomDispatchCamera(DispatchObject dispatch)
+    public AscomDispatchCamera(IDispatchTransport dispatch)
     {
         _dispatch = dispatch;
     }

--- a/src/TianWen.Lib/Devices/Ascom/ComInterop/AscomDispatchCoverCalibrator.cs
+++ b/src/TianWen.Lib/Devices/Ascom/ComInterop/AscomDispatchCoverCalibrator.cs
@@ -7,7 +7,7 @@ namespace TianWen.Lib.Devices.Ascom.ComInterop;
 [DispatchInterface]
 internal sealed partial class AscomDispatchCoverCalibrator : IDisposable
 {
-    public AscomDispatchCoverCalibrator(DispatchObject dispatch)
+    public AscomDispatchCoverCalibrator(IDispatchTransport dispatch)
     {
         _dispatch = dispatch;
     }

--- a/src/TianWen.Lib/Devices/Ascom/ComInterop/AscomDispatchDevice.cs
+++ b/src/TianWen.Lib/Devices/Ascom/ComInterop/AscomDispatchDevice.cs
@@ -11,9 +11,12 @@ namespace TianWen.Lib.Devices.Ascom.ComInterop;
 [DispatchInterface]
 internal sealed partial class AscomDispatchDevice : IDisposable
 {
-    public AscomDispatchDevice(string progId)
+    public AscomDispatchDevice(string progId, IServiceProvider? serviceProvider = null)
     {
-        _dispatch = new DispatchObject(progId);
+        // The transport is in-proc DispatchObject for CET-safe drivers, or an out-of-process CET-off host
+        // for in-proc .NET Framework drivers that would otherwise fastfail on connect. See
+        // DispatchTransportFactory + docs/plans/ascom-oop-host.md.
+        _dispatch = DispatchTransportFactory.Create(progId, serviceProvider);
     }
 
     // Common ASCOM device members — generated implementations via source generator
@@ -30,9 +33,9 @@ internal sealed partial class AscomDispatchDevice : IDisposable
     public partial void Disconnect();
 
     /// <summary>
-    /// Access the underlying dispatch object for device-specific calls.
+    /// Access the underlying dispatch transport for device-specific calls (in-proc or out-of-process).
     /// </summary>
-    internal DispatchObject Dispatch => _dispatch;
+    internal IDispatchTransport Dispatch => _dispatch;
 
     public void Dispose() => _dispatch.Dispose();
 }

--- a/src/TianWen.Lib/Devices/Ascom/ComInterop/AscomDispatchFilterWheel.cs
+++ b/src/TianWen.Lib/Devices/Ascom/ComInterop/AscomDispatchFilterWheel.cs
@@ -7,7 +7,7 @@ namespace TianWen.Lib.Devices.Ascom.ComInterop;
 [DispatchInterface]
 internal sealed partial class AscomDispatchFilterWheel : IDisposable
 {
-    public AscomDispatchFilterWheel(DispatchObject dispatch)
+    public AscomDispatchFilterWheel(IDispatchTransport dispatch)
     {
         _dispatch = dispatch;
     }

--- a/src/TianWen.Lib/Devices/Ascom/ComInterop/AscomDispatchFocuser.cs
+++ b/src/TianWen.Lib/Devices/Ascom/ComInterop/AscomDispatchFocuser.cs
@@ -7,7 +7,7 @@ namespace TianWen.Lib.Devices.Ascom.ComInterop;
 [DispatchInterface]
 internal sealed partial class AscomDispatchFocuser : IDisposable
 {
-    public AscomDispatchFocuser(DispatchObject dispatch)
+    public AscomDispatchFocuser(IDispatchTransport dispatch)
     {
         _dispatch = dispatch;
     }

--- a/src/TianWen.Lib/Devices/Ascom/ComInterop/AscomDispatchTelescope.cs
+++ b/src/TianWen.Lib/Devices/Ascom/ComInterop/AscomDispatchTelescope.cs
@@ -11,7 +11,7 @@ namespace TianWen.Lib.Devices.Ascom.ComInterop;
 [DispatchInterface]
 internal sealed partial class AscomDispatchTelescope : IDisposable
 {
-    public AscomDispatchTelescope(DispatchObject dispatch)
+    public AscomDispatchTelescope(IDispatchTransport dispatch)
     {
         _dispatch = dispatch;
     }
@@ -76,12 +76,13 @@ internal sealed partial class AscomDispatchTelescope : IDisposable
     public partial void MoveAxis(int Axis, double Rate);
 
     /// <summary>
-    /// Calls <c>AxisRates(axis)</c> and returns the resulting <c>IAxisRates</c> collection wrapped as a
-    /// <see cref="DispatchObject"/>. Caller disposes. The collection exposes <c>Count</c> plus a 1-indexed
-    /// <c>Item(i)</c> parameterized property that yields an <c>IRate</c> with <c>Minimum</c>/<c>Maximum</c>.
-    /// Hand-written because the source generator only emits primitive COM return types.
+    /// Calls <c>AxisRates(axis)</c> and returns the resulting <c>IAxisRates</c> collection as an
+    /// <see cref="IDispatchTransport"/>. Caller disposes. The collection exposes <c>Count</c> plus a
+    /// 1-indexed <c>Item(i)</c> parameterized property that yields an <c>IRate</c> with
+    /// <c>Minimum</c>/<c>Maximum</c>. Hand-written because the source generator only emits primitive
+    /// COM return types.
     /// </summary>
-    public DispatchObject AxisRates(int Axis) => _dispatch.InvokeMethodDispatch("AxisRates", Axis);
+    public IDispatchTransport AxisRates(int Axis) => _dispatch.InvokeMethodDispatch("AxisRates", Axis);
 
     public void Dispose() { /* dispatch owned by AscomDispatchDevice */ }
 }

--- a/src/TianWen.Lib/Devices/Ascom/ComInterop/AscomHostJob.cs
+++ b/src/TianWen.Lib/Devices/Ascom/ComInterop/AscomHostJob.cs
@@ -1,0 +1,128 @@
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
+using System.Threading;
+
+namespace TianWen.Lib.Devices.Ascom.ComInterop;
+
+/// <summary>
+/// A process-wide Win32 Job Object with <c>KILL_ON_JOB_CLOSE</c> that every spawned
+/// <c>tianwen-ascomhost</c> helper is assigned to. When our process exits (even a hard kill), the OS
+/// closes the job handle and terminates every assigned helper — no orphaned CET-off hosts.
+/// <para>
+/// This is a backstop. The primary lifetime tie is the loopback socket: when the parent dies its TCP
+/// connection closes, the helper's server loop sees EOF and exits on its own. The Job Object covers the
+/// edge case where a helper is blocked in a driver COM call and hasn't noticed the EOF yet.
+/// </para>
+/// </summary>
+[SupportedOSPlatform("windows")]
+internal static partial class AscomHostJob
+{
+    private const uint JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE = 0x2000;
+    private const int JobObjectExtendedLimitInformation = 9;
+
+    private static readonly Lock _gate = new();
+    private static nint _job; // 0 until created; intentionally never closed (closing it would kill helpers)
+
+    /// <summary>Assigns <paramref name="processHandle"/> to the shared kill-on-close job. Best-effort:
+    /// on any failure the caller still has the socket-EOF lifetime tie, so we swallow and move on.</summary>
+    public static void TryAssign(nint processHandle)
+    {
+        try
+        {
+            var job = EnsureJob();
+            if (job != 0)
+            {
+                _ = AssignProcessToJobObject(job, processHandle);
+            }
+        }
+        catch
+        {
+            // best-effort backstop only
+        }
+    }
+
+    private static nint EnsureJob()
+    {
+        if (_job != 0)
+        {
+            return _job;
+        }
+
+        lock (_gate) // one-time job creation; not on any hot/render path
+        {
+            if (_job != 0)
+            {
+                return _job;
+            }
+
+            var job = CreateJobObjectW(0, null);
+            if (job == 0)
+            {
+                return 0;
+            }
+
+            var info = new JOBOBJECT_EXTENDED_LIMIT_INFORMATION();
+            info.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+            if (!SetInformationJobObject(job, JobObjectExtendedLimitInformation, ref info, (uint)Marshal.SizeOf<JOBOBJECT_EXTENDED_LIMIT_INFORMATION>()))
+            {
+                _ = CloseHandle(job);
+                return 0;
+            }
+
+            _job = job;
+            return _job;
+        }
+    }
+
+    [LibraryImport("kernel32.dll", StringMarshalling = StringMarshalling.Utf16, SetLastError = true)]
+    private static partial nint CreateJobObjectW(nint lpJobAttributes, string? lpName);
+
+    [LibraryImport("kernel32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static partial bool SetInformationJobObject(nint hJob, int jobObjectInformationClass, ref JOBOBJECT_EXTENDED_LIMIT_INFORMATION lpJobObjectInformation, uint cbJobObjectInformationLength);
+
+    [LibraryImport("kernel32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static partial bool AssignProcessToJobObject(nint hJob, nint hProcess);
+
+    [LibraryImport("kernel32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static partial bool CloseHandle(nint hObject);
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct JOBOBJECT_BASIC_LIMIT_INFORMATION
+    {
+        public long PerProcessUserTimeLimit;
+        public long PerJobUserTimeLimit;
+        public uint LimitFlags;
+        public nuint MinimumWorkingSetSize;
+        public nuint MaximumWorkingSetSize;
+        public uint ActiveProcessLimit;
+        public nuint Affinity;
+        public uint PriorityClass;
+        public uint SchedulingClass;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct IO_COUNTERS
+    {
+        public ulong ReadOperationCount;
+        public ulong WriteOperationCount;
+        public ulong OtherOperationCount;
+        public ulong ReadTransferCount;
+        public ulong WriteTransferCount;
+        public ulong OtherTransferCount;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct JOBOBJECT_EXTENDED_LIMIT_INFORMATION
+    {
+        public JOBOBJECT_BASIC_LIMIT_INFORMATION BasicLimitInformation;
+        public IO_COUNTERS IoInfo;
+        public nuint ProcessMemoryLimit;
+        public nuint JobMemoryLimit;
+        public nuint PeakProcessMemoryUsed;
+        public nuint PeakJobMemoryUsed;
+    }
+}

--- a/src/TianWen.Lib/Devices/Ascom/ComInterop/AscomHostProcess.cs
+++ b/src/TianWen.Lib/Devices/Ascom/ComInterop/AscomHostProcess.cs
@@ -1,0 +1,206 @@
+using System;
+using System.Buffers;
+using System.Diagnostics;
+using System.IO;
+using System.Net;
+using System.Net.Sockets;
+using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
+using System.Text.Json;
+using System.Threading;
+
+namespace TianWen.Lib.Devices.Ascom.ComInterop;
+
+/// <summary>
+/// Owns one spawned <c>tianwen-ascomhost</c> helper process, its loopback TCP connection, and the
+/// synchronous JSON-RPC request/response over it. One helper hosts one COM object.
+/// <para>
+/// Calls are <b>synchronous</b> and single-flight (serialized by <see cref="_gate"/>): the helper serves
+/// requests sequentially and never sends unsolicited messages, so the reply to request N is the next
+/// line — no async receive loop / id-correlation dictionary is needed (unlike the event-pushing PHD2
+/// client). This matches the inherently synchronous, single-apartment ASCOM COM surface the transport
+/// replaces (a blocking COM call becomes a blocking loopback round-trip).
+/// </para>
+/// </summary>
+[SupportedOSPlatform("windows")]
+internal sealed class AscomHostProcess : IDisposable
+{
+    private static readonly ReadOnlyMemory<byte> CRLF = "\r\n"u8.ToArray();
+
+    private readonly Process _process;
+    private readonly TcpClient _tcp;
+    private readonly NetworkStream _stream;
+    private readonly StreamReader _reader;
+    private readonly Lock _gate = new(); // serialize the single-flight request/response on the shared socket; never on a render thread (driver calls are offloaded)
+    private long _id;
+    private bool _disposed;
+
+    private AscomHostProcess(Process process, TcpClient tcp)
+    {
+        _process = process;
+        _tcp = tcp;
+        _stream = tcp.GetStream();
+        _reader = new StreamReader(_stream);
+    }
+
+    /// <summary>
+    /// Spawns the helper, reads its <c>PORT n</c> handshake line, and connects to the loopback port.
+    /// Assigns the child to the kill-on-close job so it can't orphan us.
+    /// </summary>
+    public static AscomHostProcess Spawn(string exePath, TimeSpan handshakeTimeout)
+    {
+        var process = new Process
+        {
+            StartInfo = new ProcessStartInfo(exePath)
+            {
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                CreateNoWindow = true,
+            },
+        };
+        process.Start();
+
+        try
+        {
+            AscomHostJob.TryAssign(process.Handle);
+
+            // The helper prints "PORT <n>" as its first stdout line once the socket is bound. Bound the
+            // wait so a helper that dies before printing (or hangs) doesn't block the caller forever.
+            var handshake = ReadHandshake(process, handshakeTimeout);
+            if (handshake is null || !handshake.StartsWith("PORT ", StringComparison.Ordinal)
+                || !int.TryParse(handshake.AsSpan("PORT ".Length), out var port))
+            {
+                var stderr = process.StandardError.ReadToEnd();
+                throw new IOException($"ASCOM host did not report a port (got '{handshake}'). stderr: {stderr}");
+            }
+
+            var tcp = new TcpClient();
+            tcp.Connect(IPAddress.Loopback, port);
+            return new AscomHostProcess(process, tcp);
+        }
+        catch
+        {
+            TryKill(process);
+            process.Dispose();
+            throw;
+        }
+    }
+
+    private static string? ReadHandshake(Process process, TimeSpan timeout)
+    {
+        // ReadLineAsync().Wait(timeout) would leak the read; instead read on a background thread and
+        // bound the wait. The helper prints the line within milliseconds of a successful start.
+        string? line = null;
+        var done = new ManualResetEventSlim(false);
+        var thread = new Thread(() =>
+        {
+            try { line = process.StandardOutput.ReadLine(); }
+            catch { /* process died; line stays null */ }
+            finally { done.Set(); }
+        })
+        { IsBackground = true, Name = "ascomhost-handshake" };
+        thread.Start();
+        done.Wait(timeout);
+        return line;
+    }
+
+    /// <summary>
+    /// Sends a JSON-RPC request and returns the correlated response document (caller reads <c>result</c>
+    /// and disposes it). Throws <see cref="COMException"/> carrying the peer's HResult on an <c>error</c>
+    /// response, so the driver's <c>catch (COMException) when (HResult == DISP_E_UNKNOWNNAME)</c>
+    /// Platform-6 fallback works across the wire.
+    /// </summary>
+    public JsonDocument Call(string method, Action<Utf8JsonWriter>? writeParams)
+    {
+        lock (_gate)
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
+
+            var id = ++_id;
+            var buffer = new ArrayBufferWriter<byte>(128);
+            using (var writer = new Utf8JsonWriter(buffer, new JsonWriterOptions { Indented = false }))
+            {
+                writer.WriteStartObject();
+                writer.WriteString("method", method);
+                writer.WriteNumber("id", id);
+                if (writeParams is not null)
+                {
+                    writer.WritePropertyName("params");
+                    writeParams(writer);
+                }
+                writer.WriteEndObject();
+            }
+
+            WriteLine(buffer.WrittenMemory);
+
+            var line = _reader.ReadLine() ?? throw new IOException("ASCOM host closed the connection");
+            var response = JsonDocument.Parse(line);
+
+            var root = response.RootElement;
+            if (root.TryGetProperty("error", out var error))
+            {
+                var message = error.ValueKind is JsonValueKind.Object && error.TryGetProperty("message", out var m)
+                    ? m.GetString()
+                    : error.ToString();
+                var code = error.ValueKind is JsonValueKind.Object && error.TryGetProperty("code", out var c) && c.TryGetInt32(out var ci)
+                    ? ci
+                    : 0;
+                response.Dispose();
+                throw code != 0
+                    ? new COMException(message ?? "ASCOM host error", code)
+                    : new InvalidOperationException(message ?? "ASCOM host error");
+            }
+
+            if (!root.TryGetProperty("id", out var respId) || !respId.TryGetInt64(out var rid) || rid != id)
+            {
+                var actual = root.ToString();
+                response.Dispose();
+                throw new IOException($"ASCOM host response id was not {id}: {actual}");
+            }
+
+            return response;
+        }
+    }
+
+    private void WriteLine(ReadOnlyMemory<byte> jsonUtf8)
+    {
+        _stream.Write(jsonUtf8.Span);
+        _stream.Write(CRLF.Span);
+        _stream.Flush();
+    }
+
+    public void Dispose()
+    {
+        lock (_gate)
+        {
+            if (_disposed)
+            {
+                return;
+            }
+            _disposed = true;
+        }
+
+        // Closing the socket makes the helper's server loop see EOF and exit; the job object + explicit
+        // kill are the backstops.
+        try { _reader.Dispose(); } catch { /* ignore */ }
+        try { _tcp.Dispose(); } catch { /* ignore */ }
+        TryKill(_process);
+        _process.Dispose();
+    }
+
+    private static void TryKill(Process process)
+    {
+        try
+        {
+            if (!process.HasExited)
+            {
+                process.Kill(entireProcessTree: true);
+            }
+        }
+        catch
+        {
+            // already gone / not started
+        }
+    }
+}

--- a/src/TianWen.Lib/Devices/Ascom/ComInterop/AscomHostProcess.cs
+++ b/src/TianWen.Lib/Devices/Ascom/ComInterop/AscomHostProcess.cs
@@ -2,8 +2,7 @@ using System;
 using System.Buffers;
 using System.Diagnostics;
 using System.IO;
-using System.Net;
-using System.Net.Sockets;
+using System.IO.Pipes;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 using System.Text.Json;
@@ -12,14 +11,20 @@ using System.Threading;
 namespace TianWen.Lib.Devices.Ascom.ComInterop;
 
 /// <summary>
-/// Owns one spawned <c>tianwen-ascomhost</c> helper process, its loopback TCP connection, and the
+/// Owns one spawned <c>tianwen-ascomhost</c> helper process, its named-pipe connection, and the
 /// synchronous JSON-RPC request/response over it. One helper hosts one COM object.
+/// <para>
+/// The transport is a per-user named pipe (no network stack / loopback port / firewall involvement). To
+/// avoid a create-vs-connect race, the <b>parent owns the pipe server</b>: it creates the server pipe
+/// with a GUID name, passes that name to the helper as a launch argument, spawns it, then waits for the
+/// helper (the pipe client) to connect.
+/// </para>
 /// <para>
 /// Calls are <b>synchronous</b> and single-flight (serialized by <see cref="_gate"/>): the helper serves
 /// requests sequentially and never sends unsolicited messages, so the reply to request N is the next
 /// line — no async receive loop / id-correlation dictionary is needed (unlike the event-pushing PHD2
 /// client). This matches the inherently synchronous, single-apartment ASCOM COM surface the transport
-/// replaces (a blocking COM call becomes a blocking loopback round-trip).
+/// replaces (a blocking COM call becomes a blocking pipe round-trip).
 /// </para>
 /// </summary>
 [SupportedOSPlatform("windows")]
@@ -28,81 +33,89 @@ internal sealed class AscomHostProcess : IDisposable
     private static readonly ReadOnlyMemory<byte> CRLF = "\r\n"u8.ToArray();
 
     private readonly Process _process;
-    private readonly TcpClient _tcp;
-    private readonly NetworkStream _stream;
+    private readonly NamedPipeServerStream _pipe;
     private readonly StreamReader _reader;
-    private readonly Lock _gate = new(); // serialize the single-flight request/response on the shared socket; never on a render thread (driver calls are offloaded)
+    private readonly Lock _gate = new(); // serialize the single-flight request/response on the shared pipe; never on a render thread (driver calls are offloaded)
     private long _id;
     private bool _disposed;
 
-    private AscomHostProcess(Process process, TcpClient tcp)
+    private AscomHostProcess(Process process, NamedPipeServerStream pipe)
     {
         _process = process;
-        _tcp = tcp;
-        _stream = tcp.GetStream();
-        _reader = new StreamReader(_stream);
+        _pipe = pipe;
+        _reader = new StreamReader(pipe);
     }
 
     /// <summary>
-    /// Spawns the helper, reads its <c>PORT n</c> handshake line, and connects to the loopback port.
+    /// Creates the server pipe, spawns the helper (passing the pipe name), and waits for it to connect.
     /// Assigns the child to the kill-on-close job so it can't orphan us.
     /// </summary>
-    public static AscomHostProcess Spawn(string exePath, TimeSpan handshakeTimeout)
+    public static AscomHostProcess Spawn(string exePath, TimeSpan connectTimeout)
     {
-        var process = new Process
-        {
-            StartInfo = new ProcessStartInfo(exePath)
-            {
-                UseShellExecute = false,
-                RedirectStandardOutput = true,
-                RedirectStandardError = true,
-                CreateNoWindow = true,
-            },
-        };
-        process.Start();
-
+        var pipeName = $"tianwen-ascomhost-{Guid.NewGuid():N}";
+        var pipe = new NamedPipeServerStream(
+            pipeName, PipeDirection.InOut, 1, PipeTransmissionMode.Byte, PipeOptions.CurrentUserOnly);
+        Process? process = null;
         try
         {
+            process = new Process
+            {
+                StartInfo = new ProcessStartInfo(exePath)
+                {
+                    UseShellExecute = false,
+                    RedirectStandardError = true,
+                    CreateNoWindow = true,
+                },
+            };
+            process.StartInfo.ArgumentList.Add(pipeName);
+            process.Start();
             AscomHostJob.TryAssign(process.Handle);
 
-            // The helper prints "PORT <n>" as its first stdout line once the socket is bound. Bound the
-            // wait so a helper that dies before printing (or hangs) doesn't block the caller forever.
-            var handshake = ReadHandshake(process, handshakeTimeout);
-            if (handshake is null || !handshake.StartsWith("PORT ", StringComparison.Ordinal)
-                || !int.TryParse(handshake.AsSpan("PORT ".Length), out var port))
+            if (!WaitForConnection(pipe, connectTimeout))
             {
                 var stderr = process.StandardError.ReadToEnd();
-                throw new IOException($"ASCOM host did not report a port (got '{handshake}'). stderr: {stderr}");
+                throw new IOException($"ASCOM host did not connect to pipe '{pipeName}' within {connectTimeout}. stderr: {stderr}");
             }
 
-            var tcp = new TcpClient();
-            tcp.Connect(IPAddress.Loopback, port);
-            return new AscomHostProcess(process, tcp);
+            return new AscomHostProcess(process, pipe);
         }
         catch
         {
-            TryKill(process);
-            process.Dispose();
+            pipe.Dispose(); // unblocks the accept thread if it is still waiting
+            if (process is not null)
+            {
+                TryKill(process);
+                process.Dispose();
+            }
             throw;
         }
     }
 
-    private static string? ReadHandshake(Process process, TimeSpan timeout)
+    private static bool WaitForConnection(NamedPipeServerStream pipe, TimeSpan timeout)
     {
-        // ReadLineAsync().Wait(timeout) would leak the read; instead read on a background thread and
-        // bound the wait. The helper prints the line within milliseconds of a successful start.
-        string? line = null;
+        // WaitForConnection has no timeout overload; run it on a background thread and bound the wait so
+        // a helper that dies before connecting (or hangs) can't block the caller forever.
+        var connected = false;
         var done = new ManualResetEventSlim(false);
         var thread = new Thread(() =>
         {
-            try { line = process.StandardOutput.ReadLine(); }
-            catch { /* process died; line stays null */ }
-            finally { done.Set(); }
+            try
+            {
+                pipe.WaitForConnection();
+                connected = true;
+            }
+            catch
+            {
+                // pipe disposed / connection failed; connected stays false
+            }
+            finally
+            {
+                done.Set();
+            }
         })
-        { IsBackground = true, Name = "ascomhost-handshake" };
+        { IsBackground = true, Name = "ascomhost-pipe-accept" };
         thread.Start();
-        done.Wait(timeout);
-        return line;
+        return done.Wait(timeout) && connected;
     }
 
     /// <summary>
@@ -165,9 +178,9 @@ internal sealed class AscomHostProcess : IDisposable
 
     private void WriteLine(ReadOnlyMemory<byte> jsonUtf8)
     {
-        _stream.Write(jsonUtf8.Span);
-        _stream.Write(CRLF.Span);
-        _stream.Flush();
+        _pipe.Write(jsonUtf8.Span);
+        _pipe.Write(CRLF.Span);
+        _pipe.Flush();
     }
 
     public void Dispose()
@@ -181,10 +194,10 @@ internal sealed class AscomHostProcess : IDisposable
             _disposed = true;
         }
 
-        // Closing the socket makes the helper's server loop see EOF and exit; the job object + explicit
+        // Disposing the pipe makes the helper's serve loop see EOF and exit; the job object + explicit
         // kill are the backstops.
         try { _reader.Dispose(); } catch { /* ignore */ }
-        try { _tcp.Dispose(); } catch { /* ignore */ }
+        try { _pipe.Dispose(); } catch { /* ignore */ }
         TryKill(_process);
         _process.Dispose();
     }

--- a/src/TianWen.Lib/Devices/Ascom/ComInterop/DispatchObject.cs
+++ b/src/TianWen.Lib/Devices/Ascom/ComInterop/DispatchObject.cs
@@ -11,7 +11,7 @@ namespace TianWen.Lib.Devices.Ascom.ComInterop;
 /// Uses raw vtable function pointers — no reflection, no dynamic, no Type.InvokeMember.
 /// </summary>
 [SupportedOSPlatform("windows")]
-internal sealed unsafe class DispatchObject : IDisposable
+internal sealed unsafe class DispatchObject : IDispatchTransport
 {
     private nint _pDispatch;
     private readonly Dictionary<string, int> _dispIdCache = new(StringComparer.OrdinalIgnoreCase);
@@ -249,7 +249,7 @@ internal sealed unsafe class DispatchObject : IDisposable
     /// Invokes a method that returns an IDispatch object (e.g. <c>AxisRates(axis)</c> → <c>IAxisRates</c>).
     /// Returns a new <see cref="DispatchObject"/> wrapping the sub-dispatch; the caller owns and must dispose it.
     /// </summary>
-    public DispatchObject InvokeMethodDispatch(string name, params object[] args)
+    public IDispatchTransport InvokeMethodDispatch(string name, params object[] args)
     {
         var variants = ArgsToVariants(args);
         try
@@ -268,7 +268,7 @@ internal sealed unsafe class DispatchObject : IDisposable
     /// Reads a parameterized property that returns an IDispatch object (e.g. <c>Item(index)</c> on an
     /// ASCOM collection → <c>IRate</c>). Collection default properties use <see cref="NativeMethods.DISPATCH_PROPERTYGET"/>.
     /// </summary>
-    public DispatchObject GetPropertyDispatch(string name, params object[] args)
+    public IDispatchTransport GetPropertyDispatch(string name, params object[] args)
     {
         var variants = ArgsToVariants(args);
         try

--- a/src/TianWen.Lib/Devices/Ascom/ComInterop/DispatchTransportFactory.cs
+++ b/src/TianWen.Lib/Devices/Ascom/ComInterop/DispatchTransportFactory.cs
@@ -1,0 +1,104 @@
+using Microsoft.Extensions.Logging;
+using System;
+using System.IO;
+using System.Runtime.Versioning;
+
+namespace TianWen.Lib.Devices.Ascom.ComInterop;
+
+/// <summary>
+/// Builds the right <see cref="IDispatchTransport"/> for an ASCOM ProgID: an out-of-process
+/// <see cref="RemoteDispatchTransport"/> for CET-incompatible in-proc .NET Framework drivers
+/// (<see cref="AscomComServerClassifier"/>), or an in-proc <see cref="DispatchObject"/> for everything
+/// else. If a driver needs the helper but it can't be found/started, falls back to in-proc with a warning
+/// (the pre-Phase-4 behaviour — which may fastfail on connect, but is no worse than before).
+/// </summary>
+[SupportedOSPlatform("windows")]
+internal static class DispatchTransportFactory
+{
+    private const string HelperExeName = "tianwen-ascomhost.exe";
+
+    // The connect-path DoEvents busy-spin runs on the helper; give the handshake generous headroom.
+    private static readonly TimeSpan HandshakeTimeout = TimeSpan.FromSeconds(10);
+
+    public static IDispatchTransport Create(string progId, IServiceProvider? serviceProvider)
+    {
+        var logger = (serviceProvider?.GetService(typeof(ILoggerFactory)) as ILoggerFactory)
+            ?.CreateLogger("TianWen.Lib.Devices.Ascom.ComInterop.DispatchTransportFactory");
+
+        if (AscomComServerClassifier.RequiresOutOfProcessHost(progId, out var reason))
+        {
+            if (TryLocateHelper(out var exePath))
+            {
+                try
+                {
+                    var transport = RemoteDispatchTransport.Create(exePath, progId, HandshakeTimeout);
+                    logger?.LogInformation(
+                        "ASCOM {ProgId} hosted out-of-process ({Reason}) via {Exe}.", progId, reason, exePath);
+                    return transport;
+                }
+                catch (Exception ex)
+                {
+                    logger?.LogError(ex,
+                        "Failed to start the out-of-process ASCOM host for {ProgId} ({Reason}); falling back to in-proc (may fastfail on connect).",
+                        progId, reason);
+                }
+            }
+            else
+            {
+                logger?.LogWarning(
+                    "ASCOM {ProgId} needs the out-of-process host ({Reason}) but {Exe} was not found (set TIANWEN_ASCOMHOST or ship it beside the app); falling back to in-proc (may fastfail on connect).",
+                    progId, reason, HelperExeName);
+            }
+        }
+        else
+        {
+            logger?.LogDebug("ASCOM {ProgId} runs in-proc ({Reason}).", progId, reason);
+        }
+
+        return new DispatchObject(progId);
+    }
+
+    /// <summary>
+    /// Resolves the helper exe: explicit <c>TIANWEN_ASCOMHOST</c> override, then beside the running app
+    /// (production layout), then the sibling build output (dev/test layout).
+    /// </summary>
+    internal static bool TryLocateHelper(out string exePath)
+    {
+        var overridePath = Environment.GetEnvironmentVariable("TIANWEN_ASCOMHOST");
+        if (!string.IsNullOrWhiteSpace(overridePath) && File.Exists(overridePath))
+        {
+            exePath = overridePath;
+            return true;
+        }
+
+        var beside = Path.Combine(AppContext.BaseDirectory, HelperExeName);
+        if (File.Exists(beside))
+        {
+            exePath = beside;
+            return true;
+        }
+
+        // Dev/test: walk up to the solution root and into TianWen.AscomHost's build output for the same
+        // configuration as the running assembly.
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null && !File.Exists(Path.Combine(dir.FullName, "TianWen.slnx")))
+        {
+            dir = dir.Parent;
+        }
+        if (dir is not null)
+        {
+            var config = AppContext.BaseDirectory.Contains($"{Path.DirectorySeparatorChar}Release{Path.DirectorySeparatorChar}", StringComparison.OrdinalIgnoreCase)
+                ? "Release"
+                : "Debug";
+            var devPath = Path.Combine(dir.FullName, "TianWen.AscomHost", "bin", config, "net10.0-windows", HelperExeName);
+            if (File.Exists(devPath))
+            {
+                exePath = devPath;
+                return true;
+            }
+        }
+
+        exePath = string.Empty;
+        return false;
+    }
+}

--- a/src/TianWen.Lib/Devices/Ascom/ComInterop/IDispatchTransport.cs
+++ b/src/TianWen.Lib/Devices/Ascom/ComInterop/IDispatchTransport.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Runtime.Versioning;
+
+namespace TianWen.Lib.Devices.Ascom.ComInterop;
+
+/// <summary>
+/// The seam between an ASCOM dispatch wrapper and the COM object it drives. Two implementations:
+/// <list type="bullet">
+///   <item><see cref="DispatchObject"/> -- the in-proc raw-vtable IDispatch call (the local transport,
+///     used for every driver that is CET-safe: native in-proc, comhost, or out-of-proc
+///     <c>LocalServer32</c>).</item>
+///   <item><see cref="RemoteDispatchTransport"/> -- the same typed surface projected over JSON-RPC to a
+///     CET-off out-of-process host (<c>tianwen-ascomhost</c>), used only for the CET-incompatible
+///     in-proc .NET Framework drivers (<c>InprocServer32 = mscoree.dll</c>) that otherwise fastfail our
+///     CET-on process on connect (0xC0000409). See <see cref="AscomComServerClassifier"/> +
+///     docs/plans/ascom-oop-host.md.</item>
+/// </list>
+/// The surface mirrors <see cref="DispatchObject"/> exactly, so the <c>[DispatchInterface]</c>
+/// source generator and every hand-written wrapper are transport-agnostic -- they hold an
+/// <see cref="IDispatchTransport"/> field and never know which side of the CET boundary the driver is on.
+/// </summary>
+[SupportedOSPlatform("windows")]
+internal interface IDispatchTransport : IDisposable
+{
+    bool GetBool(string name);
+    int GetInt(string name);
+    short GetShort(string name);
+    double GetDouble(string name);
+    string GetString(string name);
+    DateTime GetDateTime(string name);
+    string[] GetStringArray(string name);
+    int[] GetIntArray(string name);
+    int[,] GetInt2DArray(string name);
+    object? GetObject(string name);
+
+    void Set(string name, bool value);
+    void Set(string name, int value);
+    void Set(string name, short value);
+    void Set(string name, double value);
+    void Set(string name, string value);
+    void Set(string name, DateTime value);
+
+    void InvokeMethod(string name);
+    void InvokeMethod(string name, params object[] args);
+    bool InvokeMethodBool(string name, params object[] args);
+    int InvokeMethodInt(string name, params object[] args);
+    double InvokeMethodDouble(string name, params object[] args);
+    object? InvokeMethodObject(string name, params object[] args);
+
+    /// <summary>Invokes a method returning an IDispatch sub-object (e.g. telescope <c>AxisRates(axis)</c>).
+    /// The caller owns and must dispose the returned transport.</summary>
+    IDispatchTransport InvokeMethodDispatch(string name, params object[] args);
+
+    /// <summary>Reads a parameterized property returning an IDispatch sub-object (e.g. an ASCOM
+    /// collection's <c>Item(index)</c>). The caller owns and must dispose the returned transport.</summary>
+    IDispatchTransport GetPropertyDispatch(string name, params object[] args);
+}

--- a/src/TianWen.Lib/Devices/Ascom/ComInterop/RemoteDispatchTransport.cs
+++ b/src/TianWen.Lib/Devices/Ascom/ComInterop/RemoteDispatchTransport.cs
@@ -1,0 +1,220 @@
+using System;
+using System.Globalization;
+using System.Runtime.Versioning;
+using System.Text.Json;
+
+namespace TianWen.Lib.Devices.Ascom.ComInterop;
+
+/// <summary>
+/// An <see cref="IDispatchTransport"/> that drives a COM object living in an out-of-process CET-off
+/// <c>tianwen-ascomhost</c> helper. Each typed call is projected onto the helper's JSON-RPC vocabulary
+/// (<c>get*</c>/<c>set*</c>/<c>invoke*</c>, keyed by an object handle) — the mechanical mirror of
+/// <see cref="AscomComHost"/>'s handler. Used only for CET-incompatible in-proc .NET Framework drivers
+/// (see <see cref="AscomComServerClassifier"/>); every other driver uses <see cref="DispatchObject"/>
+/// in-proc. See docs/plans/ascom-oop-host.md.
+/// </summary>
+[SupportedOSPlatform("windows")]
+internal sealed class RemoteDispatchTransport : IDispatchTransport
+{
+    private readonly AscomHostProcess _host;
+    private readonly int _handle;
+    private bool _disposed;
+
+    private RemoteDispatchTransport(AscomHostProcess host, int handle)
+    {
+        _host = host;
+        _handle = handle;
+    }
+
+    /// <summary>Spawns the helper, connects, and creates the COM object for <paramref name="progId"/>.</summary>
+    public static RemoteDispatchTransport Create(string exePath, string progId, TimeSpan handshakeTimeout)
+    {
+        var host = AscomHostProcess.Spawn(exePath, handshakeTimeout);
+        try
+        {
+            int handle;
+            using (var response = host.Call("create", w =>
+            {
+                w.WriteStartArray();
+                w.WriteStringValue(progId);
+                w.WriteEndArray();
+            }))
+            {
+                handle = response.RootElement.GetProperty("result").GetInt32();
+            }
+            return new RemoteDispatchTransport(host, handle);
+        }
+        catch
+        {
+            host.Dispose();
+            throw;
+        }
+    }
+
+    // ---- getters ----
+    public bool GetBool(string name) => Scalar("getBool", name, static r => r.GetBoolean());
+    public int GetInt(string name) => Scalar("getInt", name, static r => r.GetInt32());
+    public short GetShort(string name) => Scalar("getShort", name, static r => r.GetInt16());
+    public double GetDouble(string name) => Scalar("getDouble", name, static r => r.GetDouble());
+    public string GetString(string name) => Scalar("getString", name, static r => r.GetString() ?? string.Empty);
+    public DateTime GetDateTime(string name) => Scalar("getDateTime", name,
+        static r => DateTime.Parse(r.GetString() ?? string.Empty, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind));
+
+    public string[] GetStringArray(string name) => Scalar("getStringArray", name, static r =>
+    {
+        var arr = new string[r.GetArrayLength()];
+        var i = 0;
+        foreach (var e in r.EnumerateArray())
+        {
+            arr[i++] = e.GetString() ?? string.Empty;
+        }
+        return arr;
+    });
+
+    public int[] GetIntArray(string name) => Scalar("getIntArray", name, static r =>
+    {
+        var arr = new int[r.GetArrayLength()];
+        var i = 0;
+        foreach (var e in r.EnumerateArray())
+        {
+            arr[i++] = e.GetInt32();
+        }
+        return arr;
+    });
+
+    public int[,] GetInt2DArray(string name) => Scalar("getInt2DArray", name, static r =>
+    {
+        var rows = r.GetArrayLength();
+        var cols = rows > 0 ? r[0].GetArrayLength() : 0;
+        var arr = new int[rows, cols];
+        var i = 0;
+        foreach (var row in r.EnumerateArray())
+        {
+            var j = 0;
+            foreach (var cell in row.EnumerateArray())
+            {
+                arr[i, j++] = cell.GetInt32();
+            }
+            i++;
+        }
+        return arr;
+    });
+
+    public object? GetObject(string name)
+        => throw new NotSupportedException($"Reading opaque VARIANT property '{name}' over the out-of-process ASCOM host is not supported.");
+
+    // ---- setters ----
+    public void Set(string name, bool value) => SetValue("setBool", name, w => w.WriteBooleanValue(value));
+    public void Set(string name, int value) => SetValue("setInt", name, w => w.WriteNumberValue(value));
+    public void Set(string name, short value) => SetValue("setShort", name, w => w.WriteNumberValue(value));
+    public void Set(string name, double value) => SetValue("setDouble", name, w => w.WriteNumberValue(value));
+    public void Set(string name, string value) => SetValue("setString", name, w => w.WriteStringValue(value));
+    public void Set(string name, DateTime value) => SetValue("setDateTime", name, w => w.WriteStringValue(value.ToString("o", CultureInfo.InvariantCulture)));
+
+    // ---- invokes ----
+    public void InvokeMethod(string name) => Invoke("invoke", name, []).Dispose();
+    public void InvokeMethod(string name, params object[] args) => Invoke("invoke", name, args).Dispose();
+    public bool InvokeMethodBool(string name, params object[] args) => Invoke("invokeBool", name, args).ReadResult(static r => r.GetBoolean());
+    public int InvokeMethodInt(string name, params object[] args) => Invoke("invokeInt", name, args).ReadResult(static r => r.GetInt32());
+    public double InvokeMethodDouble(string name, params object[] args) => Invoke("invokeDouble", name, args).ReadResult(static r => r.GetDouble());
+
+    public object? InvokeMethodObject(string name, params object[] args)
+        => throw new NotSupportedException($"Invoking '{name}' with an opaque VARIANT return over the out-of-process ASCOM host is not supported.");
+
+    // Sub-dispatch (telescope AxisRates / collection Item) needs handle-returning support in the helper,
+    // deferred to the Phase 5 mount generalization. No crash-cluster device (cover/focuser/FW/switch) uses it.
+    public IDispatchTransport InvokeMethodDispatch(string name, params object[] args)
+        => throw new NotSupportedException($"Sub-dispatch method '{name}' over the out-of-process ASCOM host is not yet supported (Phase 5).");
+
+    public IDispatchTransport GetPropertyDispatch(string name, params object[] args)
+        => throw new NotSupportedException($"Sub-dispatch property '{name}' over the out-of-process ASCOM host is not yet supported (Phase 5).");
+
+    private T Scalar<T>(string method, string name, Func<JsonElement, T> read)
+    {
+        using var response = _host.Call(method, w => WriteHandleName(w, name));
+        return read(response.RootElement.GetProperty("result"));
+    }
+
+    private void SetValue(string method, string name, Action<Utf8JsonWriter> writeValue)
+    {
+        using var response = _host.Call(method, w =>
+        {
+            w.WriteStartArray();
+            w.WriteNumberValue(_handle);
+            w.WriteStringValue(name);
+            writeValue(w);
+            w.WriteEndArray();
+        });
+    }
+
+    private JsonDocument Invoke(string method, string name, object[] args) => _host.Call(method, w =>
+    {
+        w.WriteStartArray();
+        w.WriteNumberValue(_handle);
+        w.WriteStringValue(name);
+        foreach (var arg in args)
+        {
+            WriteArg(w, arg);
+        }
+        w.WriteEndArray();
+    });
+
+    private void WriteHandleName(Utf8JsonWriter w, string name)
+    {
+        w.WriteStartArray();
+        w.WriteNumberValue(_handle);
+        w.WriteStringValue(name);
+        w.WriteEndArray();
+    }
+
+    private static void WriteArg(Utf8JsonWriter w, object arg)
+    {
+        switch (arg)
+        {
+            case bool b: w.WriteBooleanValue(b); break;
+            case int n: w.WriteNumberValue(n); break;
+            case short s: w.WriteNumberValue(s); break;
+            case double d: w.WriteNumberValue(d); break;
+            case string str: w.WriteStringValue(str); break;
+            case DateTime dt: w.WriteStringValue(dt.ToString("o", CultureInfo.InvariantCulture)); break;
+            default: throw new ArgumentException($"Unsupported ASCOM argument type: {arg?.GetType()}");
+        }
+    }
+
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+        _disposed = true;
+
+        try
+        {
+            using (_host.Call("release", w =>
+            {
+                w.WriteStartArray();
+                w.WriteNumberValue(_handle);
+                w.WriteEndArray();
+            })) { }
+        }
+        catch
+        {
+            // host may already be gone; the host dispose below kills it regardless
+        }
+
+        _host.Dispose();
+    }
+}
+
+file static class RemoteDispatchExtensions
+{
+    // Reads the "result" of a call document and disposes it in one expression.
+    public static T ReadResult<T>(this JsonDocument document, Func<JsonElement, T> read)
+    {
+        using (document)
+        {
+            return read(document.RootElement.GetProperty("result"));
+        }
+    }
+}

--- a/src/TianWen.Lib/Devices/DeviceDiscovery.cs
+++ b/src/TianWen.Lib/Devices/DeviceDiscovery.cs
@@ -95,7 +95,8 @@ internal class DeviceDiscovery(
 
     public IEnumerable<DeviceType> RegisteredDeviceTypes => _supportedSources.SelectMany(s => s.RegisteredDeviceTypes).ToHashSet();
 
-    public IEnumerable<DeviceBase> RegisteredDevices(DeviceType type) => _supportedSources.SelectMany(s => s.RegisteredDevices(type));
+    public IEnumerable<DeviceBase> RegisteredDevices(DeviceType type)
+        => NativeDriverBlacklist.FilterSuperseded(_supportedSources.SelectMany(s => s.RegisteredDevices(type)), logger);
 
     public async ValueTask DiscoverOnlyDeviceType(DeviceType type, CancellationToken cancellationToken)
     {

--- a/src/TianWen.Lib/Devices/NativeDriverBlacklist.cs
+++ b/src/TianWen.Lib/Devices/NativeDriverBlacklist.cs
@@ -1,0 +1,96 @@
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+
+namespace TianWen.Lib.Devices;
+
+/// <summary>
+/// Hides ASCOM COM drivers for which TianWen ships a first-class native backend, so a discovery picker
+/// offers exactly one entry per physical device instead of the native driver plus its redundant (often
+/// buggier) ASCOM twin. The motivating case is the Gemini FlatPanel Lite: its ASCOM driver both
+/// CET-crashes an in-proc host and stores its COM port in a per-process <c>user.config</c> (so it
+/// silently fails to connect from any host that did not configure it) -- the native serial backend has
+/// neither problem.
+/// <para>
+/// The hide is <b>conditional on native availability</b>: an ASCOM ProgID is dropped only when the
+/// discovery pass actually surfaced a native device of the superseding family (matched by
+/// <see cref="DeviceBase.DeviceClass"/>, the URI host). If the native SDK can't load or no device is
+/// present, no native device is discovered and the ASCOM twin passes through as the fallback -- the user
+/// is never left with no driver.
+/// </para>
+/// <para>
+/// The correlation is pure data (ASCOM ProgID -&gt; native <see cref="DeviceBase.DeviceClass"/>) matched
+/// against the already-discovered devices, so no device family references another and the ASCOM subsystem
+/// depends on nothing here. ProgID matching is exact + case-insensitive; an unknown vendor ProgID variant
+/// is simply not hidden (a duplicate entry is a safe failure, a missing device is not).
+/// </para>
+/// </summary>
+internal static class NativeDriverBlacklist
+{
+    // ASCOM ProgID -> DeviceClass (URI host, == the native device type name) of the family that supersedes
+    // it. Only vendors whose native driver is a genuine, complete replacement for the SAME device type are
+    // listed. Deliberately excluded: ASCOM.GeminiFocuserPro (a different Gemini product, not natively
+    // implemented) and the mount drivers (ASCOM.iOptron2017/OnStep/SkyWatcher), whose native equivalents
+    // cover only a vendor subset -- e.g. native iOptron is the SkyGuider Pro, not the CEM/GEM/HEM range
+    // ASCOM.iOptron2017.Telescope drives -- so hiding them would remove mounts we cannot otherwise control.
+    private static readonly IReadOnlyDictionary<string, string> _nativeClassByProgId =
+        new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            // Gemini FlatPanel Lite -- native serial cover/calibrator (GeminiDevice, AddGemini).
+            ["ASCOM.GeminiFPLite.CoverCalibrator"] = "GeminiDevice",
+
+            // ZWO ASI camera / EAF focuser / EFW filter wheel -- native ZWO SDK (ZWODevice, AddZWO).
+            ["ASCOM.ASICamera2.Camera"] = "ZWODevice",
+            ["ASCOM.ASICamera2_2.Camera"] = "ZWODevice",
+            ["ASCOM.EAF.Focuser"] = "ZWODevice",
+            ["ASCOM.EAF_2.Focuser"] = "ZWODevice",
+            ["ASCOM.EFW2.FilterWheel"] = "ZWODevice",
+            ["ASCOM.EFW2_2.FilterWheel"] = "ZWODevice",
+
+            // QHYCCD camera / filter wheel / focuser -- native QHYCCD SDK (QHYDevice, AddQHY).
+            ["ASCOM.QHYCCD.Camera"] = "QHYDevice",
+            ["ASCOM.QHYCCD_CAM2.Camera"] = "QHYDevice",
+            ["ASCOM.QHYCCD_GUIDER.Camera"] = "QHYDevice",
+            ["ASCOM.QHYCFW.FilterWheel"] = "QHYDevice",
+            ["ASCOM.QHYCFW2st.FilterWheel"] = "QHYDevice",
+            ["ASCOM.QHYFWRS232.FilterWheel"] = "QHYDevice",
+            ["ASCOM.qfoc.Focuser"] = "QHYDevice",
+        };
+
+    /// <summary>Looks up the native <see cref="DeviceBase.DeviceClass"/> that supersedes an ASCOM ProgID, if any.</summary>
+    public static bool TryGetNativeClass(string progId, out string nativeClass)
+        => _nativeClassByProgId.TryGetValue(progId, out nativeClass!);
+
+    /// <summary>
+    /// Filters <paramref name="devices"/> (the discovered devices of a single <see cref="DeviceType"/>),
+    /// dropping any ASCOM driver whose ProgID is superseded by a native family that is also present in the
+    /// same set. Everything else passes through unchanged.
+    /// </summary>
+    public static IEnumerable<DeviceBase> FilterSuperseded(IEnumerable<DeviceBase> devices, ILogger logger)
+    {
+        // Two passes over a single-type list (small): collect the DeviceClasses actually discovered, then
+        // drop ASCOM twins whose superseding native family is among them. A native device's DeviceClass is
+        // never itself a blacklisted ASCOM ProgID, so recording all classes can't cause a false hide.
+        // DeviceClass comes from Uri.Host, which URI normalisation lower-cases ("ZWODevice" -> "zwodevice"),
+        // so the mapped native class ("ZWODevice") must be matched case-insensitively.
+        var materialized = devices as IReadOnlyList<DeviceBase> ?? [.. devices];
+        var classesPresent = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var device in materialized)
+        {
+            classesPresent.Add(device.DeviceClass);
+        }
+
+        foreach (var device in materialized)
+        {
+            if (_nativeClassByProgId.TryGetValue(device.DeviceId, out var nativeClass)
+                && classesPresent.Contains(nativeClass))
+            {
+                logger.LogDebug("Hiding ASCOM driver {ProgId} from discovery; superseded by discovered native {NativeClass}.",
+                    device.DeviceId, nativeClass);
+                continue;
+            }
+
+            yield return device;
+        }
+    }
+}

--- a/src/TianWen.Lib/Devices/OpenPHD2/OpenPHD2GuiderDriver.cs
+++ b/src/TianWen.Lib/Devices/OpenPHD2/OpenPHD2GuiderDriver.cs
@@ -44,11 +44,12 @@ namespace TianWen.Lib.Devices.OpenPHD2;
 
 internal class OpenPHD2GuiderDriver : IGuider, IDeviceSource<OpenPHD2GuiderDevice>
 {
-    private readonly ConcurrentDictionary<long, JsonDocument> _responses = [];
     private readonly OpenPHD2GuiderDevice _guiderDevice;
     private readonly SemaphoreSlim _sync = new(1, 1);
-    private readonly AsyncManualResetEvent _receiveResponseSignal = new(false);
     private IUtf8TextBasedConnection? _connection;
+    // JSON-RPC id-correlation + the receive loop now live in the shared JsonRpcClient; this driver
+    // supplies only the PHD2-specific concerns (event handling, param serialization, error wrapping).
+    private JsonRpcClient? _rpcClient;
     private string? _selectedProfileName;
     private List<OpenPHD2GuiderDevice> _equipmentProfiles = [];
     private CancellationTokenSource _cts = new();
@@ -132,82 +133,6 @@ internal class OpenPHD2GuiderDriver : IGuider, IDeviceSource<OpenPHD2GuiderDevic
     /// <param name="deviceType"></param>
     /// <returns></returns>
     public IEnumerable<OpenPHD2GuiderDevice> RegisteredDevices(DeviceType deviceType) => deviceType is DeviceType.Guider ? _equipmentProfiles : [];
-
-    private async Task ReceiveMessagesAsync(CancellationToken cancellationToken)
-    {
-        string? line = null;
-        try
-        {
-            while (_connection is { } connection && !cancellationToken.IsCancellationRequested)
-            {
-                try
-                {
-                    line = await connection.ReadLineAsync(cancellationToken).ConfigureAwait(false);
-                }
-                catch (OperationCanceledException oce) when (oce.CancellationToken.IsCancellationRequested)
-                {
-                    // cancellation requested
-                    break;
-                }
-                catch (Exception ex)
-                {
-                    OnGuidingErrorEvent(new GuidingErrorEventArgs(ActiveGuiderDevice, $"Error {ex.Message} while reading from input stream", ex));
-                    // use recovery logic
-                }
-
-                if (line == null)
-                {
-                    // phd2 disconnected
-                    // todo: re-connect (?)
-                    break;
-                }
-
-                JsonDocument j;
-                try
-                {
-                    j = JsonDocument.Parse(line);
-                }
-                catch (JsonException ex)
-                {
-                    OnGuidingErrorEvent(new GuidingErrorEventArgs(
-                        ActiveGuiderDevice,
-                        $"ignoring invalid json from server: {ex.Message}: {line}",
-                        ex
-                    ));
-                    continue;
-                }
-
-                if (j.RootElement.TryGetProperty("jsonrpc", out var _)
-                    && j.RootElement.TryGetProperty("id", out var idProp)
-                    && idProp.ValueKind is JsonValueKind.Number
-                    && idProp.TryGetInt32(out var id)
-                )
-                {
-                    _ = _responses.AddOrUpdate(id, j,
-                        (_, old) =>
-                        {
-                            old.Dispose();
-                            return j;
-                        }
-                    );
-
-                    _receiveResponseSignal.Set(true);
-                }
-                else
-                {
-                    await HandleEventAsync(j, cancellationToken);
-                }
-            }
-        }
-        catch (Exception ex)
-        {
-            OnGuidingErrorEvent(new GuidingErrorEventArgs(ActiveGuiderDevice, $"caught exception in worker thread while processing: {line}: {ex.Message}", ex));
-        }
-        finally
-        {
-            Interlocked.Exchange(ref _connection, null)?.Dispose();
-        }
-    }
 
     private async ValueTask HandleEventAsync(JsonDocument @event, CancellationToken cancellationToken = default)
     {
@@ -340,81 +265,65 @@ internal class OpenPHD2GuiderDriver : IGuider, IDeviceSource<OpenPHD2GuiderDevic
         OnGuiderStateChangedEvent(new GuiderStateChangedEventArgs(ActiveGuiderDevice, eventName ?? "Unknown", newAppState ?? "Unknown"));
     }
 
-    static long MessageId = 0;
-
-    static long MakeJsonRPCCall(IBufferWriter<byte> buffer, string method, params object[] @params)
+    // PHD2 parameter serialization (array form: primitives, null, and the SettleRequest object),
+    // lifted verbatim from the old MakeJsonRPCCall. The JSON-RPC envelope (method/id) and response
+    // correlation are now the shared JsonRpcClient's job; this writes only the `params` value.
+    static void WriteParams(Utf8JsonWriter req, object[] @params)
     {
-        using var req = new Utf8JsonWriter(buffer, new JsonWriterOptions { Indented = false });
-        var id = Interlocked.Increment(ref MessageId);
-
-        req.WriteStartObject();
-        req.WriteString("method", method);
-        req.WriteNumber("id", id);
-
-        if (@params is { Length: > 0 })
+        req.WriteStartArray();
+        foreach (var param in @params)
         {
-            req.WritePropertyName("params");
-
-            req.WriteStartArray();
-            foreach (var param in @params)
+            if (param is null)
             {
-                if (param is null)
+                req.WriteNullValue();
+            }
+            else
+            {
+                var typeCode = Type.GetTypeCode(param.GetType());
+                switch (typeCode)
                 {
-                    req.WriteNullValue();
-                }
-                else
-                {
-                    var typeCode = Type.GetTypeCode(param.GetType());
-                    switch (typeCode)
-                    {
-                        case TypeCode.Boolean:
-                            req.WriteBooleanValue((bool)param);
-                            break;
+                    case TypeCode.Boolean:
+                        req.WriteBooleanValue((bool)param);
+                        break;
 
-                        case TypeCode.Int32:
-                            req.WriteNumberValue((int)param);
-                            break;
+                    case TypeCode.Int32:
+                        req.WriteNumberValue((int)param);
+                        break;
 
-                        case TypeCode.Int64:
-                            req.WriteNumberValue((long)param);
-                            break;
+                    case TypeCode.Int64:
+                        req.WriteNumberValue((long)param);
+                        break;
 
-                        case TypeCode.Single:
-                            req.WriteNumberValue((float)param);
-                            break;
+                    case TypeCode.Single:
+                        req.WriteNumberValue((float)param);
+                        break;
 
-                        case TypeCode.Double:
-                            req.WriteNumberValue((double)param);
-                            break;
+                    case TypeCode.Double:
+                        req.WriteNumberValue((double)param);
+                        break;
 
-                        case TypeCode.Object:
-                            if (param is SettleRequest settleRequest)
-                            {
-                                req.WriteStartObject();
-                                req.WriteNumber("pixels", settleRequest.Pixels);
-                                req.WriteNumber("time", settleRequest.Time);
-                                req.WriteNumber("timeout", settleRequest.Timeout);
-                                req.WriteEndObject();
-                            }
-                            else
-                            {
-                                throw new ArgumentException($"Param {param} of type {param.GetType()} which is an object is not handled", nameof(@params));
-                            }
-                            break;
+                    case TypeCode.Object:
+                        if (param is SettleRequest settleRequest)
+                        {
+                            req.WriteStartObject();
+                            req.WriteNumber("pixels", settleRequest.Pixels);
+                            req.WriteNumber("time", settleRequest.Time);
+                            req.WriteNumber("timeout", settleRequest.Timeout);
+                            req.WriteEndObject();
+                        }
+                        else
+                        {
+                            throw new ArgumentException($"Param {param} of type {param.GetType()} which is an object is not handled", nameof(@params));
+                        }
+                        break;
 
-                        default:
-                            throw new ArgumentException($"Param {param} of type {param.GetType()} which is type code {typeCode} is not handled", nameof(@params));
-                    }
+                    default:
+                        throw new ArgumentException($"Param {param} of type {param.GetType()} which is type code {typeCode} is not handled", nameof(@params));
                 }
             }
-            req.WriteEndArray();
         }
-
-        req.WriteEndObject();
-        return id;
+        req.WriteEndArray();
     }
-
-    static bool IsFailedResponse(JsonDocument response) => response.RootElement.TryGetProperty("error", out _);
 
     public void Dispose()
     {
@@ -427,6 +336,7 @@ internal class OpenPHD2GuiderDriver : IGuider, IDeviceSource<OpenPHD2GuiderDevic
         if (disposing)
         {
             _cts.Dispose();
+            Interlocked.Exchange(ref _rpcClient, null)?.Dispose();
             Interlocked.Exchange(ref _connection, null)?.Dispose();
         }
     }
@@ -474,9 +384,24 @@ internal class OpenPHD2GuiderDriver : IGuider, IDeviceSource<OpenPHD2GuiderDevic
             try
             {
                 Interlocked.Exchange(ref _connection, connection)?.Dispose();
+
+                // The shared JsonRpcClient owns id-correlation + the receive loop over this connection.
+                // PHD2 supplies: notifications -> HandleEventAsync (which then owns/disposes the doc), and
+                // read/parse faults -> a guiding-error event. Reconnect makes a fresh client each time.
+                var rpcClient = new JsonRpcClient(
+                    connection,
+                    onNotification: async (doc, ct) =>
+                    {
+                        try { await HandleEventAsync(doc, ct).ConfigureAwait(false); }
+                        finally { doc.Dispose(); }
+                    },
+                    onError: (ex, context) => OnGuidingErrorEvent(
+                        new GuidingErrorEventArgs(ActiveGuiderDevice, $"Error {ex.Message} while {context}", ex)));
+                Interlocked.Exchange(ref _rpcClient, rpcClient)?.Dispose();
+
                 var cts = new CancellationTokenSource();
                 var oldCts = Interlocked.Exchange(ref _cts, cts);
-                var oldTask = Interlocked.Exchange(ref _receiveTask, ReceiveMessagesAsync(cts.Token));
+                var oldTask = Interlocked.Exchange(ref _receiveTask, rpcClient.ReceiveLoopAsync(cts.Token));
                 try
                 {
                     if (oldTask is { IsCanceled: false })
@@ -507,6 +432,7 @@ internal class OpenPHD2GuiderDriver : IGuider, IDeviceSource<OpenPHD2GuiderDevic
             {
                 oldCts.Dispose();
             }
+            Interlocked.Exchange(ref _rpcClient, null)?.Dispose();
             Interlocked.Exchange(ref _connection, null)?.Dispose();
         }
 
@@ -534,35 +460,23 @@ internal class OpenPHD2GuiderDriver : IGuider, IDeviceSource<OpenPHD2GuiderDevic
     {
         EnsureConnected();
 
-        var buffer = new ArrayBufferWriter<byte>(128);
-        var id = MakeJsonRPCCall(buffer, method, @params);
-
-        // send request
-        if (_connection is not { } connection || !await connection.WriteLineAsync(buffer.WrittenMemory, cancellationToken).ConfigureAwait(false))
+        if (_rpcClient is not { } client)
         {
-            throw new GuiderException($"Failed to send message {method} params: {string.Join(", ", @params)}");
+            throw new GuiderException($"Not connected to {_guiderDevice.DisplayName}; cannot send '{method}'");
         }
 
-        // wait for response
-        JsonDocument? response;
-        while (!_responses.TryRemove(id, out response))
+        try
         {
-            await _receiveResponseSignal.WaitAsync(cancellationToken);
+            return await client.CallAsync(
+                method,
+                @params is { Length: > 0 } ? writer => WriteParams(writer, @params) : null,
+                cancellationToken).ConfigureAwait(false);
         }
-
-        if (IsFailedResponse(response))
+        catch (JsonRpcException ex)
         {
-            throw new GuiderException(
-                (response.RootElement.GetProperty("error").TryGetProperty("message", out var message) ? message.GetString() : null)
-                    ?? "error response did not contain error message");
+            // Preserve the driver's existing exception contract (callers catch GuiderException).
+            throw new GuiderException(ex.Message, ex);
         }
-
-        if (!response.RootElement.TryGetProperty("id", out var responseIdElement) || !responseIdElement.TryGetInt32(out int responseId) || responseId != id)
-        {
-            throw new GuiderException($"Response id was not {id}: {response.RootElement}");
-        }
-
-        return response;
     }
 
     public IEnumerable<DeviceType> RegisteredDeviceTypes => [DriverType];

--- a/src/TianWen.slnx
+++ b/src/TianWen.slnx
@@ -14,6 +14,7 @@
   <Project Path="TianWen.AI/TianWen.AI.csproj" />
   <Project Path="TianWen.AI.Imaging/TianWen.AI.Imaging.csproj" />
   <Project Path="TianWen.AI.MCP/TianWen.AI.MCP.csproj" />
+  <Project Path="TianWen.AscomHost/TianWen.AscomHost.csproj" />
   <Project Path="TianWen.Cli/TianWen.Cli.csproj" />
   <Project Path="TianWen.Hosting/TianWen.Hosting.csproj" />
   <Project Path="TianWen.Server/TianWen.Server.csproj" />


### PR DESCRIPTION
Makes CET-incompatible in-proc .NET Framework ASCOM COM drivers usable from TianWen without the `0xC0000409` (STATUS_STACK_BUFFER_OVERRUN) fastfail crash, and stops offering ASCOM drivers we already reimplement natively.

## The crash (root cause)
A cluster of vendor ASCOM drivers (Gemini FlatPanel Lite, iOptron, DeepSkyDad, …) busy-spin `Application.DoEvents()` in their `Connected=true` setter. The legacy in-proc .NET Framework 4.x CLR they load is **not CET-compatible**, so under our CET-on process the shadow-stack check trips `RtlFailFast` and hard-crashes — no catchable exception. NINA (CET off) connects the same drivers fine. This **supersedes** the earlier STA-message-pump theory, which was the wrong fix.

## The fix — a tiny CET-off out-of-process helper
- **`tianwen-ascomhost`**: AOT-native, `<CETCompat>false</CETCompat>`, hosts the COM object on a dedicated STA thread and exposes `DispatchObject`'s typed surface over JSON-RPC.
- **Transport**: per-user **named pipe** (no network stack / port / firewall involvement); parent owns the server + passes a GUID name as a launch arg (race-free). PHD2 keeps its TCP client.
- **Routing**: `AscomComServerClassifier` sends a driver out-of-process only when its `InprocServer32` is `mscoree.dll`; native/`LocalServer32` drivers stay in-proc. The 8 `AscomXxxDriver` classes are unchanged (`IDispatchTransport` seam). COM `HResult` fidelity is preserved across the wire so the Platform-6 fallback still works.

## Native-driver blacklist (new)
`NativeDriverBlacklist` hides an ASCOM driver from discovery when TianWen ships a native backend for it, so the picker shows one entry per device instead of the native driver plus its buggier ASCOM twin.
- **Conditional on native availability** — hides only when the discovery pass surfaced a native device of the superseding family (matched by `DeviceBase.DeviceClass`); a missing SDK / absent device leaves the ASCOM twin as fallback.
- **Zero coupling** — pure `ProgID → native DeviceClass` data matched in the neutral `DeviceDiscovery` aggregation; no device family references another, no per-source vendor interface. Case-insensitive match (pinned by tests, which caught a `Uri.Host` lower-casing bug).
- **Scope**: Gemini FlatPanel Lite, ZWO ASI/EAF/EFW, QHYCCD cam/CFW/qfoc. Excludes `GeminiFocuserPro` (no native impl) and mounts (native covers only a vendor subset).

## Hardware findings (Phase 5, real Gemini panel on COM3)
- The transport works end to end through the CET-off helper: identity reads, `get_Connected`, `set_Connected` all round-trip. The **survival test passes** — the `DoEvents` busy-spin runs to completion with no fastfail.
- The panel still won't illuminate via the **ASCOM** driver: decompilation shows it connects against `Settings.Default.MyComPort`, a per-host `user.config` setting our helper never wrote → empty port. (The earlier "Connected getter throws" was a diagnostic artifact — `Connecting`, absent on this V1 driver, evaluated first in a log line.) The blacklist is the answer: steer to the native serial `GeminiFlatPanelDriver`, which has neither the CET crash nor the per-host-port bug.

## Tests
- `NativeDriverBlacklistTests` (13) — hidden-when-native-present, kept-as-fallback, non-blacklisted kept, GeminiFocuserPro survives, case-insensitive ProgID/DeviceClass.
- `AscomOutOfProcessConnectTests` (Simulators, gated) — 7/7 real-driver classification + real Gemini survives through the helper.
- Full solution builds clean; fast unit suite green (3 pre-existing `RcAstro*` CLI-environment failures, unrelated — verified by stashing this change).

## Deferred
Mount sub-dispatch (`AxisRates`) over the wire; win-arm64 publish + ship-beside-app; optional `user.config` seeding for other `user.config`-based CET-incompatible drivers.

Plan: `docs/plans/ascom-oop-host.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G75ioQxR7zpmnpd18PbpqT