### PR TITLE
fix(rc-astro): drop --engine flag (renamed to --device in CLI v0.9.x)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -802,8 +802,10 @@ A CPU-first planetary stacker, **completely separate** from the deep-sky `Imagin
   RC-Astro's `.onnx` files are **encrypted at rest** (only the official binary can decrypt them; the
   license forbids extracting the weights), so they are driven through the `rc-astro` CLI's `--json`
   NDJSON protocol, **not** loaded into ORT. `RcAstroEnhancerBase` writes the plate to a temp FITS
-  (`WriteToFitsFile`, BITPIX=-32), runs `rc-astro <product> <in> -o <out> --depth 32F --engine auto
-  --overwrite --json`, parses the NDJSON event stream (`RcAstroCli` + `RcAstroEvent`), and reads the
+  (`WriteToFitsFile`, BITPIX=-32), runs `rc-astro <product> <in> -o <out> --depth 32F --overwrite
+  --json` (compute device left to the CLI default `auto` -- RC-Astro renamed the old `--engine` flag to
+  `--device` in v0.9.x, so we omit it rather than track the name), parses the NDJSON event stream
+  (`RcAstroCli` + `RcAstroEvent`), and reads the
   result back (`TryReadFitsFile`). RC normalises to [0,1] internally, so no rescaling. Role mapping:
   sxt -> `IStarRemover` (default `-o` is the starless plate), nxt -> `IDenoiseEnhancer`
   (noise-adaptive `--dn` from `EstimateNoiseProfile`, log-mapped 0.70-0.95), bxt ->

--- a/src/TianWen.AI.Imaging/RcAstro/IRcAstroCli.cs
+++ b/src/TianWen.AI.Imaging/RcAstro/IRcAstroCli.cs
@@ -34,7 +34,7 @@ namespace TianWen.AI.Imaging.RcAstro
 
         /// <summary>
         /// Runs <c>rc-astro &lt;productKey&gt; &lt;inputPath&gt; -o &lt;outputPath&gt;</c>
-        /// with the shared machine-mode flags (<c>--depth 32F --engine ... --overwrite --json</c>)
+        /// with the shared machine-mode flags (<c>--depth 32F --overwrite --json</c>)
         /// plus <paramref name="extraArgs"/>, streaming progress out of the
         /// NDJSON event stream. Throws <see cref="RcAstroCliException"/> on a
         /// non-zero exit or an <c>error</c> event.

--- a/src/TianWen.AI.Imaging/RcAstro/RcAstroCli.cs
+++ b/src/TianWen.AI.Imaging/RcAstro/RcAstroCli.cs
@@ -26,20 +26,16 @@ namespace TianWen.AI.Imaging.RcAstro
         private const int LicenseProbeTimeoutMs = 15_000;
 
         private readonly ILogger<RcAstroCli>? _logger;
-        private readonly string _engine;
         private readonly ConcurrentDictionary<string, bool> _licenseCache = new();
 
         /// <param name="logger">Optional diagnostics logger.</param>
-        /// <param name="engine">Value for <c>--engine</c>: "auto" (default; resolves
-        /// to GPU/DirectML when available), "dml", or "cpu".</param>
-        public RcAstroCli(ILogger<RcAstroCli>? logger = null, string engine = "auto")
+        public RcAstroCli(ILogger<RcAstroCli>? logger = null)
         {
             _logger = logger;
-            _engine = engine;
             ExecutablePath = LocateExecutable();
             if (ExecutablePath is not null)
             {
-                _logger?.LogDebug("RC-Astro CLI located at {Path} (engine={Engine})", ExecutablePath, _engine);
+                _logger?.LogDebug("RC-Astro CLI located at {Path}", ExecutablePath);
             }
             else
             {
@@ -93,8 +89,10 @@ namespace TianWen.AI.Imaging.RcAstro
             psi.ArgumentList.Add(outputPath);
             psi.ArgumentList.Add("--depth");
             psi.ArgumentList.Add("32F");
-            psi.ArgumentList.Add("--engine");
-            psi.ArgumentList.Add(_engine);
+            // Compute device is left to the CLI default (auto -> GPU/DirectML when available). We used to
+            // pass "--engine auto", but RC-Astro renamed that flag to "--device" (v0.9.x), which made the
+            // old flag a hard error (exit 109). Omitting it entirely keeps us decoupled from the flag name
+            // across CLI versions -- "auto" is the default anyway.
             psi.ArgumentList.Add("--overwrite");
             psi.ArgumentList.Add("--json");
             foreach (var arg in extraArgs)

--- a/src/TianWen.AI.Imaging/RcAstro/RcAstroEnhancerBase.cs
+++ b/src/TianWen.AI.Imaging/RcAstro/RcAstroEnhancerBase.cs
@@ -34,7 +34,7 @@ namespace TianWen.AI.Imaging.RcAstro
 
         /// <summary>
         /// Product-specific CLI flags appended after the shared
-        /// input/-o/--depth/--engine/--overwrite/--json arguments. Return an
+        /// input/-o/--depth/--overwrite/--json arguments. Return an
         /// empty list to run the product on its defaults. <paramref name="tuning"/>
         /// carries optional per-product strength overrides (null fields = the
         /// enhancer's own defaults, i.e. today's behaviour).


### PR DESCRIPTION
## Problem
RC-Astro renamed the compute-engine flag `--engine` → `--device` (CLI v0.9.x). Our `RcAstroCli` still passed `--engine auto`, so a current CLI (v0.9.9, 2026-07-02) rejects it:

```
RC-Astro 'sxt' failed (exit 109): The following argument was not expected: --engine
```

Because the flag is added in the shared arg-builder, **every** RC-Astro enhance — `sxt` star removal, `bxt` deconvolution, `nxt` denoise — fails before doing any work on any machine with an up-to-date `rc-astro`. CI is blind to it (runners have no `rc-astro` binary, so the RC path is never selected).

## Fix
Rather than chase the flag name across CLI versions, **omit it entirely** — `auto` is the CLI's own default compute device, so we stay decoupled from the rename. Also removes the now-unused `engine` ctor param/field (no caller ever passed it) and updates the invocation docs (`IRcAstroCli`, `RcAstroEnhancerBase`, CLAUDE.md).

## Verification
`RcAstroStarRemoverTests` + `RcAstroPhase2Tests` — 13/13 green against the locally installed RC-Astro v0.9.9 (the 3 that were failing now pass). Unrelated to and independent of the ASCOM OOP-host work (#79).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G75ioQxR7zpmnpd18PbpqT