### PR TITLE
fix(planner): pin follows selection into the pinned section

### DIFF
--- a/src/TianWen.Cli/Tui/TuiPlannerTab.cs
+++ b/src/TianWen.Cli/Tui/TuiPlannerTab.cs
@@ -226,7 +226,9 @@ internal sealed class TuiPlannerTab(
                     case InputKey.Enter:
                         if (plannerState.SelectedTargetIndex >= 0 && plannerState.SelectedTargetIndex < filtered.Count)
                         {
-                            PlannerActions.ToggleProposal(plannerState, filtered[plannerState.SelectedTargetIndex].Target);
+                            // followPinnedSelection: the cursor follows the pinned target into the
+                            // pinned section (render's EnsureVisible then scrolls it into view).
+                            PlannerActions.ToggleProposal(plannerState, filtered[plannerState.SelectedTargetIndex].Target, followPinnedSelection: true);
                             NeedsRedraw = true;
                         }
                         return false;

--- a/src/TianWen.Lib.Tests/PlannerSelectionTests.cs
+++ b/src/TianWen.Lib.Tests/PlannerSelectionTests.cs
@@ -1,0 +1,133 @@
+using Shouldly;
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using TianWen.Lib.Astrometry.SOFA;
+using TianWen.Lib.Devices;
+using TianWen.Lib.Sequencing;
+using TianWen.UI.Abstractions;
+using Xunit;
+
+namespace TianWen.Lib.Tests;
+
+/// <summary>
+/// Tests for planner list-selection behaviour around pinning
+/// (<see cref="PlannerActions.ToggleProposal"/>). The GUI/TUI navigate the pinned-first
+/// <see cref="PlannerActions.GetFilteredTargets"/> list, so on a pin the cursor should
+/// follow the object into the pinned section at the top (<c>followPinnedSelection: true</c>)
+/// instead of being left at the old index where an unrelated target slides under it. The
+/// <c>plan</c> CLI navigates the un-reordered <see cref="PlannerState.TonightsBest"/> and
+/// keeps the default (no follow).
+/// </summary>
+public class PlannerSelectionTests
+{
+    private static readonly DateTimeOffset NightStart = new(2025, 12, 15, 18, 0, 0, TimeSpan.Zero);
+    private static readonly DateTimeOffset NightEnd = new(2025, 12, 16, 6, 0, 0, TimeSpan.Zero);
+
+    private static Target T(int id) => new(0, 45, $"T{id}", null);
+
+    // Peak at a fraction of the night so GetFilteredTargets' peak-time sort is deterministic.
+    private static List<(DateTimeOffset Time, double Alt)> PeakProfile(double peakFraction)
+    {
+        var nightSeconds = (NightEnd - NightStart).TotalSeconds;
+        var peakTime = NightStart + TimeSpan.FromSeconds(nightSeconds * peakFraction);
+        return [(NightStart, 0), (peakTime, 80), (NightEnd, 0)];
+    }
+
+    /// <summary>Builds a state with <paramref name="targets"/> as unpinned TonightsBest entries.</summary>
+    private static PlannerState BuildUnpinnedState(
+        IReadOnlyList<(Target Target, List<(DateTimeOffset, double)> Profile)> targets)
+    {
+        var state = new PlannerState
+        {
+            AstroDark = NightStart,
+            AstroTwilight = NightEnd,
+            MinHeightAboveHorizon = 0,
+        };
+
+        var scoredBuilder = ImmutableDictionary.CreateBuilder<Target, ScoredTarget>();
+        var profilesBuilder = ImmutableDictionary.CreateBuilder<Target, List<(DateTimeOffset Time, double Alt)>>();
+        var tonightsBuilder = ImmutableArray.CreateBuilder<ScoredTarget>();
+
+        for (var i = 0; i < targets.Count; i++)
+        {
+            var (target, profile) = targets[i];
+            var optimalStart = NightStart + TimeSpan.FromMinutes(60 * (i + 1));
+            var scored = new ScoredTarget(target, (Half)1.0, (Half)1.0,
+                new Dictionary<RaDecEventTime, RaDecEventInfo>(),
+                OptimalStart: optimalStart, OptimalDuration: TimeSpan.FromHours(1));
+            scoredBuilder[target] = scored;
+            profilesBuilder[target] = profile;
+            tonightsBuilder.Add(scored);
+        }
+
+        state.ScoredTargets = scoredBuilder.ToImmutable();
+        state.AltitudeProfiles = profilesBuilder.ToImmutable();
+        state.TonightsBest = tonightsBuilder.ToImmutable();
+        return state;
+    }
+
+    [Fact]
+    public void GivenUnpinnedTargetWhenPinnedWithFollowThenSelectionMovesToPinnedSlot()
+    {
+        var a = T(1);
+        var b = T(2);
+        var c = T(3);
+        // Ascending peak times so the unpinned filtered order matches TonightsBest order [a, b, c].
+        var state = BuildUnpinnedState([(a, PeakProfile(0.2)), (b, PeakProfile(0.5)), (c, PeakProfile(0.8))]);
+
+        // Cursor on C (last row of the all-unpinned list).
+        var before = PlannerActions.GetFilteredTargets(state);
+        before[2].Target.ShouldBe(c);
+        state.SelectedTargetIndex = 2;
+
+        PlannerActions.ToggleProposal(state, c, followPinnedSelection: true);
+
+        // C is now pinned -> sorted to the top; the cursor followed it there.
+        var after = PlannerActions.GetFilteredTargets(state);
+        state.PinnedCount.ShouldBe(1);
+        state.SelectedTargetIndex.ShouldBe(0);
+        after[state.SelectedTargetIndex].Target.ShouldBe(c);
+    }
+
+    [Fact]
+    public void GivenPinWithoutFollowThenSelectionIndexStaysPut()
+    {
+        var a = T(1);
+        var b = T(2);
+        var c = T(3);
+        var state = BuildUnpinnedState([(a, PeakProfile(0.2)), (b, PeakProfile(0.5)), (c, PeakProfile(0.8))]);
+        state.SelectedTargetIndex = 2;
+
+        // Default (no follow) -- the `plan` CLI path. Index is unchanged, so after the
+        // pinned-to-top reorder a *different* target sits under the cursor (legacy behaviour,
+        // which is correct for the CLI since it navigates the un-reordered TonightsBest).
+        PlannerActions.ToggleProposal(state, c);
+
+        state.SelectedTargetIndex.ShouldBe(2);
+        var after = PlannerActions.GetFilteredTargets(state);
+        after[2].Target.ShouldNotBe(c);
+    }
+
+    [Fact]
+    public void GivenUnpinWithFollowThenSelectionUsesClampNotFollow()
+    {
+        var a = T(1);
+        var b = T(2);
+        var state = BuildUnpinnedState([(a, PeakProfile(0.3)), (b, PeakProfile(0.7))]);
+
+        // Pin both; filtered pinned order is [a, b] by peak time.
+        PlannerActions.ToggleProposal(state, a, followPinnedSelection: true);
+        PlannerActions.ToggleProposal(state, b, followPinnedSelection: true);
+        state.PinnedCount.ShouldBe(2);
+        state.SelectedTargetIndex = 1;
+
+        // Unpin b. followPinnedSelection is ignored on an unpin: the index is in range (1 < 2),
+        // so the clamp leaves it put rather than following anything.
+        PlannerActions.ToggleProposal(state, b, followPinnedSelection: true);
+
+        state.SelectedTargetIndex.ShouldBe(1);
+        var after = PlannerActions.GetFilteredTargets(state);
+        state.SelectedTargetIndex.ShouldBeLessThan(after.Count);
+    }
+}

--- a/src/TianWen.UI.Abstractions/PlannerActions.cs
+++ b/src/TianWen.UI.Abstractions/PlannerActions.cs
@@ -1079,9 +1079,19 @@ public static class PlannerActions
     /// <summary>
     /// Toggles a target: if already proposed, removes it; otherwise adds it.
     /// </summary>
-    public static void ToggleProposal(PlannerState state, Target target, ObservationPriority priority = ObservationPriority.Normal)
+    /// <param name="followPinnedSelection">
+    /// When true and this call PINS the target, moves <see cref="PlannerState.SelectedTargetIndex"/>
+    /// to the target's new row in the pinned-first filtered list (i.e. the cursor follows the object
+    /// you just pinned into the pinned section at the top). The GUI/TUI planner tabs -- which navigate
+    /// the reordered <see cref="GetFilteredTargets"/> list -- pass true so the selection doesn't get
+    /// left at the old index with an unrelated target sliding under it. The <c>plan</c> CLI navigates
+    /// the un-reordered <see cref="PlannerState.TonightsBest"/> directly (same index keeps the same
+    /// object under the cursor), so it leaves this false. Ignored on an unpin.
+    /// </param>
+    public static void ToggleProposal(PlannerState state, Target target, ObservationPriority priority = ObservationPriority.Normal, bool followPinnedSelection = false)
     {
         var existingIndex = FindProposalIndex(state.Proposals, target);
+        var justPinned = existingIndex < 0;
         if (existingIndex >= 0)
         {
             state.Proposals = state.Proposals.RemoveAt(existingIndex);
@@ -1094,10 +1104,28 @@ public static class PlannerActions
         }
         RecomputeHandoffSliders(state);
 
-        // Clamp selection to valid range — cursor stays at same position so the next
-        // item in the list naturally appears under it
         var filtered = GetFilteredTargets(state);
-        if (state.SelectedTargetIndex >= filtered.Count)
+
+        // On a pin (when the caller opts in) the cursor follows the target to its slot in the
+        // pinned section, rather than staying at the old index where the target that shifted up
+        // after the pinned-to-top reorder would appear under it.
+        var followed = false;
+        if (justPinned && followPinnedSelection)
+        {
+            for (var i = 0; i < filtered.Count; i++)
+            {
+                if (filtered[i].Target == target)
+                {
+                    state.SelectedTargetIndex = i;
+                    followed = true;
+                    break;
+                }
+            }
+        }
+
+        // Otherwise clamp selection to valid range — cursor stays put so the next item in the
+        // list naturally appears under it (the unpin path, and the no-follow CLI path).
+        if (!followed && state.SelectedTargetIndex >= filtered.Count)
         {
             state.SelectedTargetIndex = Math.Max(0, filtered.Count - 1);
         }

--- a/src/TianWen.UI.Abstractions/PlannerTab.cs
+++ b/src/TianWen.UI.Abstractions/PlannerTab.cs
@@ -348,7 +348,13 @@ namespace TianWen.UI.Abstractions
                     var capturedTarget = scored.Target;
                     pinLeaf = Layout.Builder.Text("+", BaseFontSize, PinnedText, TextAlign.Center, TextAlign.Center)
                         .WFixed(BaseFontSize * 1.5f).HStar().Bg(PinnedBg)
-                        .Clickable(new HitResult.ButtonHit("AddProposal"), _ => PlannerActions.ToggleProposal(state, capturedTarget));
+                        .Clickable(new HitResult.ButtonHit("AddProposal"), _ =>
+                        {
+                            // Match the keyboard-pin behaviour: the selection follows the pinned target
+                            // up into the pinned section, and we scroll it into view.
+                            PlannerActions.ToggleProposal(state, capturedTarget, followPinnedSelection: true);
+                            EnsureVisible(state.SelectedTargetIndex);
+                        });
                 }
 
                 // Whole row: [pad | name * | type | info | pad | pin]. Column widths + fonts are raw design
@@ -569,7 +575,10 @@ namespace TianWen.UI.Abstractions
                     return true;
 
                 case InputKey.Enter when state.SelectedTargetIndex >= 0 && state.SelectedTargetIndex < filtered.Count:
-                    PlannerActions.ToggleProposal(state, filtered[state.SelectedTargetIndex].Target);
+                    PlannerActions.ToggleProposal(state, filtered[state.SelectedTargetIndex].Target, followPinnedSelection: true);
+                    // On a pin the selection followed the target into the pinned section at the top;
+                    // scroll it into view (a no-op when it's already visible).
+                    EnsureVisible(state.SelectedTargetIndex);
                     return true;
 
                 case InputKey.P when state.SelectedTargetIndex >= 0 && state.SelectedTargetIndex < filtered.Count:


### PR DESCRIPTION
## Problem
Pinning a target in the Planner (arrow to it, press Enter) left the list cursor at the same numeric index. But the list (`GetFilteredTargets`) is **pinned-first**, so the pinned target jumps to the top section and an unrelated target slides under the cursor — confusing (reported from real use).

## Fix
`PlannerActions.ToggleProposal` gains an opt-in **`followPinnedSelection`** flag. On a **pin**, the cursor moves to the target's new row in the pinned section; on an **unpin** the old clamp behaviour is kept.

- **GUI** Enter (`PlannerTab`) and the **`[+]`** button pass `true`, then `EnsureVisible(...)` scrolls the row into view.
- **TUI** Enter passes `true` (its render already `EnsureVisible`s the selected index).
- **`plan` CLI** stays on the default (`false`): it navigates the un-reordered `TonightsBest`, where the same index already keeps the same object under the cursor — so it must *not* get the filtered-list index.

Side effect: the altitude chart highlight now stays on the object you pinned instead of jumping to a different curve.

## Tests
- New `PlannerSelectionTests.cs` (3): pin-with-follow moves to the pinned slot; pin-without-follow stays put (CLI); unpin uses the clamp.
- All 12 planner unit tests green; `TianWen.Lib.Tests` + `TianWen.Cli` build with 0 warnings; clean GUI smoke run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)