### PR TITLE
build(deps): bump SdlVulkan.Renderer 6.16 -> 6.18 + fix inspector MCP launch

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -2,8 +2,8 @@
   "mcpServers": {
     "sdl-ui-inspector": {
       "type": "stdio",
-      "command": "dnx",
-      "args": ["SdlVulkan.Renderer.Inspector", "--yes"]
+      "command": "dotnet",
+      "args": ["dnx", "SdlVulkan.Renderer.Inspector@6.18.1461", "--yes"]
     }
   }
 }

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -197,9 +197,16 @@
          6.10 adds DebugSignalArgs (JsonElement OptInt/OptDouble/OptBool/OptString extension members) used by
          Program.cs's DebugInspector SignalFactories; without this bump the GUI DEBUG build fails CS1061.
          6.11 was the prior pin (lockstep rebuild against DIR.Lib 6.4).
-         6.16 is the current pin: re-pins its own DIR.Lib floor 6.6.* -> 6.8.* (so it requires DIR.Lib >= 6.8),
-         which is why the DIR.Lib pin above must move to 6.8.* in lockstep. -->
-    <PackageVersion Include="SdlVulkan.Renderer" Version="6.16.*" />
+         6.16 re-pinned its own DIR.Lib floor 6.6.* -> 6.8.* (requires DIR.Lib >= 6.8), which is why the
+         DIR.Lib pin above sits at 6.8.* in lockstep.
+         6.17 hardens GPU-wedge recovery: stuck-fence recovery runs on a sacrificial background task the
+         render thread only polls (a truly hung driver can block inside teardown), + SDF atlas hazard fixes.
+         6.18 is the current pin: idles the render loop while a window is minimized. A minimized window
+         reports a non-zero pixel size on Windows, so the old size guard missed it and the loop busy-spun
+         through swapchain recreation (~270ms/frame) for invisible frames; now gated on the SDL minimized
+         flag (~0% CPU while minimized, instant repaint on restore). Also DEBUG-only inspector additions
+         (minimize/maximize/restore + a per-iteration command pump). No DIR.Lib floor change. -->
+    <PackageVersion Include="SdlVulkan.Renderer" Version="6.18.*" />
     <PackageVersion Include="SDL3-CS" Version="3.5.0-preview.20260213-150035" />
     <PackageVersion Include="SDL3-CS.Native" Version="3.5.0-preview.20260205-174353" />
     <!-- Canon DSLR -->


### PR DESCRIPTION
Consumes **SdlVulkan.Renderer 6.18.1461** (SharpAstro/SdlVulkan.Renderer#41) and fixes the inspector MCP sidecar launch.

## Renderer 6.18
- **Minimize idle-fix**: a minimized window reports a non-zero pixel size on Windows, so the old size guard missed it and the render loop busy-spun through swapchain recreation (~270 ms/frame, ~full-core CPU) for invisible frames. Now gated on the SDL minimized flag -> **~0% CPU** while minimized, instant repaint on restore.
- Also folds in 6.17's GPU-wedge resilience.
- `Directory.Packages.props`: pin `6.16.*` -> `6.18.*` (no DIR.Lib floor change).

## `.mcp.json` inspector launch (two fixes so the MCP server connects)
- `command "dnx"` -> `"dotnet dnx"`: Windows `CreateProcess` only auto-appends `.exe`, never `.cmd`, and there's no `dnx.exe` here (only `dnx.cmd`), so the bare-`dnx` spawn never launched the server. `dotnet` is an `.exe` and resolves; portable to Linux/macOS/CI (`dnx` == `dotnet dnx`).
- Pin `@6.18.1461`: an unpinned `dnx <pkg>` does a nuget.org "resolve latest" round-trip on every launch, which under load blew the MCP client's 30 s connect timeout. A concrete version resolves from cache -- deterministic ~3.6 s start.

## Validation
Release + `UseLocalSiblings=false` build (the CI path) compiles clean against the published 6.18.1461. Minimize/restore validated end-to-end via the inspector (0% CPU minimized, instant resume). TianWen unit/functional tests don't reference the renderer, so they're unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ATx1GGJ6CyDBF2yjTqrvm7
