### PR TITLE
feat(dataset): --resume checkpoints a stopped bake on the manifest

### DIFF
--- a/src/TianWen.AI.Imaging/DatasetBuildRunner.cs
+++ b/src/TianWen.AI.Imaging/DatasetBuildRunner.cs
@@ -36,17 +36,23 @@ public static class DatasetBuildRunner
     /// and were skipped. Discovery only validates HEADERS, so a truncated file with a clean header
     /// surfaces here, at register time — fault-isolated per session so one bad frame can never
     /// abort a multi-hour archive bake. Failures are logged per session; a crashed-then-restarted
-    /// run starts fresh (the manifest is regenerated), so partial output never needs repairing.</param>
+    /// run starts fresh (the manifest is regenerated) unless <see cref="DatasetBuildOptions.Resume"/>
+    /// checkpoints it, so partial output never needs repairing.</param>
     /// <param name="SkippedNoDark">Sessions skipped because no master dark could be resolved and
     /// <see cref="DatasetBuildOptions.RequireDarkCalibration"/> is set — an uncalibrated N2N pair
     /// shares the sensor's fixed-pattern dark signal (correlated between subs), so it is not a valid
     /// training sample. Distinct from <paramref name="Failed"/> (an error), and from the silent
     /// too-few-subs skip.</param>
+    /// <param name="Resumed">Sessions skipped wholesale because their tiles were already in the
+    /// manifest (<see cref="DatasetBuildOptions.Resume"/>) — their prior tile counts fold into
+    /// <paramref name="TotalTiles"/> but they are NOT re-registered, so the PSF/noise report of a
+    /// resumed run covers only the sessions registered in THAT run.</param>
     public sealed record RunResult(
         int Sessions,
         int Registered,
         int Failed,
         int SkippedNoDark,
+        int Resumed,
         int TotalTiles,
         int TestSessions,
         bool ParityChecked,
@@ -86,9 +92,16 @@ public static class DatasetBuildRunner
         var testSessions = await DatasetSplitWriter.WriteAsync(sessions.Select(s => s.Id), options.TestFraction, splitPath, cancellationToken);
         progress?.Report($"[dataset] pinned test split: {testSessions.Length}/{sessions.Length} sessions held out");
 
-        // Fresh manifest per run (the exporter appends per session).
+        // Fresh manifest per run (the exporter appends per session) -- UNLESS resuming, where the
+        // existing manifest IS the checkpoint: a session's rows are appended in one block as the
+        // LAST step of its export, so "rows present" == "session fully exported". The in-flight
+        // session a stop interrupted has no rows and re-runs cleanly (tile names are deterministic,
+        // so its partial files are simply overwritten).
         var manifestPath = Path.Combine(outDir, DatasetTileExporter.ManifestFileName);
-        if (File.Exists(manifestPath))
+        var priorTiles = options.Resume
+            ? await DatasetTileExporter.ReadManifestSessionTileCountsAsync(manifestPath, cancellationToken)
+            : new Dictionary<string, int>(StringComparer.Ordinal);
+        if (!options.Resume && File.Exists(manifestPath))
         {
             File.Delete(manifestPath);
         }
@@ -102,6 +115,7 @@ public static class DatasetBuildRunner
         var registered = 0;
         var failed = 0;
         var skippedNoDark = 0;
+        var resumed = 0;
         var totalTiles = 0;
         var parityChecked = false;
         var parityMaxDiff = 0.0;
@@ -110,6 +124,13 @@ public static class DatasetBuildRunner
         {
             cancellationToken.ThrowIfCancellationRequested();
             idx++;
+            if (priorTiles.TryGetValue(session.Id, out var tiles))
+            {
+                resumed++;
+                totalTiles += tiles;
+                progress?.Report($"[dataset] ({idx}/{sessions.Length}) {session.Id} resumed ({tiles} tiles already exported)");
+                continue;
+            }
             progress?.Report($"[dataset] ({idx}/{sessions.Length}) {session.Id} ...");
 
             // Fault-isolated per session: discovery validated only HEADERS, so a truncated /
@@ -174,12 +195,20 @@ public static class DatasetBuildRunner
         await DatasetPsfNoiseReport.WriteMarkdownAsync(reportAcc.Build(), reportPath, cancellationToken);
 
         TryDelete(scratchRoot);
+        if (resumed > 0)
+        {
+            // The report accumulator only sees sessions registered THIS run -- a resumed session's
+            // registration scratch is long gone, so its PSF stats cannot be re-measured cheaply.
+            logger?.LogWarning(
+                "Resume: PSF/noise report covers only the {Registered} session(s) registered in this run; {Resumed} resumed session(s) are not re-measured.",
+                registered, resumed);
+        }
         progress?.Report(
-            $"[dataset] done: {registered}/{sessions.Length} sessions -> {totalTiles} tiles " +
+            $"[dataset] done: {registered}/{sessions.Length} sessions{(resumed > 0 ? $" (+{resumed} resumed)" : "")} -> {totalTiles} tiles " +
             $"({failed} failed, {skippedNoDark} skipped-no-dark); " +
             $"parity {(parityChecked ? parityMaxDiff == 0.0 ? "OK" : $"DIFF {parityMaxDiff}" : "n/a")}");
         return new RunResult(
-            sessions.Length, registered, failed, skippedNoDark, totalTiles, testSessions.Length,
+            sessions.Length, registered, failed, skippedNoDark, resumed, totalTiles, testSessions.Length,
             parityChecked, parityMaxDiff, manifestPath, splitPath, reportPath);
     }
 

--- a/src/TianWen.AI.Imaging/DatasetTileExporter.cs
+++ b/src/TianWen.AI.Imaging/DatasetTileExporter.cs
@@ -458,6 +458,44 @@ public static class DatasetTileExporter
         return fwhm[fwhm.Length / 2];
     }
 
+    /// <summary>Reads the shared JSONL manifest back into per-session tile counts — the resume
+    /// checkpoint (<see cref="DatasetBuildOptions.Resume"/>). A session listed here was FULLY
+    /// exported: its rows are appended in one block as the last step of its export, after every
+    /// tile file is on disk. Unparseable lines (a torn tail from a killed run — the same case
+    /// <see cref="AppendManifestAsync"/> self-heals on the next append) are skipped, never fatal;
+    /// a missing file yields an empty map (resume of a fresh output degrades to a normal run).</summary>
+    public static async Task<Dictionary<string, int>> ReadManifestSessionTileCountsAsync(string manifestPath, CancellationToken ct)
+    {
+        var counts = new Dictionary<string, int>(StringComparer.Ordinal);
+        if (!File.Exists(manifestPath))
+        {
+            return counts;
+        }
+        await foreach (var line in File.ReadLinesAsync(manifestPath, ct))
+        {
+            if (string.IsNullOrWhiteSpace(line))
+            {
+                continue;
+            }
+            TileManifestRow? row;
+            // Resilience over untrusted tail bytes (killed mid-append): there is no TryDeserialize,
+            // so the torn-line skip has to be exception-based, mirroring TryReadFitsHeader's contract.
+            try
+            {
+                row = JsonSerializer.Deserialize(line, DatasetManifestJsonContext.Default.TileManifestRow);
+            }
+            catch (JsonException)
+            {
+                continue;
+            }
+            if (row is not null)
+            {
+                counts[row.SessionId] = counts.TryGetValue(row.SessionId, out var n) ? n + 1 : 1;
+            }
+        }
+        return counts;
+    }
+
     /// <summary>Appends this session's rows to the shared JSONL manifest. Self-healing: a torn
     /// last line (a previous session's append interrupted mid-write — reachable because the build
     /// runner fault-isolates per session and keeps going) is truncated back to the last complete

--- a/src/TianWen.Cli/DatasetSubCommand.cs
+++ b/src/TianWen.Cli/DatasetSubCommand.cs
@@ -114,6 +114,12 @@ internal sealed class DatasetSubCommand(IConsoleHost consoleHost, ILogger<Datase
         {
             Description = "Stop after session discovery and print the inventory (no tiles written).",
         };
+        var resumeOpt = new Option<bool>("--resume")
+        {
+            Description = "Continue a stopped run: keep the existing manifest as the checkpoint and " +
+                          "skip every session already fully exported to it (the interrupted session " +
+                          "re-runs cleanly). Use the SAME roots and gates as the stopped run.",
+        };
 
         var buildCommand = new Command("build", "Build the training tile set from raw archive lights.")
         {
@@ -121,7 +127,7 @@ internal sealed class DatasetSubCommand(IConsoleHost consoleHost, ILogger<Datase
             {
                 archiveRootOpt, outOpt,
                 minExposureOpt, maxExposureOpt, excludeInstrumeOpt, excludeObjectOpt, excludePathOpt, minSubsOpt,
-                tileSizeOpt, cellsOpt, subsPerCellOpt, testFractionOpt, requireDarkOpt, requireGainMatchOpt, softwareOpt, discoverOnlyOpt,
+                tileSizeOpt, cellsOpt, subsPerCellOpt, testFractionOpt, requireDarkOpt, requireGainMatchOpt, softwareOpt, discoverOnlyOpt, resumeOpt,
             },
         };
         buildCommand.SetAction(async (parseResult, ct) =>
@@ -160,6 +166,7 @@ internal sealed class DatasetSubCommand(IConsoleHost consoleHost, ILogger<Datase
                 RequireDarkCalibration = parseResult.GetValue(requireDarkOpt),
                 RequireGainMatch = parseResult.GetValue(requireGainMatchOpt),
                 SoftwareIncludePattern = parseResult.GetValue(softwareOpt)!,
+                Resume = parseResult.GetValue(resumeOpt),
             };
 
             // User path exclusions append to the built-in processed-data defaults (never replace them).
@@ -199,7 +206,8 @@ internal sealed class DatasetSubCommand(IConsoleHost consoleHost, ILogger<Datase
             var result = await DatasetBuildRunner.RunAsync(options, logger, progress, ct);
 
             consoleHost.WriteScrollable(
-                $"[dataset] {result.Registered}/{result.Sessions} sessions -> {result.TotalTiles} tiles" +
+                $"[dataset] {result.Registered}/{result.Sessions} sessions" +
+                $"{(result.Resumed > 0 ? $" (+{result.Resumed} resumed)" : "")} -> {result.TotalTiles} tiles" +
                 $"{(result.Failed > 0 ? $" ({result.Failed} FAILED, see log)" : "")}" +
                 $"{(result.SkippedNoDark > 0 ? $" ({result.SkippedNoDark} skipped: no dark calibration)" : "")}; " +
                 $"{result.TestSessions} test sessions held out; " +

--- a/src/TianWen.Lib.Tests/DatasetBuildRunnerTests.cs
+++ b/src/TianWen.Lib.Tests/DatasetBuildRunnerTests.cs
@@ -2,6 +2,7 @@ using Shouldly;
 using System;
 using System.IO;
 using System.Linq;
+using System.Text.Json;
 using System.Threading.Tasks;
 using TianWen.AI.Imaging;
 using TianWen.Lib.Imaging.Dataset;
@@ -180,6 +181,82 @@ namespace TianWen.Lib.Tests
             result.SkippedNoDark.ShouldBe(1);
             result.TotalTiles.ShouldBe(0);
             File.Exists(result.ManifestPath).ShouldBeFalse();
+        }
+
+        /// <summary>Full-file copies with shifted DATE-OBS — a second VALID session (unlike
+        /// <see cref="WriteTruncatedCopies"/>, whose copies explode at register time), so the
+        /// resume test has two completed sessions to checkpoint.</summary>
+        private static void WriteShiftedCopies(string srcDir, string dstDir)
+        {
+            Directory.CreateDirectory(dstDir);
+            foreach (var src in Directory.GetFiles(srcDir, "light_*.fits"))
+            {
+                var bytes = File.ReadAllBytes(src);
+                PatchAscii(bytes, "T00:00:0", "T00:59:0");
+                File.WriteAllBytes(Path.Combine(dstDir, Path.GetFileName(src)), bytes);
+            }
+        }
+
+        [Fact]
+        public async Task Run_Resume_SkipsCheckpointedSessions_AndCompletesTheInterruptedOne()
+        {
+            var ct = TestContext.Current.CancellationToken;
+            var root = Path.Combine(_dir, "archive");
+            var m42 = Path.Combine(root, "M42", "LIGHT");
+            Directory.CreateDirectory(m42);
+            Directory.CreateDirectory(Path.Combine(root, "DARK"));
+            RgbBayerSyntheticFixture.WriteSyntheticLights(m42);
+            RgbBayerSyntheticFixture.WriteSyntheticDarks(Path.Combine(root, "DARK"));
+            WriteShiftedCopies(m42, Path.Combine(root, "N43", "LIGHT"));
+
+            var outDir = Path.Combine(_dir, "out");
+            var options = new DatasetBuildOptions
+            {
+                ArchiveRoots = [root],
+                OutputDir = outDir,
+                MinExposure = TimeSpan.FromSeconds(0.5),
+                MaxExposure = TimeSpan.FromMinutes(5),
+                MinSubsPerSession = 4,
+                TileSize = 64,
+                CellsPerSession = 20,
+                SubsPerCell = 3,
+            };
+
+            var first = await DatasetBuildRunner.RunAsync(options, cancellationToken: ct);
+            first.Registered.ShouldBe(2);
+
+            // Simulate a stop that landed AFTER M42's export and DURING N43's: rows append as the
+            // LAST step of an export, so the interrupted N43 has none — plus the torn half-row the
+            // kill left behind.
+            var rows = File.ReadAllLines(first.ManifestPath).Where(l => l.Trim().Length > 0).ToArray();
+            var m42Rows = rows.Where(l =>
+                JsonSerializer.Deserialize(l, DatasetManifestJsonContext.Default.TileManifestRow)!
+                    .SessionId.StartsWith("M42|", StringComparison.Ordinal)).ToArray();
+            m42Rows.Length.ShouldBeInRange(1, rows.Length - 1); // both sessions really are in the manifest
+            File.WriteAllText(first.ManifestPath, string.Join('\n', m42Rows) + "\n{\"tile\":\"torn-mid-wr");
+
+            var resumedRun = await DatasetBuildRunner.RunAsync(options with { Resume = true }, cancellationToken: ct);
+
+            // M42 checkpointed, N43 re-exported; totals line up with the uninterrupted run.
+            resumedRun.Resumed.ShouldBe(1);
+            resumedRun.Registered.ShouldBe(1);
+            resumedRun.TotalTiles.ShouldBe(first.TotalTiles);
+            resumedRun.ParityChecked.ShouldBeTrue(); // the re-exported session fed the parity gate
+
+            // Manifest healed + complete: every row parseable, per-session counts match the
+            // uninterrupted run — M42's rows were neither dropped nor duplicated.
+            var counts = await DatasetTileExporter.ReadManifestSessionTileCountsAsync(first.ManifestPath, ct);
+            counts.Values.Sum().ShouldBe(first.TotalTiles);
+            counts.Single(kv => kv.Key.StartsWith("M42|", StringComparison.Ordinal)).Value.ShouldBe(m42Rows.Length);
+
+            // Resume again with everything complete: nothing re-runs, manifest byte-identical.
+            var manifestBytes = File.ReadAllBytes(first.ManifestPath);
+            var third = await DatasetBuildRunner.RunAsync(options with { Resume = true }, cancellationToken: ct);
+            third.Resumed.ShouldBe(2);
+            third.Registered.ShouldBe(0);
+            third.TotalTiles.ShouldBe(first.TotalTiles);
+            third.ParityChecked.ShouldBeFalse(); // nothing exported this run to gate
+            File.ReadAllBytes(first.ManifestPath).ShouldBe(manifestBytes);
         }
 
         [Fact]

--- a/src/TianWen.Lib/Imaging/Dataset/DatasetBuildOptions.cs
+++ b/src/TianWen.Lib/Imaging/Dataset/DatasetBuildOptions.cs
@@ -101,4 +101,14 @@ public sealed record DatasetBuildOptions
     /// regardless of authoring software, so a master dark authored by any tool still resolves. Empty
     /// (the default) disables the gate.</summary>
     public string SoftwareIncludePattern { get; init; } = "";
+
+    /// <summary>When true, a stopped run continues where it left off: the existing manifest is the
+    /// checkpoint (kept, not regenerated), and any session whose tiles are already listed in it is
+    /// skipped wholesale — a session's rows are appended in one block as the LAST step of its
+    /// export, so "rows present" means "fully exported". The session a stop interrupted mid-export
+    /// has no rows and re-runs cleanly (deterministic tile names overwrite its partial files).
+    /// Assumes the SAME archive roots and gates as the interrupted run — changed options make the
+    /// checkpoint's session set stale. The PSF/noise report of a resumed run covers only the
+    /// sessions registered in that run. Default false (fresh manifest, prior behaviour).</summary>
+    public bool Resume { get; init; } = false;
 }


### PR DESCRIPTION
## Summary

A multi-hour `tianwen dataset build` could not survive a stop: the runner deleted the manifest at start and re-ran all sessions (only the master cache carried over). The manifest already had checkpoint semantics for free -- a session's rows append in ONE block as the LAST step of its export -- so `--resume` keeps it and skips every session already listed:

- Resumed sessions are counted separately and their prior tiles fold into the total; the interrupted session (no rows yet) re-runs cleanly, partial tile files overwritten by deterministic names.
- The checkpoint reader tolerates the torn tail a kill leaves (same case the appender already self-heals).
- A resumed run's PSF/noise report covers only that run's registered sessions (logged as a warning).

## Validation

E2E stop/resume test: two-session synthetic archive, manifest cut back to one session + a torn half-row -> resume re-exports exactly the interrupted session (tile totals equal the uninterrupted run, no duplicated rows); a second resume is a full no-op with a byte-identical manifest. Dataset suite green.

Motivation: the live 2025+2026 rebake (~10 h) must be stopped ~3 h in today; with this flag the restart loses only the in-flight session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ATx1GGJ6CyDBF2yjTqrvm7