### PR TITLE
feat(planetary): Canon Live View video (Phase E core)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -909,6 +909,17 @@ A CPU-first planetary stacker, **completely separate** from the deep-sky `Imagin
   (Debug + WARN): live-control-applied, a capture heartbeat (every 250 frames), and per-stack start/done +
   duration with a long-running-stack WARN — the trail to diagnose a future stall (pair with the inspector
   `render_liveness` watchdog above).
+- **Concrete `IVideoCameraDriver` implementers.** `FakeCameraDriver` (synthetic drifting disk, full ROI-jog).
+  `CanonCameraDriver` (**Phase E core, shipped**): FC.SDK Live View (EVF) streaming — each EVF JPEG frame
+  decodes straight from the SDK `byte[]` via `Image.TryDecodeRaster` (the in-memory core of
+  `TryReadViaCodecs`, no temp-file round-trip) into a **3-channel [0,1] RGB `Image`** (EVF is camera-processed,
+  not raw CFA), single-stream gated + mutually exclusive with the single-shot CR2 path, ISO live-tunable via
+  `ApplyVideoControlsAsync`. `CanVideoCapture => Connected`; **`CanJogRoi => false`** — Canon EVF has no
+  host-side ROI pan through the published FC.SDK 1.4 (`Evf_ZoomPosition`/`Evf_ZoomRect` are POINT/RECT
+  properties but FC.SDK exposes only a `uint32` accessor), so the recenter loop falls back to mount jog. The
+  5x/10x EVF-zoom planetary regime + zoom-crop ROI-jog is **deferred** pending an FC.SDK 1.5 point/rect
+  property accessor (see [`docs/plans/planetary-native-video.md`](docs/plans/planetary-native-video.md)
+  Phase E). `DALCameraDriver` (ZWO/QHY native raw video) is Phase D — not yet implemented.
 - **COM recenter loop** (Phase C — hold the planet centred): `PlanetaryRecenterController.Decide` (pure, in
   `TianWen.Lib/Imaging/Planetary/`) takes the disk centre of mass + the readout-window geometry and returns a
   `RecenterDecision` — a **per-axis-deadband** (not distance — a big offset on one axis must not drag the other

--- a/docs/plans/live-planetary-capture.md
+++ b/docs/plans/live-planetary-capture.md
@@ -59,7 +59,7 @@ seam, a controller + tab on top, and a recenter controller.
 | B | rapid-exposure fallback + Fake video (`SyntheticPlanetRenderer`) + `PlanetaryCaptureController` + 🪐 tab + signals | no | backend DONE; GUI tab remaining |
 | C | `PlanetaryRecenterController` (ROI auto + mount opt-in) + `JogMountSignal` + manual nudge | no | DONE 2026-06-28 |
 | D | native ZWO + QHY raw video (DAL `ICMOSNativeInterface` + ring buffer + ROI-jog bypass) | **yes (DAL -> 2 SDKs -> TianWen)** | TODO -- detailed plan: [planetary-native-video.md](planetary-native-video.md) |
-| E | Canon Live View `IVideoCameraDriver` (JPEG) via FC.SDK | no | TODO -- detailed plan: [planetary-native-video.md](planetary-native-video.md) |
+| E | Canon Live View `IVideoCameraDriver` (JPEG) via FC.SDK | core: no / zoom-pan: yes | **core DONE 2026-07-16** (full-frame stream, `CanJogRoi=false`); EVF-zoom-pan deferred (needs FC.SDK 1.5 point/rect accessor). Detail: [planetary-native-video.md](planetary-native-video.md) |
 
 > **Phases D + E are fleshed out in [`planetary-native-video.md`](planetary-native-video.md)** (the two
 > real-hardware phases behind the same `IVideoCameraDriver` contract; grounded in the actual sibling-SDK

--- a/docs/plans/planetary-native-video.md
+++ b/docs/plans/planetary-native-video.md
@@ -254,6 +254,18 @@ publish latency.
 
 # Phase E -- Canon Live View (JPEG)
 
+> **Status (2026-07-16): E core SHIPPED; EVF-zoom-pan DEFERRED.** `CanonCameraDriver` implements
+> `IVideoCameraDriver` -- full-frame Live View streaming (EVF JPEG -> 3-channel [0,1] `Image` via the new
+> in-memory `Image.TryDecodeRaster`, no temp-file round-trip), single-stream gate + mutual exclusion with the
+> single-shot CR2 path, and ISO live-tuning. Shipped as a **pure TianWen commit** against the already-published
+> FC.SDK 1.4. `CanJogRoi` is **false** (recenter falls back to mount jog, which `PlanetaryRecenterController`
+> already handles). **The 5x/10x EVF-zoom planetary regime (E.3) is deferred**: the plan below claimed it was
+> reachable via the generic property accessors with no SDK release, but that is only true for the zoom *level*
+> (`Evf_Zoom`, a `uint`). The pannable crop actuator `Evf_ZoomPosition` (0x508) and the `Evf_ZoomRect` (0x541)
+> read that `VideoRoi` needs are **POINT/RECT** properties (8+ bytes), and FC.SDK exposes only a `uint32`
+> property accessor -- so EVF-zoom-pan needs an **FC.SDK point/rect property accessor** (a 1.4 -> 1.5 release),
+> not a single in-tree commit. Follow-up tracked below and in `docs/todo/drivers.md`.
+
 Canon EOS bodies stream a live host feed only one way through FC.SDK: **Live View (EVF) JPEG**. That feed has
 two regimes -- full-frame (downscaled, framing quality) and **5x/10x zoom** (a near-1:1-pixel crop of a small
 region). The zoom regime is the real planetary mode for a DSLR and is what this phase targets (E.3); the
@@ -321,9 +333,17 @@ This is the heart of Phase E for planets. Setting `Evf_Zoom` (`0x507`, `EdsPrope
 makes the Live View feed a **near-1:1-pixel magnified crop** of a small sensor region -- exactly what DSLR
 planetary shooters use for Jupiter / Saturn. `Evf_ZoomPosition` (`0x508`, `:60`) / `Evf_ZoomRect` (`0x541`,
 `:70`) move that crop across the sensor; `CanonZoom` (PTP op `0x9158`, `PtpOperationCode.cs:47`) is the
-underlying operation. All three exist as property IDs / op codes but have **no typed wrappers** on
-`CanonCamera` today -- they are reachable via the generic `GetPropertyAsync`/`SetPropertyAsync`, so Phase E
-adds thin `SetEvfZoomAsync` / `SetEvfZoomPositionAsync` helpers (or drives the generics directly).
+underlying operation.
+
+**Correction (why this needs an FC.SDK release, not a single in-tree commit):** only the zoom *level*
+`Evf_Zoom` is a plain `uint` reachable via the generic `SetPropertyAsync`. `Evf_ZoomPosition` (the actual
+pan actuator) is an `EdsPoint` (two int32s) and `Evf_ZoomRect` is an `EdsRect` -- 8+ byte payloads. FC.SDK's
+only generic accessor is `GetPropertyUInt32Async` / the 4-byte `SetPropValue` (verified in
+`CanonPtpSession.cs`), which reads/writes just the first uint32, so it cannot round-trip a point/rect. So the
+deferred EVF-zoom-pan work is: (1) **FC.SDK 1.5** -- add typed `SetEvfZoomAsync` + `SetEvfZoomPositionAsync`
+(byte[]-payload `SetPropValue`, mirroring the existing `SetCustomFunctionBlockAsync`) and an `Evf_ZoomRect`
+read; wait for NuGet; then (2) TianWen -- set the zoom in `CaptureVideoAsync`, wire `JogRoiAsync` ->
+`SetEvfZoomPositionAsync`, report the zoom rect from `VideoRoi`, flip `CanJogRoi` to true when zoomed.
 
 Because the zoom crop is pannable, it **is** the Canon ROI jog:
 - **`CanJogRoi` -> true** (when zoomed). `JogRoiAsync(dx, dy)` writes a new `Evf_ZoomPosition` -- the same
@@ -394,7 +414,8 @@ proven end to end.
 
 | Phase | Scope | SDK/DAL release? | Risk |
 |---|---|:--:|:--:|
-| E | `CanonCameraDriver : IVideoCameraDriver` via FC.SDK Live View + EVF zoom (JPEG) | no | Low |
+| E core (**DONE**) | `CanonCameraDriver : IVideoCameraDriver` full-frame Live View (JPEG); `CanJogRoi=false` | no | Low |
+| E zoom-pan (deferred) | 5x/10x EVF zoom + `Evf_ZoomPosition` ROI jog + `Evf_ZoomRect` `VideoRoi` | yes (FC.SDK 1.5 point/rect accessor -> TianWen) | Medium |
 | D | `ICMOSNativeInterface` video verbs + ZWO/QHY native + `DALCameraDriver : IVideoCameraDriver` | yes (DAL -> 2 SDKs -> TianWen) | High |
 
 # Docs to ship with the feature

--- a/docs/todo/drivers.md
+++ b/docs/todo/drivers.md
@@ -19,6 +19,19 @@ Part of the TianWen TODO set. See [TODO.md](../../TODO.md) for the index and the
       MSB-aligned/left-shifted (max ~65532) — `OutputDataAlignment` is the hook, deliberately not acted on
       without hardware (a wrong guess over-scales → clips highlights). ZWO needs nothing
       (`ASI_CAMERA_INFO.BitDepth` is the true ADC depth, e.g. 14 for ASI533).
+- [~] **Canon Live View video: EVF-zoom planetary regime + host-side ROI jog (Phase E zoom-pan).** Phase E
+      *core* shipped 2026-07-16 (`CanonCameraDriver : IVideoCameraDriver`, full-frame EVF JPEG streaming,
+      `CanJogRoi=false` → recenter falls back to mount jog). The 5x/10x zoom crop — the DSLR planetary regime
+      and its pannable host-side ROI jog — is deferred because it needs an **FC.SDK 1.5** addition: the zoom
+      *level* `Evf_Zoom` (0x507) is a plain `uint` (reachable today via the generic accessor), but the pan
+      actuator `Evf_ZoomPosition` (0x508) is an `EdsPoint` and `Evf_ZoomRect` (0x541) an `EdsRect` (8+ byte
+      payloads), and FC.SDK exposes only `GetPropertyUInt32Async` / a 4-byte `SetPropValue`. Work: (1) FC.SDK
+      1.5 — typed `SetEvfZoomAsync` + `SetEvfZoomPositionAsync` (byte[]-payload `SetPropValue`, mirroring
+      `SetCustomFunctionBlockAsync`) + an `Evf_ZoomRect` read; wait for NuGet; (2) TianWen — set zoom in
+      `CaptureVideoAsync`, wire `JogRoiAsync` → `SetEvfZoomPositionAsync`, report the rect from `VideoRoi`,
+      flip `CanJogRoi` to true when zoomed. Per-body zoom-position units vary → verify on hardware (the Phase C
+      per-axis cap bounds a wrong guess to a small mis-pan). Detail:
+      [../plans/planetary-native-video.md](../plans/planetary-native-video.md) Phase E.
 
 ## Cover / Calibrator (`ICoverDriver`)
 

--- a/src/TianWen.Lib.Tests/CodecsFacadeImportTests.cs
+++ b/src/TianWen.Lib.Tests/CodecsFacadeImportTests.cs
@@ -98,6 +98,61 @@ public class CodecsFacadeImportTests(ITestOutputHelper testOutput)
     }
 
     [Fact]
+    public void GivenRgb8RasterBytesWhenDecodedInMemoryThenThreeChannelUnitRangeImage()
+    {
+        // Pins the Canon Live View decode contract: the EVF path decodes each JPEG frame straight from the
+        // SDK byte[] via Image.TryDecodeRaster (no temp-file round-trip). Exercised losslessly with PNG here
+        // (format sniffing is SharpAstro.Codecs' job); a camera-processed frame is demosaiced RGB, so the
+        // decoded Image must be 3-channel and normalised to [0,1].
+        const int w = 8, h = 6;
+        var rgba = new byte[w * h * 4];
+        for (var y = 0; y < h; y++)
+        for (var x = 0; x < w; x++)
+        {
+            var i = (y * w + x) * 4;
+            rgba[i] = (byte)(x * 30);     // R ramps with x
+            rgba[i + 1] = (byte)(y * 40); // G ramps with y
+            rgba[i + 2] = 100;            // B constant
+            rgba[i + 3] = 255;            // A opaque, dropped on decode
+        }
+        var bytes = PngWriter.Encode(rgba, w, h);
+
+        // when — decoded from the in-memory buffer, NOT a file (the EVF-frame path)
+        var ok = Image.TryDecodeRaster(bytes, out var image);
+
+        // then
+        ok.ShouldBeTrue("an in-memory raster buffer should decode through the facade");
+        image.ShouldNotBeNull();
+        image.Width.ShouldBe(w);
+        image.Height.ShouldBe(h);
+        image.ChannelCount.ShouldBe(3); // alpha dropped -> colour master
+
+        var r = image.GetChannelSpan(0);
+        var g = image.GetChannelSpan(1);
+        var b = image.GetChannelSpan(2);
+        const float tol = 1f / 255f;
+        for (var y = 0; y < h; y++)
+        for (var x = 0; x < w; x++)
+        {
+            var p = y * w + x;
+            r[p].ShouldBeInRange(0f, 1f);
+            r[p].ShouldBe((x * 30) / 255f, tol);
+            g[p].ShouldBe((y * 40) / 255f, tol);
+            b[p].ShouldBe(100 / 255f, tol);
+        }
+        testOutput.WriteLine($"in-memory RGB raster decoded: {w}x{h}, 3 channels, [0,1]");
+    }
+
+    [Fact]
+    public void GivenGarbageBytesWhenDecodedInMemoryThenReturnsFalse()
+    {
+        // The EVF path relies on TryDecodeRaster failing softly (no throw) on a malformed frame so the
+        // capture loop can back off and keep streaming rather than tear down on one bad JPEG.
+        Image.TryDecodeRaster([0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07], out var image).ShouldBeFalse();
+        image.ShouldBeNull();
+    }
+
+    [Fact]
     public void GivenUndecodableContentWhenReadViaFacadeThenReturnsFalse()
     {
         // A .png the facade routes to but cannot sniff/decode returns false (no throw,

--- a/src/TianWen.Lib/Devices/Canon/CanonCameraDriver.cs
+++ b/src/TianWen.Lib/Devices/Canon/CanonCameraDriver.cs
@@ -20,7 +20,7 @@ namespace TianWen.Lib.Devices.Canon;
 /// and <see cref="CanonCamera.BulbStartAsync"/>/<see cref="CanonCamera.BulbEndAsync"/> for longer exposures.
 /// Images are downloaded as CR2 and decoded via Magick.NET.
 /// </summary>
-internal sealed class CanonCameraDriver : ICameraDriver
+internal sealed class CanonCameraDriver : ICameraDriver, IVideoCameraDriver
 {
     /// <summary>Canon Tv codes for standard shutter speeds up to 30s.</summary>
     private static readonly (uint Code, TimeSpan Duration)[] TvTable =
@@ -152,6 +152,10 @@ internal sealed class CanonCameraDriver : ICameraDriver
     private bool _bulbActive;
     private TaskCompletionSource<uint>? _objectAddedTcs;
     private Task? _downloadTask;
+
+    // Live View (IVideoCameraDriver) single-stream gate: 0/1. Streaming and single-shot StartExposureAsync
+    // are mutually exclusive (the camera is in one mode), mirroring FakeCameraDriver's "stream OR expose" rule.
+    private int _videoActive;
 
     // Image state
     private Channel? _lastImageData;
@@ -502,6 +506,12 @@ internal sealed class CanonCameraDriver : ICameraDriver
             throw new InvalidOperationException("Camera not connected");
         }
 
+        if (Volatile.Read(ref _videoActive) == 1)
+        {
+            throw new InvalidOperationException(
+                "Cannot start a single-shot exposure while a Canon Live View video stream is running.");
+        }
+
         var startTime = TimeProvider.GetUtcNow();
         _lastExposureStartTime = startTime;
         _lastExposureDuration = duration;
@@ -698,6 +708,176 @@ internal sealed class CanonCameraDriver : ICameraDriver
         }
 
         return bestCode;
+    }
+
+    // ── Live View video (IVideoCameraDriver) ─────────────────────────────────────
+    // Canon EOS bodies stream a host feed only as Live View (EVF) JPEG: a camera-processed
+    // (demosaiced + white-balanced + tone-mapped) RGB frame, ~1024x680, at the EVF's own ~15-30 fps.
+    // We decode each frame straight from the SDK byte[] into a 3-channel [0,1] Image (Image.TryDecodeRaster,
+    // no temp-file round-trip) and yield it; the planetary live-stack pipeline consumes it as a colour master.
+    //
+    // Core (this build): full-frame framing / EAA streaming, mutually exclusive with single-shot capture.
+    // Deferred (needs an FC.SDK point/rect property accessor): the 5x/10x EVF-zoom planetary regime + its
+    // pannable zoom crop as the host-side ROI jog. Evf_Zoom (the magnification level) is a plain uint and is
+    // reachable today, but Evf_ZoomPosition (0x508) / Evf_ZoomRect (0x541) are POINT/RECT properties (8+ bytes)
+    // and FC.SDK only exposes a uint32 property accessor -- so CanJogRoi is false here and the recenter loop
+    // falls back to mount jog (PlanetaryRecenterController already degrades cleanly). EVF exposure is also
+    // EVF-auto, not a true integration time (ISO/gain tuning still works via ApplyVideoControlsAsync).
+
+    /// <summary>EVF poll cadence floor -- the feed runs at its own fps; we treat the requested exposure as a
+    /// poll interval clamped to this range so a large "exposure" can't stall the feed to one frame per minute.</summary>
+    private static readonly TimeSpan MinVideoPace = TimeSpan.FromMilliseconds(15);
+    private static readonly TimeSpan MaxVideoPace = TimeSpan.FromMilliseconds(500);
+
+    /// <inheritdoc/>
+    public bool CanVideoCapture => Connected;
+
+    /// <inheritdoc/>
+    // Canon EVF has no host-side ROI pan through the currently-published FC.SDK (see the region banner);
+    // the recenter loop falls back to mount jog. Promote to true once EVF-zoom-pan lands.
+    public bool CanJogRoi => false;
+
+    /// <inheritdoc/>
+    public int DroppedFrames => 0; // EVF has no drop counter.
+
+    /// <inheritdoc/>
+    // Full-frame window: without an FC.SDK zoom-rect read we can't report a magnified EVF crop's origin/size,
+    // and CanJogRoi is false so the recenter loop never reads this for panning. Sensor-sized default.
+    public RoiRect VideoRoi => new(0, 0, CameraXSize, CameraYSize);
+
+    /// <inheritdoc/>
+    public async IAsyncEnumerable<Image> CaptureVideoAsync(
+        VideoCaptureOptions options,
+        [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        if (_camera is not { } camera || !Connected)
+        {
+            throw new InvalidOperationException("Camera is not connected");
+        }
+
+        if (Interlocked.CompareExchange(ref _videoActive, 1, 0) != 0)
+        {
+            throw new InvalidOperationException("A video capture is already running on this camera.");
+        }
+
+        try
+        {
+            if (options.Gain is { } gain)
+            {
+                await SetGainAsync(gain, cancellationToken);
+            }
+
+            var startErr = await camera.StartLiveViewAsync(cancellationToken);
+            if (startErr is not EdsError.OK)
+            {
+                throw new CanonDriverException(startErr, "Failed to start Canon Live View");
+            }
+
+            // Requested exposure as a poll-cadence floor (EVF has no true integration time), clamped so a huge
+            // value can't stall the feed. Live-tunable exposure is not modelled on EVF; ISO is (ApplyVideoControls).
+            var pace = options.Exposure <= TimeSpan.Zero ? MinVideoPace
+                : options.Exposure < MinVideoPace ? MinVideoPace
+                : options.Exposure > MaxVideoPace ? MaxVideoPace
+                : options.Exposure;
+
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                // Disconnect out from under an active stream (app shutdown) is a stop signal too.
+                if (!Connected)
+                {
+                    yield break;
+                }
+
+                // Fetch the next EVF JPEG. The await carries no yield, so its OCE is caught here and turned
+                // into a clean stop (yield return / yield break inside a try/catch is a compile error).
+                EdsError err = EdsError.OK;
+                byte[] jpeg = [];
+                var cancelled = false;
+                try
+                {
+                    (err, jpeg) = await camera.GetLiveViewFrameAsync(cancellationToken);
+                }
+                catch (OperationCanceledException)
+                {
+                    cancelled = true;
+                }
+                if (cancelled)
+                {
+                    yield break;
+                }
+
+                if (err is not EdsError.OK || jpeg.Length == 0)
+                {
+                    // EVF frame not ready yet (ObjectNotReady / DeviceBusy): brief back-off, keep streaming.
+                    if (await PaceAsync(MinVideoPace, cancellationToken))
+                    {
+                        yield break;
+                    }
+                    continue;
+                }
+
+                if (!Image.TryDecodeRaster(jpeg, out var frame))
+                {
+                    Logger.LogDebug("Canon EVF JPEG frame ({Bytes} bytes) failed to decode", jpeg.Length);
+                    if (await PaceAsync(MinVideoPace, cancellationToken))
+                    {
+                        yield break;
+                    }
+                    continue;
+                }
+
+                yield return frame;
+
+                if (await PaceAsync(pace, cancellationToken))
+                {
+                    yield break;
+                }
+            }
+        }
+        finally
+        {
+            // Best-effort stop on CancellationToken.None so the EVF is always torn down even on a cancelled stream.
+            try
+            {
+                await camera.StopLiveViewAsync(CancellationToken.None);
+            }
+            catch (Exception ex)
+            {
+                Logger.LogDebug(ex, "Canon Live View stop failed");
+            }
+            Interlocked.Exchange(ref _videoActive, 0);
+        }
+    }
+
+    /// <summary>Sleeps the poll interval; returns true if the wait was cancelled (the stream should stop).</summary>
+    private async ValueTask<bool> PaceAsync(TimeSpan interval, CancellationToken cancellationToken)
+    {
+        try
+        {
+            await TimeProvider.SleepAsync(interval, cancellationToken);
+            return false;
+        }
+        catch (OperationCanceledException)
+        {
+            return true;
+        }
+    }
+
+    /// <inheritdoc/>
+    public ValueTask JogRoiAsync(int dxPixels, int dyPixels, CancellationToken cancellationToken = default)
+        => throw new InvalidOperationException(
+            "Canon Live View does not support host-side ROI jog (EVF zoom pan needs an FC.SDK point-property "
+            + "accessor); CanJogRoi is false and the recenter loop uses mount jog instead.");
+
+    /// <inheritdoc/>
+    public async ValueTask ApplyVideoControlsAsync(VideoCaptureOptions controls, CancellationToken cancellationToken = default)
+    {
+        // Live-tune the running stream. ISO (gain) is a real EVF control; exposure on EVF is auto (not a true
+        // integration time), so it is intentionally not applied -- see the region banner. No-op gain when null.
+        if (controls.Gain is { } gain)
+        {
+            await SetGainAsync(gain, cancellationToken);
+        }
     }
 
     // --- IDisposable ---

--- a/src/TianWen.Lib/Imaging/Image.Import.cs
+++ b/src/TianWen.Lib/Imaging/Image.Import.cs
@@ -212,6 +212,28 @@ public partial class Image
         try
         {
             var bytes = File.ReadAllBytes(fileName);
+            return TryDecodeRaster(bytes, out image);
+        }
+        catch
+        {
+            image = null;
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Decode an in-memory raster buffer (PNG / JPEG / JPEG XR / OpenEXR / JPEG XL) the
+    /// <c>SharpAstro.Codecs</c> facade recognises into a mono or RGB float <see cref="Image"/>,
+    /// normalised to [0, 1]. The byte-buffer core of <see cref="TryReadViaCodecs"/> (which reads a
+    /// file then delegates here). The Canon Live View path decodes each EVF JPEG frame straight from
+    /// the SDK <c>byte[]</c> through this — a per-frame temp-file round-trip would dominate a
+    /// 15-30 fps stream. A camera-processed EVF JPEG is demosaiced RGB, so it decodes to a
+    /// 3-channel <see cref="Image"/> the live-stack pipeline consumes as a colour master.
+    /// </summary>
+    internal static bool TryDecodeRaster(byte[] bytes, [NotNullWhen(true)] out Image? image)
+    {
+        try
+        {
             if (!ImageCodecs.TryDecode(bytes, out var decoded))
             {
                 image = null;


### PR DESCRIPTION
## What

`CanonCameraDriver` now implements `IVideoCameraDriver` — full-frame Canon **Live View (EVF) JPEG** streaming for planetary / EAA capture, wired into the existing live-stack pipeline with **zero** controller or registration changes (consumption is capability-only: `camera is IVideoCameraDriver { CanVideoCapture: true }`, else the rapid-exposure fallback).

Phase E **core** from [`docs/plans/planetary-native-video.md`](https://github.com/SharpAstro/tianwen/blob/feat/canon-liveview-video/docs/plans/planetary-native-video.md). Pure TianWen commit against the already-published FC.SDK 1.4 — no SDK/DAL release.

### Driver
- **`CaptureVideoAsync`** — start EVF → decode each EVF JPEG straight from the SDK `byte[]` into a 3-channel `[0,1]` RGB `Image` (no per-frame temp file) → yield. Single-stream gate (`Interlocked.CompareExchange`); best-effort `StopLiveViewAsync` on `CancellationToken.None` in `finally`; `ObjectNotReady` / `DeviceBusy` frames are polled past rather than tearing the stream down.
- **Mutually exclusive** with the single-shot CR2 path — `StartExposureAsync` throws while streaming, mirroring `FakeCameraDriver`'s "stream OR expose" rule.
- **`ApplyVideoControlsAsync`** tunes ISO live (EVF exposure is auto, documented). `DroppedFrames = 0`, `VideoRoi` = sensor window, **`CanJogRoi = false`** → recenter falls back to mount jog (`PlanetaryRecenterController` already handles this cleanly).
- **`Image.TryDecodeRaster(byte[])`** — factored the in-memory decode core out of `TryReadViaCodecs` so the file and EVF paths share one implementation.

## Deferred (tracked)

EVF-zoom pan — the 5×/10× planetary regime + host-side ROI jog — needs an **FC.SDK 1.5 point/rect property accessor**, so it is deferred. Only the zoom *level* (`Evf_Zoom`) is a `uint` reachable via the generic accessor; `Evf_ZoomPosition` (0x508) / `Evf_ZoomRect` (0x541) are POINT/RECT payloads and FC.SDK exposes only a `uint32` accessor. The plan overstated "no SDK release" for E.3 — **corrected** in the plan, marked `[~]` in `docs/todo/drivers.md`, and noted in `CLAUDE.md`.

## Tests

- 2 new decode tests pin the EVF contract: in-memory bytes → 3-channel `[0,1]` RGB `Image`, and soft-fail (no throw) on garbage so the capture loop backs off.
- The stream/gate behaviour itself is hardware-smoke per the plan (no way to stub a real `CanonCamera` without hardware); the shared `IVideoCameraDriver` gate contract is already covered by `FakeCameraVideoTests`.
- Full solution builds clean (0 warnings); touched-area suite (Codecs / Import / Canon / Planetary / Video / Tiff) — **249 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)