### PR TITLE
build(deps): bump DIR.Lib 6.4.*->6.8.* + SdlVulkan.Renderer 6.11.*->6.16.*

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -103,9 +103,11 @@
          `using Layout = DIR.Lib.Layout;` and write Layout.Node / Layout.Builder / Layout.Sizing. Lockstep
          with Console.Lib 3.3 + SdlVulkan.Renderer 6.7.
          6.3 bumped alongside SdlVulkan.Renderer 6.10 (which requires DIR.Lib >= 6.3.1201).
-         6.4 is the current pin; the DIR.Lib / SdlVulkan.Renderer / Console.Lib lockstep continues
-         (SdlVulkan.Renderer 6.11 + Console.Lib 3.5). -->
-    <PackageVersion Include="DIR.Lib" Version="6.4.*" />
+         6.4-6.6 continue the lockstep with SdlVulkan.Renderer 6.11-6.15 + Console.Lib 3.5.
+         6.8 is the current pin; DIR.Lib.Shaping 6.8 rebuilt against SharpAstro.Fonts.Shaping 1.5.551
+         (F6+F7: ~3-4x faster, zero-alloc shaping), but TianWen does not reference the shaping satellite,
+         so this bump only lifts the core off the stale 6.4 line (lockstep with SdlVulkan.Renderer 6.16). -->
+    <PackageVersion Include="DIR.Lib" Version="6.8.*" />
     <!-- DIR.Lib 3.0 extracted its codec layer to these sibling packages, which
          ship as a lockstep family from the Codecs repo. 3.0 brought a
          binary-breaking SharpAstro.Tiff change (TiffPageOptions.IccProfile is
@@ -194,8 +196,10 @@
          (ArrangedNode.Depth + PixelWidgetBase.GetCapturedLayout + LayoutInspection).
          6.10 adds DebugSignalArgs (JsonElement OptInt/OptDouble/OptBool/OptString extension members) used by
          Program.cs's DebugInspector SignalFactories; without this bump the GUI DEBUG build fails CS1061.
-         6.11 is the current pin (lockstep rebuild against DIR.Lib 6.4). -->
-    <PackageVersion Include="SdlVulkan.Renderer" Version="6.11.*" />
+         6.11 was the prior pin (lockstep rebuild against DIR.Lib 6.4).
+         6.16 is the current pin: re-pins its own DIR.Lib floor 6.6.* -> 6.8.* (so it requires DIR.Lib >= 6.8),
+         which is why the DIR.Lib pin above must move to 6.8.* in lockstep. -->
+    <PackageVersion Include="SdlVulkan.Renderer" Version="6.16.*" />
     <PackageVersion Include="SDL3-CS" Version="3.5.0-preview.20260213-150035" />
     <PackageVersion Include="SDL3-CS.Native" Version="3.5.0-preview.20260205-174353" />
     <!-- Canon DSLR -->


### PR DESCRIPTION
Re-pins the two SharpAstro UI siblings onto their current minor lines after the DIR.Lib 6.8 / SdlVulkan.Renderer 6.16 release chain.

## Why
- `SdlVulkan.Renderer` **6.16.1421** raises its own DIR.Lib floor `6.6.* -> 6.8.*`, so it requires `DIR.Lib >= 6.8`. The two must move in lockstep — a patch-glob (`6.4.*`) never crosses a minor, so CI stayed on the stale line.
- `DIR.Lib` **6.8.1341** (+ `DIR.Lib.Shaping` 6.8.1341, rebuilt against `SharpAstro.Fonts.Shaping` 1.5.551 for the F6+F7 ~3-4x faster, zero-alloc shaper).

## Scope for TianWen
This is a **line-lift only, not a perf change**: TianWen does not reference the `DIR.Lib.Shaping` satellite (no csproj ref, no shaping-API usage), and the renderer core is shaping-agnostic — so the faster shaper does not reach this app. The bump just moves TianWen off the stale `6.4.*`/`6.11.*` pins onto the current `6.8.*`/`6.16.*` lines.

## Verification
`dotnet restore -p:UseLocalSiblings=false` (the package path CI takes): all 17 projects restored, exit 0, zero NU errors/warnings — 6.8.1341 and 6.16.1421 are indexed on nuget.org and resolve compatibly. CPM comments carry no `--` sequences (no NU1015).

🤖 Generated with [Claude Code](https://claude.com/claude-code)