### PR TITLE
tools(archive): step-0 organization scripts (dedup index, moves, session summaries)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ src/TianWen.Lib/Astrometry/Catalogs/*.gs.gz
 !src/TianWen.Lib/Astrometry/Catalogs/pickles_sed.gs.gz
 # Lavapipe min-repro zip (built artifact for upstream bug filing)
 LavapipeMinRepro.zip
+__pycache__/

--- a/docs/plans/ai-denoise-deconv.md
+++ b/docs/plans/ai-denoise-deconv.md
@@ -102,7 +102,9 @@ Load-bearing hazards for the dataset builder (all detailed with examples in the 
 dedup across Astro-Pics ↔ BobbyBox-Temp *and* within Astro-Pics itself — content-hash + `DATE-OBS`
 pass (Step 0's `dup-files.csv`); (2) never ingest `AutoSave`/`PROC`/`pixinsight`/XISF processed intermediates — gate on
 `IMAGETYP='Light'` + `EXPTIME` in [10, 300] s from headers, not folder names (BobbyBox-Temp
-especially: raw subs and XISF intermediates share the same session folders); (3) mixed Bayer
+especially: raw subs and XISF intermediates share the same session folders), **and exclude
+simulator cameras by `INSTRUME`** (Step 0 found 139 "Camera V3 simulator" lights from a
+2024-03-15 N.I.N.A. test session — synthetic frames would poison the noise model); (3) mixed Bayer
 patterns (RGGB vs GRBG) and mono+FILTER sessions need per-camera debayer; (4) `2026-02-20 BAD LIGHT
 EXAMPLES` (33 hand-flagged bad frames) is a free validation set for the quality gate; (5) 39+4
 `.7z` archives (~100 GB, mostly pre-2023/planetary, already out of v1 scope) are invisible to a

--- a/docs/plans/ai-denoise-deconv.md
+++ b/docs/plans/ai-denoise-deconv.md
@@ -88,9 +88,19 @@ N.I.N.A. headers, per-session BIAS/DARK/DARKFLAT/FLAT — holds an estimated **~
 candidate raw lights** before quality filtering. Older eras (2021–2022, ASI294/QHY178m, ~668 GB)
 are lower value; SER/planetary and CR2/DSLR are excluded in v1.
 
+**Step 0 (archive organization, before any builder code):** `tools/astro-archive-dedup.py` — a
+READ-ONLY scanner producing a resumable per-file header index (`fits-index.jsonl`) plus three
+reports: `dup-files.csv` (exact-dup groups, identity = camera + `DATE-OBS` + exposure + dims,
+hash-confirmed; cross-root flagged), `nights-rollup.csv` (per camera/night light counts split
+dup/unique — the "what in BobbyBox is actually new" answer), and `calibration-coverage.csv` (per
+light group: matching darks/bias found anywhere in the archive — because **calibration masters are
+shared between sessions**, per-session folders cannot be assumed). Any physical
+extraction/filing of BobbyBox uniques into Astro-Pics happens as a user-reviewed step from these
+reports; the script itself never moves or deletes anything.
+
 Load-bearing hazards for the dataset builder (all detailed with examples in the survey doc): (1)
 dedup across Astro-Pics ↔ BobbyBox-Temp *and* within Astro-Pics itself — content-hash + `DATE-OBS`
-pass; (2) never ingest `AutoSave`/`PROC`/`pixinsight`/XISF processed intermediates — gate on
+pass (Step 0's `dup-files.csv`); (2) never ingest `AutoSave`/`PROC`/`pixinsight`/XISF processed intermediates — gate on
 `IMAGETYP='Light'` + `EXPTIME` in [10, 300] s from headers, not folder names (BobbyBox-Temp
 especially: raw subs and XISF intermediates share the same session folders); (3) mixed Bayer
 patterns (RGGB vs GRBG) and mono+FILTER sessions need per-camera debayer; (4) `2026-02-20 BAD LIGHT
@@ -101,8 +111,11 @@ folder scan unless extracted — watch for new ones under future 2024+ sessions.
 ### 2.4 Dataset builder (`tianwen dataset build`, new CLI subcommand)
 
 C# tooling in-repo, reusing existing Lib machinery end-to-end (scan `FitsFolderFrameSource` →
-dedup → quality gate → calibrate with session masters via `MasterFrameBuilder` → debayer → register
-subs to the session master → tile export). Per session:
+dedup → quality gate → calibrate via `MasterFrameBuilder` → debayer → register subs to the session
+master → tile export). **Calibration is resolved by header match across the whole archive, never by
+session folder** (confirmed 2026-07-11: dark/bias libraries are shared between sessions) — the same
+`MasterGroupKey`-style identity (camera, exposure, gain, binning, ±temp) the stacker already uses;
+Step 0's `calibration-coverage.csv` is the coverage map. Per session:
 
 - **Quality gate** per sub: `FindStarsAsync` star count + median HFD + ellipticity, thresholded
   *relative to the session median* (absolute thresholds don't transfer across focal lengths); drops
@@ -113,8 +126,8 @@ subs to the session master → tile export). Per session:
   Export the master tile + a random 4–8 subs per cell (not all subs — bounds dataset size).
 - **Output**: fp16 tiles (npy-compatible raw blobs) + a JSONL manifest per tile: source file,
   session id, camera, gain, exposure, tile coords, per-tile noise σ (MAD), session median FWHM.
-  Manifest rows written via a **canonical sort before any sampling** (bullclip lesson: parallel
-  writers break every downstream seeded operation).
+  Manifest rows written via a **canonical sort before any sampling** (parallel writers break every
+  downstream seeded operation otherwise).
 - Budget: ~60 sessions × ~300 cells × ~9 tiles ≈ 160k tiles ≈ **50–80 GB** — one upload to a cloud
   volume, regenerable from scratch by re-running the command.
 
@@ -136,8 +149,8 @@ run the C# stretch and the stored bytes side by side) pins this in CI-able form.
 - **Losses:** L1 (MAE) primary + MS-SSIM auxiliary; plus a **flux-preservation regulariser**
   (per-tile mean/aperture-sum penalty) — see §7.
 - **Optimisation:** AdamW, cosine schedule, grad-norm clip 1.0, early stop on held-out val, seeded
-  end-to-end. Mirrors both the Croman talk and the bullclip trainer's proven recipe.
-- **Discipline (bullclip patterns, adopted wholesale):**
+  end-to-end. Mirrors the Croman talk's recipe and prior in-house ML-pipeline experience.
+- **Discipline (proven in-house ML-pipeline patterns, adopted wholesale):**
   - `training/EXPERIMENTS.md` — every run logged, ablations base-vs-+change on the **pinned split**,
     negative verdicts recorded to stop re-litigation.
   - **Pinned held-out split by SESSION** (never by tile/frame — adjacent tiles leak noise/PSF stats
@@ -153,12 +166,17 @@ run the C# stretch and the stored bytes side by side) pins this in CI-able form.
 
 - Repo layout: `training/` at repo root (Python: `dataset.py`, `train_denoise.py`,
   `train_deconv.py`, `export_onnx.py`, `parity_check.py`, `requirements.txt`, `EXPERIMENTS.md`,
-  `test-sessions.txt`). Dev smoke runs: torch-CPU under WSL (no win-arm64 wheels — bullclip
-  precedent, `requirements-seq.txt`-style venv bootstrap documented).
-- **Full runs: RunPod Secure Cloud RTX 4090** (~$0.35–0.69/hr, per-second billing, persistent
-  network volume ~$0.07/GB/mo for the tile set). First usable model ≈ 24–72 GPU-h ≈ **$15–50/run**;
-  Vast.ai interruptible (~$0.13–0.37/hr) once checkpoint-resume is proven. Checkpoint every N steps
-  to the volume; pull back only checkpoint + ONNX.
+  `test-sessions.txt`). Dev smoke runs: torch-CPU under WSL (no win-arm64 torch wheels; the venv
+  bootstrap gets documented in `requirements.txt` comments).
+- **Full runs: an internal AKS GPU dev pool as a k8s Job** (Tesla T4 16 GB, 4 vCPU / 28 GB,
+  `nvidia.com/gpu: 1`; the workload-identity Job + blob-storage pattern is already proven
+  in-house). 16 GB VRAM fits NAFNet-32/64 @ 256 px with AMP; T4 ≈ 3–5× slower than a 4090, so a full
+  run is ~4–10 days — fine unattended with checkpoint-every-N-steps (restarts free). The 4-vCPU
+  loader is not a bottleneck (tiles are pre-baked fp16).
+- **Ablation sweeps (optional fast lane): RunPod Secure Cloud RTX 4090** (~$0.35–0.69/hr,
+  per-second billing, network volume ~$0.07/GB/mo) — ≈ 24–72 GPU-h ≈ **$15–50/run** when iteration
+  speed matters; Vast.ai interruptible (~$0.13–0.37/hr) once checkpoint-resume is proven. Pull back
+  only checkpoint + ONNX.
 - Local Adreno/DirectML is for **inference smoke only** (the existing TianWen.AI path); Hexagon NPU
   is inference-only with no vision-model path (verified) — neither trains anything.
 
@@ -185,7 +203,8 @@ run the C# stretch and the stored bytes side by side) pins this in CI-able form.
 
 | Phase | Deliverable | Exit criterion |
 |---|---|---|
-| **P0 — Dataset + stats** | `tianwen dataset build` (scan/dedup/gate/calibrate/register/tile+manifest, zero-skew export); archive PSF/noise distribution report; pinned `test-sessions.txt` | Tile set regenerable one-command; BAD LIGHT set 100% rejected by gate; parity check green |
+| **Step 0 — Archive organization** | `tools/astro-archive-dedup.py` READ-ONLY scan (header index + dup-files / nights-rollup / calibration-coverage reports); user-reviewed filing of BobbyBox uniques into Astro-Pics from the reports | Dup report reviewed; unique-to-BobbyBox sessions identified/filed; calibration coverage map exists (feeds P0's header-matched calibration) |
+| **P0 — Dataset + stats** | `tianwen dataset build` (scan/dedup/gate/calibrate/register/tile+manifest, zero-skew export; calibration header-matched archive-wide, never per-folder); archive PSF/noise distribution report; pinned `test-sessions.txt` | Tile set regenerable one-command; BAD LIGHT set 100% rejected by gate; parity check green |
 | **P1 — Denoiser v1** | `training/` N2N pipeline; NAFNet-32 color run on RunPod; ONNX + contract; `OnnxTianWenDenoiser` + `--ai-backend tianwen`; eval report | Beats classical baseline + no photometric regression (§7) on held-out sessions; visually clean on 3 reference masters |
 | **P2 — Deconvolver v1** | Synthetic-PSF pipeline (measured-distribution sweep); psf01-conditioned NAFNet; `OnnxTianWenDeconvolver`; eval incl. FWHM-reduction + artefact checks | Measured FWHM reduction on held-out masters without ringing/worms; photometric gates hold |
 | **P3 — Ship** | Auto-order wiring, fetch-script + release assets, CLI/GUI surfacing, `docs` + CLAUDE.md section | `stack --enhance --ai-backend tianwen` end-to-end on a fresh machine (models auto-fetched) |
@@ -199,7 +218,7 @@ run the C# stretch and the stored bytes side by side) pins this in CI-able form.
   contrast without ringing); "worm"/hallucination spot-checks at 1:1.
 - **No RC-Astro or SAS outputs in any metric.** Qualitative side-by-sides for a blog post are the
   user's call as an ordinary product comparison — never part of the automated loop.
-- Human adjudication: a tiny local compare page (bullclip's `hand_label_server` lesson: blind A/B,
+- Human adjudication: a tiny local compare page (an in-house-learned lesson: blind A/B,
   don't score against "what the user kept").
 
 ## 7. The differentiator: photometric integrity

--- a/docs/plans/ai-denoise-deconv.md
+++ b/docs/plans/ai-denoise-deconv.md
@@ -12,9 +12,12 @@ Scope boundaries settled up front:
   Runtime inference only — **no Python, no on-device training** for the imaging models. (On-device
   online learning remains a NeuralGuider-only feature; its PPEC-style per-rig adaptation is out of
   scope here.)
-- **Star removal (SXT-analogue) is out of scope.** It requires hand-edited ground truth (Croman: "no
-  other way"); denoise and deconvolution have self-supervised / synthetic ground truth. Keep
-  `IStarRemover` on RC/SAS.
+- **Star removal (SXT-analogue) is in scope as a LATER phase** (P4, after denoise/deconv prove the
+  pipeline) via the inject-and-remove bootstrap (§2.5). Croman's "hand-edit is the only way" holds
+  only when you need ground truth for *existing* stars; synthetic injection gives exact truth by
+  construction. Until its eval gates pass, `IStarRemover` stays on RC/SAS — but a TianWen remover
+  is required for the tier to run the full canonical program (the starless plate is the workhorse
+  intermediate: `RemoveStarsStep`, `--split-plates`, star/starless dual stretch).
 
 ## 1. Licensing constraint (load-bearing — read first)
 
@@ -139,6 +142,29 @@ inference path uses — `AiNafnetInputs` MTF pre-stretch (target median 0.25, au
 re-implements preprocessing; it consumes tiles as-stored. A `parity-check` diff (export N tiles,
 run the C# stretch and the stored bytes side by side) pins this in CI-able form.
 
+### 2.5 Star-removal ground truth — inject-and-remove bootstrap (P4)
+
+Ground truth for *existing* stars would need hand editing; ground truth for *injected* stars is
+exact by construction. Four stages, fully license-clean (own data + own synthetics + own model):
+
+1. **Classical bootstrap starless plates**: PSF-fit subtraction at `FindStarsAsync` detections +
+   multi-scale inpaint. Imperfections are acceptable — residual artifacts become background the
+   net must *preserve*, never content it must invent.
+2. **Synthetic star injection** onto those plates, drawn from the archive's measured PSF
+   distribution (same P0 stats that calibrate the deconv sweep): Moffat cores, lens halos,
+   saturation/bloom for the bright tail. Input = plate + injected stars, target = plate.
+   Advantage of this archive: all optics are refractive (Samyang 135, ZS61, FMA180, SH61) — no
+   spider vanes, no diffraction spikes — so the morphology distribution is far narrower than a
+   general-purpose remover must handle.
+3. **Self-refinement loop**: run the trained net on real images → better starless plates →
+   re-inject → retrain. Distills only our own model.
+4. **Output contract** matches `RemoveStarsStep`'s additive split (stars = input − starless).
+
+Eval is objective because injected truth is exact: removal completeness on injected stars,
+pixel-level background preservation under them, flux conservation of the stars plate; plus
+existing-star spot checks at 1:1 (the bright-saturated tail is the known hard case — keep RC/SAS
+preferred until it passes).
+
 ## 3. Model + training
 
 - **Architecture: NAFNet** (width 32 first, 64 if capacity-limited; ~5–20 M params) — the same
@@ -210,7 +236,8 @@ run the C# stretch and the stored bytes side by side) pins this in CI-able form.
 | **P1 — Denoiser v1** | `training/` N2N pipeline; NAFNet-32 color run on RunPod; ONNX + contract; `OnnxTianWenDenoiser` + `--ai-backend tianwen`; eval report | Beats classical baseline + no photometric regression (§7) on held-out sessions; visually clean on 3 reference masters |
 | **P2 — Deconvolver v1** | Synthetic-PSF pipeline (measured-distribution sweep); psf01-conditioned NAFNet; `OnnxTianWenDeconvolver`; eval incl. FWHM-reduction + artefact checks | Measured FWHM reduction on held-out masters without ringing/worms; photometric gates hold |
 | **P3 — Ship** | Auto-order wiring, fetch-script + release assets, CLI/GUI surfacing, `docs` + CLAUDE.md section | `stack --enhance --ai-backend tianwen` end-to-end on a fresh machine (models auto-fetched) |
-| **P4 — Deferred** | Strength/frequency conditioning beyond Blend-lerp; mono-native models; drizzle-truth sharper tier; frame-quality classifier from BAD-examples; dataset-contribution flow for other users | — |
+| **P4 — Star remover** | Inject-and-remove bootstrap (§2.5): classical starless plates + measured-PSF star injector + self-refinement; `OnnxTianWenStarRemover : IStarRemover` (additive split) — completes the tier so the full canonical program runs TianWen-only | Injected-star removal completeness + background preservation + stars-plate flux conservation on held-out sessions; bright-saturated tail passes 1:1 spot checks (RC/SAS stay preferred until then) |
+| **P5 — Deferred** | Strength/frequency conditioning beyond Blend-lerp; mono-native models; drizzle-truth sharper tier; frame-quality classifier from BAD-examples; dataset-contribution flow for other users | — |
 
 ## 6. Evaluation (all internal, license-clean)
 

--- a/docs/plans/ai-denoise-deconv.md
+++ b/docs/plans/ai-denoise-deconv.md
@@ -120,7 +120,17 @@ dedup → quality gate → calibrate via `MasterFrameBuilder` → debayer → re
 master → tile export). **Calibration is resolved by header match across the whole archive, never by
 session folder** (confirmed 2026-07-11: dark/bias libraries are shared between sessions) — the same
 `MasterGroupKey`-style identity (camera, exposure, gain, binning, ±temp) the stacker already uses;
-Step 0's `calibration-coverage.csv` is the coverage map. Per session:
+Step 0's `calibration-coverage.csv` is the coverage map. **Masters are built once per
+`MasterGroupKey` group and cached on disk** (the `StackingPipeline.BuildMastersAsync` mechanism —
+a shared dark library serving five sessions is one group, one master), with two builder-specific
+requirements: the cache dir is **one shared archive-wide location** (not per-run `outputDir`, so
+build-once holds across all ~180 sessions and re-runs), and the cached master carries an
+**input-set fingerprint** (frame count + content hashes stamped into its header) so a grown dark
+library invalidates its stale master instead of silently cache-hitting on the slug. Foreign
+pre-existing masters (PixInsight XISF / DBE'd TIFs in `PROC` dirs) are deliberately **not**
+reused — unknown rejection/scaling provenance breaks the "pure function of inputs" cache trust;
+raw calibration frames exist for essentially every 2022+ session, so rebuilding is cheap and
+reproducible. Per session:
 
 - **Quality gate** per sub: `FindStarsAsync` star count + median HFD + ellipticity, thresholded
   *relative to the session median* (absolute thresholds don't transfer across focal lengths); drops

--- a/tools/astro-archive-dedup.py
+++ b/tools/astro-archive-dedup.py
@@ -1,0 +1,318 @@
+#!/usr/bin/env python
+"""Astro archive dedup + organization report (READ-ONLY).
+
+Step 0 of docs/plans/ai-denoise-deconv.md: reconcile D:\\BobbyBox-Temp against
+D:\\Astro-Pics before the dataset builder exists. Identity is FITS-header-based
+(camera + DATE-OBS + exposure + dimensions), never filename/path-based, because
+the same sub can be filed twice under different names/layouts. Nothing on disk
+is modified; all output goes to --out.
+
+Outputs (in --out):
+  fits-index.jsonl          per-file header index (cache; resumable by size+mtime)
+  dup-files.csv             exact-duplicate groups (same identity key, hash-confirmed)
+  nights-rollup.csv         per (camera, night): light counts per root, dup/unique split
+  calibration-coverage.csv  per light (camera, exptime, gain, bin): matching darks found where
+  summary.txt               human summary (also printed to console)
+
+Usage:
+  python tools/astro-archive-dedup.py --root "D:\\Astro-Pics" --root "D:\\BobbyBox-Temp" --out "D:\\Astro-Reports"
+  ... --limit 500          # smoke test on the first N FITS files found
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+import os
+import re
+import sys
+from collections import defaultdict
+from datetime import datetime, timedelta
+from pathlib import Path
+
+FITS_EXTS = {".fits", ".fit", ".fts"}
+BLOCK = 2880
+MAX_HEADER_BLOCKS = 12  # 12 * 36 = 432 cards, plenty for capture software headers
+
+# Path fragments that mark processed/non-raw content (report tag, not an exclusion --
+# dupes among processed files are still worth knowing about).
+PROCESSED_DIR_RE = re.compile(
+    r"(?i)(?:^|[\\/])(proc[^\\/]*|reproc|pixinsight|pi_swap|autosave|master[^\\/]*|output|process(?:ed|ing)?)(?:[\\/]|$)"
+)
+
+
+def parse_fits_header(path: str) -> dict | None:
+    """Read primary-HDU header cards until END. Returns {} keys uppercased, or None on I/O error."""
+    try:
+        with open(path, "rb") as f:
+            raw = f.read(BLOCK * MAX_HEADER_BLOCKS)
+    except OSError:
+        return None
+    if len(raw) < BLOCK or not raw.startswith(b"SIMPLE"):
+        return None
+    header: dict[str, str] = {}
+    for off in range(0, len(raw) - 79, 80):
+        card = raw[off : off + 80].decode("ascii", "replace")
+        key = card[:8].strip()
+        if key == "END":
+            break
+        if not key or card[8:10] != "= ":
+            continue
+        value = card[10:]
+        if value.lstrip().startswith("'"):  # quoted string; comment slash may appear later
+            m = re.match(r"\s*'((?:[^']|'')*)'", value)
+            value = m.group(1).replace("''", "'").strip() if m else value.strip()
+        else:
+            value = value.split("/", 1)[0].strip()
+        header[key.upper()] = value
+    return header
+
+
+def ffloat(v: str | None) -> float | None:
+    if v is None:
+        return None
+    try:
+        return float(v)
+    except ValueError:
+        return None
+
+
+def night_of(date_obs: str | None) -> str:
+    """Bucket DATE-OBS into an observing night (local-ish: shift -12h so an
+    evening-to-morning session lands on one date). Empty string when unknown."""
+    if not date_obs:
+        return ""
+    try:
+        dt = datetime.fromisoformat(date_obs.rstrip("Z").split(".")[0])
+    except ValueError:
+        return ""
+    return (dt - timedelta(hours=12)).date().isoformat()
+
+
+def frame_type(header: dict, path: str) -> str:
+    t = (header.get("IMAGETYP") or header.get("FRAMETYP") or "").upper()
+    for kind in ("LIGHT", "DARKFLAT", "FLAT", "DARK", "BIAS"):
+        if kind in t:
+            # DARKFLAT before FLAT/DARK so 'DarkFlat' doesn't misclassify.
+            return kind
+    # Fall back to folder names for header-less/odd files.
+    up = path.upper()
+    for kind in ("DARKFLAT", "LIGHT", "FLAT", "DARK", "BIAS"):
+        if f"\\{kind}" in up or f"/{kind}" in up:
+            return kind
+    return "UNKNOWN"
+
+
+def sha_first_mib(path: str) -> str:
+    h = hashlib.sha256()
+    try:
+        with open(path, "rb") as f:
+            h.update(f.read(1024 * 1024))
+    except OSError:
+        return ""
+    return h.hexdigest()
+
+
+def scan_files(roots: list[str], limit: int | None) -> list[tuple[str, str, int, float]]:
+    """Yield (root, path, size, mtime) for every FITS file under the roots."""
+    out = []
+    for root in roots:
+        for dirpath, dirnames, filenames in os.walk(root):
+            for name in filenames:
+                if os.path.splitext(name)[1].lower() in FITS_EXTS:
+                    full = os.path.join(dirpath, name)
+                    try:
+                        st = os.stat(full)
+                    except OSError:
+                        continue
+                    out.append((root, full, st.st_size, st.st_mtime))
+                    if limit and len(out) >= limit:
+                        return out
+    return out
+
+
+def load_cache(cache_path: Path) -> dict[str, dict]:
+    cache: dict[str, dict] = {}
+    if cache_path.exists():
+        with open(cache_path, "r", encoding="utf-8") as f:
+            for line in f:
+                try:
+                    rec = json.loads(line)
+                    cache[rec["path"]] = rec
+                except (json.JSONDecodeError, KeyError):
+                    continue
+    return cache
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--root", action="append", required=True, help="archive root (repeatable)")
+    ap.add_argument("--out", required=True, help="report/cache output directory (created if missing)")
+    ap.add_argument("--limit", type=int, default=None, help="smoke test: stop after N files")
+    ap.add_argument("--rehash", action="store_true", help="ignore the index cache and re-read all headers")
+    args = ap.parse_args()
+
+    out_dir = Path(args.out)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    cache_path = out_dir / "fits-index.jsonl"
+    cache = {} if args.rehash else load_cache(cache_path)
+
+    print(f"[scan] enumerating FITS under: {', '.join(args.root)}")
+    files = scan_files(args.root, args.limit)
+    print(f"[scan] {len(files)} FITS files found; {len(cache)} cached header records")
+
+    records: list[dict] = []
+    fresh = 0
+    with open(cache_path, "a", encoding="utf-8") as cache_out:
+        for i, (root, path, size, mtime) in enumerate(files):
+            cached = cache.get(path)
+            if cached and cached.get("size") == size and abs(cached.get("mtime", 0) - mtime) < 2:
+                records.append(cached)
+            else:
+                header = parse_fits_header(path) or {}
+                rec = {
+                    "path": path,
+                    "root": root,
+                    "size": size,
+                    "mtime": mtime,
+                    "camera": header.get("INSTRUME", ""),
+                    "date_obs": header.get("DATE-OBS", ""),
+                    "exptime": ffloat(header.get("EXPTIME") or header.get("EXPOSURE")),
+                    "gain": ffloat(header.get("GAIN")),
+                    "binning": header.get("XBINNING", ""),
+                    "naxis1": header.get("NAXIS1", ""),
+                    "naxis2": header.get("NAXIS2", ""),
+                    "filter": header.get("FILTER", ""),
+                    "bayer": header.get("BAYERPAT", ""),
+                    "set_temp": ffloat(header.get("SET-TEMP")),
+                    "ccd_temp": ffloat(header.get("CCD-TEMP")),
+                    "type": frame_type(header, path),
+                    "swcreate": header.get("SWCREATE", ""),
+                    "stack_n": header.get("STACK_N", ""),
+                    "processed_path": bool(PROCESSED_DIR_RE.search(path)),
+                }
+                cache_out.write(json.dumps(rec) + "\n")
+                records.append(rec)
+                fresh += 1
+                if fresh % 1000 == 0:
+                    cache_out.flush()
+                    print(f"[index] {fresh} headers read ({i + 1}/{len(files)} files seen)")
+    print(f"[index] done: {fresh} headers read fresh, {len(records) - fresh} from cache")
+
+    # ---- duplicate detection: identity = camera + DATE-OBS + exptime + dims ----
+    by_key: dict[tuple, list[dict]] = defaultdict(list)
+    for r in records:
+        if r["date_obs"] and r["camera"]:
+            key = (r["camera"], r["date_obs"], r["exptime"], r["naxis1"], r["naxis2"])
+        else:
+            key = ("<no-header>", r["size"], os.path.basename(r["path"]).lower(), "", "")
+        by_key[key].append(r)
+
+    dup_rows: list[dict] = []
+    n_dup_groups = n_dup_files = dup_bytes = 0
+    n_cross_root_groups = 0
+    for key, group in by_key.items():
+        if len(group) < 2:
+            continue
+        hashes = {r["path"]: sha_first_mib(r["path"]) for r in group}
+        by_hash: dict[str, list[dict]] = defaultdict(list)
+        for r in group:
+            by_hash[hashes[r["path"]] + f":{r['size']}"].append(r)
+        for hsh, same in by_hash.items():
+            if len(same) < 2:
+                continue
+            n_dup_groups += 1
+            n_dup_files += len(same) - 1
+            dup_bytes += sum(r["size"] for r in same[1:])
+            roots_in_group = {r["root"] for r in same}
+            if len(roots_in_group) > 1:
+                n_cross_root_groups += 1
+            for r in same:
+                dup_rows.append({
+                    "group": n_dup_groups,
+                    "camera": key[0],
+                    "date_obs": key[1],
+                    "type": r["type"],
+                    "size": r["size"],
+                    "cross_root": len(roots_in_group) > 1,
+                    "path": r["path"],
+                })
+
+    with open(out_dir / "dup-files.csv", "w", newline="", encoding="utf-8") as f:
+        w = csv.DictWriter(f, fieldnames=["group", "camera", "date_obs", "type", "size", "cross_root", "path"])
+        w.writeheader()
+        w.writerows(dup_rows)
+
+    # ---- per-night rollup (lights only, raw paths only) ----
+    nights: dict[tuple, dict] = defaultdict(lambda: defaultdict(int))
+    dup_paths = {row["path"] for row in dup_rows}
+    for r in records:
+        if r["type"] != "LIGHT" or r["processed_path"] or r["stack_n"]:
+            continue
+        key = (r["camera"], night_of(r["date_obs"]))
+        nights[key][f"lights@{Path(r['root']).name}"] += 1
+        nights[key]["dup" if r["path"] in dup_paths else "unique"] += 1
+
+    with open(out_dir / "nights-rollup.csv", "w", newline="", encoding="utf-8") as f:
+        root_cols = [f"lights@{Path(r).name}" for r in args.root]
+        w = csv.writer(f)
+        w.writerow(["camera", "night", *root_cols, "dup", "unique"])
+        for (camera, night), counts in sorted(nights.items()):
+            w.writerow([camera, night, *(counts.get(c, 0) for c in root_cols),
+                        counts.get("dup", 0), counts.get("unique", 0)])
+
+    # ---- calibration coverage: darks/bias are shared across sessions, resolve by header ----
+    dark_sets: dict[tuple, dict] = defaultdict(lambda: {"count": 0, "roots": set(), "nights": set()})
+    for r in records:
+        if r["type"] in ("DARK", "BIAS") and not r["processed_path"]:
+            k = (r["type"], r["camera"], r["exptime"] if r["type"] == "DARK" else None, r["gain"], r["binning"])
+            dark_sets[k]["count"] += 1
+            dark_sets[k]["roots"].add(Path(r["root"]).name)
+            dark_sets[k]["nights"].add(night_of(r["date_obs"]))
+
+    cov_rows = []
+    light_groups: dict[tuple, int] = defaultdict(int)
+    for r in records:
+        if r["type"] == "LIGHT" and not r["processed_path"] and not r["stack_n"]:
+            light_groups[(r["camera"], r["exptime"], r["gain"], r["binning"], night_of(r["date_obs"]))] += 1
+    # exptime/gain are None for headerless lights; sort None-last instead of crashing the <.
+    def none_last(v):
+        return (v is None, v if v is not None else 0.0)
+
+    for (camera, exptime, gain, binning, night), count in sorted(
+            light_groups.items(),
+            key=lambda kv: (kv[0][0], kv[0][4], none_last(kv[0][1]), none_last(kv[0][2]), str(kv[0][3]))):
+        dk = dark_sets.get(("DARK", camera, exptime, gain, binning))
+        bk = dark_sets.get(("BIAS", camera, None, gain, binning))
+        cov_rows.append({
+            "camera": camera, "night": night, "exptime": exptime, "gain": gain, "binning": binning,
+            "lights": count,
+            "darks_found": dk["count"] if dk else 0,
+            "darks_roots": ";".join(sorted(dk["roots"])) if dk else "",
+            "bias_found": bk["count"] if bk else 0,
+        })
+    with open(out_dir / "calibration-coverage.csv", "w", newline="", encoding="utf-8") as f:
+        w = csv.DictWriter(f, fieldnames=["camera", "night", "exptime", "gain", "binning",
+                                          "lights", "darks_found", "darks_roots", "bias_found"])
+        w.writeheader()
+        w.writerows(cov_rows)
+
+    uncovered = [c for c in cov_rows if c["lights"] >= 10 and c["darks_found"] == 0]
+    summary = [
+        f"files indexed:        {len(records)}",
+        f"duplicate groups:     {n_dup_groups} ({n_dup_files} redundant files, {dup_bytes / 1e9:.1f} GB reclaimable)",
+        f"  cross-root groups:  {n_cross_root_groups} (BobbyBox <-> Astro-Pics)",
+        f"light (camera,night) groups: {len(light_groups)}",
+        f"  with NO matching darks anywhere (>=10 lights): {len(uncovered)}",
+        "reports: dup-files.csv, nights-rollup.csv, calibration-coverage.csv",
+    ]
+    text = "\n".join(summary)
+    (out_dir / "summary.txt").write_text(text, encoding="utf-8")
+    print("\n[summary]\n" + text)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/astro-archive-dedup.py
+++ b/tools/astro-archive-dedup.py
@@ -168,7 +168,10 @@ def main() -> int:
     with open(cache_path, "a", encoding="utf-8") as cache_out:
         for i, (root, path, size, mtime) in enumerate(files):
             cached = cache.get(path)
-            if cached and cached.get("size") == size and abs(cached.get("mtime", 0) - mtime) < 2:
+            # "set_temp" doubles as a schema marker: records written before the temperature
+            # fields existed re-read once, making the temp upgrade resumable without --rehash.
+            if cached and cached.get("size") == size and abs(cached.get("mtime", 0) - mtime) < 2 \
+                    and "set_temp" in cached:
                 records.append(cached)
             else:
                 header = parse_fits_header(path) or {}

--- a/tools/astro-archive-hardlink.py
+++ b/tools/astro-archive-hardlink.py
@@ -8,9 +8,12 @@ distinct copy is replaced by a hardlink to it -- both directory layouts keep wor
 redundant blocks are freed, and nothing is deleted (content is identical by construction).
 
 Safety model:
-  - Copies are verified byte-identical BEFORE linking: full-content SHA-256 by default
-    (doubles as a bit-rot audit -- mismatching "duplicates" are flagged to mismatches.csv and
-    never linked); --quick-verify hashes only first+last MiB + size instead.
+  - Copies are verified BEFORE linking. Default: SHA-256 of first + last MiB + exact size --
+    astro frames are noise-dominated (high entropy), so same sub-second DATE-OBS + same size +
+    same head/tail bytes is decisive, and the head MiB contains the whole FITS header (catches
+    edited-header twins, e.g. WCS written back in place). --full-verify hashes entire files
+    instead (mid-file bit-rot audit; ~10x the reads). Mismatches are flagged to mismatches.csv
+    and never linked either way.
   - Already-hardlinked pairs (same st_ino) are detected via os.stat and skipped.
   - Links are created next to the dup then atomically swapped in with os.replace.
   - Same-volume only (hardlinks cannot cross volumes; guarded by st_dev).
@@ -18,7 +21,7 @@ Safety model:
 
 Usage:
   python tools/astro-archive-hardlink.py --index "D:\\Astro-Reports\\fits-index.jsonl" ^
-      --canonical "D:\\Astro-Pics" --out "D:\\Astro-Reports" [--apply] [--quick-verify]
+      --canonical "D:\\Astro-Pics" --out "D:\\Astro-Reports" [--apply] [--full-verify]
 """
 
 from __future__ import annotations
@@ -65,9 +68,10 @@ def main() -> int:
     ap.add_argument("--canonical", required=True, help="root whose copies are kept as the primary")
     ap.add_argument("--out", required=True, help="directory for plan/log/mismatch CSVs")
     ap.add_argument("--apply", action="store_true", help="create the hardlinks (default: dry-run)")
-    ap.add_argument("--quick-verify", action="store_true",
-                    help="verify first+last MiB + size instead of full content")
+    ap.add_argument("--full-verify", action="store_true",
+                    help="hash entire files instead of first+last MiB + size (~10x the reads)")
     args = ap.parse_args()
+    quick = not args.full_verify
 
     out_dir = Path(args.out)
     out_dir.mkdir(parents=True, exist_ok=True)
@@ -139,7 +143,7 @@ def main() -> int:
 
     if not args.apply:
         print("[dry-run] nothing linked; re-run with --apply "
-              f"({'quick' if args.quick_verify else 'FULL'}-content verification before each link)")
+              f"({'FULL' if args.full_verify else 'quick'}-content verification before each link)")
         return 0
 
     log_path = out_dir / "hardlink-log.csv"
@@ -156,9 +160,9 @@ def main() -> int:
         for i, p in enumerate(plan):
             keeper, dup, size = p["keeper"], p["dup"], p["size"]
             if keeper not in keeper_hashes:
-                keeper_hashes[keeper] = sha256_of(keeper, args.quick_verify)
+                keeper_hashes[keeper] = sha256_of(keeper, quick)
             kh = keeper_hashes[keeper]
-            dh = sha256_of(dup, args.quick_verify)
+            dh = sha256_of(dup, quick)
             verified_bytes += size * 2
             if kh is None or dh is None:
                 mw.writerow([keeper, dup, size, "unreadable"])

--- a/tools/astro-archive-hardlink.py
+++ b/tools/astro-archive-hardlink.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python
+"""Astro archive hardlink dedup: collapse verified duplicate FITS copies into NTFS hardlinks.
+
+Consumes fits-index.jsonl (astro-archive-dedup.py). Duplicate groups share header identity
+(camera + DATE-OBS + exposure + dims); within each group one KEEPER is chosen (prefer the
+canonical root, then non-processed paths, then the shortest path) and every other physically
+distinct copy is replaced by a hardlink to it -- both directory layouts keep working, the
+redundant blocks are freed, and nothing is deleted (content is identical by construction).
+
+Safety model:
+  - Copies are verified byte-identical BEFORE linking: full-content SHA-256 by default
+    (doubles as a bit-rot audit -- mismatching "duplicates" are flagged to mismatches.csv and
+    never linked); --quick-verify hashes only first+last MiB + size instead.
+  - Already-hardlinked pairs (same st_ino) are detected via os.stat and skipped.
+  - Links are created next to the dup then atomically swapped in with os.replace.
+  - Same-volume only (hardlinks cannot cross volumes; guarded by st_dev).
+  - Dry-run by default: writes hardlink-plan.csv, touches nothing.
+
+Usage:
+  python tools/astro-archive-hardlink.py --index "D:\\Astro-Reports\\fits-index.jsonl" ^
+      --canonical "D:\\Astro-Pics" --out "D:\\Astro-Reports" [--apply] [--quick-verify]
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+import os
+import sys
+from collections import defaultdict
+from datetime import datetime, timezone
+from pathlib import Path
+
+MIB = 1024 * 1024
+
+
+def sha256_of(path: str, quick: bool) -> str | None:
+    h = hashlib.sha256()
+    try:
+        size = os.path.getsize(path)
+        with open(path, "rb") as f:
+            if quick and size > 2 * MIB:
+                h.update(f.read(MIB))
+                f.seek(size - MIB)
+                h.update(f.read(MIB))
+            else:
+                for chunk in iter(lambda: f.read(8 * MIB), b""):
+                    h.update(chunk)
+    except OSError:
+        return None
+    return h.hexdigest()
+
+
+def identity(rec: dict) -> tuple | None:
+    if rec["date_obs"] and rec["camera"]:
+        return (rec["camera"], rec["date_obs"], rec["exptime"], rec["naxis1"], rec["naxis2"])
+    return None  # headerless files: content-only identity is too weak to auto-link
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--index", required=True, help="fits-index.jsonl from astro-archive-dedup.py")
+    ap.add_argument("--canonical", required=True, help="root whose copies are kept as the primary")
+    ap.add_argument("--out", required=True, help="directory for plan/log/mismatch CSVs")
+    ap.add_argument("--apply", action="store_true", help="create the hardlinks (default: dry-run)")
+    ap.add_argument("--quick-verify", action="store_true",
+                    help="verify first+last MiB + size instead of full content")
+    args = ap.parse_args()
+
+    out_dir = Path(args.out)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    canonical = os.path.normpath(args.canonical)
+
+    # Last record per path wins (the organize step appends re-pointed records).
+    by_path: dict[str, dict] = {}
+    with open(args.index, "r", encoding="utf-8") as f:
+        for line in f:
+            try:
+                rec = json.loads(line)
+                by_path[rec["path"]] = rec
+            except (json.JSONDecodeError, KeyError):
+                continue
+
+    groups: dict[tuple, list[dict]] = defaultdict(list)
+    for rec in by_path.values():
+        key = identity(rec)
+        if key is not None:
+            groups[key].append(rec)
+
+    def keeper_rank(rec: dict, st: os.stat_result) -> tuple:
+        under_canonical = os.path.normpath(rec["path"]).startswith(canonical + os.sep)
+        return (0 if under_canonical else 1, 1 if rec["processed_path"] else 0, len(rec["path"]))
+
+    plan: list[dict] = []          # pending link actions
+    mismatches: list[dict] = []
+    already_linked = 0
+    stat_cache: dict[str, os.stat_result] = {}
+    for key, recs in groups.items():
+        if len(recs) < 2:
+            continue
+        live: list[tuple[dict, os.stat_result]] = []
+        for rec in recs:
+            try:
+                st = os.stat(rec["path"])
+            except OSError:
+                continue  # stale index path
+            stat_cache[rec["path"]] = st
+            live.append((rec, st))
+        if len(live) < 2:
+            continue
+        # Size differences within a header-identity group are treated as distinct files.
+        by_size: dict[int, list[tuple[dict, os.stat_result]]] = defaultdict(list)
+        for rec, st in live:
+            by_size[st.st_size].append((rec, st))
+        for size, members in by_size.items():
+            if len(members) < 2:
+                continue
+            members.sort(key=lambda m: keeper_rank(m[0], m[1]))
+            keeper, kst = members[0]
+            for rec, st in members[1:]:
+                if st.st_dev != kst.st_dev:
+                    continue  # cannot hardlink across volumes
+                if st.st_ino == kst.st_ino:
+                    already_linked += 1
+                    continue
+                plan.append({"keeper": keeper["path"], "dup": rec["path"], "size": size,
+                             "dup_nlink": st.st_nlink, "camera": key[0], "date_obs": key[1]})
+
+    plan_path = out_dir / "hardlink-plan.csv"
+    with open(plan_path, "w", newline="", encoding="utf-8") as f:
+        w = csv.DictWriter(f, fieldnames=["keeper", "dup", "size", "dup_nlink", "camera", "date_obs"])
+        w.writeheader()
+        w.writerows(plan)
+    total_bytes = sum(p["size"] for p in plan)
+    print(f"[plan] {len(plan)} link candidates, {total_bytes / 1e9:.1f} GB reclaimable, "
+          f"{already_linked} already hardlinked; plan: {plan_path}")
+
+    if not args.apply:
+        print("[dry-run] nothing linked; re-run with --apply "
+              f"({'quick' if args.quick_verify else 'FULL'}-content verification before each link)")
+        return 0
+
+    log_path = out_dir / "hardlink-log.csv"
+    mm_path = out_dir / "mismatches.csv"
+    linked = freed = verified_bytes = 0
+    keeper_hashes: dict[str, str | None] = {}
+    with open(log_path, "a", newline="", encoding="utf-8") as lf, \
+         open(mm_path, "a", newline="", encoding="utf-8") as mf:
+        lw, mw = csv.writer(lf), csv.writer(mf)
+        if lf.tell() == 0:
+            lw.writerow(["when_utc", "dup_replaced", "keeper", "size"])
+        if mf.tell() == 0:
+            mw.writerow(["keeper", "dup", "size", "note"])
+        for i, p in enumerate(plan):
+            keeper, dup, size = p["keeper"], p["dup"], p["size"]
+            if keeper not in keeper_hashes:
+                keeper_hashes[keeper] = sha256_of(keeper, args.quick_verify)
+            kh = keeper_hashes[keeper]
+            dh = sha256_of(dup, args.quick_verify)
+            verified_bytes += size * 2
+            if kh is None or dh is None:
+                mw.writerow([keeper, dup, size, "unreadable"])
+                mismatches.append(p)
+                continue
+            if kh != dh:
+                mw.writerow([keeper, dup, size, "content differs (bit-rot or false dup) - NOT linked"])
+                mismatches.append(p)
+                continue
+            tmp = dup + ".twlink.tmp"
+            try:
+                if os.path.exists(tmp):
+                    os.remove(tmp)
+                os.link(keeper, tmp)
+                os.replace(tmp, dup)
+            except OSError as e:
+                mw.writerow([keeper, dup, size, f"link failed: {e}"])
+                mismatches.append(p)
+                continue
+            lw.writerow([datetime.now(timezone.utc).isoformat(), dup, keeper, size])
+            linked += 1
+            if p["dup_nlink"] == 1:
+                freed += size
+            if (i + 1) % 500 == 0:
+                lf.flush()
+                print(f"[link] {i + 1}/{len(plan)} processed, {freed / 1e9:.1f} GB freed, "
+                      f"{verified_bytes / 1e9:.0f} GB verified")
+    print(f"[apply] {linked} hardlinks created, {freed / 1e9:.1f} GB freed, "
+          f"{len(mismatches)} skipped (see {mm_path}); log: {log_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/astro-archive-organize.py
+++ b/tools/astro-archive-organize.py
@@ -79,27 +79,68 @@ def parse_night(night: str) -> date | None:
         return None
 
 
-def best_elsewhere(candidates: list[dict], session: str, session_nights: set[str]) -> str:
+def temp_of(rec: dict) -> float | None:
+    """Sensor temperature for matching: the cooler setpoint when present (what the user dialed
+    in and what a dark library is shot at), else the measured CCD temperature (uncooled rigs)."""
+    return rec.get("set_temp") if rec.get("set_temp") is not None else rec.get("ccd_temp")
+
+
+def median_temp(recs: list[dict]) -> float | None:
+    temps = sorted(t for r in recs if (t := temp_of(r)) is not None)
+    return temps[len(temps) // 2] if temps else None
+
+
+def temp_bucket(delta: float | None) -> int:
+    """Dark current doubles every ~6 C, so temp distance dominates dark matching.
+    unknown ranks between 'close' and 'far' rather than winning or losing outright."""
+    if delta is None:
+        return 2
+    return 0 if delta <= 1.0 else 1 if delta <= 2.0 else 3
+
+
+def best_elsewhere(candidates: list[dict], session_nights: set[str],
+                   session_temp: float | None, kind: str) -> str:
     """Rank a calibration pool (minus in-session frames) by containing directory; returns a
-    short human line like '40x in <dir> (±3 d)'."""
+    short human line like '40x in <dir> (dT 0.5C, +/-3 d)'. Darks/bias rank temperature-first
+    (a months-old library at the same setpoint beats a warm same-night set); flats/darkflats
+    rank night-proximity-first (they track the optical train's dust, not the sensor)."""
     session_dates = [d for n in session_nights if (d := parse_night(n))]
-    by_dir: dict[str, dict] = defaultdict(lambda: {"count": 0, "dist": None})
+    by_dir: dict[str, dict] = defaultdict(lambda: {"count": 0, "dist": None, "temps": []})
     for r in candidates:
         dir_ = os.path.dirname(r["path"])
         info = by_dir[dir_]
         info["count"] += 1
+        if (t := temp_of(r)) is not None:
+            info["temps"].append(t)
         cal_date = parse_night(night_of(r["date_obs"]))
         if cal_date and session_dates:
             dist = min(abs((cal_date - s).days) for s in session_dates)
             info["dist"] = dist if info["dist"] is None else min(info["dist"], dist)
     if not by_dir:
         return "none found anywhere"
-    ranked = sorted(by_dir.items(),
-                    key=lambda kv: (kv[1]["dist"] if kv[1]["dist"] is not None else 9999,
-                                    -kv[1]["count"]))
-    dir_, info = ranked[0]
-    dist = f", ±{info['dist']} d" if info["dist"] is not None else ""
-    return f"{info['count']}x in {dir_}{dist}"
+
+    def dir_delta(info: dict) -> float | None:
+        if session_temp is None or not info["temps"]:
+            return None
+        temps = sorted(info["temps"])
+        return abs(temps[len(temps) // 2] - session_temp)
+
+    def rank(kv: tuple) -> tuple:
+        info = kv[1]
+        dist = info["dist"] if info["dist"] is not None else 9999
+        tb = temp_bucket(dir_delta(info))
+        if kind in ("DARK", "BIAS"):
+            return (tb, -info["count"], dist)
+        return (dist, tb, -info["count"])
+
+    dir_, info = sorted(by_dir.items(), key=rank)[0]
+    parts = []
+    if (delta := dir_delta(info)) is not None:
+        parts.append(f"dT {delta:.1f}C" + (" (!)" if delta > 2.0 else ""))
+    if info["dist"] is not None:
+        parts.append(f"+/-{info['dist']} d")
+    detail = f" ({', '.join(parts)})" if parts else ""
+    return f"{info['count']}x in {dir_}{detail}"
 
 
 def cal_key(kind: str, r: dict) -> tuple:
@@ -153,15 +194,18 @@ def write_summaries(records: list[dict], roots: list[str]) -> int:
             groups[(r["filter"] or "-", r["exptime"], r["gain"], r["binning"], r["camera"])] += 1
 
         in_session = {kind: info["cal"].get(kind, []) for kind in ("DARK", "BIAS", "FLAT", "DARKFLAT")}
+        session_temp = median_temp(lights)
+        temp_note = f" @ {session_temp:.0f}C setpoint" if session_temp is not None else ""
         lines = [
             f"# Session summary - {os.path.basename(session)}",
             "",
             f"> Machine-written by `tools/astro-archive-organize.py --write-summaries` on {today};",
             "> safe to delete, regenerated on the next organize run. Matching is by FITS header",
-            "> (camera + exposure + gain + binning [+ filter]); sensor temperature is NOT compared.",
+            "> (camera + exposure + gain + binning [+ filter]); darks/bias rank temperature-first",
+            "> (dT vs the lights' setpoint, >2C flagged), flats rank night-proximity-first.",
             "",
             f"- Nights: {nights[0]} .. {nights[-1]} ({len(nights)})" if nights else "- Nights: unknown",
-            f"- Camera: {', '.join(cameras) or 'unknown'}" + (f" ({', '.join(bayer)})" if bayer else ""),
+            f"- Camera: {', '.join(cameras) or 'unknown'}" + (f" ({', '.join(bayer)})" if bayer else "") + temp_note,
             "",
             "## Lights",
             "",
@@ -189,9 +233,15 @@ def write_summaries(records: list[dict], roots: list[str]) -> int:
                          "FLAT": f"{filt} b{binning}",
                          "DARKFLAT": f"g{gain} b{binning}"}[kind]
                 if own:
-                    lines.append(f"| {kind.title()} | {label} | {len(own)} | - |")
+                    own_cell = str(len(own))
+                    if (own_temp := median_temp(own)) is not None:
+                        delta = abs(own_temp - session_temp) if session_temp is not None else None
+                        own_cell += f" @ {own_temp:.0f}C"
+                        if kind in ("DARK", "BIAS") and delta is not None and delta > 2.0:
+                            own_cell += f" (dT {delta:.1f}C (!))"
+                    lines.append(f"| {kind.title()} | {label} | {own_cell} | - |")
                 else:
-                    elsewhere = best_elsewhere(pools.get(key, []), session, set(nights))
+                    elsewhere = best_elsewhere(pools.get(key, []), set(nights), session_temp, kind)
                     lines.append(f"| {kind.title()} | {label} | 0 | {elsewhere} |")
         lines.append("")
         (Path(session) / "_session-summary.md").write_text("\n".join(lines), encoding="utf-8")
@@ -215,13 +265,21 @@ def main() -> int:
     source = os.path.normpath(args.source)
     canonical = os.path.normpath(args.canonical)
 
-    records = []
+    # The index is append-only (schema upgrades and move re-pointing append updated records),
+    # so the LAST record per path wins — a flat list double-counts every upgraded file — and
+    # records whose file no longer exists (pre-move paths) would create phantom session dirs
+    # and calibration pools pointing at vanished directories.
+    by_path: dict[str, dict] = {}
     with open(args.index, "r", encoding="utf-8") as f:
         for line in f:
             try:
-                records.append(json.loads(line))
-            except json.JSONDecodeError:
+                rec = json.loads(line)
+                by_path[rec["path"]] = rec
+            except (json.JSONDecodeError, KeyError):
                 continue
+    records = [r for r in by_path.values() if os.path.exists(r["path"])]
+    if len(records) != len(by_path):
+        print(f"[index] {len(by_path) - len(records)} stale-path records ignored")
 
     # Header-identity set of every raw light already in the canonical root.
     canonical_lights = set()

--- a/tools/astro-archive-organize.py
+++ b/tools/astro-archive-organize.py
@@ -1,0 +1,351 @@
+#!/usr/bin/env python
+"""Astro archive organizer: file BobbyBox-only sessions into the canonical root.
+
+Consumes the header index produced by astro-archive-dedup.py (fits-index.jsonl) and
+classifies every top-level directory under --source against --canonical:
+
+  MOVE       has lights, NONE of them exist in canonical (by header identity), single year
+  DUPLICATE  every light already exists in canonical (candidate for hardlink dedup, not move)
+  MIXED      some lights unique, some duplicated -- needs a human decision
+  NO_LIGHTS  no FITS lights in the index (cal-only, planetary SER, workspaces) -- manual
+  MULTI_YEAR unique lights but spanning years -- manual filing
+
+Default is a DRY-RUN that writes move-plan.csv; --apply executes the MOVE rows as
+same-volume renames (instant, no data copy) into <canonical>\\<year>\\<original dir name>,
+refusing if the target already exists, and records every rename in move-log.csv (the undo
+record: swap columns to reverse). Nothing is ever deleted.
+
+Usage:
+  python tools/astro-archive-organize.py --index "D:\\Astro-Reports\\fits-index.jsonl" ^
+      --source "D:\\BobbyBox-Temp" --canonical "D:\\Astro-Pics" --out "D:\\Astro-Reports"
+  ... --apply     # execute the MOVE rows after reviewing move-plan.csv
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import os
+import sys
+from collections import defaultdict
+from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
+
+FRAME_DIR_NAMES = {"light", "lights", "dark", "darks", "bias", "biases", "flat", "flats",
+                   "darkflat", "darkflats", "autosave", "rawframes"}
+
+
+def night_of(date_obs: str) -> str:
+    if not date_obs:
+        return ""
+    try:
+        dt = datetime.fromisoformat(date_obs.rstrip("Z").split(".")[0])
+    except ValueError:
+        return ""
+    return (dt - timedelta(hours=12)).date().isoformat()
+
+
+def identity(rec: dict) -> tuple:
+    return (rec["camera"], rec["date_obs"], rec["exptime"], rec["naxis1"], rec["naxis2"])
+
+
+def top_dir(path: str, root: str) -> str | None:
+    rel = os.path.relpath(path, root)
+    if rel.startswith(".."):
+        return None
+    head = rel.replace("/", "\\").split("\\", 1)[0]
+    return head if head and head != rel else None  # files directly in root have no session dir
+
+
+def session_dir_of(path: str, root: str) -> str | None:
+    """The directory that owns a frame: the parent of the shallowest frame-type folder in
+    its path (…\\<session>\\LIGHT\\…), or the file's own directory when frames sit loose.
+    A frame-type folder directly under the root is a shared library, not a session."""
+    rel = os.path.relpath(path, root)
+    if rel.startswith(".."):
+        return None
+    comps = rel.replace("/", "\\").split("\\")[:-1]
+    for i, comp in enumerate(comps):
+        if comp.lower() in FRAME_DIR_NAMES:
+            return os.path.join(root, *comps[:i]) if i > 0 else None
+    return os.path.join(root, *comps) if comps else None
+
+
+def parse_night(night: str) -> date | None:
+    try:
+        return date.fromisoformat(night)
+    except ValueError:
+        return None
+
+
+def best_elsewhere(candidates: list[dict], session: str, session_nights: set[str]) -> str:
+    """Rank a calibration pool (minus in-session frames) by containing directory; returns a
+    short human line like '40x in <dir> (±3 d)'."""
+    session_dates = [d for n in session_nights if (d := parse_night(n))]
+    by_dir: dict[str, dict] = defaultdict(lambda: {"count": 0, "dist": None})
+    for r in candidates:
+        dir_ = os.path.dirname(r["path"])
+        info = by_dir[dir_]
+        info["count"] += 1
+        cal_date = parse_night(night_of(r["date_obs"]))
+        if cal_date and session_dates:
+            dist = min(abs((cal_date - s).days) for s in session_dates)
+            info["dist"] = dist if info["dist"] is None else min(info["dist"], dist)
+    if not by_dir:
+        return "none found anywhere"
+    ranked = sorted(by_dir.items(),
+                    key=lambda kv: (kv[1]["dist"] if kv[1]["dist"] is not None else 9999,
+                                    -kv[1]["count"]))
+    dir_, info = ranked[0]
+    dist = f", ±{info['dist']} d" if info["dist"] is not None else ""
+    return f"{info['count']}x in {dir_}{dist}"
+
+
+def cal_key(kind: str, r: dict) -> tuple:
+    if kind == "DARK":
+        return ("DARK", r["camera"], r["exptime"], r["gain"], r["binning"])
+    if kind == "BIAS":
+        return ("BIAS", r["camera"], r["gain"], r["binning"])
+    if kind == "FLAT":
+        return ("FLAT", r["camera"], r["filter"], r["binning"])
+    return ("DARKFLAT", r["camera"], r["gain"], r["binning"])
+
+
+def write_summaries(records: list[dict], roots: list[str]) -> int:
+    """Drop a machine-written _session-summary.md into every session dir that owns raw
+    lights: light inventory + in-session calibration counts + most-likely matches elsewhere."""
+    raw = [r for r in records if not r["processed_path"] and not r["stack_n"]]
+    sessions: dict[str, dict] = defaultdict(lambda: {"lights": [], "cal": defaultdict(list)})
+    pools: dict[tuple, list[dict]] = defaultdict(list)
+    for r in raw:
+        root = next((rt for rt in roots if os.path.normpath(r["root"]) == os.path.normpath(rt)), None)
+        if root is None:
+            continue
+        session = session_dir_of(r["path"], root)
+        kind = r["type"]
+        if kind == "LIGHT":
+            if session:
+                sessions[session]["lights"].append(r)
+            continue
+        if kind == "DARK":
+            pools[("DARK", r["camera"], r["exptime"], r["gain"], r["binning"])].append(r)
+        elif kind == "BIAS":
+            pools[("BIAS", r["camera"], r["gain"], r["binning"])].append(r)
+        elif kind == "FLAT":
+            pools[("FLAT", r["camera"], r["filter"], r["binning"])].append(r)
+        elif kind == "DARKFLAT":
+            pools[("DARKFLAT", r["camera"], r["gain"], r["binning"])].append(r)
+        if session:
+            sessions[session]["cal"][kind].append(r)
+
+    written = 0
+    today = datetime.now(timezone.utc).date().isoformat()
+    for session, info in sessions.items():
+        lights = info["lights"]
+        if not lights or not os.path.isdir(session):
+            continue
+        nights = sorted({n for r in lights if (n := night_of(r["date_obs"]))})
+        cameras = sorted({r["camera"] for r in lights if r["camera"]})
+        bayer = sorted({r["bayer"] for r in lights if r["bayer"]})
+        groups: dict[tuple, int] = defaultdict(int)
+        for r in lights:
+            groups[(r["filter"] or "-", r["exptime"], r["gain"], r["binning"], r["camera"])] += 1
+
+        in_session = {kind: info["cal"].get(kind, []) for kind in ("DARK", "BIAS", "FLAT", "DARKFLAT")}
+        lines = [
+            f"# Session summary - {os.path.basename(session)}",
+            "",
+            f"> Machine-written by `tools/astro-archive-organize.py --write-summaries` on {today};",
+            "> safe to delete, regenerated on the next organize run. Matching is by FITS header",
+            "> (camera + exposure + gain + binning [+ filter]); sensor temperature is NOT compared.",
+            "",
+            f"- Nights: {nights[0]} .. {nights[-1]} ({len(nights)})" if nights else "- Nights: unknown",
+            f"- Camera: {', '.join(cameras) or 'unknown'}" + (f" ({', '.join(bayer)})" if bayer else ""),
+            "",
+            "## Lights",
+            "",
+            "| Filter | Exp (s) | Gain | Bin | Count | Integration |",
+            "|---|---|---|---|---|---|",
+        ]
+        for (filt, exptime, gain, binning, camera), count in sorted(groups.items(), key=lambda kv: str(kv[0])):
+            integ = f"{count * exptime / 3600:.1f} h" if exptime else "?"
+            lines.append(f"| {filt} | {exptime if exptime is not None else '?'} | "
+                         f"{gain if gain is not None else '?'} | {binning or '?'} | {count} | {integ} |")
+        lines += ["", "## Calibration", "",
+                  "| Kind | For | In session | Most likely elsewhere |", "|---|---|---|---|"]
+        seen_cal_rows: set[tuple] = set()
+        for (filt, exptime, gain, binning, camera), _count in sorted(groups.items(), key=lambda kv: str(kv[0])):
+            for kind, key in (("DARK", ("DARK", camera, exptime, gain, binning)),
+                              ("BIAS", ("BIAS", camera, gain, binning)),
+                              ("FLAT", ("FLAT", camera, filt if filt != "-" else "", binning)),
+                              ("DARKFLAT", ("DARKFLAT", camera, gain, binning))):
+                if key in seen_cal_rows:
+                    continue
+                seen_cal_rows.add(key)
+                own = [r for r in in_session[kind] if cal_key(kind, r) == key]
+                label = {"DARK": f"{exptime if exptime is not None else '?'} s g{gain} b{binning}",
+                         "BIAS": f"g{gain} b{binning}",
+                         "FLAT": f"{filt} b{binning}",
+                         "DARKFLAT": f"g{gain} b{binning}"}[kind]
+                if own:
+                    lines.append(f"| {kind.title()} | {label} | {len(own)} | - |")
+                else:
+                    elsewhere = best_elsewhere(pools.get(key, []), session, set(nights))
+                    lines.append(f"| {kind.title()} | {label} | 0 | {elsewhere} |")
+        lines.append("")
+        (Path(session) / "_session-summary.md").write_text("\n".join(lines), encoding="utf-8")
+        written += 1
+    return written
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--index", required=True, help="fits-index.jsonl from astro-archive-dedup.py")
+    ap.add_argument("--source", required=True, help="root whose unique sessions get filed (BobbyBox)")
+    ap.add_argument("--canonical", required=True, help="canonical archive root (Astro-Pics)")
+    ap.add_argument("--out", required=True, help="directory for move-plan.csv / move-log.csv")
+    ap.add_argument("--apply", action="store_true", help="execute MOVE rows (default: dry-run)")
+    ap.add_argument("--write-summaries", action="store_true",
+                    help="write _session-summary.md into every session dir that owns raw lights")
+    args = ap.parse_args()
+
+    out_dir = Path(args.out)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    source = os.path.normpath(args.source)
+    canonical = os.path.normpath(args.canonical)
+
+    records = []
+    with open(args.index, "r", encoding="utf-8") as f:
+        for line in f:
+            try:
+                records.append(json.loads(line))
+            except json.JSONDecodeError:
+                continue
+
+    # Header-identity set of every raw light already in the canonical root.
+    canonical_lights = set()
+    for r in records:
+        if os.path.normpath(r["root"]) == canonical and r["type"] == "LIGHT" and not r["processed_path"]:
+            canonical_lights.add(identity(r))
+
+    # Per source top-level dir: light/dup counts, frame types, nights, years.
+    dirs: dict[str, dict] = defaultdict(lambda: {
+        "lights": 0, "dup_lights": 0, "frames": defaultdict(int), "nights": set(), "years": set()})
+    for r in records:
+        if os.path.normpath(r["root"]) != source:
+            continue
+        d = top_dir(r["path"], source)
+        if d is None:
+            continue
+        info = dirs[d]
+        info["frames"][r["type"]] += 1
+        if r["type"] == "LIGHT" and not r["processed_path"]:
+            info["lights"] += 1
+            if identity(r) in canonical_lights:
+                info["dup_lights"] += 1
+            night = night_of(r["date_obs"])
+            if night:
+                info["nights"].add(night)
+                info["years"].add(night[:4])
+
+    plan_rows = []
+    for d, info in sorted(dirs.items()):
+        lights, dups = info["lights"], info["dup_lights"]
+        years = sorted(info["years"])
+        if lights == 0:
+            cls, target = "NO_LIGHTS", ""
+        elif dups == lights:
+            cls, target = "DUPLICATE", ""
+        elif dups > 0:
+            cls, target = "MIXED", ""
+        elif len(years) != 1:
+            cls, target = "MULTI_YEAR", ""
+        else:
+            cls = "MOVE"
+            target = os.path.join(canonical, years[0], d)
+        plan_rows.append({
+            "class": cls,
+            "dir": os.path.join(source, d),
+            "target": target,
+            "lights": lights,
+            "dup_lights": dups,
+            "nights": len(info["nights"]),
+            "years": ";".join(years),
+            "frame_types": ";".join(f"{k}:{v}" for k, v in sorted(info["frames"].items())),
+        })
+
+    plan_path = out_dir / "move-plan.csv"
+    with open(plan_path, "w", newline="", encoding="utf-8") as f:
+        w = csv.DictWriter(f, fieldnames=["class", "dir", "target", "lights", "dup_lights",
+                                          "nights", "years", "frame_types"])
+        w.writeheader()
+        w.writerows(plan_rows)
+
+    by_class = defaultdict(list)
+    for row in plan_rows:
+        by_class[row["class"]].append(row)
+    print(f"[plan] {plan_path}")
+    for cls in ("MOVE", "MIXED", "DUPLICATE", "MULTI_YEAR", "NO_LIGHTS"):
+        rows = by_class.get(cls, [])
+        n_lights = sum(r["lights"] for r in rows)
+        print(f"  {cls:<10} {len(rows):>3} dirs, {n_lights:>6} lights")
+        if cls in ("MOVE", "MIXED", "MULTI_YEAR"):
+            for r in rows:
+                print(f"    {r['dir']}  (lights={r['lights']} dup={r['dup_lights']} years={r['years']})"
+                      + (f" -> {r['target']}" if r["target"] else ""))
+
+    if not args.apply:
+        print("[dry-run] no moves executed; re-run with --apply to execute the MOVE rows")
+        if args.write_summaries:
+            written = write_summaries(records, [source, canonical])
+            print(f"[summaries] {written} _session-summary.md files written")
+        return 0
+
+    log_path = out_dir / "move-log.csv"
+    moved = 0
+    renames: list[tuple[str, str]] = []
+    with open(log_path, "a", newline="", encoding="utf-8") as f:
+        w = csv.writer(f)
+        if f.tell() == 0:
+            w.writerow(["when_utc", "from", "to"])
+        for row in by_class.get("MOVE", []):
+            src, dst = row["dir"], row["target"]
+            if not os.path.isdir(src):
+                print(f"[skip] source vanished: {src}")
+                continue
+            if os.path.exists(dst):
+                print(f"[skip] target exists: {dst}")
+                continue
+            os.makedirs(os.path.dirname(dst), exist_ok=True)
+            os.rename(src, dst)
+            w.writerow([datetime.now(timezone.utc).isoformat(), src, dst])
+            renames.append((src, dst))
+            moved += 1
+            print(f"[moved] {src} -> {dst}")
+    print(f"[apply] {moved} directories moved; undo record: {log_path}")
+
+    # Keep the header index consistent without a rescan: append updated records with the
+    # moved paths (and root swapped to canonical). The cache loader keeps the LAST record
+    # per path, and stale old-path records simply stop matching anything on disk.
+    if renames:
+        updated = 0
+        with open(args.index, "a", encoding="utf-8") as f:
+            for r in records:
+                for src, dst in renames:
+                    if r["path"].startswith(src + os.sep):
+                        r["path"] = dst + r["path"][len(src):]  # in-memory too: summaries below
+                        r["root"] = canonical
+                        f.write(json.dumps(r) + "\n")
+                        updated += 1
+                        break
+        print(f"[index] {updated} index records re-pointed to their new paths")
+
+    if args.write_summaries:
+        written = write_summaries(records, [source, canonical])
+        print(f"[summaries] {written} _session-summary.md files written")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Step 0 of `docs/plans/ai-denoise-deconv.md`, already executed against the real archive.

## Tools

- **`tools/astro-archive-dedup.py`** (READ-ONLY): resumable FITS-header index; duplicate groups by header identity (camera + `DATE-OBS` + exposure + dims) confirmed with first-MiB SHA-256; per-night light rollup; archive-wide calibration-coverage map (darks/bias libraries are shared between sessions — matching is by header, never by folder).
- **`tools/astro-archive-organize.py`**: classifies source dirs against the canonical root (MOVE/MIXED/DUPLICATE/…), dry-run plan by default, `--apply` = same-volume renames with an undo log + in-place index re-pointing; `--write-summaries` drops a machine-written `_session-summary.md` (lights inventory + in-session calibration + most-likely-elsewhere matches) into every session dir.

## Real-run results

73,040 files indexed · 12,440 dup groups (13,470 redundant files, ~301 GB reclaimable, 7,805 cross-root) · 6 unique dirs (2,952 lights, incl. an unfiled 2024-02-03 night) filed into the canonical root · 271 session summaries written · 66 light groups flagged with no matching darks anywhere (19 in the 2024+ band).

Plan doc updated in step: Step-0 phase row, calibration-by-header invariant, infra section (internal AKS T4 pool for full runs, RunPod as ablation fast lane).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ATx1GGJ6CyDBF2yjTqrvm7