### PR TITLE
fix(skymap): keep selection reticles + alt/az live on date/time scrub

### DIFF
--- a/src/TianWen.Lib.Tests/SkyMapTimeScrubTests.cs
+++ b/src/TianWen.Lib.Tests/SkyMapTimeScrubTests.cs
@@ -1,6 +1,7 @@
 using System;
 using DIR.Lib;
 using Shouldly;
+using TianWen.Lib.Astrometry.SOFA;
 using TianWen.UI.Abstractions;
 using Xunit;
 
@@ -77,5 +78,94 @@ public class SkyMapTimeScrubTests
         dayColor.ShouldBe(new RGBAColor32(0x28, 0x34, 0x50, 0xFF));   // daylight dusty blue
         nightColor.ShouldBe(new RGBAColor32(0x02, 0x03, 0x08, 0xFF)); // night
         nightColor.ShouldNotBe(dayColor);
+    }
+
+    // The renderer places the Zenith reticle at RA = LST, Dec = latitude of the sky map's
+    // CURRENT viewing instant (base date + scrub offset). The fixed-point info panel must
+    // resolve its alt/az at that SAME instant -- these two tests pin the math contract that
+    // AppSignalHandler.SkyMapViewingUtc now guarantees for every sky-map handler.
+    // Southern site from the repro screenshot (Dec of the "Zenith" object read -37:52:35).
+    private const double ReproSiteLat = -37.876;
+    private const double ReproSiteLon = 145.0;
+
+    [Fact]
+    public void ZenithInfoPanel_BuiltAtTheMapsViewingInstant_ReadsNinetyDegAltitude()
+    {
+        var viewingUtc = new DateTimeOffset(2026, 7, 11, 8, 33, 0, TimeSpan.Zero);
+        var site = SiteContext.Create(ReproSiteLat, ReproSiteLon, viewingUtc);
+        site.IsValid.ShouldBeTrue();
+
+        // Exactly how VkSkyMapTab.RenderFixedPointMarkers derives the Zenith marker's RA/Dec.
+        var zenithRa = site.LST;                                         // hours
+        var zenithDec = double.RadiansToDegrees(Math.Asin(site.SinLat)); // == latitude
+
+        var panel = SkyMapInfoPanelData.FromPosition(
+            "Zenith", zenithRa, zenithDec, ReproSiteLat, ReproSiteLon, viewingUtc, site);
+
+        panel.AltDeg.ShouldBe(90.0, 0.05);
+    }
+
+    [Fact]
+    public void ZenithInfoPanel_BuiltAtAnUnscrubbedInstant_DivergesFromZenith()
+    {
+        // Regression guard: the fixed-point / mount info handlers used to drop the sky-map
+        // scrub offset, so a scrubbed Zenith was placed at the scrubbed LST but its alt/az was
+        // computed at the un-scrubbed instant. Reproduce that mismatch (the ~7.2h back-solved
+        // from the screenshot's Alt +9.9 deg / Az 229 deg) and confirm it is NOT overhead.
+        var placedUtc = new DateTimeOffset(2026, 7, 11, 8, 33, 0, TimeSpan.Zero);
+        var placed = SiteContext.Create(ReproSiteLat, ReproSiteLon, placedUtc);
+        var zenithRa = placed.LST;
+        var zenithDec = double.RadiansToDegrees(Math.Asin(placed.SinLat));
+
+        var mismatchedUtc = placedUtc + TimeSpan.FromHours(7.2);
+        var mismatched = SiteContext.Create(ReproSiteLat, ReproSiteLon, mismatchedUtc);
+
+        var panel = SkyMapInfoPanelData.FromPosition(
+            "Zenith", zenithRa, zenithDec, ReproSiteLat, ReproSiteLon, mismatchedUtc, mismatched);
+
+        panel.AltDeg.ShouldBeLessThan(20.0); // the exact bug the user saw: far below overhead
+    }
+
+    [Fact]
+    public void WithLiveHorizontal_RefreshesAltAzForTheNewInstant_ButKeepsRaDec()
+    {
+        // A fixed DSO well off the pole so its alt/az swings substantially over a few hours (Helix-ish).
+        const double raHours = 22.494;
+        const double decDeg = -20.837;
+
+        var t1 = new DateTimeOffset(2026, 7, 11, 9, 36, 0, TimeSpan.Zero);
+        var site1 = SiteContext.Create(ReproSiteLat, ReproSiteLon, t1);
+        var panel = SkyMapInfoPanelData.FromPosition(
+            "Helix", raHours, decDeg, ReproSiteLat, ReproSiteLon, t1, site1);
+
+        // Four hours later -- a fixed-RA/Dec object's alt/az must move (this is the staleness the fix cures).
+        var t2 = t1 + TimeSpan.FromHours(4);
+        var site2 = SiteContext.Create(ReproSiteLat, ReproSiteLon, t2);
+        var refreshed = panel.WithLiveHorizontal(site2);
+
+        // RA/Dec are viewing-time independent -- untouched.
+        refreshed.RA.ShouldBe(panel.RA);
+        refreshed.Dec.ShouldBe(panel.Dec);
+
+        // Alt/Az tracked the new instant: moved noticeably, and match a full rebuild at t2 exactly.
+        Math.Abs(refreshed.AltDeg - panel.AltDeg).ShouldBeGreaterThan(5.0);
+        var direct = SkyMapInfoPanelData.FromPosition(
+            "Helix", raHours, decDeg, ReproSiteLat, ReproSiteLon, t2, site2);
+        refreshed.AltDeg.ShouldBe(direct.AltDeg, 1e-9);
+        refreshed.AzDeg.ShouldBe(direct.AzDeg, 1e-9);
+
+        // Rise/transit/set are NOT recomputed here (they only shift on a date change) -- stay as-is.
+        refreshed.TransitTime.ShouldBe(panel.TransitTime);
+    }
+
+    [Fact]
+    public void WithLiveHorizontal_WithInvalidSite_ReturnsUnchanged()
+    {
+        var t1 = new DateTimeOffset(2026, 7, 11, 9, 36, 0, TimeSpan.Zero);
+        var site1 = SiteContext.Create(ReproSiteLat, ReproSiteLon, t1);
+        var panel = SkyMapInfoPanelData.FromPosition(
+            "Helix", 22.494, -20.837, ReproSiteLat, ReproSiteLon, t1, site1);
+
+        panel.WithLiveHorizontal(default).ShouldBe(panel); // default SiteContext.IsValid == false
     }
 }

--- a/src/TianWen.UI.Abstractions/AppSignalHandler.cs
+++ b/src/TianWen.UI.Abstractions/AppSignalHandler.cs
@@ -699,6 +699,18 @@ namespace TianWen.UI.Abstractions
             }
         }
 
+        /// <summary>
+        /// The UTC instant the sky map is currently displaying: the base planning date (or the
+        /// live clock when no date is pinned) PLUS the sky-map time-scrub offset. EVERY sky-map
+        /// handler that computes alt/az or hit-tests an ephemeris position must resolve the
+        /// viewing time through here so the info panel / selection matches what the renderer
+        /// actually drew -- e.g. a scrubbed Zenith reticle must still report Alt 90 deg, not the
+        /// un-scrubbed altitude. The fixed-point / mount info handlers used to omit TimeOffset and
+        /// drifted from the click-select path once the map was scrubbed.
+        /// </summary>
+        private DateTimeOffset SkyMapViewingUtc()
+            => (_plannerState.PlanningDate?.ToUniversalTime() ?? _timeProvider.GetUtcNow()) + _skyMapState.TimeOffset;
+
         public AppSignalHandler(
             IServiceProvider sp,
             GuiAppState appState,
@@ -854,8 +866,7 @@ namespace TianWen.UI.Abstractions
                 var db = sp.GetRequiredService<ICelestialObjectDB>();
                 // Include the sky-map scrub offset so a planet commit resolves the SAME live position
                 // the map is showing (and reads the render's planet cache without thrashing it).
-                var viewingUtc = (plannerState.PlanningDate?.ToUniversalTime() ?? _timeProvider.GetUtcNow())
-                    + skyMapState.TimeOffset;
+                var viewingUtc = SkyMapViewingUtc();
                 var site = SiteContext.Create(plannerState.SiteLatitude, plannerState.SiteLongitude, viewingUtc);
                 SkyMapSearchActions.CommitResult(
                     skySearch, skyMapState, db,
@@ -1032,11 +1043,10 @@ namespace TianWen.UI.Abstractions
                 var cx = rect.X + rect.Width * 0.5f;
                 var cy = rect.Y + rect.Height * 0.5f;
                 // Match the render's viewing instant: base date/now PLUS the sky-map scrub offset
-                // (State.TimeOffset). Planet positions are ephemeris-computed and move with time, so
-                // hit-testing them (and the panel's alt/az) must use the same instant the renderer
-                // drew -- otherwise a scrubbed planet dot is unclickable.
-                var viewingUtc = (plannerState.PlanningDate?.ToUniversalTime() ?? _timeProvider.GetUtcNow())
-                    + skyMapState.TimeOffset;
+                // (State.TimeOffset), via SkyMapViewingUtc. Planet positions are ephemeris-computed
+                // and move with time, so hit-testing them (and the panel's alt/az) must use the same
+                // instant the renderer drew -- otherwise a scrubbed planet dot is unclickable.
+                var viewingUtc = SkyMapViewingUtc();
                 var site = SiteContext.Create(plannerState.SiteLatitude, plannerState.SiteLongitude, viewingUtc);
 
                 SkyMapSearchActions.SelectObjectByClick(
@@ -1066,19 +1076,25 @@ namespace TianWen.UI.Abstractions
 
             bus.Subscribe<SkyMapShowFixedPointInfoSignal>(sig =>
             {
-                var viewingUtc = plannerState.PlanningDate?.ToUniversalTime() ?? _timeProvider.GetUtcNow();
+                // Must include the sky-map scrub offset (via SkyMapViewingUtc): the Zenith/NCP/SCP
+                // reticles are placed by the renderer at the scrubbed LST, so the panel's alt/az
+                // has to be computed at the SAME instant or a scrubbed Zenith reads e.g. +9.9 deg
+                // instead of +90 deg.
+                var viewingUtc = SkyMapViewingUtc();
                 var site = SiteContext.Create(plannerState.SiteLatitude, plannerState.SiteLongitude, viewingUtc);
                 skySearch.InfoPanel = SkyMapInfoPanelData.FromPosition(
                     sig.Name, sig.RaHours, sig.DecDeg,
                     plannerState.SiteLatitude, plannerState.SiteLongitude,
-                    viewingUtc, site);
+                    viewingUtc, site) with { FixedPoint = sig.FixedPoint };
                 skyMapState.NeedsRedraw = true;
                 appState.NeedsRedraw = true;
             });
 
             bus.Subscribe<SkyMapShowMountInfoSignal>(sig =>
             {
-                var viewingUtc = plannerState.PlanningDate?.ToUniversalTime() ?? _timeProvider.GetUtcNow();
+                // Same scrub-consistency requirement as the fixed-point handler: the mount reticle
+                // is projected at the scrubbed LST, so its reported alt/az must be too.
+                var viewingUtc = SkyMapViewingUtc();
                 var site = SiteContext.Create(plannerState.SiteLatitude, plannerState.SiteLongitude, viewingUtc);
                 skySearch.InfoPanel = SkyMapInfoPanelData.FromMount(
                     sig.Name, sig.RaHours, sig.DecDeg,

--- a/src/TianWen.UI.Abstractions/GuiSignals.cs
+++ b/src/TianWen.UI.Abstractions/GuiSignals.cs
@@ -343,7 +343,11 @@ public readonly record struct SkyMapSlewToObjectSignal(
 public readonly record struct SkyMapShowFixedPointInfoSignal(
     string Name,
     double RaHours,
-    double DecDeg);
+    double DecDeg,
+    // Which fixed point was clicked. SkyFixedPoint.Zenith flags the info panel as horizon-relative
+    // so the renderer re-resolves it to the current overhead point each frame; NCP/SCP are
+    // equatorially fixed (no re-resolution).
+    SkyFixedPoint FixedPoint = SkyFixedPoint.None);
 
 /// <summary>
 /// Open the sky-map info panel for the MOUNT marker (the believed pointing reticle).

--- a/src/TianWen.UI.Abstractions/SkyFixedPoint.cs
+++ b/src/TianWen.UI.Abstractions/SkyFixedPoint.cs
@@ -1,0 +1,25 @@
+namespace TianWen.UI.Abstractions
+{
+    /// <summary>
+    /// A selectable fixed reference point on the sky map (the amber reticles). Distinguishes points
+    /// whose sky coordinates are constant in the equatorial frame (the celestial poles, fixed at
+    /// Dec +/-90) from the <see cref="Zenith"/>, which is horizon-relative -- its RA (= LST) and
+    /// Dec (= latitude) both advance with the viewing time. A zenith selection must therefore
+    /// re-resolve to the current overhead point every frame (the same live treatment planets get)
+    /// or its crosshair drifts off the marker when the map is date-/time-scrubbed.
+    /// </summary>
+    public enum SkyFixedPoint
+    {
+        /// <summary>Not a fixed reference point -- an ordinary catalog object, position, or mount.</summary>
+        None = 0,
+
+        /// <summary>The local zenith (horizon-relative: re-resolved to the live overhead point each frame).</summary>
+        Zenith,
+
+        /// <summary>North celestial pole (Dec +90, equatorially fixed -- no re-resolution needed).</summary>
+        NorthCelestialPole,
+
+        /// <summary>South celestial pole (Dec -90, equatorially fixed -- no re-resolution needed).</summary>
+        SouthCelestialPole,
+    }
+}

--- a/src/TianWen.UI.Abstractions/SkyMapInfoPanelData.cs
+++ b/src/TianWen.UI.Abstractions/SkyMapInfoPanelData.cs
@@ -28,7 +28,11 @@ public readonly record struct SkyMapInfoPanelData(
     double? AngularSizeDeg,
     CelestialObjectShape? Shape,
     CatalogIndex? Index,
-    bool IsMount = false)
+    bool IsMount = false,
+    // Which fixed reference point (if any) this selection is. SkyFixedPoint.Zenith flags the
+    // panel as horizon-relative so the renderer re-resolves it to the current overhead point each
+    // frame instead of freezing it at the click-time RA/Dec (see SkyFixedPoint).
+    SkyFixedPoint FixedPoint = SkyFixedPoint.None)
 {
     /// <summary>
     /// Build a panel payload for a catalog object at the given site and viewing time.
@@ -132,6 +136,28 @@ public readonly record struct SkyMapInfoPanelData(
         DateTimeOffset viewingUtc,
         in SiteContext site)
         => FromPosition(name, raHours, decDeg, siteLat, siteLon, viewingUtc, site) with { IsMount = true };
+
+    /// <summary>
+    /// Returns a copy with Alt/Az recomputed for the current <paramref name="site"/>, leaving the
+    /// (viewing-time-independent) RA/Dec and the date-resolved rise/transit/set untouched. Alt/Az are
+    /// horizon coordinates -- they swing with the hour angle even for a fixed-RA/Dec star or DSO -- so a
+    /// selection panel left open while the map is time-scrubbed must refresh them or it shows a stale
+    /// altitude (the "Helix still says Alt -30 four hours later" bug). Deliberately cheap: only the O(1)
+    /// <see cref="ComputeAltAz"/> trig runs, so this is safe to call every frame while the panel is
+    /// visible. Rise/transit/set are NOT recomputed here -- they only shift on a DATE change, and the
+    /// iterative Meeus solve is too heavy to re-run per frame. Solar-system bodies and the zenith take
+    /// the fuller per-frame re-resolve instead (their RA/Dec move too); this is the fixed-object path.
+    /// </summary>
+    public SkyMapInfoPanelData WithLiveHorizontal(in SiteContext site)
+    {
+        if (!site.IsValid)
+        {
+            return this;
+        }
+
+        var (altDeg, azDeg) = ComputeAltAz(RA, Dec, site);
+        return this with { AltDeg = altDeg, AzDeg = azDeg };
+    }
 
     // Local-only alt/az from a SiteContext (fast; no SOFA pipeline needed for display).
     // For the precision plate-solving needs the full Transform path — but the info

--- a/src/TianWen.UI.Abstractions/SkyMapTab.Search.cs
+++ b/src/TianWen.UI.Abstractions/SkyMapTab.Search.cs
@@ -63,6 +63,19 @@ namespace TianWen.UI.Abstractions
             // remain visible after the user closes the search window.
             if (State.Search.InfoPanel is { } info)
             {
+                // The zenith is horizon-relative: its RA (= LST) and Dec (= latitude) advance with the
+                // viewing time, so a selection made earlier must re-resolve to the CURRENT overhead point
+                // each frame -- the same live treatment the solar-system bodies get below -- or the
+                // crosshair drifts off the amber Zenith marker as the map is date-/time-scrubbed.
+                // Projecting (RA = LST, Dec = latitude) reproduces the marker's own unit vector exactly,
+                // so the re-resolved crosshair lands right on it.
+                if (info.FixedPoint == SkyFixedPoint.Zenith && site.IsValid)
+                {
+                    var zenithRa = site.LST;
+                    var zenithDec = double.RadiansToDegrees(Math.Asin(site.SinLat));
+                    info = SkyMapInfoPanelData.FromPosition("Zenith", zenithRa, zenithDec,
+                        siteLat, siteLon, viewingTime, site) with { FixedPoint = SkyFixedPoint.Zenith };
+                }
                 // A solar-system body's true RA/Dec is viewing-time dependent, so a selection made on an
                 // earlier date/time would otherwise freeze the crosshair + RA/Dec/Alt at that instant while
                 // the live planet dot moves on (the "Venus moved but the crosshair didn't" bug). Only a
@@ -71,7 +84,7 @@ namespace TianWen.UI.Abstractions
                 // re-resolve from the per-frame cache the dot/label draws from (keyed on the SAME
                 // viewingTime) and rebuild the panel via the shared builder, so stepping the date keeps the
                 // marker on the planet and its Alt/RA/Dec live.
-                if (info.Index is { } selIdx && selIdx.IsSolarSystemObject)
+                else if (info.Index is { } selIdx && selIdx.IsSolarSystemObject)
                 {
                     if (selIdx.ToCatalog() == Catalog.Comet)
                     {
@@ -103,6 +116,15 @@ namespace TianWen.UI.Abstractions
                             }
                         }
                     }
+                }
+                else
+                {
+                    // Fixed-RA/Dec selection (star / DSO / plain position / mount marker). Its RA/Dec don't
+                    // move with time, so the reticle already tracks (it projects through the live view
+                    // matrix), but Alt/Az are horizon coordinates that DO swing with the hour angle -- so
+                    // refresh just those from the current site each frame. Cheap (O(1) trig); rise/transit/
+                    // set stay date-resolved (see WithLiveHorizontal).
+                    info = info.WithLiveHorizontal(site);
                 }
 
                 DrawInfoPanel(plannerState, info, contentRect, fontPath, dpiScale,

--- a/src/TianWen.UI.Gui/VkSkyMapTab.cs
+++ b/src/TianWen.UI.Gui/VkSkyMapTab.cs
@@ -992,12 +992,14 @@ public sealed unsafe class VkSkyMapTab(VkRenderer renderer) : SkyMapTab<VulkanCo
         // mount drivers that reject exactly-polar targets; RA is arbitrary at the pole.
         DrawFixedMarker(contentRect, dpiScale, fontPath, fontSize, lineH, ppr, cx, cy,
             ux: 0.0, uy: 0.0, uz: 1.0, label: "NCP", color: _poleColor,
-            slewName: "North Celestial Pole", slewRA: 0.0, slewDec: 89.999, hitTag: "NCP");
+            slewName: "North Celestial Pole", slewRA: 0.0, slewDec: 89.999, hitTag: "NCP",
+            fixedPoint: SkyFixedPoint.NorthCelestialPole);
 
         // South Celestial Pole (Dec=-90).
         DrawFixedMarker(contentRect, dpiScale, fontPath, fontSize, lineH, ppr, cx, cy,
             ux: 0.0, uy: 0.0, uz: -1.0, label: "SCP", color: _poleColor,
-            slewName: "South Celestial Pole", slewRA: 0.0, slewDec: -89.999, hitTag: "SCP");
+            slewName: "South Celestial Pole", slewRA: 0.0, slewDec: -89.999, hitTag: "SCP",
+            fixedPoint: SkyFixedPoint.SouthCelestialPole);
 
         // Zenith, N/S/E/W are only meaningful with a valid site in horizon mode.
         // In equatorial mode the horizon itself isn't drawn, so cardinal labels
@@ -1015,7 +1017,7 @@ public sealed unsafe class VkSkyMapTab(VkRenderer renderer) : SkyMapTab<VulkanCo
         DrawFixedMarker(contentRect, dpiScale, fontPath, fontSize, lineH, ppr, cx, cy,
             ux: zx, uy: zy, uz: zz, label: "Zenith", color: _zenithColor,
             slewName: "Zenith", slewRA: site.LST, slewDec: double.RadiansToDegrees(Math.Asin(site.SinLat)),
-            hitTag: "Zenith");
+            hitTag: "Zenith", fixedPoint: SkyFixedPoint.Zenith);
 
         // N/S/E/W horizon labels - orientation only, no slew handler. Skip the reticle
         // circle, just drop a letter at the projected horizon point.
@@ -1042,7 +1044,8 @@ public sealed unsafe class VkSkyMapTab(VkRenderer renderer) : SkyMapTab<VulkanCo
         double ppr, float cx, float cy,
         double ux, double uy, double uz,
         string label, RGBAColor32 color,
-        string slewName, double slewRA, double slewDec, string hitTag)
+        string slewName, double slewRA, double slewDec, string hitTag,
+        SkyFixedPoint fixedPoint = SkyFixedPoint.None)
     {
         if (!SkyMapProjection.ProjectUnitVec(ux, uy, uz, State.CurrentViewMatrix, ppr, cx, cy,
                 out var sx, out var sy))
@@ -1071,10 +1074,11 @@ public sealed unsafe class VkSkyMapTab(VkRenderer renderer) : SkyMapTab<VulkanCo
         var capturedName = slewName;
         var capturedRA = slewRA;
         var capturedDec = slewDec;
+        var capturedFixedPoint = fixedPoint;
         RegisterClickable(sx - hitSize * 0.5f, sy - hitSize * 0.5f, hitSize, hitSize,
             new HitResult.ButtonHit($"SkyMapFixedMarker:{hitTag}"),
             _ => PostSignal(new SkyMapShowFixedPointInfoSignal(
-                capturedName, capturedRA, capturedDec)));
+                capturedName, capturedRA, capturedDec, capturedFixedPoint)));
     }
 
     /// <summary>


### PR DESCRIPTION
## Problem

Scrubbing the sky-map time (or changing the planning date) rotated the map but left several selection-panel values frozen at click time. Reported from the GUI: a selected **Zenith** read `Alt +9.9°` instead of `+90°`, and its crosshair drifted off the amber marker.

## Root cause & fix

Three related staleness bugs in the sky-map selection path:

1. **Zenith alt read +9.9° instead of +90°.** Two of the four sky-map handlers (`SkyMapShowFixedPointInfoSignal`, `SkyMapShowMountInfoSignal`) computed the viewing instant *without* the scrub offset and had drifted from the click-select / search-commit paths. Centralised the instant into one `AppSignalHandler.SkyMapViewingUtc()` so all four agree.

2. **Zenith selection crosshair drifted off its marker.** The zenith is horizon-relative (RA = LST, Dec = latitude — both advance with time), but its selection RA/Dec were frozen. Added a `SkyFixedPoint` enum (`None`/`Zenith`/`NorthCelestialPole`/`SouthCelestialPole`) carried on the info panel + signal; the renderer now re-resolves the zenith to the live overhead point each frame — the same live treatment planets/comets already get. Projecting `(RA=LST, Dec=lat)` reproduces the marker's own unit vector, so the crosshair lands exactly on it.

3. **Fixed DSO/star Alt/Az were stale.** The reticle tracked, but the panel Alt/Az stayed frozen (Helix still read `Alt −30°` hours later). Added `SkyMapInfoPanelData.WithLiveHorizontal()` to refresh **only** Alt/Az (O(1) trig) from the current site each frame for fixed selections. RA/Dec and the heavier rise/transit/set (Meeus iteration) are left as-is, keeping the per-frame cost negligible.

Net result: **every selection reticle now stays on its object across date/time scrub**, and the panel's Alt/Az stays live.

## Verification

- Build clean (0 warnings), `TianWen.Lib.Tests` 24/24 pass (**+4 new** in `SkyMapTimeScrubTests`: zenith-at-viewing-instant → 90°, mismatched-instant → drift, `WithLiveHorizontal` refreshes Alt/Az but keeps RA/Dec, invalid-site no-op).
- Live-inspector confirmed on the running GUI:
  - **Zenith** — crosshair stays glued to the marker and Alt holds `+90.0°` after a **+5h** scrub (RA advanced 04:33 → 09:35 = one LST turn).
  - **Helix Nebula (DSO)** — crosshair tracks the object; Alt/Az update `−3.7° → −31.0°` after **+4h** while RA/Dec stay fixed and rise/transit/set stay date-resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ATx1GGJ6CyDBF2yjTqrvm7
