### PR TITLE
docs(plans): AIC-talk cross-check deltas

### DIFF
--- a/docs/plans/ai-denoise-deconv.md
+++ b/docs/plans/ai-denoise-deconv.md
@@ -182,8 +182,12 @@ preferred until it passes).
 
 ## 3. Model + training
 
-- **Architecture: NAFNet** (width 32 first, 64 if capacity-limited; ~5–20 M params) — the same
-  family the SAS AI4 models use, so the stride-16 / tile-256 / overlap-64 constraints of
+- **Architecture: NAFNet, width 32, standard block config ≈ 29 M params** (the SXT 21M / NXT 24M /
+  StarNet-V2 30M league; ~115 MB fp32 ONNX, same class as the SAS AI4 files the runtime already
+  handles). Capacity tuning goes DOWN via middle-block count on pinned-split ablations — Croman
+  ("capacity saturated"), Topaz competing at 14M, and our narrower single-user domain all say >30M
+  needs evidence, and width-64 (~116M) is off the table (4× the customer download for nothing).
+  Same family as the SAS AI4 models, so the stride-16 / tile-256 / overlap-64 constraints of
   `ChunkedNafnetRunner` hold by construction. Denoiser: 3-channel in/out (mono handled by the
   runner's channel-tiling, as `OnnxStellarSharpener` does). Deconvolver: image + `psf01` scalar.
 - **Strength control comes free:** train full-strength models; `SharpenPipeline` already applies

--- a/docs/plans/ai-denoise-deconv.md
+++ b/docs/plans/ai-denoise-deconv.md
@@ -62,11 +62,23 @@ on that carve-out:
 
 ### 2.2 Deconvolver ground truth — synthetic PSF degradation
 
-- Input = sharp master tile convolved with a synthetic PSF; target = the undegraded tile. PSF family:
-  Moffat (β 2.5–4.5) with FWHM swept over [1, 8] px, elongation/PA, mild coma term, optional linear
-  guiding-smear kernel. **Calibrate the sweep to reality:** P0 measures the archive's actual
-  FWHM/ellipticity distribution (`FindStarsAsync` over sampled subs) so the synthetic family covers
-  the observed range instead of a guess.
+- Input = sharp master tile convolved with a synthetic PSF; target = the undegraded tile;
+  **electron-domain noise is added AFTER the blur on every pair** (never optional — deconvolution
+  is ill-posed and noise amplifies under inversion, so noise-free pairs train a brittle sharpener).
+  PSF family: Moffat (β 2.5–4.5) with FWHM swept over [1, 8] px, elongation/PA, coma term, optional
+  linear guiding-smear kernel — and **position-varying**: P0 measures the archive's FWHM/
+  ellipticity/PA distribution **binned by field radius** (`FindStarsAsync` centroids give star
+  positions; fast-lens corners genuinely differ from center), and per-tile degradation samples
+  aberrations from the measured field-position distribution instead of one stationary kernel.
+- **Space-truth tier (experiment, above the own-masters baseline):** own masters are seeing-limited
+  (FWHM ~2–3 px), so they teach only relative sharpening toward their own ceiling. Public HST/JWST
+  FITS from MAST (public domain / CC-BY — degrading *public archive data with our own measured PSF
+  family* is fully independent development; HST/JWST truth is *reported* as BXT's approach in
+  RC-Astro's FAQ and secondary coverage, NOT stated in the 2022 AIC talk, which predates BXT — and
+  our justification is independent of what BXT did) become sharper truth: downsampling to the rigs' 1–3"/px scales crushes HST noise, yielding effectively
+  noiseless linear truth at our sampling. Domain gaps (filter sets ≠ OSC RGB) are handled by
+  luminance/per-channel training — PSF inversion is near-achromatic — and the tier is adopted only
+  if it beats the baseline on the pinned split.
 - **PSF conditioning mirrors the SAS conditional model exactly:** a second scalar ONNX input
   `psf01 ∈ [0,1]`, log2-encoded over [1, 8] px — the *same* encoding `HfdPsfEstimator` already
   produces and `OnnxIoNames.ImagePlusScalar` already classifies. Our model becomes a drop-in for

--- a/docs/plans/ai-denoise-deconv.md
+++ b/docs/plans/ai-denoise-deconv.md
@@ -163,6 +163,11 @@ exact by construction. Four stages, fully license-clean (own data + own syntheti
 2. **Synthetic star injection** onto those plates, drawn from the archive's measured PSF
    distribution (same P0 stats that calibrate the deconv sweep): Moffat cores, lens halos,
    saturation/bloom for the bright tail. Input = plate + injected stars, target = plate.
+   **Injection positions must be uncorrelated with the classical-removal residual sites**
+   (Croman's "the network will faithfully learn all of your mistakes"): if injected stars
+   preferentially land on inpaint artifacts, the net learns that removing a star reveals
+   artifacts — random placement keeps the truth under injected stars overwhelmingly clean
+   background.
    Advantage of this archive: all optics are refractive (Samyang 135, ZS61, FMA180, SH61) — no
    spider vanes, no diffraction spikes — so the morphology distribution is far narrower than a
    general-purpose remover must handle.
@@ -185,7 +190,10 @@ preferred until it passes).
   per-step `Blend` as a post-hoc `Image.Lerp` toward the source — that *is* the user-facing strength
   slider. NXT-style per-frequency knobs are explicitly deferred.
 - **Losses:** L1 (MAE) primary + MS-SSIM auxiliary; plus a **flux-preservation regulariser**
-  (per-tile mean/aperture-sum penalty) — see §7.
+  (per-tile mean/aperture-sum penalty) — see §7. **Adversarial/GAN losses are deliberately
+  excluded**: they optimise for plausibility, which is hallucination pressure — directly opposed
+  to the photometric-integrity gates. If perceptual quality ever needs a boost, prefer feature
+  losses with the flux regulariser as a hard constraint.
 - **Optimisation:** AdamW, cosine schedule, grad-norm clip 1.0, early stop on held-out val, seeded
   end-to-end. Mirrors the Croman talk's recipe and prior in-house ML-pipeline experience.
 - **Discipline (proven in-house ML-pipeline patterns, adopted wholesale):**
@@ -247,7 +255,7 @@ preferred until it passes).
 | **P2 — Deconvolver v1** | Synthetic-PSF pipeline (measured-distribution sweep); psf01-conditioned NAFNet; `OnnxTianWenDeconvolver`; eval incl. FWHM-reduction + artefact checks | Measured FWHM reduction on held-out masters without ringing/worms; photometric gates hold |
 | **P3 — Ship** | Auto-order wiring, fetch-script + release assets, CLI/GUI surfacing, `docs` + CLAUDE.md section | `stack --enhance --ai-backend tianwen` end-to-end on a fresh machine (models auto-fetched) |
 | **P4 — Star remover** | Inject-and-remove bootstrap (§2.5): classical starless plates + measured-PSF star injector + self-refinement; `OnnxTianWenStarRemover : IStarRemover` (additive split) — completes the tier so the full canonical program runs TianWen-only | Injected-star removal completeness + background preservation + stars-plate flux conservation on held-out sessions; bright-saturated tail passes 1:1 spot checks (RC/SAS stay preferred until then) |
-| **P5 — Deferred** | Strength/frequency conditioning beyond Blend-lerp; mono-native models; drizzle-truth sharper tier; frame-quality classifier from BAD-examples; dataset-contribution flow for other users | — |
+| **P5 — Deferred** | Strength/frequency conditioning beyond Blend-lerp; mono-native models; drizzle-truth sharper tier; frame-quality classifier from BAD-examples; dataset-contribution flow for other users; **comet-registered stacking** (P4 unlock: star-remove subs → integrate on the `CometEphemeris`-computed per-frame comet position via WCS → recombine star-registered stars plate — the AIC comet workflow, automated by ephemeris instead of manual alignment) | — |
 
 ## 6. Evaluation (all internal, license-clean)
 
@@ -263,7 +271,9 @@ preferred until it passes).
 ## 7. The differentiator: photometric integrity
 
 Croman's own stated con: AI-processed images "destroy the scientific value" — flux and centroids
-are not conserved. We train and gate on exactly that:
+are not conserved — *"unless they were specifically trained to conserve star flux or conserve the
+positions of star centroids"* (AIC talk, verbatim). That carve-out is this section: we train and
+gate on exactly that:
 
 - **Training:** flux-preservation regulariser (aperture-sum penalty over detected-star apertures +
   per-tile mean preservation).

--- a/docs/plans/ai-denoise-deconv.md
+++ b/docs/plans/ai-denoise-deconv.md
@@ -127,6 +127,16 @@ folder scan unless extracted — watch for new ones under future 2024+ sessions.
 
 ### 2.4 Dataset builder (`tianwen dataset build`, new CLI subcommand)
 
+**CLI contract — no machine specifics in the tool.** The command ships to every user, so nothing
+in the repo encodes this machine: archive locations are **required** parameters (`--archive-root`,
+repeatable; `--out`), with fail-fast errors instead of defaults pointing anywhere. Behavioural
+knobs are parameters with *portable* defaults: exposure gate (`--min/--max-exposure`, default
+10/300 s), instrument exclusion (`--exclude-instrume`, default `*simulator*` — generic, not a
+camera list), tile size/cells/subs-per-cell, split-file path. Machine-specific invocations live in
+the operator's own runner scripts outside the repo (the `run-archive-step0.ps1` pattern) or in
+docs as examples only. The step-0 python helpers already conform (paths appear solely in docstring
+usage examples) — keep that bar.
+
 C# tooling in-repo, reusing existing Lib machinery end-to-end (scan `FitsFolderFrameSource` →
 dedup → quality gate → calibrate via `MasterFrameBuilder` → debayer → register subs to the session
 master → tile export). **Calibration is resolved by header match across the whole archive, never by


### PR DESCRIPTION
Re-validated docs/plans/ai-denoise-deconv.md against the Croman AIC talk transcript. Four deltas folded in: injection-position decorrelation for the star-removal bootstrap, explicit GAN-loss rejection (hallucination pressure vs photometric gates), the talk's verbatim flux/centroid carve-out cited in §7, and comet-registered stacking (ephemeris-automated AIC comet workflow) added to P5 as a P4 unlock. Everything else in the talk was already embodied by the plan or shipped pipeline (details in the commit message).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ATx1GGJ6CyDBF2yjTqrvm7