### PR TITLE
feat(gemini): native serial Gemini Focuser Pro driver (myFocuserPro2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,8 @@ Available in `.claude/skills/<name>/SKILL.md` — auto-invocable when the reques
 TianWen is a .NET 10 library for astronomical device management, image processing, and astrometry.
 Supports cameras, mounts, focusers, filter wheels, cover/calibrators, and guiders via ASCOM, Alpaca (HTTP),
 ZWO, QHYCCD, Meade LX200, Skywatcher, OnStep (serial + WiFi/mDNS), iOptron SkyGuider Pro, Gemini FlatPanel
-Lite (native serial cover/calibrator), PHD2, and a built-in guider. Published as `TianWen.Lib` on NuGet,
+Lite (native serial cover/calibrator), Gemini Focuser Pro (native serial focuser, a rebadged myFocuserPro2),
+PHD2, and a built-in guider. Published as `TianWen.Lib` on NuGet,
 plus four AOT-published binaries (`tianwen` CLI,
 `tianwen-server` headless, `tianwen-gui`, `tianwen-fits`).
 

--- a/docs/architecture/device-architecture.md
+++ b/docs/architecture/device-architecture.md
@@ -46,6 +46,13 @@ graph LR
         QHYFocuserDriver
     end
 
+    subgraph Gemini
+        GeminiDevice
+        GeminiFlatPanelDriver
+        GeminiFocuserDevice
+        GeminiFocuserDriver
+    end
+
     subgraph Meade
         MeadeDevice
         MeadeLX200ProtocolMountDriver
@@ -93,6 +100,8 @@ graph LR
     DeviceBase --> AlpacaDevice
     DeviceBase --> ZWODevice
     DeviceBase --> QHYDevice
+    DeviceBase --> GeminiDevice
+    DeviceBase --> GeminiFocuserDevice
     DeviceBase --> MeadeDevice
     DeviceBase --> IOptronDevice
     DeviceBase --> OnStepDevice
@@ -126,6 +135,9 @@ graph LR
     QHYDevice -.-> QHYCameraControlledFilterWheelDriver
     QHYDevice -.-> QHYSerialControlledFilterWheelDriver
     QHYDevice -.-> QHYFocuserDriver
+
+    GeminiDevice -.-> GeminiFlatPanelDriver
+    GeminiFocuserDevice -.-> GeminiFocuserDriver
 
     MeadeDevice -.-> MeadeLX200ProtocolMountDriver
     IOptronDevice -.-> SgpMountDriver

--- a/docs/architecture/gemini-focuser-pro-protocol.md
+++ b/docs/architecture/gemini-focuser-pro-protocol.md
@@ -1,0 +1,128 @@
+# Gemini Focuser Pro — serial protocol
+
+Reference for TianWen's native `GeminiFocuserDriver` (`IFocuserDriver`). The Gemini Focuser Pro is a
+rebadged **myFocuserPro2** Arduino focuser controller: an absolute stepper focuser with temperature
+readout and optional temperature compensation, presented over a virtual COM port (CH34x USB-to-serial
+bridge). This document is the wire-format spec the driver implements; it is transport-only (no ASCOM
+dependency), so the focuser works on platforms without the ASCOM Platform (win-arm64, Linux, Raspberry Pi).
+
+> **Derived from the vendor `ASCOM.GeminiFocuserPro.Focuser` driver (decompiled).** Not yet validated
+> against real hardware — the command set, framing and connect sequence are transcribed from the vendor
+> driver's `comms()` transport and property getters/setters; the exact `:04#` firmware name string and the
+> DTR-reset requirement are confirmed once a unit is connected (see **Open items**).
+
+## Serial parameters
+
+| Parameter | Value |
+|-----------|-------|
+| Baud rate | 9600 (vendor default; configurable 9600–115200) |
+| Data bits | 8 |
+| Parity | None |
+| Stop bits | 1 |
+| Handshake | none; **DTR + RTS asserted** on open (resets the Arduino) |
+| Encoding | ASCII |
+
+After opening the port the Arduino auto-resets (DTR toggle) and ignores input until it has booted
+(~2 s — the vendor driver's `DelayOnConnect` defaults to 2 s). The driver sleeps through this before the
+first handshake.
+
+## Framing
+
+Commands are `:` … `#`; responses are `<status-char>` + payload + `#`.
+
+- **Command (host → device):** `:` + numeric code + optional argument + `#` (e.g. `:05<pos>#`).
+- **Response (device → host):** a single leading status char (a myFocuserPro2 response code) + the payload
+  + `#`. The decoder strips the leading char **unconditionally** — it is never part of the value — exactly
+  as the vendor driver's `Substring(1, len-2)` does. `ParsePayload` also tolerates the terminator being
+  present or already stripped by the read.
+
+Reads terminate on the `#` byte (`ProbeFraming.HashTerminated`, the same framing family as LX200). Reads
+use the cancellable **synchronous** path (`ISerialConnection.SynchronousReads`) because CH34x bridges
+spuriously abort async `BaseStream` reads (`ERROR_OPERATION_ABORTED`) after the first read.
+
+## Get commands (request → response)
+
+| Command | Reply (payload after strip) | Meaning |
+|---------|-----------------------------|---------|
+| `:02#`  | `OK` | Controller-present handshake. `OK` = a live myFocuserPro2 board. **This is the only identity check** — there is no Gemini-specific token on the wire. |
+| `:04#`  | `<name>\r\n<version>` | Firmware name + integer version. The name is whatever myFocuserPro2 build was flashed (e.g. `myFP2ESP32`); the vendor driver stores but never validates it. |
+| `:00#`  | `<int>` | Current absolute position (steps). |
+| `:01#`  | `0` / `1` | Is-moving flag (`1` = moving). |
+| `:06#`  | `<double>` | Temperature (°C). |
+| `:08#`  | `<int>` | Maximum step position (`MaxStep`; also reported as `MaxIncrement`). |
+| `:24#`  | `0` / `1` | Temperature compensation currently enabled. |
+| `:25#`  | `0` / `1` | Temperature compensation available. |
+| `:33#`  | `<double>` | Step size (microns). |
+
+## Set commands
+
+| Command | Reply | Meaning |
+|---------|-------|---------|
+| `:05<pos>#` | none (silent) | Move to absolute position `<pos>`. Poll `:01#` for completion. |
+| `:27#` | none (silent) | Halt any motion. |
+| `:230#` / `:231#` | `OK` | Temperature compensation **off** / **on** (this set command acks). |
+
+**Move/Halt are silent fire-and-forget** (unlike the FlatPanel Lite, which acks everything), so the driver
+does not wait on them — keeping the autofocus hot path fast. Only the temp-comp toggle replies, and the
+codec drains that ack (bounded) so it can't offset the next read.
+
+## Connect handshake
+
+1. Open the port (9600-8N1, DTR + RTS asserted); wait ~2 s for the Arduino boot.
+2. `:02#` — verify the payload is `OK` (else "not a Gemini Focuser").
+3. `:04#` — log the firmware name + version.
+4. `:08#` — cache `MaxStep` (`MaxIncrement` = `MaxStep`).
+5. `:33#` — cache `StepSize` (a positive value sets `CanGetStepSize`).
+6. `:25#` — cache `TempCompAvailable`.
+
+Position, is-moving, temperature and temp-comp state are polled live thereafter.
+
+## Mapping to `IFocuserDriver`
+
+| `IFocuserDriver` member | Wire behaviour |
+|-------------------------|----------------|
+| `Absolute` | always `true` |
+| `GetPositionAsync` | `:00#` (→ `int.MinValue` when unavailable) |
+| `GetIsMovingAsync` | `:01#` |
+| `GetTemperatureAsync` | `:06#` (→ `NaN` when unavailable) |
+| `MaxStep` / `MaxIncrement` | `:08#` (cached at connect) |
+| `StepSize` / `CanGetStepSize` | `:33#` (cached at connect) |
+| `TempCompAvailable` | `:25#` (cached at connect) |
+| `GetTempCompAsync` | `:24#` |
+| `SetTempCompAsync` | `:231#` / `:230#` |
+| `BeginMoveAsync(pos)` | `:05<pos>#` (clamped to `[0, MaxStep]`) |
+| `BeginHaltAsync` | `:27#` |
+| `BacklashStepsIn` / `BacklashStepsOut` | `-1` (unknown — TianWen's backlash auto-tuning owns it) |
+
+## Discovery
+
+Auto-detected by `GeminiFocuserSerialProbe` (`ISerialProbe`, `HashTerminated`, 9600 baud): it writes `:02#`
+and matches the `OK` reply, then publishes a `Focuser://GeminiFocuserDevice/GeminiFocuser_<port>?port=serial:<port>`
+URI with the `:04#` firmware name captured into metadata.
+
+**No distinctive identity.** `:02#`→`OK` is the *generic* myFocuserPro2 handshake — any myFocuserPro2-based
+controller answers it, and there is no Gemini-specific string on the wire. By design we treat any responder
+as a Gemini Focuser Pro (we don't expect to encounter other myFocuserPro2 units in practice) and surface the
+reported firmware name in metadata; if a real unit turns out to carry a distinctive flashed name, tightening
+the matcher is a one-line change.
+
+**DTR/RTS + boot delay.** Like the FlatPanel Lite, the probe declares `Warmup = 2200 ms` and
+`AssertControlLines = true` (honoured only on the isolated per-probe pass, so toggling DTR can't reset a
+different controller sharing the port on pass 1). Manual assignment
+(`Focuser://GeminiFocuserDevice/…?port=serial:COMx`) also works — that path reconstructs the device from the
+URI and the driver's own connect asserts DTR + boot-waits.
+
+## Native-driver blacklist
+
+When a native Gemini Focuser Pro is discovered, the `ASCOM.GeminiFocuserPro.Focuser` ASCOM driver is hidden
+from discovery (`NativeDriverBlacklist`, keyed on ProgID → `GeminiFocuserDevice`), so the picker offers one
+entry per physical focuser. If no native device is found, the ASCOM twin passes through as the fallback.
+
+## Open items (hardware validation)
+
+- **Exact `:04#` firmware name** — recorded in probe metadata; tighten the matcher only if a distinctive
+  string appears.
+- **DTR-reset requirement** — the vendor gates it behind a `ResetControllerOnConnect` setting; we default to
+  assert + 2.2 s boot. Confirm the board needs it (and the exact boot time).
+- **Whether Move/Halt are truly unacked on this firmware** — the vendor treats them as silent; if the board
+  acks them, add a bounded drain to `SendAsync` (mirroring the temp-comp toggle / the FlatPanel path).

--- a/src/TianWen.Lib.Tests.Simulators/GeminiFocuserHardwareTests.cs
+++ b/src/TianWen.Lib.Tests.Simulators/GeminiFocuserHardwareTests.cs
@@ -1,0 +1,105 @@
+using Meziantou.Extensions.Logging.Xunit.v3;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Shouldly;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using TianWen.Lib.Devices;
+using TianWen.Lib.Devices.Gemini;
+using TianWen.Lib.Extensions;
+using Xunit;
+
+namespace TianWen.Lib.Tests.Simulators;
+
+/// <summary>
+/// Live-hardware test for the native (ASCOM-free) Gemini Focuser Pro serial driver. There is NO Gemini
+/// simulator, so this drives a physically-connected focuser: opt in by setting
+/// <see cref="SimulatorGate.GeminiFocuserPortVar"/> to its port (e.g. <c>serial:COM5</c>); it skips cleanly
+/// when unset so a bare <c>dotnet test</c> stays green.
+/// <para>
+/// It exercises the <b>manual-assignment</b> path via a URI-addressed device -- the driver's own
+/// <see cref="GeminiFocuserDriver.ConnectAsync"/> asserts DTR+RTS and waits out the Arduino boot, then reads
+/// capabilities and performs a small, self-reversing move so the mechanism is only nudged. Uses the real
+/// <see cref="IExternal"/> (real serial + <see cref="SystemTimeProvider"/>) -- never a fake clock, since the
+/// connect boot delay and move-settle polling are genuine wall-clock waits.
+/// </para>
+/// </summary>
+public class GeminiFocuserHardwareTests(ITestOutputHelper testOutputHelper)
+{
+    // A modest nudge so the test barely disturbs focus; clamped to the reported travel below.
+    private const int MoveDelta = 500;
+    private static readonly TimeSpan MoveTimeout = TimeSpan.FromSeconds(30);
+    private static readonly TimeSpan PollInterval = TimeSpan.FromMilliseconds(250);
+
+    [Fact]
+    public async Task GivenAConnectedGeminiFocuserWhenNudgedThenItMovesAndReportsPosition()
+    {
+        if (SimulatorGate.GeminiFocuserPort is not { } port)
+        {
+            Assert.Skip($"Set {SimulatorGate.GeminiFocuserPortVar} to a connected Gemini Focuser Pro port (e.g. serial:COM5)");
+            return;
+        }
+
+        var ct = TestContext.Current.CancellationToken;
+
+        await using var sp = new ServiceCollection()
+            .AddExternal()
+            .AddAstrometry() // External's ctor resolves ICelestialObjectDB; the Gemini driver never touches it.
+            .AddLogging(b => b.AddProvider(new XUnitLoggerProvider(testOutputHelper, false)))
+            .BuildServiceProvider();
+
+        var timeProvider = sp.GetRequiredService<ITimeProvider>();
+
+        // Manual assignment: Focuser://GeminiFocuserDevice/<id>?port=serial:COMx (the driver's connect asserts DTR).
+        var device = new GeminiFocuserDevice("GeminiFocuser_hw", $"Gemini Focuser Pro on {port}", port);
+        if (device.TryInstantiateDriver(sp, out IFocuserDriver? focuser) is not true)
+        {
+            Assert.Fail($"Could not instantiate Gemini Focuser driver for {port}");
+            return;
+        }
+
+        await using (focuser)
+        {
+            await focuser.ConnectAsync(ct);
+            focuser.Connected.ShouldBeTrue();
+            focuser.Absolute.ShouldBeTrue();
+            focuser.MaxStep.ShouldBeGreaterThan(0);
+
+            var start = await focuser.GetPositionAsync(ct);
+            var temp = await focuser.GetTemperatureAsync(ct);
+            testOutputHelper.WriteLine(
+                $"connected: pos={start}, maxStep={focuser.MaxStep}, stepSize={(focuser.CanGetStepSize ? focuser.StepSize.ToString("0.0") : "n/a")}, " +
+                $"temp={(double.IsNaN(temp) ? "n/a" : temp.ToString("0.0"))}, tempCompAvailable={focuser.TempCompAvailable}");
+
+            start.ShouldBeGreaterThanOrEqualTo(0);
+
+            // Nudge inward or outward, whichever stays within travel, then reverse back to the start.
+            var target = start + MoveDelta <= focuser.MaxStep ? start + MoveDelta : Math.Max(0, start - MoveDelta);
+
+            await MoveAndSettleAsync(focuser, target, timeProvider, ct);
+            var afterMove = await focuser.GetPositionAsync(ct);
+            testOutputHelper.WriteLine($"moved -> target {target}, landed {afterMove}");
+            Math.Abs(afterMove - target).ShouldBeLessThanOrEqualTo(MoveDelta, "focuser should land at (or very near) the commanded position");
+
+            await MoveAndSettleAsync(focuser, start, timeProvider, ct);
+            var restored = await focuser.GetPositionAsync(ct);
+            testOutputHelper.WriteLine($"restored -> target {start}, landed {restored}");
+
+            await focuser.DisconnectAsync(ct);
+            focuser.Connected.ShouldBeFalse();
+        }
+    }
+
+    private static async Task MoveAndSettleAsync(IFocuserDriver focuser, int target, ITimeProvider timeProvider, CancellationToken ct)
+    {
+        await focuser.BeginMoveAsync(target, ct);
+
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        cts.CancelAfter(MoveTimeout);
+        while (await focuser.GetIsMovingAsync(cts.Token))
+        {
+            await timeProvider.SleepAsync(PollInterval, cts.Token);
+        }
+    }
+}

--- a/src/TianWen.Lib.Tests.Simulators/SimulatorGate.cs
+++ b/src/TianWen.Lib.Tests.Simulators/SimulatorGate.cs
@@ -23,6 +23,11 @@ internal static class SimulatorGate
     /// Gemini simulator -- so it is opt-in and skips when unset.</summary>
     public const string GeminiFlatPanelPortVar = "TIANWEN_GEMINI_FPLITE_PORT";
 
+    /// <summary>Serial port of a physically-connected Gemini Focuser Pro (a rebadged myFocuserPro2), e.g.
+    /// <c>serial:COM5</c> or bare <c>COM5</c> / <c>/dev/ttyUSB0</c>. Like the FlatPanel this needs REAL
+    /// hardware on a real port -- there is no Gemini simulator -- so it is opt-in and skips when unset.</summary>
+    public const string GeminiFocuserPortVar = "TIANWEN_GEMINI_FOCUSER_PORT";
+
     /// <summary>The configured Alpaca simulator base URL (trailing slash trimmed), or <see langword="null"/> when unset.</summary>
     public static string? AlpacaBaseUrl =>
         Environment.GetEnvironmentVariable(AlpacaBaseUrlVar) is { Length: > 0 } url ? url.TrimEnd('/') : null;
@@ -35,6 +40,13 @@ internal static class SimulatorGate
     /// <see langword="null"/> when unset. A bare port name (<c>COM3</c>) gains the <c>serial:</c> prefix.</summary>
     public static string? GeminiFlatPanelPort =>
         Environment.GetEnvironmentVariable(GeminiFlatPanelPortVar) is { Length: > 0 } port
+            ? (port.Contains(':') ? port : $"serial:{port}")
+            : null;
+
+    /// <summary>The Gemini Focuser Pro serial port, normalised to the <c>serial:</c> URI form, or
+    /// <see langword="null"/> when unset. A bare port name (<c>COM5</c>) gains the <c>serial:</c> prefix.</summary>
+    public static string? GeminiFocuserPort =>
+        Environment.GetEnvironmentVariable(GeminiFocuserPortVar) is { Length: > 0 } port
             ? (port.Contains(':') ? port : $"serial:{port}")
             : null;
 }

--- a/src/TianWen.Lib.Tests/FakeGeminiFocuserSerialDevice.cs
+++ b/src/TianWen.Lib.Tests/FakeGeminiFocuserSerialDevice.cs
@@ -1,0 +1,153 @@
+using DotNext.Threading;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using TianWen.Lib.Connections;
+
+namespace TianWen.Lib.Tests;
+
+/// <summary>
+/// In-memory <see cref="ISerialConnection"/> that simulates a Gemini Focuser Pro (myFocuserPro2) controller:
+/// it parses the <c>':' … '#'</c> framed commands, holds position / target / temperature / temp-comp state,
+/// answers the get commands with a <c>&lt;status-char&gt;&lt;payload&gt;#</c> reply, and treats the set
+/// commands (Move/Halt) as silent. Used by the protocol and probe tests — no hardware.
+/// </summary>
+internal sealed class FakeGeminiFocuserSerialDevice(
+    string firmwareName = "myFP2",
+    int firmwareVersion = 312,
+    bool present = true,
+    int maxStep = 100_000,
+    bool tempCompAvailable = true) : ISerialConnection
+{
+    private readonly SemaphoreSlim _sem = new(1, 1);
+    private readonly Queue<byte> _readBuffer = new();
+
+    public int Position { get; set; } = 50_000;
+    public int Target { get; private set; } = 50_000;
+    public bool Moving { get; set; }
+    public double Temperature { get; set; } = 12.5;
+    public double StepSize { get; set; } = 5.0;
+    public bool TempCompEnabled { get; private set; }
+    public List<string> WrittenCommands { get; } = [];
+
+    /// <summary>Models a dead USB bridge: <see cref="IsOpen"/> stays true but no reply is ever enqueued.</summary>
+    public bool Dead { get; set; }
+
+    public bool IsOpen { get; private set; } = true;
+    public Encoding Encoding => Encoding.ASCII;
+    public bool TryClose() { IsOpen = false; return true; }
+    public void Dispose() => TryClose();
+
+    public ValueTask<ResourceLock> WaitAsync(CancellationToken cancellationToken) => _sem.AcquireLockAsync(cancellationToken);
+
+    public ValueTask<bool> TryWriteAsync(ReadOnlyMemory<byte> data, CancellationToken cancellationToken)
+    {
+        if (Dead)
+        {
+            return ValueTask.FromResult(true);
+        }
+
+        var raw = Encoding.GetString(data.Span);
+        var start = raw.IndexOf(':');
+        var end = raw.IndexOf('#');
+        if (start < 0 || end < 0 || end <= start)
+        {
+            return ValueTask.FromResult(false);
+        }
+
+        var body = raw.Substring(start + 1, end - start - 1);
+        WrittenCommands.Add($":{body}#");
+        HandleCommand(body);
+        return ValueTask.FromResult(true);
+    }
+
+    private void HandleCommand(string body)
+    {
+        // Get commands reply "<status-char><payload>#"; set commands are silent (Move/Halt) or ack "OK"
+        // (temp-comp toggle). The status char is arbitrary here (the codec strips it unconditionally).
+        switch (body)
+        {
+            case "02": // controller present
+                Enqueue(present ? "!OK#" : "!NO#");
+                break;
+            case "04": // firmware name + version
+                Enqueue($"F{firmwareName}\r\n{firmwareVersion.ToString(CultureInfo.InvariantCulture)}#");
+                break;
+            case "00": // position
+                Enqueue($"P{Position.ToString(CultureInfo.InvariantCulture)}#");
+                break;
+            case "01": // is moving
+                Enqueue($"I{(Moving ? "1" : "0")}#");
+                break;
+            case "06": // temperature
+                Enqueue($"T{Temperature.ToString("0.00", CultureInfo.InvariantCulture)}#");
+                break;
+            case "08": // max step
+                Enqueue($"M{maxStep.ToString(CultureInfo.InvariantCulture)}#");
+                break;
+            case "24": // temp comp enabled
+                Enqueue($"A{(TempCompEnabled ? "1" : "0")}#");
+                break;
+            case "25": // temp comp available
+                Enqueue($"B{(tempCompAvailable ? "1" : "0")}#");
+                break;
+            case "33": // step size
+                Enqueue($"Q{StepSize.ToString("0.0", CultureInfo.InvariantCulture)}#");
+                break;
+            case "27": // halt — silent
+                Moving = false;
+                break;
+            case "230": // temp comp off — acks OK
+                TempCompEnabled = false;
+                Enqueue("!OK#");
+                break;
+            case "231": // temp comp on — acks OK
+                TempCompEnabled = true;
+                Enqueue("!OK#");
+                break;
+            default:
+                if (body.StartsWith("05", StringComparison.Ordinal)
+                    && int.TryParse(body.AsSpan(2), NumberStyles.Integer, CultureInfo.InvariantCulture, out var t))
+                {
+                    // Move to absolute target — silent.
+                    Target = t;
+                    Moving = true;
+                }
+                break;
+        }
+    }
+
+    private void Enqueue(string framed)
+    {
+        foreach (var ch in framed)
+        {
+            _readBuffer.Enqueue((byte)ch);
+        }
+    }
+
+    public ValueTask<string?> TryReadTerminatedAsync(ReadOnlyMemory<byte> terminators, CancellationToken cancellationToken)
+    {
+        var sb = new StringBuilder();
+        while (_readBuffer.Count > 0)
+        {
+            var by = _readBuffer.Dequeue();
+            foreach (var t in terminators.Span)
+            {
+                if (by == t)
+                {
+                    return ValueTask.FromResult<string?>(sb.ToString());
+                }
+            }
+            sb.Append((char)by);
+        }
+
+        return ValueTask.FromResult<string?>(null);
+    }
+
+    public ValueTask<string?> TryReadExactlyAsync(int count, CancellationToken cancellationToken) => throw new NotSupportedException();
+    public ValueTask<int> TryReadTerminatedRawAsync(Memory<byte> message, ReadOnlyMemory<byte> terminators, CancellationToken cancellationToken) => throw new NotSupportedException();
+    public ValueTask<bool> TryReadExactlyRawAsync(Memory<byte> message, CancellationToken cancellationToken) => throw new NotSupportedException();
+}

--- a/src/TianWen.Lib.Tests/GeminiFocuserProtocolTests.cs
+++ b/src/TianWen.Lib.Tests/GeminiFocuserProtocolTests.cs
@@ -1,0 +1,122 @@
+using Shouldly;
+using System.Threading;
+using System.Threading.Tasks;
+using TianWen.Lib.Devices.Gemini;
+using Xunit;
+
+namespace TianWen.Lib.Tests;
+
+/// <summary>
+/// Exercises the pure <see cref="GeminiFocuserProtocol"/> wire codec against an in-memory myFocuserPro2
+/// controller (<see cref="FakeGeminiFocuserSerialDevice"/>): get commands round-trip their payload, set
+/// commands write the right frame and mutate controller state, and <see cref="GeminiFocuserProtocol.ParsePayload"/>
+/// strips the leading status char + trailing terminator.
+/// </summary>
+public class GeminiFocuserProtocolTests
+{
+    private static CancellationToken Ct => TestContext.Current.CancellationToken;
+
+    [Fact]
+    public async Task Identify_returns_OK_on_a_present_controller()
+    {
+        var conn = new FakeGeminiFocuserSerialDevice();
+        (await GeminiFocuserProtocol.IdentifyAsync(conn, Ct)).ShouldBe(GeminiFocuserProtocol.PresentReply);
+        conn.WrittenCommands.ShouldContain(":02#");
+    }
+
+    [Fact]
+    public async Task Identify_returns_non_OK_when_absent()
+    {
+        var conn = new FakeGeminiFocuserSerialDevice(present: false);
+        (await GeminiFocuserProtocol.IdentifyAsync(conn, Ct)).ShouldNotBe(GeminiFocuserProtocol.PresentReply);
+    }
+
+    [Fact]
+    public async Task Firmware_reply_splits_name_and_version()
+    {
+        var conn = new FakeGeminiFocuserSerialDevice(firmwareName: "myFP2ESP32", firmwareVersion: 312);
+        var fw = await GeminiFocuserProtocol.GetFirmwareAsync(conn, Ct);
+
+        fw.ShouldNotBeNull();
+        fw!.Value.Name.ShouldBe("myFP2ESP32");
+        fw.Value.Version.ShouldBe(312);
+    }
+
+    [Fact]
+    public async Task Position_maxstep_temperature_stepsize_round_trip()
+    {
+        var conn = new FakeGeminiFocuserSerialDevice(maxStep: 90_000) { Position = 42_345, Temperature = -3.25, StepSize = 4.8 };
+
+        (await GeminiFocuserProtocol.GetPositionAsync(conn, Ct)).ShouldBe(42_345);
+        (await GeminiFocuserProtocol.GetMaxStepAsync(conn, Ct)).ShouldBe(90_000);
+        (await GeminiFocuserProtocol.GetTemperatureAsync(conn, Ct)).ShouldBe(-3.25, 0.001);
+        (await GeminiFocuserProtocol.GetStepSizeAsync(conn, Ct)).ShouldNotBeNull().ShouldBe(4.8, 0.001);
+    }
+
+    [Fact]
+    public async Task IsMoving_reflects_controller_state()
+    {
+        var conn = new FakeGeminiFocuserSerialDevice { Moving = false };
+        (await GeminiFocuserProtocol.GetIsMovingAsync(conn, Ct)).ShouldBeFalse();
+
+        conn.Moving = true;
+        (await GeminiFocuserProtocol.GetIsMovingAsync(conn, Ct)).ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task TempComp_available_and_get_round_trip()
+    {
+        var conn = new FakeGeminiFocuserSerialDevice(tempCompAvailable: true);
+        (await GeminiFocuserProtocol.GetTempCompAvailableAsync(conn, Ct)).ShouldBeTrue();
+        (await GeminiFocuserProtocol.GetTempCompAsync(conn, Ct)).ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task SetTempComp_writes_the_toggle_frame_and_updates_state()
+    {
+        var conn = new FakeGeminiFocuserSerialDevice(tempCompAvailable: true);
+
+        await GeminiFocuserProtocol.SetTempCompAsync(conn, enabled: true, Ct);
+        conn.WrittenCommands.ShouldContain(":231#");
+        (await GeminiFocuserProtocol.GetTempCompAsync(conn, Ct)).ShouldBeTrue();
+
+        await GeminiFocuserProtocol.SetTempCompAsync(conn, enabled: false, Ct);
+        conn.WrittenCommands.ShouldContain(":230#");
+        (await GeminiFocuserProtocol.GetTempCompAsync(conn, Ct)).ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task Move_writes_the_absolute_target_frame_and_starts_motion()
+    {
+        var conn = new FakeGeminiFocuserSerialDevice();
+
+        await GeminiFocuserProtocol.MoveAsync(conn, 61_500, Ct);
+
+        conn.WrittenCommands.ShouldContain(":0561500#");
+        conn.Target.ShouldBe(61_500);
+        conn.Moving.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task Halt_writes_the_halt_frame_and_stops_motion()
+    {
+        var conn = new FakeGeminiFocuserSerialDevice { Moving = true };
+
+        await GeminiFocuserProtocol.HaltAsync(conn, Ct);
+
+        conn.WrittenCommands.ShouldContain(":27#");
+        conn.Moving.ShouldBeFalse();
+    }
+
+    [Theory]
+    [InlineData("P12345#", "12345")] // leading status char + trailing terminator stripped
+    [InlineData("P12345", "12345")]  // terminator already stripped by the read
+    [InlineData("!OK", "OK")]
+    [InlineData("X", "")]            // bare status char -> empty payload
+    public void ParsePayload_strips_status_char_and_terminator(string raw, string expected)
+        => GeminiFocuserProtocol.ParsePayload(raw).ShouldBe(expected);
+
+    [Fact]
+    public void ParsePayload_returns_null_for_null()
+        => GeminiFocuserProtocol.ParsePayload(null).ShouldBeNull();
+}

--- a/src/TianWen.Lib.Tests/GeminiFocuserSerialProbeTests.cs
+++ b/src/TianWen.Lib.Tests/GeminiFocuserSerialProbeTests.cs
@@ -1,0 +1,57 @@
+using Shouldly;
+using System.Threading.Tasks;
+using TianWen.Lib.Devices;
+using TianWen.Lib.Devices.Discovery;
+using TianWen.Lib.Devices.Gemini;
+using Xunit;
+
+namespace TianWen.Lib.Tests;
+
+/// <summary>
+/// Exercises <see cref="GeminiFocuserSerialProbe"/> against an in-memory myFocuserPro2 controller: a valid
+/// <c>:02#</c> handshake produces a <see cref="Discovery.SerialProbeMatch"/> with the port + firmware baked
+/// into the URI/metadata, a non-present controller produces no match, and the probe advertises the right
+/// device host + framing.
+/// </summary>
+public class GeminiFocuserSerialProbeTests
+{
+    [Fact]
+    public async Task Valid_handshake_produces_a_match_with_port_and_firmware()
+    {
+        var conn = new FakeGeminiFocuserSerialDevice(firmwareName: "myFP2ESP32", firmwareVersion: 312);
+        var probe = new GeminiFocuserSerialProbe();
+
+        var match = await probe.ProbeAsync("serial:COM5", conn, TestContext.Current.CancellationToken);
+
+        match.ShouldNotBeNull();
+        match.Port.ShouldBe("serial:COM5");
+        // System.Uri lower-cases scheme + host.
+        match.DeviceUri.Scheme.ShouldBe("focuser");
+        match.DeviceUri.Host.ShouldBe(nameof(GeminiFocuserDevice).ToLowerInvariant());
+        match.DeviceUri.QueryValue(DeviceQueryKey.Port).ShouldBe("serial:COM5");
+        match.Metadata.ShouldNotBeNull();
+        match.Metadata!["firmwareName"].ShouldBe("myFP2ESP32");
+        match.Metadata!["firmware"].ShouldBe("312");
+    }
+
+    [Fact]
+    public async Task Absent_controller_produces_no_match()
+    {
+        var conn = new FakeGeminiFocuserSerialDevice(present: false);
+        var probe = new GeminiFocuserSerialProbe();
+
+        var match = await probe.ProbeAsync("serial:COM5", conn, TestContext.Current.CancellationToken);
+
+        match.ShouldBeNull();
+    }
+
+    [Fact]
+    public void Probe_advertises_the_Gemini_focuser_device_host_and_hash_framing()
+    {
+        var probe = new GeminiFocuserSerialProbe();
+        probe.MatchesDeviceHosts.ShouldContain(nameof(GeminiFocuserDevice));
+        probe.Framing.ShouldBe(ProbeFraming.HashTerminated);
+        probe.BaudRate.ShouldBe(GeminiFocuserProtocol.Baud);
+        probe.AssertControlLines.ShouldBeTrue();
+    }
+}

--- a/src/TianWen.Lib.Tests/NativeDriverBlacklistTests.cs
+++ b/src/TianWen.Lib.Tests/NativeDriverBlacklistTests.cs
@@ -64,10 +64,21 @@ public class NativeDriverBlacklistTests
     }
 
     [Fact]
-    public void GivenGeminiFocuserProThenItIsNotHiddenByTheNativeGeminiCoverFamily()
+    public void GivenGeminiFocuserProWithNativeFocuserPresentThenAscomGeminiFocuserIsHidden()
     {
-        // GeminiFocuserPro is a different product with no native impl -- must survive even if a native
-        // GeminiDevice (the flat panel) is present.
+        // The native Gemini Focuser Pro (a rebadged myFocuserPro2) supersedes its ASCOM twin.
+        var ids = FilterIds(
+            Ascom(DeviceType.Focuser, "ASCOM.GeminiFocuserPro.Focuser"),
+            Native("GeminiFocuserDevice", DeviceType.Focuser, "COM5"));
+
+        ids.ShouldBe(["COM5"]);
+    }
+
+    [Fact]
+    public void GivenGeminiFocuserProThenItIsNotHiddenByTheFlatPanelCoverFamily()
+    {
+        // The flat-panel cover family (GeminiDevice) is a DIFFERENT native class from the focuser
+        // (GeminiFocuserDevice), so its presence must not hide the ASCOM focuser.
         var ids = FilterIds(
             Ascom(DeviceType.Focuser, "ASCOM.GeminiFocuserPro.Focuser"),
             Native("GeminiDevice", DeviceType.Focuser, "COM3"));
@@ -77,6 +88,7 @@ public class NativeDriverBlacklistTests
 
     [Theory]
     [InlineData("ASCOM.GeminiFPLite.CoverCalibrator", "GeminiDevice")]
+    [InlineData("ASCOM.GeminiFocuserPro.Focuser", "GeminiFocuserDevice")]
     [InlineData("ascom.asicamera2.camera", "ZWODevice")] // case-insensitive ProgID match
     [InlineData("ASCOM.EFW2_2.FilterWheel", "ZWODevice")]
     [InlineData("ASCOM.qfoc.Focuser", "QHYDevice")]
@@ -89,7 +101,6 @@ public class NativeDriverBlacklistTests
 
     [Theory]
     [InlineData("ASCOM.PlayerOne.Camera")]
-    [InlineData("ASCOM.GeminiFocuserPro.Focuser")]
     [InlineData("ASCOM.iOptron2017.Telescope")]
     public void GivenUnlistedProgIdThenNoNativeClass(string progId)
         => NativeDriverBlacklist.TryGetNativeClass(progId, out _).ShouldBeFalse();

--- a/src/TianWen.Lib/Devices/Gemini/GeminiFocuserDevice.cs
+++ b/src/TianWen.Lib/Devices/Gemini/GeminiFocuserDevice.cs
@@ -1,0 +1,53 @@
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Specialized;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using TianWen.Lib;
+using TianWen.Lib.Connections;
+
+namespace TianWen.Lib.Devices.Gemini;
+
+/// <summary>
+/// Gemini Focuser Pro robotic focuser addressed by URI. The <c>port</c> query parameter carries the serial
+/// port (e.g. <c>serial:COM5</c>); baud is fixed at <see cref="GeminiFocuserProtocol.Baud"/>. A native
+/// (ASCOM-free) driver for the rebadged myFocuserPro2 Arduino controller — see
+/// <c>docs/architecture/gemini-focuser-pro-protocol.md</c>. Distinct from the flat-panel
+/// <see cref="GeminiDevice"/> (different product, protocol and <see cref="DeviceBase.DeviceClass"/>).
+/// </summary>
+public record class GeminiFocuserDevice(Uri DeviceUri) : DeviceBase(DeviceUri)
+{
+    public GeminiFocuserDevice(string deviceId, string displayName, string port)
+        : this(new Uri($"{DeviceType.Focuser}://{typeof(GeminiFocuserDevice).Name}/{deviceId}?{new NameValueCollection { [DeviceQueryKey.Port.Key] = port }.ToQueryString()}#{displayName}"))
+    {
+        // calls primary constructor
+    }
+
+    protected override IDeviceDriver? NewInstanceFromDevice(IServiceProvider sp) => DeviceType switch
+    {
+        DeviceType.Focuser => new GeminiFocuserDriver(this, sp),
+        _ => null
+    };
+
+    public override async ValueTask<ISerialConnection?> ConnectSerialDeviceAsync(IExternal external, ILogger logger, ITimeProvider timeProvider, int baud = GeminiFocuserProtocol.Baud, Encoding? encoding = null, CancellationToken cancellationToken = default)
+    {
+        var port = Query.QueryValue(DeviceQueryKey.Port);
+        if (port is null)
+        {
+            return null;
+        }
+
+        // The myFocuserPro2 Arduino resets when DTR is asserted on open (classic auto-reset); the driver
+        // then waits out the boot before handshaking. Asserting DTR+RTS matches the vendor driver's
+        // ResetControllerOnConnect path and the FlatPanel's CH34x requirement.
+        var conn = await external.OpenSerialDeviceAsync(port, GeminiFocuserProtocol.Baud, encoding ?? Encoding.ASCII, assertControlLines: true, cancellationToken);
+        if (conn is not null)
+        {
+            // CH34x bridges spuriously abort async BaseStream reads (ERROR_OPERATION_ABORTED) after the first
+            // read, so use the cancellable synchronous read path (see ISerialConnection.SynchronousReads).
+            conn.SynchronousReads = true;
+        }
+        return conn;
+    }
+}

--- a/src/TianWen.Lib/Devices/Gemini/GeminiFocuserDeviceSource.cs
+++ b/src/TianWen.Lib/Devices/Gemini/GeminiFocuserDeviceSource.cs
@@ -1,0 +1,42 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using TianWen.Lib.Devices.Discovery;
+
+namespace TianWen.Lib.Devices.Gemini;
+
+/// <summary>
+/// Discovers Gemini Focuser Pro focusers. Serial probing lives in <see cref="GeminiFocuserSerialProbe"/> and
+/// runs inside <see cref="ISerialProbeService"/>; this source just reads the matches the service has already
+/// published (each match's URI already has the deviceId + port baked in by the probe).
+/// </summary>
+internal sealed class GeminiFocuserDeviceSource(ISerialProbeService probeService) : IDeviceSource<GeminiFocuserDevice>
+{
+    private Dictionary<DeviceType, IReadOnlyList<GeminiFocuserDevice>> _cachedDevices = new();
+
+    public IEnumerable<DeviceType> RegisteredDeviceTypes => [DeviceType.Focuser];
+
+    // Reads serial-probe matches from ISerialProbeService, so must run after the serial probe pass.
+    public bool ConsumesSerialProbe => true;
+
+    public ValueTask<bool> CheckSupportAsync(CancellationToken cancellationToken) => ValueTask.FromResult(true);
+
+    public IEnumerable<GeminiFocuserDevice> RegisteredDevices(DeviceType deviceType) =>
+        _cachedDevices.TryGetValue(deviceType, out var devices) ? devices : [];
+
+    public ValueTask DiscoverAsync(CancellationToken cancellationToken)
+    {
+        var focusers = new List<GeminiFocuserDevice>();
+        foreach (var match in probeService.ResultsFor("GeminiFocuser"))
+        {
+            focusers.Add(new GeminiFocuserDevice(match.DeviceUri));
+        }
+
+        Interlocked.Exchange(ref _cachedDevices, new Dictionary<DeviceType, IReadOnlyList<GeminiFocuserDevice>>
+        {
+            [DeviceType.Focuser] = focusers
+        });
+
+        return ValueTask.CompletedTask;
+    }
+}

--- a/src/TianWen.Lib/Devices/Gemini/GeminiFocuserDriver.cs
+++ b/src/TianWen.Lib/Devices/Gemini/GeminiFocuserDriver.cs
@@ -1,0 +1,242 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using TianWen.Lib.Connections;
+
+namespace TianWen.Lib.Devices.Gemini;
+
+/// <summary>
+/// Native (ASCOM-free) driver for the Gemini Focuser Pro, a serial absolute focuser built on a
+/// <c>myFocuserPro2</c> Arduino controller. Drives the <see cref="GeminiFocuserProtocol"/> <c>:NN#</c> wire
+/// codec over an <see cref="ISerialConnection"/> and maps it to <see cref="IFocuserDriver"/>. Works on any
+/// platform with a COM port (no ASCOM Platform required).
+/// </summary>
+internal sealed class GeminiFocuserDriver(GeminiFocuserDevice device, IServiceProvider serviceProvider) : IFocuserDriver
+{
+    // The Arduino resets when the port opens (DTR auto-reset) and ignores input for ~2s while it boots — the
+    // vendor ASCOM driver hard-sleeps on connect. We sleep through the boot before the first handshake so
+    // early writes aren't dropped and their late replies can't desync later reads. Reconnect goes through the
+    // liveness path (already-open conn), not here, so this cost is paid only on a genuine cold open.
+    private static readonly TimeSpan BootDelay = TimeSpan.FromMilliseconds(2200);
+    private const int HandshakeAttempts = 3;
+    private static readonly TimeSpan HandshakeTimeout = TimeSpan.FromSeconds(1);
+    private static readonly TimeSpan HandshakeRetryInterval = TimeSpan.FromMilliseconds(400);
+
+    private volatile ISerialConnection? _conn;
+    private volatile bool _connected;
+
+    // Immutable-ish capabilities cached at connect (a COM round-trip per read would be another place a
+    // stalled controller could throw on the hot path).
+    private int _maxStep = int.MaxValue;
+    private double _stepSize = double.NaN;
+    private bool _tempCompAvailable;
+
+    public bool Absolute => true;
+
+    public int MaxStep => _maxStep;
+
+    // A myFocuserPro2 accepts an absolute move anywhere in [0, MaxStep], so the largest single increment is
+    // the full travel — the vendor driver reports MaxStep for MaxIncrement too.
+    public int MaxIncrement => _maxStep;
+
+    public bool CanGetStepSize => !double.IsNaN(_stepSize);
+
+    public double StepSize => _stepSize;
+
+    public bool TempCompAvailable => _tempCompAvailable;
+
+    // Unknown/unmeasured — TianWen's own backlash auto-tuning owns these (mirrors the ZWO/ASCOM native paths).
+    public int BacklashStepsIn => -1;
+
+    public int BacklashStepsOut => -1;
+
+    public async ValueTask<int> GetPositionAsync(CancellationToken cancellationToken = default)
+        => _conn is { IsOpen: true } conn && await GeminiFocuserProtocol.GetPositionAsync(conn, cancellationToken).ConfigureAwait(false) is { } pos
+            ? pos
+            : int.MinValue;
+
+    public ValueTask<bool> GetIsMovingAsync(CancellationToken cancellationToken = default)
+        => _conn is { IsOpen: true } conn
+            ? GeminiFocuserProtocol.GetIsMovingAsync(conn, cancellationToken)
+            : ValueTask.FromResult(false);
+
+    public ValueTask<double> GetTemperatureAsync(CancellationToken cancellationToken = default)
+        => _conn is { IsOpen: true } conn
+            ? GeminiFocuserProtocol.GetTemperatureAsync(conn, cancellationToken)
+            : ValueTask.FromResult(double.NaN);
+
+    public ValueTask<bool> GetTempCompAsync(CancellationToken cancellationToken = default)
+        => _conn is { IsOpen: true } conn && _tempCompAvailable
+            ? GeminiFocuserProtocol.GetTempCompAsync(conn, cancellationToken)
+            : ValueTask.FromResult(false);
+
+    public async ValueTask SetTempCompAsync(bool value, CancellationToken cancellationToken = default)
+    {
+        if (_conn is { IsOpen: true } conn && _tempCompAvailable)
+        {
+            await GeminiFocuserProtocol.SetTempCompAsync(conn, value, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    public async Task BeginMoveAsync(int position, CancellationToken cancellationToken = default)
+    {
+        if (_conn is not { IsOpen: true } conn)
+        {
+            throw new InvalidOperationException($"{device.DisplayName} is not connected");
+        }
+
+        if (position is < 0 || position > _maxStep)
+        {
+            throw new ArgumentOutOfRangeException(nameof(position), position, $"Absolute position must be between 0 and {_maxStep}");
+        }
+
+        await GeminiFocuserProtocol.MoveAsync(conn, position, cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task BeginHaltAsync(CancellationToken cancellationToken = default)
+    {
+        if (_conn is { IsOpen: true } conn)
+        {
+            await GeminiFocuserProtocol.HaltAsync(conn, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    public string Name => device.DisplayName;
+
+    public string? Description => "Gemini Focuser Pro serial focuser";
+
+    public string? DriverInfo => Description;
+
+    public string? DriverVersion => typeof(IDeviceDriver).Assembly.GetName().Version?.ToString() ?? "1.0";
+
+    public bool Connected => _connected;
+
+    public DeviceType DriverType => DeviceType.Focuser;
+
+    public IExternal External { get; } = serviceProvider.GetRequiredService<IExternal>();
+
+    public ILogger Logger { get; } = serviceProvider.GetRequiredService<ILoggerFactory>().CreateLogger(nameof(GeminiFocuserDriver));
+
+    public ITimeProvider TimeProvider { get; } = serviceProvider.GetRequiredService<ITimeProvider>();
+
+    public event EventHandler<DeviceConnectedEventArgs>? DeviceConnectedEvent;
+
+    public async ValueTask ConnectAsync(CancellationToken cancellationToken = default)
+    {
+        // SerialPort.IsOpen only records that Open() succeeded — a dead USB bridge (unplugged CH34x,
+        // re-enumerated port) keeps reporting IsOpen until an actual read/write fails. Re-verify with the
+        // cheap :02# handshake so a reconnect (e.g. ResilientCall's fault callback) rebuilds the connection
+        // instead of no-opping against a dead handle. TryClose evicts it from IExternal's per-address cache.
+        if (_conn is { IsOpen: true } existing)
+        {
+            string? identity = null;
+            try
+            {
+                identity = await GeminiFocuserProtocol.IdentifyAsync(existing, cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                Logger.LogWarning(ex, "Gemini Focuser {DeviceId}: liveness handshake threw on a nominally open connection.", device.DeviceId);
+            }
+
+            if (identity == GeminiFocuserProtocol.PresentReply)
+            {
+                _connected = true;
+                return;
+            }
+
+            Logger.LogWarning("Gemini Focuser {DeviceId}: open connection did not answer the handshake; rebuilding the connection.", device.DeviceId);
+            existing.TryClose();
+            _conn = null;
+        }
+
+        if (await device.ConnectSerialDeviceAsync(External, Logger, TimeProvider, GeminiFocuserProtocol.Baud, Encoding.ASCII, cancellationToken).ConfigureAwait(false)
+            is not { IsOpen: true } conn)
+        {
+            throw new InvalidOperationException($"Could not open serial port for {device.DisplayName}");
+        }
+
+        try
+        {
+            // Sleep through the controller's power-on-reset boot before the first handshake (see BootDelay).
+            await TimeProvider.SleepAsync(BootDelay, cancellationToken).ConfigureAwait(false);
+
+            // Booted now: a couple of clean handshake attempts. Retry only on NO answer.
+            string? identity = null;
+            for (var attempt = 0; attempt < HandshakeAttempts; attempt++)
+            {
+                using (var attemptCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken))
+                {
+                    attemptCts.CancelAfter(HandshakeTimeout);
+                    try
+                    {
+                        identity = await GeminiFocuserProtocol.IdentifyAsync(conn, attemptCts.Token).ConfigureAwait(false);
+                    }
+                    catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+                    {
+                        identity = null;
+                    }
+                }
+
+                if (identity is not null)
+                {
+                    break;
+                }
+
+                await TimeProvider.SleepAsync(HandshakeRetryInterval, cancellationToken).ConfigureAwait(false);
+            }
+
+            if (identity != GeminiFocuserProtocol.PresentReply)
+            {
+                throw new InvalidOperationException($"Device on {device.DeviceId} is not a Gemini Focuser (handshake: '{identity ?? "<none>"}')");
+            }
+
+            var firmware = await GeminiFocuserProtocol.GetFirmwareAsync(conn, cancellationToken).ConfigureAwait(false);
+            if (firmware is { } fw)
+            {
+                Logger.LogInformation("Gemini Focuser {DeviceId}: firmware '{Name}' version {Version}.", device.DeviceId, fw.Name, fw.Version?.ToString() ?? "?");
+            }
+
+            // Cache the immutable-ish capabilities once (see field comment).
+            if (await GeminiFocuserProtocol.GetMaxStepAsync(conn, cancellationToken).ConfigureAwait(false) is { } maxStep)
+            {
+                _maxStep = maxStep;
+            }
+            else
+            {
+                Logger.LogWarning("Gemini Focuser {DeviceId}: MaxStep query returned no value; defaulting to {Default}.", device.DeviceId, _maxStep);
+            }
+
+            _stepSize = await GeminiFocuserProtocol.GetStepSizeAsync(conn, cancellationToken).ConfigureAwait(false) is { } stepSize && stepSize > 0
+                ? stepSize
+                : double.NaN;
+
+            _tempCompAvailable = await GeminiFocuserProtocol.GetTempCompAvailableAsync(conn, cancellationToken).ConfigureAwait(false);
+        }
+        catch
+        {
+            conn.TryClose();
+            throw;
+        }
+
+        _conn = conn;
+        _connected = true;
+        DeviceConnectedEvent?.Invoke(this, new DeviceConnectedEventArgs(true));
+    }
+
+    public ValueTask DisconnectAsync(CancellationToken cancellationToken = default)
+    {
+        _conn?.TryClose();
+        _conn = null;
+        _connected = false;
+        DeviceConnectedEvent?.Invoke(this, new DeviceConnectedEventArgs(false));
+        return ValueTask.CompletedTask;
+    }
+
+    public void Dispose() => _conn?.TryClose();
+
+    public ValueTask DisposeAsync() => DisconnectAsync();
+}

--- a/src/TianWen.Lib/Devices/Gemini/GeminiFocuserProtocol.cs
+++ b/src/TianWen.Lib/Devices/Gemini/GeminiFocuserProtocol.cs
@@ -1,0 +1,181 @@
+using System;
+using System.Globalization;
+using System.Threading;
+using System.Threading.Tasks;
+using TianWen.Lib.Connections;
+
+namespace TianWen.Lib.Devices.Gemini;
+
+/// <summary>
+/// Pure wire codec for the Gemini Focuser Pro serial protocol (see
+/// <c>docs/architecture/gemini-focuser-pro-protocol.md</c>). The Gemini Focuser Pro is a rebadged
+/// <c>myFocuserPro2</c> Arduino controller: commands are framed <c>':' + code + [arg] + '#'</c> and
+/// responses are <c>&lt;response-char&gt; + payload + '#'</c> — a single leading status char (which the
+/// decoder strips unconditionally, exactly as the vendor ASCOM driver's <c>Substring(1, len-2)</c> does)
+/// followed by the value. <b>Get</b> commands reply; <b>set</b> commands (Move/Halt) are silent
+/// fire-and-forget, so the driver never waits on them. Every method acquires the connection lock for its
+/// own exchange, so the driver, the discovery probe, and unit tests all share one implementation over an
+/// <see cref="ISerialConnection"/>.
+/// </summary>
+internal static class GeminiFocuserProtocol
+{
+    public const int Baud = 9600;
+
+    // Payload returned by the ':02#' controller-present handshake on a myFocuserPro2 board.
+    public const string PresentReply = "OK";
+
+    // '#'-terminated framing (the LX200 family — see ProbeFraming.HashTerminated).
+    private static readonly ReadOnlyMemory<byte> Terminator = new([(byte)'#']);
+
+    // Bounded read for the reply-bearing set command (:23x# temp-comp toggle acks "OK"); a firmware that
+    // stays silent just times out cleanly. The get commands are bounded by the caller's own token/budget.
+    private static readonly TimeSpan AckTimeout = TimeSpan.FromMilliseconds(750);
+
+    /// <summary>Sends <c>:02#</c> (controller-present handshake) and returns the payload — <see cref="PresentReply"/> on a live myFocuserPro2 board, else null/other.</summary>
+    public static ValueTask<string?> IdentifyAsync(ISerialConnection conn, CancellationToken cancellationToken)
+        => QueryAsync(conn, ":02#", cancellationToken);
+
+    /// <summary>
+    /// Sends <c>:04#</c> and parses the <c>&lt;name&gt;\r\n&lt;version&gt;</c> firmware reply. The Gemini
+    /// Focuser Pro ships whatever myFocuserPro2 firmware name was flashed (there is no distinctive "Gemini"
+    /// token on the wire — the vendor driver stores this name but never validates it), so we surface it as
+    /// metadata rather than gating discovery on it.
+    /// </summary>
+    public static async ValueTask<(string Name, int? Version)?> GetFirmwareAsync(ISerialConnection conn, CancellationToken cancellationToken)
+    {
+        var payload = await QueryAsync(conn, ":04#", cancellationToken).ConfigureAwait(false);
+        if (payload is not { Length: > 0 })
+        {
+            return null;
+        }
+
+        // Reply body (leading status char already stripped) is "<name>\r\n<version>". Split on the first CR;
+        // the version is the digits that follow (skipping CR/LF). Tolerant of a name-only reply.
+        var cr = payload.IndexOf('\r');
+        if (cr < 0)
+        {
+            return (payload.Trim(), null);
+        }
+
+        var name = payload[..cr];
+        var rest = payload[cr..].Trim();
+        return (name, int.TryParse(rest, NumberStyles.Integer, CultureInfo.InvariantCulture, out var v) ? v : null);
+    }
+
+    /// <summary>Sends <c>:00#</c> and returns the current absolute position, or null when unavailable/unparseable.</summary>
+    public static ValueTask<int?> GetPositionAsync(ISerialConnection conn, CancellationToken cancellationToken)
+        => QueryIntAsync(conn, ":00#", cancellationToken);
+
+    /// <summary>Sends <c>:01#</c> and returns whether the focuser is moving (payload <c>1</c> = moving).</summary>
+    public static async ValueTask<bool> GetIsMovingAsync(ISerialConnection conn, CancellationToken cancellationToken)
+        => await QueryIntAsync(conn, ":01#", cancellationToken).ConfigureAwait(false) is { } m && m != 0;
+
+    /// <summary>Sends <c>:08#</c> and returns the maximum step position, or null when unavailable/unparseable.</summary>
+    public static ValueTask<int?> GetMaxStepAsync(ISerialConnection conn, CancellationToken cancellationToken)
+        => QueryIntAsync(conn, ":08#", cancellationToken);
+
+    /// <summary>Sends <c>:06#</c> and returns the temperature in °C, or NaN when unavailable/unparseable.</summary>
+    public static async ValueTask<double> GetTemperatureAsync(ISerialConnection conn, CancellationToken cancellationToken)
+    {
+        var payload = await QueryAsync(conn, ":06#", cancellationToken).ConfigureAwait(false);
+        return double.TryParse(payload, NumberStyles.Float, CultureInfo.InvariantCulture, out var t) ? t : double.NaN;
+    }
+
+    /// <summary>Sends <c>:33#</c> and returns the step size in microns, or null when unavailable/unparseable.</summary>
+    public static async ValueTask<double?> GetStepSizeAsync(ISerialConnection conn, CancellationToken cancellationToken)
+    {
+        var payload = await QueryAsync(conn, ":33#", cancellationToken).ConfigureAwait(false);
+        return double.TryParse(payload, NumberStyles.Float, CultureInfo.InvariantCulture, out var s) ? s : null;
+    }
+
+    /// <summary>Sends <c>:24#</c> and returns whether temperature compensation is currently enabled.</summary>
+    public static async ValueTask<bool> GetTempCompAsync(ISerialConnection conn, CancellationToken cancellationToken)
+        => await QueryIntAsync(conn, ":24#", cancellationToken).ConfigureAwait(false) is { } t && t != 0;
+
+    /// <summary>Sends <c>:25#</c> and returns whether the controller supports temperature compensation.</summary>
+    public static async ValueTask<bool> GetTempCompAvailableAsync(ISerialConnection conn, CancellationToken cancellationToken)
+        => await QueryIntAsync(conn, ":25#", cancellationToken).ConfigureAwait(false) is { } t && t != 0;
+
+    /// <summary>Enables (<c>:231#</c>) or disables (<c>:230#</c>) temperature compensation; this set command acks with <c>OK</c>.</summary>
+    public static async ValueTask SetTempCompAsync(ISerialConnection conn, bool enabled, CancellationToken cancellationToken)
+    {
+        using var @lock = await conn.WaitAsync(cancellationToken).ConfigureAwait(false);
+        if (!await conn.TryWriteAsync(enabled ? ":231#" : ":230#", cancellationToken).ConfigureAwait(false))
+        {
+            return;
+        }
+
+        // The temp-comp toggle is the one set command the controller acks ("OK"); drain it (bounded) so it
+        // can't offset the next query's read. A silent firmware just times out cleanly.
+        using var ackCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        ackCts.CancelAfter(AckTimeout);
+        try
+        {
+            _ = await conn.TryReadTerminatedAsync(Terminator, ackCts.Token).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+        {
+            // No ack within AckTimeout — fine.
+        }
+    }
+
+    /// <summary>Commands an absolute move to <paramref name="position"/> (<c>:05&lt;pos&gt;#</c>). Silent fire-and-forget — poll <see cref="GetIsMovingAsync"/>.</summary>
+    public static ValueTask MoveAsync(ISerialConnection conn, int position, CancellationToken cancellationToken)
+        => SendAsync(conn, $":05{Math.Max(0, position).ToString(CultureInfo.InvariantCulture)}#", cancellationToken);
+
+    /// <summary>Halts any motion (<c>:27#</c>). Silent fire-and-forget.</summary>
+    public static ValueTask HaltAsync(ISerialConnection conn, CancellationToken cancellationToken)
+        => SendAsync(conn, ":27#", cancellationToken);
+
+    private static async ValueTask<int?> QueryIntAsync(ISerialConnection conn, string command, CancellationToken cancellationToken)
+    {
+        var payload = await QueryAsync(conn, command, cancellationToken).ConfigureAwait(false);
+        return int.TryParse(payload, NumberStyles.Integer, CultureInfo.InvariantCulture, out var v) ? v : null;
+    }
+
+    /// <summary>Writes a '#'-terminated command and returns the framed reply's payload (leading status char and trailing '#' stripped).</summary>
+    private static async ValueTask<string?> QueryAsync(ISerialConnection conn, string command, CancellationToken cancellationToken)
+    {
+        using var @lock = await conn.WaitAsync(cancellationToken).ConfigureAwait(false);
+        if (!await conn.TryWriteAsync(command, cancellationToken).ConfigureAwait(false))
+        {
+            return null;
+        }
+
+        var raw = await conn.TryReadTerminatedAsync(Terminator, cancellationToken).ConfigureAwait(false);
+        return ParsePayload(raw);
+    }
+
+    /// <summary>
+    /// Writes a '#'-terminated set command with no reply read. myFocuserPro2 set commands (Move/Halt) are
+    /// silent, so — unlike the FlatPanel, which acks everything — there is nothing to drain here. Kept fast
+    /// because the imaging/autofocus hot path issues moves frequently.
+    /// </summary>
+    private static async ValueTask SendAsync(ISerialConnection conn, string command, CancellationToken cancellationToken)
+    {
+        using var @lock = await conn.WaitAsync(cancellationToken).ConfigureAwait(false);
+        _ = await conn.TryWriteAsync(command, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Parses a framed reply by stripping the single leading status char and an optional trailing <c>'#'</c>
+    /// (the read may or may not include the terminator). Mirrors the vendor driver's unconditional
+    /// <c>Substring(1, len-2)</c>: the leading char is a status code, never part of the value.
+    /// </summary>
+    internal static string? ParsePayload(string? raw)
+    {
+        if (raw is null)
+        {
+            return null;
+        }
+
+        var s = raw;
+        if (s.EndsWith('#'))
+        {
+            s = s[..^1];
+        }
+
+        // Drop the leading status char. A zero-length body (bare status char) yields an empty payload.
+        return s.Length >= 1 ? s[1..] : null;
+    }
+}

--- a/src/TianWen.Lib/Devices/Gemini/GeminiFocuserSerialProbe.cs
+++ b/src/TianWen.Lib/Devices/Gemini/GeminiFocuserSerialProbe.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using TianWen.Lib.Connections;
+using TianWen.Lib.Devices.Discovery;
+
+namespace TianWen.Lib.Devices.Gemini;
+
+/// <summary>
+/// Serial probe for the Gemini Focuser Pro. Sends <c>:02#</c> and matches the myFocuserPro2
+/// controller-present reply (<c>OK</c>). The Gemini Focuser Pro carries no distinctive identity on the wire
+/// (it is a rebadged myFocuserPro2, and the vendor ASCOM driver validates nothing beyond this handshake), so
+/// the match is deliberately the generic myFocuserPro2 handshake and any responder is surfaced as a Gemini
+/// Focuser Pro — the reported <c>:04#</c> firmware name is captured into metadata so the actual flashed name
+/// is visible once real hardware connects. Shares the 9600-baud probe group (the LX200 family); framing is
+/// <c>#</c>-terminated.
+/// </summary>
+internal sealed class GeminiFocuserSerialProbe : ISerialProbe
+{
+    public string Name => "GeminiFocuser";
+    public int BaudRate => GeminiFocuserProtocol.Baud;
+    public Encoding Encoding => Encoding.ASCII;
+    public ProbeFraming Framing => ProbeFraming.HashTerminated;
+    public TimeSpan Budget => TimeSpan.FromMilliseconds(500);
+    public int MaxAttempts => 1;
+
+    // The myFocuserPro2 Arduino resets when the port opens (DTR auto-reset) and ignores input until it has
+    // booted (~2s). Discovery reopens the port per probe, so the boot restarts every probe — warm up here.
+    public TimeSpan Warmup => TimeSpan.FromMilliseconds(2200);
+
+    // The Arduino holds in reset until DTR is asserted; honoured only on the isolated per-probe pass
+    // (see ISerialProbe.AssertControlLines) so we don't reset a different DTR-triggered controller on pass 1.
+    public bool AssertControlLines => true;
+
+    private static readonly IReadOnlyCollection<string> _hosts = [nameof(GeminiFocuserDevice)];
+    public IReadOnlyCollection<string> MatchesDeviceHosts => _hosts;
+
+    public async ValueTask<SerialProbeMatch?> ProbeAsync(string port, ISerialConnection conn, CancellationToken cancellationToken)
+    {
+        var identity = await GeminiFocuserProtocol.IdentifyAsync(conn, cancellationToken);
+        if (identity != GeminiFocuserProtocol.PresentReply)
+        {
+            return null;
+        }
+
+        var firmware = await GeminiFocuserProtocol.GetFirmwareAsync(conn, cancellationToken);
+
+        var portWithoutPrefix = ISerialConnection.RemoveProtoPrrefix(port);
+        var deviceId = $"GeminiFocuser_{portWithoutPrefix}";
+        var displayName = $"Gemini Focuser Pro on {portWithoutPrefix}";
+        var query = $"{DeviceQueryKey.Port.Key}={Uri.EscapeDataString(port)}";
+        var uri = new Uri($"{DeviceType.Focuser}://{typeof(GeminiFocuserDevice).Name}/{deviceId}?{query}#{displayName}");
+
+        Dictionary<string, string>? metadata = null;
+        if (firmware is { } fw)
+        {
+            metadata = new Dictionary<string, string> { ["firmwareName"] = fw.Name };
+            if (fw.Version is { } v)
+            {
+                metadata["firmware"] = v.ToString();
+            }
+        }
+
+        return new SerialProbeMatch(port, uri, metadata);
+    }
+}

--- a/src/TianWen.Lib/Devices/NativeDriverBlacklist.cs
+++ b/src/TianWen.Lib/Devices/NativeDriverBlacklist.cs
@@ -29,15 +29,17 @@ internal static class NativeDriverBlacklist
 {
     // ASCOM ProgID -> DeviceClass (URI host, == the native device type name) of the family that supersedes
     // it. Only vendors whose native driver is a genuine, complete replacement for the SAME device type are
-    // listed. Deliberately excluded: ASCOM.GeminiFocuserPro (a different Gemini product, not natively
-    // implemented) and the mount drivers (ASCOM.iOptron2017/OnStep/SkyWatcher), whose native equivalents
-    // cover only a vendor subset -- e.g. native iOptron is the SkyGuider Pro, not the CEM/GEM/HEM range
-    // ASCOM.iOptron2017.Telescope drives -- so hiding them would remove mounts we cannot otherwise control.
+    // listed. Deliberately excluded: the mount drivers (ASCOM.iOptron2017/OnStep/SkyWatcher), whose native
+    // equivalents cover only a vendor subset -- e.g. native iOptron is the SkyGuider Pro, not the CEM/GEM/HEM
+    // range ASCOM.iOptron2017.Telescope drives -- so hiding them would remove mounts we cannot otherwise control.
     private static readonly IReadOnlyDictionary<string, string> _nativeClassByProgId =
         new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
         {
             // Gemini FlatPanel Lite -- native serial cover/calibrator (GeminiDevice, AddGemini).
             ["ASCOM.GeminiFPLite.CoverCalibrator"] = "GeminiDevice",
+
+            // Gemini Focuser Pro -- native serial focuser, a rebadged myFocuserPro2 (GeminiFocuserDevice, AddGemini).
+            ["ASCOM.GeminiFocuserPro.Focuser"] = "GeminiFocuserDevice",
 
             // ZWO ASI camera / EAF focuser / EFW filter wheel -- native ZWO SDK (ZWODevice, AddZWO).
             ["ASCOM.ASICamera2.Camera"] = "ZWODevice",

--- a/src/TianWen.Lib/Extensions/GeminiServiceCollectionExtensions.cs
+++ b/src/TianWen.Lib/Extensions/GeminiServiceCollectionExtensions.cs
@@ -6,10 +6,13 @@ namespace TianWen.Lib.Extensions;
 public static class GeminiServiceCollectionExtensions
 {
     /// <summary>
-    /// Registers the Gemini FlatPanel Lite as a native (ASCOM-free) serial cover/calibrator device source
-    /// plus its discovery probe (9600 baud, <c>#</c>-terminated, shares the LX200-family probe group).
+    /// Registers the native (ASCOM-free) Gemini serial devices plus their discovery probes (9600 baud,
+    /// <c>#</c>-terminated, sharing the LX200-family probe group): the FlatPanel Lite cover/calibrator and
+    /// the Focuser Pro (a rebadged myFocuserPro2 controller).
     /// </summary>
     public static IServiceCollection AddGemini(this IServiceCollection services) => services
         .AddDevicSource<GeminiDevice, GeminiDeviceSource>(uri => new GeminiDevice(uri))
-        .AddSerialProbe<GeminiFlatPanelSerialProbe>();
+        .AddSerialProbe<GeminiFlatPanelSerialProbe>()
+        .AddDevicSource<GeminiFocuserDevice, GeminiFocuserDeviceSource>(uri => new GeminiFocuserDevice(uri))
+        .AddSerialProbe<GeminiFocuserSerialProbe>();
 }


### PR DESCRIPTION
## Summary

Native (ASCOM-free) serial `IFocuserDriver` for the **Gemini Focuser Pro**, a rebadged **myFocuserPro2** Arduino controller. Mirrors the existing Gemini FlatPanel Lite set and closes the last Gemini blacklist gap.

Protocol reverse-engineered from the decompiled vendor `ASCOM.GeminiFocuserPro.Focuser` driver (`:NN#` framing, 9600 8N1, `comms()` transport + property getters/setters).

### What's added
- **`GeminiFocuserProtocol`** — pure `:NN#` wire codec (get/set commands; `ParsePayload` strips the leading status char + terminator, matching the vendor's `Substring(1, len-2)`), reused by driver + probe + tests.
- **`GeminiFocuserDriver`** (`IFocuserDriver`) — DTR-reset + ~2.2 s boot connect, `:02#` liveness/reconnect, caches MaxStep/StepSize/TempCompAvailable at connect. Move/Halt are silent fire-and-forget (fast autofocus path); only the temp-comp toggle acks (drained).
- **`GeminiFocuserDevice`** — new URI record (`DeviceClass = geminifocuserdevice`), asserts DTR+RTS + `SynchronousReads` for CH34x.
- **`GeminiFocuserSerialProbe` / `GeminiFocuserDeviceSource`** — auto-discovery via the generic myFP2 `:02#`→`OK` handshake; captures the `:04#` firmware name into metadata.
- **Wiring**: `AddGemini()` registers both Gemini sets. **Blacklist**: `ASCOM.GeminiFocuserPro.Focuser → GeminiFocuserDevice`, hiding the ASCOM twin only when the native focuser is discovered.

### Identity caveat (by design)
`:02#`→`OK` is the *generic* myFocuserPro2 handshake — there is no Gemini-specific token on the wire. We treat any responder as a Gemini Focuser Pro (no other myFP2 units expected in practice) and surface the flashed `:04#` name in metadata; tightening the matcher later is a one-liner.

### Tests
All green (77 in the Gemini/blacklist/discovery slice): `GeminiFocuserProtocolTests`, `GeminiFocuserSerialProbeTests` + `FakeGeminiFocuserSerialDevice`, updated `NativeDriverBlacklistTests`, and a hardware-gated `GeminiFocuserHardwareTests` (`TIANWEN_GEMINI_FOCUSER_PORT`, skips when unset).

### Docs
`docs/architecture/gemini-focuser-pro-protocol.md`; added the missing Gemini subgraph (FlatPanel + Focuser) to `device-architecture.md`; CLAUDE.md driver-list update.

### Open items (hardware validation — the ~10%)
1. Exact `:04#` firmware name (tighten matcher only if distinctive).
2. DTR-reset actually required + exact boot time.
3. Whether Move/Halt are truly unacked (add a bounded drain if not).

🤖 Generated with [Claude Code](https://claude.com/claude-code)