### PR TITLE
feat(web): in-browser planner on GitHub Pages (web showcase P0/P1/P5)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,115 @@
+name: pages
+
+# Deploy the TianWen.UI.Web in-browser planner to GitHub Pages.
+#
+# TianWen.UI.Web is a standalone Blazor WebAssembly app hosting PlannerTab<WebGlContext>
+# (WebGl.Renderer) - a fully static site, no server. It lives OUTSIDE TianWen.slnx + CPM,
+# so the PR `dotnet.yml` loop never builds it; this workflow is its sole CI and publishes
+# to https://sharpastro.github.io/tianwen/. Design + findings: docs/plans/web-showcase.md.
+#
+# Two deploy-only concerns handled here (neither applies to local dev on :5099):
+#  - Mono WASM AOT (RunAOTCompilation=true): measured 24-42x on the catalog init + planner
+#    sweep - the interpreted build is unshippable. ubuntu-x64 runs the mainstream AOT
+#    toolchain, so no WasmDedup=false / extra interpret-excludes beyond the csproj's
+#    P/Invoke-dense vendor SDKs (those crash the WIN-ARM64 cross-compiler; see the csproj).
+#  - comets-sbdb.json bake: JPL's SBDB API sends no CORS headers, so the app can never
+#    fetch it from a browser origin. The runner curls the exact query the desktop uses and
+#    ships the response as a same-origin static asset; AddAstrometry(cometQueryUri: ...)
+#    points the UNCHANGED source/parser/cache stack at it. Weekly schedule keeps it fresh
+#    (the app-side cache TTL is also 7 days).
+#
+# NOTE: Pages must be enabled once with build type "workflow" (Settings -> Pages ->
+# Source: "GitHub Actions", or `gh api -X POST repos/{owner}/{repo}/pages -f build_type=workflow`).
+
+on:
+  push:
+    branches: [main, feat/web-showcase] # TODO drop feat/web-showcase after merge
+    paths:
+      - 'src/TianWen.UI.Web/**'
+      - 'src/TianWen.UI.Abstractions/**'
+      - 'src/TianWen.Lib/**'
+      - '.github/workflows/pages.yml'
+  schedule:
+    # Weekly redeploy purely to re-bake comets-sbdb.json (orbit solutions update on
+    # new observation arcs; the cache TTL is 7 days). Mondays 03:17 UTC.
+    - cron: '17 3 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# One deploy at a time; let an in-flight deploy finish rather than cancelling it.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+
+      # AOT compilation (and the Release relink) need the Emscripten/LLVM toolchain.
+      - name: Install wasm-tools workload
+        run: dotnet workload install wasm-tools
+
+      # Bake the comet snapshot BEFORE publish so it rides the static-web-assets pipeline.
+      # Same query string as SbdbCometSource.DefaultQueryUrl - keep them in sync.
+      - name: Bake comets-sbdb.json (JPL SBDB has no CORS headers)
+        run: |
+          set -euo pipefail
+          curl -sf --retry 3 --retry-delay 10 \
+            'https://ssd-api.jpl.nasa.gov/sbdb_query.api?sb-kind=c&fields=prefix,pdes,name,M1,K1,e,q,i,om,w,tp,epoch' \
+            -o src/TianWen.UI.Web/wwwroot/comets-sbdb.json
+          # Shape check: the parser needs fields+data; a JPL error page must fail the build,
+          # not deploy as a corrupt asset the app then chokes on.
+          jq -e '.fields and .data and (.count | tonumber > 0)' src/TianWen.UI.Web/wwwroot/comets-sbdb.json > /dev/null
+          echo "baked $(jq -r '.count' src/TianWen.UI.Web/wwwroot/comets-sbdb.json) comets"
+
+      # No sibling checkouts in CI: WebGl.Renderer + DIR.Lib resolve from NuGet
+      # (UseLocalSiblings=false). Lightweight strips the 30 MB tyc2 catalog; AOT is the
+      # measured 24-42x compute win (docs/plans/web-showcase.md).
+      - name: Publish TianWen.UI.Web (Release, Lightweight, AOT)
+        run: dotnet publish src/TianWen.UI.Web/TianWen.UI.Web.csproj -c Release -o publish -p:UseLocalSiblings=false -p:Lightweight=true -p:RunAOTCompilation=true --nologo
+
+      - name: Rewrite base href for the /tianwen/ project-site subpath
+        run: |
+          set -euo pipefail
+          idx="publish/wwwroot/index.html"
+          # github.io serves this project site under /tianwen/, not root. Local dev
+          # keeps <base href="/" />; patch only the published copy.
+          sed -i 's|<base href="/" />|<base href="/tianwen/" />|' "$idx"
+          grep -q '<base href="/tianwen/" />' "$idx" || { echo "base href not rewritten"; exit 1; }
+
+      - name: SPA 404 fallback + .nojekyll
+        run: |
+          set -euo pipefail
+          # Jekyll strips _framework/ (leading underscore) - .nojekyll disables Jekyll.
+          touch publish/wwwroot/.nojekyll
+          # Static hosts 404 on client-side deep links; GitHub Pages serves 404.html
+          # for unknown paths, so a copy of index.html makes routes resolve.
+          cp publish/wwwroot/index.html publish/wwwroot/404.html
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: publish/wwwroot
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -62,8 +62,11 @@ jobs:
       - name: Compute LFS cache key
         id: lfs-key
         run: |
+          # Same include set AND same key prefix as dotnet.yml's build job, deliberately: caches
+          # are repo-scoped, so this restores the entry dotnet.yml already populated from main
+          # instead of storing a byte-identical duplicate.
           HASH=$(git ls-files '*.lz' '*.ttf' '*.bin.gz' | xargs cat | sha256sum | cut -c1-16)
-          echo "key=lfs-pages-${HASH}" >> $GITHUB_OUTPUT
+          echo "key=lfs-build-${HASH}" >> $GITHUB_OUTPUT
       - uses: actions/cache@v5
         with:
           path: .git/lfs

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -50,10 +50,29 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
+        with:
+          lfs: false
+
+      # Catalog .lz sources, prebaked .bin.gz snapshots, and the wwwroot .ttf font are git-LFS
+      # objects; without this pull the checkout leaves pointer text and the managed lzip
+      # preprocess fails ("Invalid lzip magic bytes" - the first deploy run's failure) or, worse,
+      # pointer text gets embedded/served. Narrow include + object cache mirrors dotnet.yml
+      # (skips the ~120 MB of test fixtures a full LFS pull would drag in).
+      - name: Compute LFS cache key
+        id: lfs-key
+        run: |
+          HASH=$(git ls-files '*.lz' '*.ttf' '*.bin.gz' | xargs cat | sha256sum | cut -c1-16)
+          echo "key=lfs-pages-${HASH}" >> $GITHUB_OUTPUT
+      - uses: actions/cache@v5
+        with:
+          path: .git/lfs
+          key: ${{ steps.lfs-key.outputs.key }}
+      - name: Fetch required LFS objects
+        run: git lfs pull --include="*.lz,*.ttf,*.bin.gz"
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '10.0.x'
 

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@ src/TianWen.Lib/Astrometry/Catalogs/*.gs.gz
 # Lavapipe min-repro zip (built artifact for upstream bug filing)
 LavapipeMinRepro.zip
 __pycache__/
+# CI-baked comet snapshot (pages.yml curls JPL SBDB into wwwroot on the runner)
+src/TianWen.UI.Web/wwwroot/comets-sbdb.json

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ LavapipeMinRepro.zip
 __pycache__/
 # CI-baked comet snapshot (pages.yml curls JPL SBDB into wwwroot on the runner)
 src/TianWen.UI.Web/wwwroot/comets-sbdb.json
+# Isolated AOT-publish output (local :5100 perf builds; keeps the dev server's obj/bin unclobbered)
+bin-aot/
+obj-aot/

--- a/docs/plans/web-showcase.md
+++ b/docs/plans/web-showcase.md
@@ -238,11 +238,12 @@ lands; **P2 -> P3** then adds the atlas. P2 gates P3 across the NuGet release bo
     `RenderFrame` - every event ends in one; the web host has no frame loop. Restore runs after
     EVERY compute, deliberately: the first compute may run before geolocation lands (saved pins
     get site-invalidated at >1 deg drift) and the post-geolocation recompute then restores them.
-- **One local server.** The dual dev(:5099)/AOT-static(:5100) setup existed only for the A/B
-  benchmark; a stale second copy cost a full debugging round ("the fix doesn't work" = testing
-  yesterday's publish). Local dev = `dotnet run` on :5099 (always interpreted -
-  `RunAOTCompilation` has NO effect on `dotnet run`); the AOT publish is CI's artifact (P5).
-  Don't resurrect the second local server.
+- **Local servers.** Local dev = `dotnet run` on :5099 (always interpreted - `RunAOTCompilation`
+  has NO effect on `dotnet run`); the AOT publish is CI's artifact (P5). A second local AOT
+  instance on :5100 is legitimate for realistic perf comparison, but ONLY brought up together
+  with a fresh publish and torn down afterwards - the trap is STALENESS, not the port: a
+  left-running stale copy cost a full debugging round ("the fix doesn't work" = testing
+  yesterday's publish).
 - Tab title is text-only ("TianWen") in both `<PageTitle>` and the index.html fallback: the
   favicon IS the telescope emoji (inline SVG data URI), so a title emoji renders twice.
 
@@ -260,6 +261,32 @@ in `WebGl.Renderer/docs/plans/webglcanvas-1.2-input.md`; then
 Planner.razor's `tianwenCanvasMetrics`/`tianwenWatchResize`/`tianwenDragCapture` helpers and the
 resize plumbing all delete in favour of `OnReady`/`OnResized`. Also in 1.1: DIR.Lib 6.11's
 read-only `SdfGlyphDiskCache` mode (the single-threaded-WASM-friendly variant).
+
+## P2+P3 findings (2026-07-17, sky map SHIPPED)
+
+- **P2 shipped as WebGl.Renderer 1.3**: RegisterPipeline (custom GLSL ES 3.00, split
+  vertex/instance layouts, topology, additive blend, per-pipeline std140 UBO binding points),
+  persistent buffers, DrawBuffer/DrawInstanced opcodes, attributeless (gl_VertexID) pipelines.
+  Attribute-state hygiene matters: divisors are context-global per location (explicit reset per
+  draw), stale enabled arrays disabled, dynamic VBO re-bound after custom draws.
+- **P3 shipped**: `WebGlSkyMapPipeline` + `WebSkyMapTab` (TianWen.UI.Web/SkyMap) over the new
+  shared `SkyMapGpuGeometry` + `SkyMapUbo` (TianWen.UI.Abstractions) - the Vulkan pipeline now
+  delegates to the same builders (one geometry path). Star field = the HR catalog (~8.6k stars,
+  enumeration only); `TryGetHipStarLite` gained the HR/HD cross-ref fallback (Lightweight has no
+  Tycho-2, so the O(1) HIP path misses for every figure star). Horizon ground fill ported
+  (attributeless full-screen inverse-projection pass). Validated interpreted AND AOT.
+- **Port gotchas (browser GPU)**: GLSL ES defaults `int` to highp in VS but mediump in FS - a
+  uniform block used in BOTH stages fails to LINK on an int member unless `precision highp int;`
+  is declared (the fill pass was the first two-stage block). GL NDC Y is up (negate vs Vulkan in
+  the final mapping; gl_VertexIndex -> gl_VertexID). Input ordering is load-bearing: hit-test
+  clickable regions BEFORE HandleInput (the sky map consumes every press for drag tracking).
+- **Local AOT publishes are isolated** (`obj-aot`/`bin-aot` via a project-scoped
+  Directory.Build.props block + symmetric DefaultItemExcludes): a publish sharing the dev obj/bin
+  regenerates fingerprinted assets under the running dev server (404s), and a GLOBAL
+  -p:BaseIntermediateOutputPath poisons sibling root-csproj globs (CS0579).
+- **Deferred from the sky map v1**: `RenderObjectOverlay` port (DSO/star markers + click-select
+  via OverlayEngine), schedule/mount/fixed-point marker overlays, Milky Way texture, F3 search
+  index wiring, comet markers (repo loads; markers draw via base labels only).
 
 ## Deferred
 

--- a/docs/plans/web-showcase.md
+++ b/docs/plans/web-showcase.md
@@ -246,6 +246,21 @@ lands; **P2 -> P3** then adds the atlas. P2 gates P3 across the NuGet release bo
 - Tab title is text-only ("TianWen") in both `<PageTitle>` and the index.html fallback: the
   favicon IS the telescope emoji (inline SVG data URI), so a title emoji renders twice.
 
+## WebGlCanvas 1.1 assessment (2026-07-17, do NOT migrate yet)
+
+WebGl.Renderer 1.1 ships `<WebGlCanvas>` - the reusable hi-dpi canvas host that folds in the
+metrics/resize/dpr pattern this repo pioneered (see `webglcanvas-1.1-findings.md`, uncommitted).
+Chess.Web migrated; **TianWen.UI.Web must NOT migrate onto 1.1**: the component only binds
+`@onclick` (fires on RELEASE - cannot start a drag) + `@onkeydown`, with no pointer-move/up, no
+wheel, no text input, and no attribute splatting - the planner would lose the divider drag, hover
+follower, and list scroll. Migration is gated on a WebGl.Renderer 1.2 that adds true
+`pointerdown`/`pointermove`/`pointerup`/`wheel` callbacks (backing-space mapped like
+`OnPointerDown`) + built-in `setPointerCapture` on press (subsumes `tianwenDragCapture`) — planned
+in `WebGl.Renderer/docs/plans/webglcanvas-1.2-input.md`; then
+Planner.razor's `tianwenCanvasMetrics`/`tianwenWatchResize`/`tianwenDragCapture` helpers and the
+resize plumbing all delete in favour of `OnReady`/`OnResized`. Also in 1.1: DIR.Lib 6.11's
+read-only `SdfGlyphDiskCache` mode (the single-threaded-WASM-friendly variant).
+
 ## Deferred
 
 - Full Tycho-2 catalog in the browser (the 30 MB payload; drops into the P2/P3 pipeline as a data

--- a/docs/plans/web-showcase.md
+++ b/docs/plans/web-showcase.md
@@ -288,6 +288,39 @@ read-only `SdfGlyphDiskCache` mode (the single-threaded-WASM-friendly variant).
   via OverlayEngine), schedule/mount/fixed-point marker overlays, Milky Way texture, F3 search
   index wiring, comet markers (repo loads; markers draw via base labels only).
 
+## Deep links + text-input/search round (2026-07-17, third session)
+
+- **Deep-linkable views**: `/` or `/planner`, and `/sky-atlas` (aliases `skymap`, `sky`). All
+  routes map to the same `Planner` component, so the router updates the route param in place
+  (no re-init/recompute); `OnParametersSet` syncs the view, the chips navigate via
+  `NavigationManager`, and browser back/forward works for free. Pages' SPA 404 fallback serves
+  deep loads under the `/tianwen/` subpath.
+- **Branding**: titlebar `🔭 天文` with pinyin tooltip (`tiānwén`); chips carry the GUI tab
+  emoji (`📅 Planner`, `🌌 Sky Atlas`, from the `VkGuiRenderer` registry).
+- **Text input + search are host-shared code now** (the second instance of the
+  GuiEventHandlerBase-invisible-to-web rule; the planner search box was inert in the browser):
+  - `TextInputInteraction` (Abstractions): the per-keystroke machinery moved verbatim out of
+    `GuiEventHandlerBase` (suggestion/result arrow nav, Tab cycling, OnKeyOverride, clipboard,
+    commit/cancel dispatch). Desktop delegates with its signal-based context; the web page
+    calls it with a field-based one. Focus BOOKKEEPING stays host-owned by design (SDL needs
+    StartTextInput; the browser doesn't).
+  - `PlannerSearchInteraction` (Abstractions): the search-input callback wiring moved out of
+    `AppSignalHandler.Planner`, parameterized on transform creation (desktop: active profile;
+    web: lat/lon fields).
+  - Sky-atlas F3 search wired on the web bus to the shared `SkyMapSearchActions`
+    (open/filter/commit/close).
+  - Web keydown nuance: the browser's keydown carries the printable character itself, so the
+    page inserts it via `HandleText` after `HandleKey`; the SDL host gets a separate TextInput
+    event instead. Ctrl+V paste into canvas inputs is a web no-op for now (browser clipboard
+    API is async-only) - deferred.
+- **Autocomplete cache must stay off the first-paint path**: `BuildAutoCompleteList` walks every
+  catalog designation (x2 canonical forms) + sorts - measured 7.4 s INTERPRETED on :5099 (fine
+  under AOT). It builds in the background task after first paint (search commit works without
+  it) and rebuilds with comet designations once comets load.
+- **Local dev comets**: `wwwroot/comets-sbdb.json` is CI-baked and gitignored, so :5099 404s it
+  by default (comet-less dev session). Bake it locally with the same curl as pages.yml when
+  comets are needed in dev; the dev server serves the source wwwroot directly, no rebuild.
+
 ## Deferred
 
 - Full Tycho-2 catalog in the browser (the 30 MB payload; drops into the P2/P3 pipeline as a data

--- a/docs/plans/web-showcase.md
+++ b/docs/plans/web-showcase.md
@@ -1,0 +1,229 @@
+# Web Showcase + In-Browser Planner & Atlas
+
+Status: IN PROGRESS (2026-07-17). P0 + P1 functionally proven end-to-end in the browser on
+branch `feat/web-showcase` (planner renders, geolocation, full-viewport hi-dpi canvas,
+keyboard/mouse via the real `HandleInput` path). Perf + deploy work in flight - see
+"P0/P1 findings" below.
+
+Goal: a static GitHub Pages site for TianWen with (1) a **showcase landing page** (no WASM,
+fast, real screenshots) and (2) a **live in-browser app** exposing the **Planner** and the
+**Sky Map ("atlas")**, rendered through the new `WebGl.Renderer` (`Renderer<WebGlContext>`, the
+Blazor-WebAssembly / WebGL2 sibling of `SdlVulkan.Renderer`). Mirrors the shipped
+`sebgod/chess` -> `Chess.Web` pattern.
+
+Deploy target: `https://SharpAstro.github.io/tianwen/`.
+
+## Why this is feasible
+
+TianWen's GUI tabs are already generic over the render surface: every tab is
+`class XxxTab<TSurface>(Renderer<TSurface> renderer) : PixelWidgetBase<TSurface>` in
+`TianWen.UI.Abstractions`, with a single Vulkan concretion (`Vk*Tab : XxxTab<VulkanContext>`)
+in `TianWen.UI.Gui`. `WebGl.Renderer` implements the full `Renderer<TSurface>` abstract/virtual
+surface (rects, ellipses, lines/polylines + dashed, MTSDF text, clip, scrim). So a browser build
+instantiates the same generic tabs with `TSurface = WebGlContext` instead of `VulkanContext`.
+
+Catalog data is embedded in `TianWen.Lib` (loaded via `Assembly.GetManifestResourceStream`), which
+works unchanged under Blazor WASM - it only adds to the download payload (see Tycho-2 gating below).
+
+## Portability findings (per render-architecture audit)
+
+| Surface | Verdict | Detail |
+|---|---|---|
+| **Planner** | Portable, low risk | `PlannerTab<TSurface>.Render`, target list, details panel are pure Layout-DSL / `Renderer<TSurface>` draws. `AltitudeChartRenderer` is a generic `static` class already proven against two surfaces (TUI `RgbaImageRenderer` + GUI `VkRenderer`). The only Vulkan bit, `VkPlannerTab.RenderChart` (caches the chart as a GPU texture via `VkRenderer.DrawTexture`), is a pure perf optimization - a `PlannerTab<WebGlContext>` that does **not** override it draws correct pixels through WebGl.Renderer's existing pipelines. |
+| **Sky Map (atlas)** | Needs new code | Base `SkyMapTab<TSurface>.RenderSkyMap` draws **only a sky-colour background fill**. All stars/grid/constellation-lines/DSO-markers/Milky-Way are issued straight to Vulkan in `VkSkyMapTab` via `VkSkyMapPipeline` (instanced buffers, raw `vkCmd*`). Labels (constellation names, grid/planet/comet labels, mount reticle, info strip) ARE portable (drawn in the base `Render` via `DrawText`/`DrawLine`). The dead `SkyMapRenderer` (CPU projector, never called) is a reusable source of projection math. There is no second `TSurface` concretion today, so the seam is untested for the sky map. |
+| Equipment / Session / LiveSession / Notifications | Portable | Empty `Vk*Tab` subclasses; all logic in the generic base. (Out of scope for v1 - listed for completeness. LiveSession's embedded preview is a `VkImageRenderer` / `VkFitsImagePipeline`, GPU-locked, not ported.) |
+| FITS viewer / Planetary / Guider preview | Not ported | `VkImageRenderer` / `VkFitsImagePipeline` (image quad + stretch/curves/HDR shader) - image-raster GPU pipeline with no WebGl.Renderer analog. Out of scope. |
+
+## The atlas decision (owner, 2026-07-17)
+
+Chosen: **proper GPU pipeline, no Tycho-2 stars for now.** Build the real instanced GPU sky
+pipeline for WebGL (so adding the full Tycho-2 catalog later is a data + payload change, not a
+re-architecture), but source the star geometry from the **HR bright-star catalog (~9k stars,
+494 KB embed)** for v1 rather than the 30 MB / ~2.5M-star `tyc2.bin.lz` firehose.
+
+Rejected alternatives: CPU immediate-mode bright-star draw (would not carry over to Tycho-2 scale);
+full Tycho-2 parity now (30 MB WASM payload + far larger up-front effort).
+
+### What "proper pipeline" requires
+
+`WebGl.Renderer` today has a fixed 8-int32-slot command stream, four compiled pipelines
+{Flat, Ellipse, Stroke, Sdf}, `drawArrays(TRIANGLES)` only, and uniforms limited to
+`uProj`/`uColor`/`uExtra` (`Opcode.cs`, `WebGlPipelines.cs`, `webgl-renderer.js`). `VkSkyMapPipeline`
+needs, at minimum: per-instance star attributes (J2000 unit-vector + magnitude + B-V), a
+custom UBO (112 bytes: view matrix + viewport, GPU stereographic projection in the vertex shader),
+instanced draw, point-sprite/quad expansion, and a texture beyond the SDF glyph atlas (Milky Way).
+
+None of that is exposed to consumers today. So P2 adds a **general custom-pipeline extensibility
+seam to `WebGl.Renderer`** (a reusable feature, not TianWen-specific - any consumer wanting custom
+GPU effects benefits):
+
+- `RegisterPipeline(vs, fs, vertexLayout, instanceLayout?, topology, blend)` -> handle, extending
+  the compiled-pipeline table past the fixed 4 (the shim's `compilePipelines` already takes arrays).
+- Persistent GPU buffers: upload instance/vertex data **once** and reference it across frames
+  (analogous to the atlas texture living outside the per-frame vertex stream), so a pan/zoom only
+  re-uploads the UBO, not the star buffer.
+- `DrawInstanced` opcode -> `gl.drawArraysInstanced`.
+- Custom-uniform / UBO upload for the active custom pipeline.
+- A general texture-upload path (reuse the `CreatePage`/`UploadTexSubImage` machinery) for the
+  Milky Way underlay (Milky Way itself is optional for v1).
+
+`WebGlSkyMapPipeline` (the shaders, geometry build, UBO layout) then lives in TianWen, on top of
+that seam - mirroring `VkSkyMapPipeline` in `TianWen.UI.Shared` over `SdlVulkan.Renderer`'s
+`VulkanContext`. Layering stays correct: general primitives in the renderer, the sky-specific
+pipeline in TianWen.
+
+**Cross-repo consequence:** P2 is a `WebGl.Renderer` sibling change. Local dev uses ProjectReference
+(the `UseLocalSiblings` switch); tianwen CI consumes it as a NuGet PackageReference, so P3 cannot be
+pushed until a `WebGl.Renderer` minor is published to nuget.org (the standard release-lib dance,
+never a local nupkg feed).
+
+## Infra adapters (both modest)
+
+1. **Browser `IExternal`** - the desktop `External` bundles `System.IO` atomic-JSON writes,
+   serial-port enumeration/open, and a TCP guider socket, none of which exist in the WASM sandbox.
+   A `BrowserExternal` provides in-memory + `localStorage` (or IndexedDB) for the JSON persistence
+   the Planner touches (`PlannerPersistence`), and **no-ops / throws** on serial + TCP members
+   (Planner + Atlas never call them). Site lat/lon via manual entry (no profile-folder enumeration)
+   for v1.
+2. **Lightweight build gate** - `tyc2.bin.lz` (30 MB) is an `EmbeddedResource` in `TianWen.Lib` and
+   would otherwise ship inside the WASM download. A `Lightweight` MSBuild property (default `false`;
+   full builds keep everything) gates the `EmbeddedResource Include`; no code change is needed
+   because `ReadTycho2Bulk` already no-ops when the manifest entry is absent. The gate MUST be passed
+   as a GLOBAL publish property - `dotnet publish ... -p:Lightweight=true` - so it flows across the
+   ProjectReference into `TianWen.Lib`'s own build; a property set only on the consuming Blazor
+   project (or the target RID) does NOT reach the referenced build. Result: the deploy payload drops
+   from ~45 MB to ~16 MB brotli. The bright-star atlas uses the HR catalog (naked-eye sky); the DSO
+   planner never needs tyc2. Note (see the atlas section): HR resolves the bright HIP stars by
+   cross-identity, but the deeper HIP/Tycho field is only available WITH tyc2 - there is no small
+   HIP-only middle tier in the repo. Further `Lightweight` candidates (dead without tyc2): the
+   `hip_to_tyc`/`hd_to_tyc` cross-ref maps (~1.2 MB); `hd_hip_cross` must STAY (bright HIP<->HR identity).
+
+## Minimal DI graph for the browser
+
+`ITimeProvider` + `BrowserExternal` (as `IExternal`) + `AddAstrometry()` (`ICelestialObjectDB`
+from embedded resources, `ICometRepository` via a JPL SBDB `fetch`, CORS permitting) + optionally
+`AddOpenMeteo()`/`AddOpenWeatherMap()` (HTTP weather band on the planner chart). Everything else in
+the desktop `Program.cs` (ZWO/QHY/Canon/ASCOM/Alpaca/Meade/OnStep/iOptron/Skywatcher/Gemini/PHD2/
+BuiltInGuider/Devices/SessionFactory/FitsViewer/PlanetaryCaptureController) is native-SDK / serial /
+COM / session machinery - inherently non-browser and irrelevant to Planner + Atlas.
+
+## Project shape (mirrors Chess.Web)
+
+New `TianWen.UI.Web` (`Microsoft.NET.Sdk.BlazorWebAssembly`, net10.0), **outside** `TianWen.slnx`
+and outside CPM (`ManagePackageVersionsCentrally=false`, versions inline), `InvariantGlobalization`,
+`TrimMode=partial`, `TrimmerRootAssembly` for TianWen.Lib / TianWen.UI.Abstractions / DIR.Lib /
+WebGl.Renderer. Sibling `WebGl.Renderer` ProjectReference under `UseLocalSiblings`, else
+`PackageReference` (floating minor). Fonts + a pre-baked `.sdfg` glyph atlas staged into the WASM
+in-memory FS at startup (chess's `LoadFontsAsync`/`LoadSdfCacheAsync` + `BakeSdfAtlas` tool pattern).
+Render-on-demand (no RAF spin loop). Canvas mouse/scroll/key routed into the tab hit-test /
+clickable-region system.
+
+## Code reuse (chess vs dotcc)
+
+`sebgod/dotcc` -> `DotCC.Web` is **not** renderer-reusable: it is a plain Blazor WASM app with
+DOM/HTML UI (MainLayout + Pages, CodeMirror + wabt), no `WebGl.Renderer` or canvas rendering. It
+shares only the generic Blazor-on-Pages shell conventions with chess (opt out of CPM,
+`TrimMode=partial`, `TrimmerRootAssembly`, `index.html` + base-href) - the pattern diverges by app.
+
+`sebgod/chess` -> `Chess.Web` is the real template and the only current `WebGl.Renderer` consumer.
+Reusable pieces, all small: `Play.razor`'s `LoadFontsAsync` + `LoadSdfCacheAsync` (stage `.ttf`/`.sdfg`
+into the WASM in-memory FS), `WebGlRenderer.CreateAsync` + `PrimeFonts`, the render-on-demand loop
+(~150 lines); `tools/BakeSdfAtlas` (already generic - out-dir + font paths as args); `pages.yml`.
+
+Decision: **copy the chess recipe for P0/P1** (fast, only two consumers so rule-of-three is not met,
+no shared lib yet). The pure-boilerplate bits - the WASM font/SDF-staging helper and a `<WebGlCanvas>`
+host component that every WebGl.Renderer Blazor consumer needs - are the clean factoring, and belong
+**in `WebGl.Renderer`** (already an `Sdk.Razor` static-web-assets package). Fold them into the P2
+custom-pipeline release (near-zero marginal cost, one source of truth); chess adopting them later is
+optional. `BakeSdfAtlas` similarly could move into the renderer package at that point.
+
+## Showcase landing page
+
+Static `index.html` + CSS at the site root (no WASM download): hero, one-line pitch, a feature
+grid (device management across ASCOM/Alpaca/native SDKs; the Planner; the Sky Map / atlas; deep-sky
+stacking + AI enhance; planetary lucky-imaging; the session automation), and a "Launch the live app"
+button into the Blazor app. Real screenshots captured from the running **Debug** GUI via the
+`sdl-ui-inspector` MCP: `run-gui`, drive to each state with `post_signal`/`describe`, `screenshot`,
+and commit the PNGs under `wwwroot/img/`. Captured during the build, not in CI.
+
+## Phasing
+
+| Phase | Scope | Repo | Risk | Ships |
+|---|---|---|---|---|
+| **P0** | Web host skeleton: `TianWen.UI.Web`, `BrowserExternal`, minimal DI, `WebGlRenderer.CreateAsync` + render-on-demand loop, font/SDF staging, Tycho-2 embed gated off, canvas input plumbing. Placeholder tab renders. | tianwen | Low | - |
+| **P1** | **Planner** tab: `PlannerTab<WebGlContext>` (no chart-texture override), `InitDBAsync`, comets, `ObservationScheduler`, manual site lat/lon, localStorage pins, optional weather. | tianwen | Low | Interactive planner |
+| **P2** | **WebGl.Renderer extensibility**: general custom-pipeline registration + persistent instance/vertex buffers + `DrawInstanced` + custom UBO/uniform upload + general texture path. Minor NuGet release. | WebGl.Renderer | Med-High | Renderer feature |
+| **P3** | **Atlas**: `WebGlSkyMapPipeline` (port `VkSkyMapPipeline` shaders/geometry) + `WebSkyMapTab<WebGlContext>` (8 render hooks), star source = HR bright stars, grid + constellation line-lists, DSO overlay ellipses, labels via base. Milky Way optional. | tianwen | Med | Interactive atlas |
+| **P4** | **Showcase landing page** + inspector screenshots. Independent of P2/P3. | tianwen | Low | Landing page |
+| **P5** | **Deploy**: `pages.yml` (ubuntu, wasm-tools workload, bake SDF atlas, publish `-p:UseLocalSiblings=false`, rewrite `<base href>` to `/tianwen/`, `.nojekyll` + `404.html` SPA fallback, upload + deploy pages). | tianwen | Low | Live site |
+
+Incremental value: **P0 -> P1 -> P4 -> P5** ships a live site (planner + showcase) before the atlas
+lands; **P2 -> P3** then adds the atlas. P2 gates P3 across the NuGet release boundary.
+
+## P0/P1 findings (2026-07-17, measured in-browser)
+
+- **It works end-to-end.** `PlannerTab<WebGlContext>` renders + interacts with ZERO changes to the
+  tab/chart code. Host shell is ~350 lines of Blazor glue (`Planner.razor` + `BrowserExternal`).
+- **Init-order gotchas fixed in the shell** (each was a real crash/hang):
+  - `Transform.DateTime` must be seeded from the time provider before `CalculateNightWindow`
+    reads `transform.DateTimeOffset` (unset JD = year -4712 -> `Arg_OleAutDateInvalid` in
+    `DateTime.FromOADate`). Desktop's `RefreshDateTimeFromTimeProvider` is Lib-internal.
+  - Blazor's `firstRender` fires during the first `await` in `OnInitializedAsync` (font fetch), so
+    an `if (firstRender && ready)` render guard NEVER fires - paint explicitly after init.
+  - Geolocation permission prompts outlive any fixed timeout: check the Permissions API state;
+    granted -> fetch before first compute, prompt -> compute with default site and recompute in
+    the background when the grant lands. A 📍 re-locate toolbar button reuses the same path.
+  - The single browser thread means `Task.Run` work QUEUES on the UI thread: the tyc2 "background"
+    bulk decode wedged the page (motivating `Lightweight`), and status lines need an explicit
+    yield (`StateHasChanged` + `Task.Delay`) to paint before a synchronous compute block.
+- **Lightweight fallout in `CelestialObjectDB`**: the hd-hip-cross snapshot hash guard reads
+  tyc2 as an input - with tyc2 stripped, verification is impossible, so the snapshot applies
+  UNVERIFIED in Lightweight builds (full builds still verify; the staleness invariant is a
+  dev/CI-time concern). Call-site fallback likewise skips the tyc2-dependent live compute.
+- **Perf: WASM AOT is the deploy recipe, measured A/B in-browser (2026-07-17).** Interpreted
+  (Release + jiterpreter + Lightweight): catalog init **13.6 s**, tonight's-best sweep +
+  profiles **24.9 s** - unshippable. AOT (`RunAOTCompilation=true`, same Lightweight publish):
+  init **554 ms (24x)**, sweep **591 ms (42x)** - native-desktop-class (desktop init is ~500 ms).
+  Payload cost: 16 -> 21 MB brotli (the AOT native code rides `dotnet.native.wasm`). Verdict
+  closes the alternatives: no decoded-DB IndexedDB snapshot, no sweep web-tuning, no
+  workers/WASI/React needed. Deploy = `dotnet publish -c Release -p:Lightweight=true
+  -p:RunAOTCompilation=true`.
+  Local win-arm64 caveat: the mono AOT cross-compiler fail-fasts (sgen assertion, 0xC0000409) on
+  the P/Invoke-dense vendor SDKs + the WasmDedup `aot-instances.dll`; worked around via
+  `_AOT_InternalForceInterpretAssemblies` (ZWO/QHY/LibUsb - browser dead weight anyway, zero perf
+  impact) + `-p:WasmDedup=false` locally. CI (ubuntu-x64) should first try WITH dedup (smaller
+  output) and only add the flag if the linux toolchain also crashes. Follow-up: find why the
+  trimmer keeps the vendor SDKs in the web bundle at all (payload + AOT both win when they go).
+- **Publish-time fingerprinting**: `index.html` MUST carry the `OverrideHtmlAssetPlaceholders`
+  markers - `<link rel="preload" id="webassembly" />`, an empty `<script type="importmap">`, and
+  `_framework/blazor.webassembly#[.{fingerprint}].js` - or the published page 404s (only
+  fingerprinted asset names exist in `_framework`). The dev server tolerates plain names, so this
+  only bites on publish. Mirrors Chess.Web.
+- **JPL SBDB has no CORS headers** - browser-side comet fetch is impossible, permanently. The
+  repository degrades gracefully (DSO-only). Fix = **bake comets in CI**: the Pages workflow curls
+  the same SBDB query on the runner, ships `comets.json` as a static asset, and the app seeds it
+  into `CometRepository`'s cache path in MEMFS (the repo's own TTL/stale logic then applies;
+  weekly redeploys keep it fresh). Zero Lib changes.
+- **Caching layers**: browser HTTP cache already covers the payload (fingerprinted assets); the
+  `IExternal` JSON caches (planner pins, comets) need a localStorage/IndexedDB-backed
+  `BrowserExternal` for cross-reload persistence (P1 polish); a decoded-DB snapshot (generalize
+  the hd-hip-cross snapshot pattern to the whole DB, IndexedDB-stored) stays deferred unless
+  AOT'd init is still too slow.
+
+## Deferred
+
+- Full Tycho-2 catalog in the browser (the 30 MB payload; drops into the P2/P3 pipeline as a data
+  source swap once shipped).
+- Milky Way texture underlay (needs the general texture path from P2; cosmetic).
+- FITS viewer / Planetary / Guider preview (image-raster GPU pipeline, no WebGl.Renderer analog).
+- Equipment / Session / LiveSession tabs in the browser (portable but device-control-oriented,
+  no value without a device layer).
+- IndexedDB-backed profile storage (v1 uses manual site entry + localStorage pins).
+
+## Open items
+
+- Confirm CORS on the JPL SBDB comet endpoint from a github.io origin (else comets degrade to
+  "no repository" - the planner/atlas both handle a null `ICometRepository`).
+- WASM payload budget after Tycho-2 gating (DSO catalogs + HR + simbad_merge + hd_hip_cross +
+  pickles_sed ~ single-digit MB compressed; verify the published `_framework` size).
+- Register this plan in `docs/plans/summary.md`.

--- a/docs/plans/web-showcase.md
+++ b/docs/plans/web-showcase.md
@@ -205,10 +205,46 @@ lands; **P2 -> P3** then adds the atlas. P2 gates P3 across the NuGet release bo
   into `CometRepository`'s cache path in MEMFS (the repo's own TTL/stale logic then applies;
   weekly redeploys keep it fresh). Zero Lib changes.
 - **Caching layers**: browser HTTP cache already covers the payload (fingerprinted assets); the
-  `IExternal` JSON caches (planner pins, comets) need a localStorage/IndexedDB-backed
-  `BrowserExternal` for cross-reload persistence (P1 polish); a decoded-DB snapshot (generalize
-  the hd-hip-cross snapshot pattern to the whole DB, IndexedDB-stored) stays deferred unless
-  AOT'd init is still too slow.
+  site + planner-session persistence SHIPPED via localStorage (see the interaction round below);
+  the comets cache stays MEMFS pending the CI bake; a decoded-DB snapshot (generalize the
+  hd-hip-cross snapshot pattern to the whole DB, IndexedDB-stored) stays deferred unless AOT'd
+  init is still too slow.
+
+## P1 interaction + persistence round (2026-07-17, second session)
+
+- **Handoff-divider drag is host-shared code now.** The slider state machine (SliderHit grab,
+  click-to-place, XToTime move, release) lived only in `GuiEventHandlerBase` - the SDL host's
+  event router, which the web host does not use - so divider clicks silently no-op'd in the
+  browser (`Planner.razor` discarded the `HitTestAndDispatch` result). Extracted to
+  `PlannerSliderInteraction` (Abstractions); the desktop handler delegates (semantics preserved,
+  incl. the active-tab gate on click-to-place) and `Planner.razor` feeds it the hit result / the
+  moves / the release. **Rule for future tab ports: interaction logic in `GuiEventHandlerBase`
+  is INVISIBLE to the web host** - anything a ported tab needs must live in a shared
+  Abstractions helper, so audit `GuiEventHandlerBase` for tab-specific blocks when porting.
+- **Pointer capture** (`tianwenDragCapture` in index.html): `setPointerCapture` on pointerdown
+  retargets the compatibility mousemove/mouseup back to the canvas, so drags keep tracking after
+  the pointer leaves the canvas (the SDL mouse-capture analogue). Without it a swipe-style
+  divider drag drops mid-gesture and can wedge in the dragging state.
+- **localStorage persistence shipped** (was the P1-polish open item):
+  - Last-used site (`tianwen.site`): loaded as the FIRST init step (kills the default-site flash
+    on F5), saved after every compute. Geolocation / manual entry refine and overwrite it.
+  - Planner session (`tianwen.planner`): pins + handoff sliders + settings. Reuses the desktop
+    DTO + restore logic - `PlannerPersistence` split so `TryRestoreFromDto` (site invalidation,
+    target matching, slider-window checks) is public with `SerializeToJson`/`TryRestoreFromJson`
+    wrappers; the file-store `TryLoadAsync` delegates to it. The save trigger is the SAME wiring
+    as desktop: `PlannerState.Bus` gets a `SignalBus`, the `IsDirty` setter auto-posts
+    `SavePlannerSessionSignal`, the razor host subscribes (new public
+    `PlannerState.MarkSessionSaved()` clears the assembly-internal flag) and the bus is pumped in
+    `RenderFrame` - every event ends in one; the web host has no frame loop. Restore runs after
+    EVERY compute, deliberately: the first compute may run before geolocation lands (saved pins
+    get site-invalidated at >1 deg drift) and the post-geolocation recompute then restores them.
+- **One local server.** The dual dev(:5099)/AOT-static(:5100) setup existed only for the A/B
+  benchmark; a stale second copy cost a full debugging round ("the fix doesn't work" = testing
+  yesterday's publish). Local dev = `dotnet run` on :5099 (always interpreted -
+  `RunAOTCompilation` has NO effect on `dotnet run`); the AOT publish is CI's artifact (P5).
+  Don't resurrect the second local server.
+- Tab title is text-only ("TianWen") in both `<PageTitle>` and the index.html fallback: the
+  favicon IS the telescope emoji (inline SVG data URI), so a title emoji renders twice.
 
 ## Deferred
 

--- a/docs/plans/web-showcase.md
+++ b/docs/plans/web-showcase.md
@@ -311,8 +311,34 @@ read-only `SdfGlyphDiskCache` mode (the single-threaded-WASM-friendly variant).
     (open/filter/commit/close).
   - Web keydown nuance: the browser's keydown carries the printable character itself, so the
     page inserts it via `HandleText` after `HandleKey`; the SDL host gets a separate TextInput
-    event instead. Ctrl+V paste into canvas inputs is a web no-op for now (browser clipboard
-    API is async-only) - deferred.
+    event instead. (This canvas keydown path is now the FALLBACK - while the CanvasTextOverlay
+    below holds focus, editing is native and the canvas never sees the keys.)
+
+## CanvasTextOverlay round (2026-07-17, fourth session)
+
+- **Native text entry over canvas widgets** (WebGl.Renderer 1.4 `CanvasTextOverlay`): a REAL
+  focusable `<input>` floated over the active canvas text widget - the standard canvas-UI
+  companion (Figma / Docs / xterm.js all do this) - so the web app gets IME composition, native
+  clipboard (Ctrl+V works), autocorrect, and the mobile soft keyboard (the driver: no mobile
+  app yet, so the web build IS the mobile story). v1 is a visible, theme-styled input covering
+  the widget (robust for every input source), not the invisible-mirror caret-fidelity variant.
+- **Host wiring** (`Planner.razor` + `.canvas-text-input` in app.css; `.canvas-host` is now
+  `position:relative`): `ActivateTextInput` shows the overlay over the widget's clickable-region
+  rect (a `GetRegisteredRegions()` scan, backing px -> CSS px via dpr; the accessor is not on
+  `IPixelWidget`, so the host types the active tab as `PixelWidgetBase<WebGlContext>`). While
+  editing, the browser input owns the TEXT: `OnInput` mirrors value+caret into `TextInputState`
+  and fires `OnTextChanged` (autocomplete); ArrowUp/Down/Enter/Escape/Tab are intercepted
+  JS-side (preventDefault, never during IME composition) and routed into the shared
+  `TextInputInteraction.HandleKey`, so suggestion nav / commit / cancel are the same code path
+  as desktop; a canvas-side rewrite (suggestion Enter-commit) pushes back via `SetValueAsync`;
+  `SyncOverlayRect` re-anchors after every RenderFrame (regions re-register per paint).
+- **Blur deactivation is deferred + epoch-guarded**: a blur caused by clicking ANOTHER canvas
+  input arrives around the same time as the re-activation - deactivating immediately would kill
+  the new focus. Only a blur that stays unanswered for ~100 ms (tap on toolbar/browser chrome)
+  deactivates.
+- **Known caveat**: iOS Safari may need a second tap for the soft keyboard on first activation
+  (focus() runs on an async continuation of the pointer gesture; Chrome/Android honour the
+  transient-activation window). Hardware-verify on a phone against the live site.
 - **Autocomplete cache must stay off the first-paint path**: `BuildAutoCompleteList` walks every
   catalog designation (x2 canonical forms) + sorts - measured 7.4 s INTERPRETED on :5099 (fine
   under AOT). It builds in the background task after first paint (search commit works without

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -27,4 +27,24 @@
       AND Exists('$(MSBuildThisFileDirectory)..\..\Lzip.Lib\src\Lzip.Lib\Lzip.Lib.csproj')">true</UseLocalSiblings>
   </PropertyGroup>
 
+  <!--
+    Local AOT publishes of the browser app (perf-comparison builds served on :5100) get their
+    own obj/bin so they never regenerate the fingerprinted framework assets underneath a running
+    `dotnet run` dev server (the boot script then 404s on the replaced dotnet.*.js). Scoped to
+    THIS project only and set here (not in the csproj) because MSBuildProjectExtensionsPath
+    derives from BaseIntermediateOutputPath at import time. A global
+    -p:BaseIntermediateOutputPath would leak into every sibling project in the graph and poison
+    root-level-csproj siblings' source globs with stale generated files (CS0579).
+  -->
+  <PropertyGroup Condition="'$(MSBuildProjectName)' == 'TianWen.UI.Web' AND '$(RunAOTCompilation)' == 'true'">
+    <BaseIntermediateOutputPath>obj-aot\</BaseIntermediateOutputPath>
+    <BaseOutputPath>bin-aot\</BaseOutputPath>
+  </PropertyGroup>
+  <!-- Whichever mode is building, the OTHER mode's build tree is not this build's
+       BaseIntermediateOutputPath and so is not auto-excluded from the default source globs -
+       its generated files would compile in twice (CS0579). Exclude all four unconditionally. -->
+  <PropertyGroup Condition="'$(MSBuildProjectName)' == 'TianWen.UI.Web'">
+    <DefaultItemExcludes>$(DefaultItemExcludes);obj\**;bin\**;obj-aot\**;bin-aot\**</DefaultItemExcludes>
+  </PropertyGroup>
+
 </Project>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -104,10 +104,13 @@
          with Console.Lib 3.3 + SdlVulkan.Renderer 6.7.
          6.3 bumped alongside SdlVulkan.Renderer 6.10 (which requires DIR.Lib >= 6.3.1201).
          6.4-6.6 continue the lockstep with SdlVulkan.Renderer 6.11-6.15 + Console.Lib 3.5.
-         6.8 is the current pin; DIR.Lib.Shaping 6.8 rebuilt against SharpAstro.Fonts.Shaping 1.5.551
-         (F6+F7: ~3-4x faster, zero-alloc shaping), but TianWen does not reference the shaping satellite,
-         so this bump only lifts the core off the stale 6.4 line (lockstep with SdlVulkan.Renderer 6.16). -->
-    <PackageVersion Include="DIR.Lib" Version="6.8.*" />
+         6.8 lifted the core off the stale 6.4 line; DIR.Lib.Shaping 6.8 rebuilt against
+         SharpAstro.Fonts.Shaping 1.5.551 (F6+F7: ~3-4x faster, zero-alloc shaping), but TianWen does
+         not reference the shaping satellite (lockstep with SdlVulkan.Renderer 6.16).
+         6.11 is the current pin: adds SdfGlyphDiskCache's read-only mode (what single-threaded
+         browser WASM needs) and is WebGl.Renderer 1.1+'s floor - TianWen.UI.Web's package graph was
+         already unifying up to 6.11 via WebGl.Renderer, so this keeps desktop + web on one version. -->
+    <PackageVersion Include="DIR.Lib" Version="6.11.*" />
     <!-- DIR.Lib 3.0 extracted its codec layer to these sibling packages, which
          ship as a lockstep family from the Codecs repo. 3.0 brought a
          binary-breaking SharpAstro.Tiff change (TiffPageOptions.IccProfile is

--- a/src/TianWen.Lib.Tests/JsonRpcServerTests.cs
+++ b/src/TianWen.Lib.Tests/JsonRpcServerTests.cs
@@ -36,7 +36,9 @@ public class JsonRpcServerTests
         return ValueTask.CompletedTask;
     };
 
-    [Fact]
+    // Timeout (not the blame-hang 5 min): a lost response must fail THIS test fast, with its
+    // name attached - the CI hang that motivated it surfaced as a whole-run abort instead.
+    [Fact(Timeout = 30_000)]
     public async Task GivenServerAndClientOverNamedPipeWhenCallingThenResultsErrorsAndVoidsRoundTrip()
     {
         var ct = TestContext.Current.CancellationToken;
@@ -84,5 +86,47 @@ public class JsonRpcServerTests
         var ex = await Should.ThrowAsync<JsonRpcException>(async () => await client.CallAsync("boom", null, ct));
         ex.Message.ShouldBe("kaboom");
         ex.Code.ShouldBe(-7);
+    }
+
+    /// <summary>
+    /// Regression for the CI linux-arm hang: the old correlation (responses dictionary + shared
+    /// auto-reset event) lost the wakeup when a response landed between the caller's dictionary
+    /// miss and its wait - a pure timing race, so hammer many sequential round-trips to open the
+    /// window repeatedly. With the pre-registered per-call completion source this cannot hang;
+    /// before the fix this test wedged within a few hundred iterations on a loaded machine.
+    /// </summary>
+    [Fact(Timeout = 60_000)]
+    public async Task GivenManySequentialCallsWhenRacingTheReceiveLoopThenNoCallHangs()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var pipeName = $"tianwen-test-{Guid.NewGuid():N}";
+
+        var serverPipe = new NamedPipeServerStream(pipeName, PipeDirection.InOut, 1, PipeTransmissionMode.Byte, PipeOptions.Asynchronous);
+        var clientPipe = new NamedPipeClientStream(".", pipeName, PipeDirection.InOut, PipeOptions.Asynchronous);
+
+        var waitForConnect = serverPipe.WaitForConnectionAsync(ct);
+        await clientPipe.ConnectAsync(ct);
+        await waitForConnect;
+
+        var server = new JsonRpcServer(MakeHandler());
+        using var serverConnection = new NamedPipeConnection(serverPipe);
+        _ = server.ServeAsync(serverConnection, ct);
+
+        using var clientConnection = new NamedPipeConnection(clientPipe);
+        using var client = new JsonRpcClient(clientConnection);
+        _ = client.ReceiveLoopAsync(ct);
+
+        for (var i = 0; i < 500; i++)
+        {
+            var captured = i;
+            using var r = await client.CallAsync("add", w =>
+            {
+                w.WriteStartArray();
+                w.WriteNumberValue(captured);
+                w.WriteNumberValue(1);
+                w.WriteEndArray();
+            }, ct);
+            r.RootElement.GetProperty("result").GetInt32().ShouldBe(captured + 1);
+        }
     }
 }

--- a/src/TianWen.Lib/Astrometry/Catalogs/CelestialObjectDB.cs
+++ b/src/TianWen.Lib/Astrometry/Catalogs/CelestialObjectDB.cs
@@ -612,10 +612,21 @@ internal sealed partial class CelestialObjectDB : ICelestialObjectDB
         }
         else if (!await TryApplyHdHipCrossSnapshotFromEmbeddedAsync(assembly, manifestNames))
         {
-            // Snapshot stale/missing/malformed -> fall back to live compute, which needs the
-            // full Tycho-2 binary. Block here until the background bulk decode finishes.
-            await EnsureTycho2DataLoadedAsync(cancellationToken);
-            BuildHdHipCrossIndicesViaTyc();
+            if (manifestNames.Any(n => n.EndsWith(".tyc2.bin.lz", StringComparison.Ordinal)))
+            {
+                // Snapshot stale/missing/malformed -> fall back to live compute, which needs the
+                // full Tycho-2 binary. Block here until the background bulk decode finishes.
+                await EnsureTycho2DataLoadedAsync(cancellationToken);
+                BuildHdHipCrossIndicesViaTyc();
+            }
+            else
+            {
+                // Lightweight build (tyc2 stripped) with no usable snapshot: the live compute is
+                // impossible without the Tycho-2 binary. Degrade to no HD<->HIP cross-indices
+                // (bright-star lookups still resolve via their direct HR/HD identities) rather
+                // than failing init.
+                _lastInitPhaseTimings.Add(("hd-hip-cross:skipped-lightweight", phaseSw.Elapsed));
+            }
         }
         _lastInitPhaseTimings.Add(("hd-hip-cross", phaseSw.Elapsed));
 
@@ -1004,11 +1015,19 @@ internal sealed partial class CelestialObjectDB : ICelestialObjectDB
             return false;
         }
 
+        // A Lightweight build (-p:Lightweight=true, e.g. the browser/WASM app) strips tyc2.bin.lz,
+        // which is one of the hash-guard's inputs - verification is then IMPOSSIBLE, not merely
+        // stale (HdHipCrossInputHasher.Compute throws on the missing input). The guard protects a
+        // dev-time invariant (rebake the snapshot when inputs change) that every full build + CI
+        // still enforce, and the lightweight artifact embeds the very same snapshot bytes, so
+        // apply it unverified instead of failing init.
+        var canVerify = manifestNames.Any(n => n.EndsWith(".tyc2.bin.lz", StringComparison.Ordinal));
+
         // Compute the input hash in parallel with snapshot read+decode: both touch ~22 MB of
         // embedded resource data and SHA-256 is CPU-bound enough to saturate a core. On a
         // representative cold start the snapshot read takes ~50 ms and the hash ~50 ms;
         // overlapping them shaves ~30-40 ms off the apply path.
-        var hashTask = Task.Run(() => HdHipCrossInputHasher.Compute(assembly, manifestNames));
+        var hashTask = canVerify ? Task.Run(() => HdHipCrossInputHasher.Compute(assembly, manifestNames)) : null;
 
         HdHipCrossSnapshot snapshot;
         byte[] storedHash;
@@ -1023,18 +1042,28 @@ internal sealed partial class CelestialObjectDB : ICelestialObjectDB
             // Treat any decode failure as "stale": fall back to live compute. Debug-time safety
             // net; in CI the snapshot is rebuilt so a malformed embedded resource is a packaging bug.
             _lastInitPhaseTimings.Add(("hd-hip-cross-snapshot:malformed", subSw.Elapsed));
-            await hashTask;  // observe to avoid unobserved-task warnings
+            if (hashTask is not null)
+            {
+                await hashTask;  // observe to avoid unobserved-task warnings
+            }
             return false;
         }
         var readElapsed = subSw.Elapsed;
         _lastInitPhaseTimings.Add(("hd-hip-cross-snapshot:read", readElapsed));
 
-        var expectedHash = await hashTask;
-        _lastInitPhaseTimings.Add(("hd-hip-cross-snapshot:hash", subSw.Elapsed - readElapsed));
-        if (!storedHash.AsSpan().SequenceEqual(expectedHash))
+        if (hashTask is not null)
         {
-            _lastInitPhaseTimings.Add(("hd-hip-cross-snapshot:stale", subSw.Elapsed));
-            return false;
+            var expectedHash = await hashTask;
+            _lastInitPhaseTimings.Add(("hd-hip-cross-snapshot:hash", subSw.Elapsed - readElapsed));
+            if (!storedHash.AsSpan().SequenceEqual(expectedHash))
+            {
+                _lastInitPhaseTimings.Add(("hd-hip-cross-snapshot:stale", subSw.Elapsed));
+                return false;
+            }
+        }
+        else
+        {
+            _lastInitPhaseTimings.Add(("hd-hip-cross-snapshot:unverified-lightweight", subSw.Elapsed));
         }
 
         var beforeApply = subSw.Elapsed;

--- a/src/TianWen.Lib/Astrometry/Catalogs/CelestialObjectDB.cs
+++ b/src/TianWen.Lib/Astrometry/Catalogs/CelestialObjectDB.cs
@@ -2090,7 +2090,12 @@ internal sealed partial class CelestialObjectDB : ICelestialObjectDB
             }
         }
 
-        return false;
+        // Tier 2 (a Lightweight build ships no Tycho-2, so the O(1) path above misses for
+        // EVERY star): the same bright-star fallback chain TryLookupHIP uses (cross-reference
+        // -> HR/HD). On a full build this only runs for the handful of HIP stars without a
+        // Tycho-2 counterpart; on Lightweight it resolves the whole ~1000-star figure seed --
+        // without it the browser sky map renders zero stars.
+        return TryLookupHIP(hipNumber, out ra, out dec, out vMag, out bv);
     }
 
     /// <summary>

--- a/src/TianWen.Lib/Astrometry/Comets/SbdbCometSource.cs
+++ b/src/TianWen.Lib/Astrometry/Comets/SbdbCometSource.cs
@@ -43,7 +43,7 @@ internal sealed class SbdbCometSource : ISbdbCometSource
     // sb-kind=c: comets only. `prefix` carries the orbit-type letter (C/P/D/X/A/I) that `pdes` omits for
     // provisional comets, so the two together reconstruct the canonical designation. Fields are requested
     // in a fixed order but the parser maps by name defensively.
-    private const string QueryUrl =
+    internal const string DefaultQueryUrl =
         "https://ssd-api.jpl.nasa.gov/sbdb_query.api?sb-kind=c&fields=prefix,pdes,name,M1,K1,e,q,i,om,w,tp,epoch";
 
     private static readonly HttpClient s_httpClient = new()
@@ -52,25 +52,41 @@ internal sealed class SbdbCometSource : ISbdbCometSource
     };
 
     private readonly HttpClient _httpClient;
+    private readonly Uri _queryUri;
     private readonly ILogger _logger;
 
     public SbdbCometSource(ILogger<SbdbCometSource> logger)
-        : this(s_httpClient, logger)
+        : this(s_httpClient, queryUri: null, logger)
     {
     }
 
     // Test seam: inject an HttpClient wrapping a canned-response handler.
     internal SbdbCometSource(HttpClient httpClient, ILogger logger)
+        : this(httpClient, queryUri: null, logger)
+    {
+    }
+
+    // Endpoint-override seam over the shared client (see queryUri remarks on the primary ctor).
+    internal SbdbCometSource(Uri? queryUri, ILogger logger)
+        : this(s_httpClient, queryUri, logger)
+    {
+    }
+
+    // queryUri overrides the live SBDB endpoint with a snapshot of the SAME query response - e.g. the
+    // browser host points it at a CI-baked same-origin static file, because JPL sends no CORS headers
+    // and a cross-origin fetch can never succeed from a browser. Null = the live JPL API.
+    internal SbdbCometSource(HttpClient httpClient, Uri? queryUri, ILogger logger)
     {
         _httpClient = httpClient;
+        _queryUri = queryUri ?? new Uri(DefaultQueryUrl);
         _logger = logger;
     }
 
     public async Task<IReadOnlyList<CometElements>> FetchAsync(CancellationToken cancellationToken)
     {
-        _logger.LogDebug("Fetching comet elements from SBDB: {Url}", QueryUrl);
+        _logger.LogDebug("Fetching comet elements from SBDB: {Url}", _queryUri);
 
-        using var response = await _httpClient.GetAsync(QueryUrl, cancellationToken);
+        using var response = await _httpClient.GetAsync(_queryUri, cancellationToken);
         response.EnsureSuccessStatusCode();
 
         using var stream = await response.Content.ReadAsStreamAsync(cancellationToken);

--- a/src/TianWen.Lib/Connections/JsonRpcClient.cs
+++ b/src/TianWen.Lib/Connections/JsonRpcClient.cs
@@ -24,7 +24,6 @@ SOFTWARE.
 
 */
 
-using DotNext.Threading;
 using System;
 using System.Buffers;
 using System.Collections.Concurrent;
@@ -56,8 +55,14 @@ internal sealed class JsonRpcClient(
     Func<JsonDocument, CancellationToken, ValueTask>? onNotification = null,
     Action<Exception, string>? onError = null) : IDisposable
 {
-    private readonly ConcurrentDictionary<long, JsonDocument> _responses = [];
-    private readonly AsyncManualResetEvent _responseSignal = new(false);
+    // Correlation is one TaskCompletionSource per in-flight id, registered BEFORE the request is
+    // written. The previous design (a responses-by-id dictionary + a shared auto-reset event) had
+    // a lost-wakeup race: DotNext's AsyncManualResetEvent.Set(autoReset: true) does NOT latch when
+    // no waiter is suspended yet, so a response landing between the caller's dictionary miss and
+    // its WaitAsync stranded the call forever (the CI linux-arm hang in
+    // JsonRpcServerTests.GivenServerAndClientOverNamedPipe...). With a pre-registered TCS the
+    // receive loop always finds the waiter, whatever the interleaving.
+    private readonly ConcurrentDictionary<long, TaskCompletionSource<JsonDocument>> _pending = [];
     private long _messageId;
 
     /// <summary>
@@ -109,13 +114,12 @@ internal sealed class JsonRpcClient(
                     && idProp.ValueKind is JsonValueKind.Number
                     && idProp.TryGetInt64(out var id))
                 {
-                    // Response: store by id (disposing any superseded doc) and wake awaiting callers.
-                    _ = _responses.AddOrUpdate(id, message, (_, old) =>
+                    // Response: hand the document to the awaiting caller. No caller (cancelled and
+                    // already cleaned up, or an id the peer invented) -> the document is ours to drop.
+                    if (!_pending.TryRemove(id, out var pending) || !pending.TrySetResult(message))
                     {
-                        old.Dispose();
-                        return message;
-                    });
-                    _responseSignal.Set(true);
+                        message.Dispose();
+                    }
                 }
                 else if (onNotification is { } handler)
                 {
@@ -132,6 +136,24 @@ internal sealed class JsonRpcClient(
         {
             onError?.Invoke(ex, $"processing: {line}");
         }
+        finally
+        {
+            // The loop is the only response producer - once it ends (peer disconnect, fault,
+            // cancellation), an in-flight CallAsync could never complete. Fail them all instead of
+            // letting them hang.
+            FailAllPending(new JsonRpcException("Connection closed before a response arrived"));
+        }
+    }
+
+    private void FailAllPending(Exception reason)
+    {
+        foreach (var kv in _pending)
+        {
+            if (_pending.TryRemove(kv.Key, out var pending))
+            {
+                pending.TrySetException(reason);
+            }
+        }
     }
 
     /// <summary>
@@ -143,10 +165,9 @@ internal sealed class JsonRpcClient(
     public async ValueTask<JsonDocument> CallAsync(string method, Action<Utf8JsonWriter>? writeParams, CancellationToken cancellationToken)
     {
         var buffer = new ArrayBufferWriter<byte>(128);
-        long id;
+        var id = Interlocked.Increment(ref _messageId);
         using (var req = new Utf8JsonWriter(buffer, new JsonWriterOptions { Indented = false }))
         {
-            id = Interlocked.Increment(ref _messageId);
             req.WriteStartObject();
             req.WriteString("method", method);
             req.WriteNumber("id", id);
@@ -158,15 +179,28 @@ internal sealed class JsonRpcClient(
             req.WriteEndObject();
         }
 
-        if (!await connection.WriteLineAsync(buffer.WrittenMemory, cancellationToken).ConfigureAwait(false))
+        // Register BEFORE sending: however fast the response races back, the receive loop finds
+        // the completion source. RunContinuationsAsynchronously keeps the loop off our stack.
+        var pending = new TaskCompletionSource<JsonDocument>(TaskCreationOptions.RunContinuationsAsynchronously);
+        _pending[id] = pending;
+        JsonDocument response;
+        try
         {
-            throw new JsonRpcException($"Failed to send request '{method}'");
-        }
+            if (!await connection.WriteLineAsync(buffer.WrittenMemory, cancellationToken).ConfigureAwait(false))
+            {
+                throw new JsonRpcException($"Failed to send request '{method}'");
+            }
 
-        JsonDocument? response;
-        while (!_responses.TryRemove(id, out response))
+            using var reg = cancellationToken.Register(
+                static state => ((TaskCompletionSource<JsonDocument>)state!).TrySetCanceled(), pending);
+            response = await pending.Task.ConfigureAwait(false);
+        }
+        finally
         {
-            await _responseSignal.WaitAsync(cancellationToken).ConfigureAwait(false);
+            // Cancel/fault path: withdraw the registration so a late response is disposed by the
+            // receive loop instead of completing an abandoned source. No-op on success (the loop
+            // already removed it).
+            _pending.TryRemove(id, out _);
         }
 
         if (response.RootElement.TryGetProperty("error", out var errorEl))
@@ -181,22 +215,11 @@ internal sealed class JsonRpcClient(
             throw new JsonRpcException(message ?? "error response did not contain a message", code);
         }
 
-        if (!response.RootElement.TryGetProperty("id", out var respId) || !respId.TryGetInt64(out var rid) || rid != id)
-        {
-            var actual = response.RootElement.ToString();
-            response.Dispose();
-            throw new JsonRpcException($"Response id was not {id}: {actual}");
-        }
-
         return response;
     }
 
     public void Dispose()
     {
-        foreach (var kv in _responses)
-        {
-            kv.Value.Dispose();
-        }
-        _responses.Clear();
+        FailAllPending(new JsonRpcException("Client disposed"));
     }
 }

--- a/src/TianWen.Lib/Extensions/AstrometryServiceCollectionExtensions.cs
+++ b/src/TianWen.Lib/Extensions/AstrometryServiceCollectionExtensions.cs
@@ -1,4 +1,5 @@
-﻿using TianWen.Lib.Astrometry.Catalogs;
+﻿using System;
+using TianWen.Lib.Astrometry.Catalogs;
 using TianWen.Lib.Astrometry.Comets;
 using TianWen.Lib.Astrometry.Focus;
 using TianWen.Lib.Astrometry.PlateSolve;
@@ -13,8 +14,14 @@ public static class AstrometryServiceCollectionExtensions
     /// Adds all implemented plate solvers (as singleton, they are supposed to be stateless), and the celestial object database.
     /// </summary>
     /// <param name="services"></param>
+    /// <param name="cometQueryUri">
+    /// Overrides the JPL SBDB comet-query endpoint with a snapshot of the same query response.
+    /// Used by the browser host, where JPL's missing CORS headers make the live API unreachable:
+    /// its CI deploy bakes the query result as a same-origin static asset and points this at it.
+    /// Null (default) = the live JPL API.
+    /// </param>
     /// <returns></returns>
-    public static IServiceCollection AddAstrometry(this IServiceCollection services) => services
+    public static IServiceCollection AddAstrometry(this IServiceCollection services, Uri? cometQueryUri = null) => services
         // Factory lambda so the typed ILogger<CatalogPlateSolver> gets resolved and
         // upcast to the non-generic ILogger ctor parameter. The shorter
         // AddSingleton<IPlateSolver, CatalogPlateSolver>() form leaves DI unable to
@@ -30,6 +37,9 @@ public static class AstrometryServiceCollectionExtensions
         .AddSingleton<ICelestialObjectDB, CelestialObjectDB>()
         // Comet elements: a keyless SBDB fetch cached weekly; the source uses a shared static HttpClient
         // (no per-call typed client needed given the weekly TTL), the repository holds the immutable map.
-        .AddSingleton<ISbdbCometSource, SbdbCometSource>()
+        // Factory lambda (not AddSingleton<I, T>) so the optional endpoint override reaches the ctor;
+        // a null override is exactly the previous registration (live JPL API, shared static client).
+        .AddSingleton<ISbdbCometSource>(sp => new SbdbCometSource(
+            cometQueryUri, sp.GetRequiredService<ILogger<SbdbCometSource>>()))
         .AddSingleton<ICometRepository, CometRepository>();
 }

--- a/src/TianWen.Lib/Extensions/ExternalServiceCollectionExtensions.cs
+++ b/src/TianWen.Lib/Extensions/ExternalServiceCollectionExtensions.cs
@@ -9,15 +9,23 @@ public static class ExternalServiceCollectionExtensions
 {
     public static IServiceCollection AddExternal(this IServiceCollection services) => services
         .AddSingleton<IUtf8TextBasedConnectionFactory, JsonRPCOverTcpConnectionFactory>()
-        // Single clock for the whole system. When the TIANWEN_NOW startup override is active, wrap
-        // the system clock in an OffsetTimeProvider here -- planner, session, fake mount/camera and
-        // mount-reported UTC all resolve ITimeProvider from DI, so they shift together (dev/test only).
-        .AddSingleton<ITimeProvider>(static sp => StartupTimeOverride.TryGet(out _, out var offset)
-            ? new SystemTimeProvider(new OffsetTimeProvider(TimeProvider.System, offset))
-            : new SystemTimeProvider())
+        .AddTimeProvider()
         .AddSingleton<IExternal, External>()
         // OS credential vault on Windows; owner-restricted file elsewhere. Both behind ICredentialStore.
         .AddSingleton<ICredentialStore>(sp => OperatingSystem.IsWindows()
             ? new WindowsCredentialStore()
             : new FileCredentialStore(sp.GetRequiredService<IExternal>()));
+
+    /// <summary>
+    /// Registers only the system clock (<see cref="ITimeProvider"/>). Split out of
+    /// <see cref="AddExternal"/> so hosts that cannot use the native <c>External</c> (e.g. a
+    /// browser/WASM build with no filesystem/serial/TCP) can still get the one shared clock.
+    /// Single clock for the whole system. When the TIANWEN_NOW startup override is active, wrap
+    /// the system clock in an OffsetTimeProvider here -- planner, session, fake mount/camera and
+    /// mount-reported UTC all resolve ITimeProvider from DI, so they shift together (dev/test only).
+    /// </summary>
+    public static IServiceCollection AddTimeProvider(this IServiceCollection services) => services
+        .AddSingleton<ITimeProvider>(static sp => StartupTimeOverride.TryGet(out _, out var offset)
+            ? new SystemTimeProvider(new OffsetTimeProvider(TimeProvider.System, offset))
+            : new SystemTimeProvider());
 }

--- a/src/TianWen.Lib/TianWen.Lib.csproj
+++ b/src/TianWen.Lib/TianWen.Lib.csproj
@@ -19,6 +19,19 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
+  <!-- Lightweight build gate. A "lightweight" build drops heavy, deep-field data a small-payload
+       host does not need (today: the ~30 MB Tycho-2 star catalog, tyc2.bin.lz) - the browser/WASM
+       app turns it on. Set as a GLOBAL property on the publish command: `dotnet publish ...
+       -p:Lightweight=true`. A global property flows into every project in the build graph, including
+       this one built as a transitive ProjectReference; a property set only on the consuming Blazor
+       project does NOT reach here (and the target RID is not browser-wasm during a ProjectReference
+       build either). ReadTycho2Bulk no-ops gracefully when the manifest entry is absent, so no code
+       change is needed. Default (false) = full build, everything embedded. The Tycho-dependent
+       cross-ref maps (hip_to_tyc/hd_to_tyc, dead without tyc2) are candidates to join this gate. -->
+  <PropertyGroup>
+    <Lightweight Condition="'$(Lightweight)' == ''">false</Lightweight>
+  </PropertyGroup>
+
   <ItemGroup>
     <Compile Remove="MAttiaverga.OpenNGC/**" />
     <Compile Remove="OpenNGC/**" />
@@ -33,6 +46,12 @@
     <None Remove="Astrometry/Catalogs/tmp-data/**" />
     <EmbeddedResource Remove="Astrometry/Catalogs/*.json" />
     <EmbeddedResource Include="Astrometry/Catalogs/*.lz" WithCulture="false" />
+    <!-- A lightweight build (-p:Lightweight=true, e.g. the browser/WASM app) gates off the ~30 MB
+         Tycho-2 star catalog (tyc2.bin.lz), keeping the download small: the WebGL atlas uses the
+         bright-star (HR) set and the planner is DSO-only. ReadTycho2Bulk (CelestialObjectDB) already
+         no-ops gracefully when the tyc2 manifest entry is absent, so this needs no code change. The
+         tiny GSC-bounds + pm-sidecar companions stay embedded but unread (harmless). Default keeps it. -->
+    <EmbeddedResource Remove="Astrometry/Catalogs/tyc2.bin.lz" Condition="'$(Lightweight)' == 'true'" />
     <!-- Tracked .gz/.bin.gz catalog files: committed in git (filter_curves,
          hd_hip_cross, pickles_sed, sensor_qe, simbad_merge), so they exist at
          project-evaluation time. Listed explicitly because the previous

--- a/src/TianWen.UI.Abstractions/AppSignalHandler.Planner.cs
+++ b/src/TianWen.UI.Abstractions/AppSignalHandler.Planner.cs
@@ -37,115 +37,24 @@ namespace TianWen.UI.Abstractions
         /// shared with the search closures before the by-area split.</summary>
         private string[]? _autoCompleteCache;
 
-        /// <summary>Wires the planner search input callbacks (autocomplete, suggestion commit).</summary>
+        /// <summary>Wires the planner search input callbacks (autocomplete, suggestion commit).
+        /// The callback bodies live in the host-agnostic <see cref="PlannerSearchInteraction"/>
+        /// (shared with the web host); this method supplies the desktop-flavoured context
+        /// (profile-derived transform, signal-based focus release).</summary>
         private void SubscribePlannerSearch(SignalBus bus)
         {
-            // Aliases over the injected fields keep the moved handler bodies verbatim
-            // (the closures captured the ctor's parameters before the by-area split).
             var appState = _appState;
-            var plannerState = _plannerState;
-            var sp = _sp;
+            var db = _sp.GetRequiredService<TianWen.Lib.Astrometry.Catalogs.ICelestialObjectDB>();
 
-            // ---------------------------------------------------------------
-            // Wire planner search input callbacks
-            // ---------------------------------------------------------------
-
-            plannerState.SearchInput.OnCommit = text =>
-            {
-                plannerState.Suggestions.Clear();
-                plannerState.SuggestionIndex = -1;
-                plannerState.LastSuggestionQuery = "";
-
-                if (appState.ActiveProfile is not null && text.Length > 0)
-                {
-                    var transform = TransformFactory.FromProfile(appState.ActiveProfile, _timeProvider, out _);
-                    if (transform is not null)
-                    {
-                        var db = sp.GetRequiredService<TianWen.Lib.Astrometry.Catalogs.ICelestialObjectDB>();
-                        var resultIdx = PlannerActions.SearchTargets(plannerState, db, transform, text, plannerState.Comets);
-                        if (resultIdx >= 0)
-                        {
-                            plannerState.SelectedTargetIndex = resultIdx;
-                            OnPlannerEnsureVisible?.Invoke(resultIdx);
-                        }
-                    }
-                }
-                return Task.CompletedTask;
-            };
-
-            plannerState.SearchInput.OnCancel = () =>
-            {
-                plannerState.SearchInput.Clear();
-                plannerState.SearchResults = [];
-                plannerState.Suggestions.Clear();
-                plannerState.SuggestionIndex = -1;
-                plannerState.LastSuggestionQuery = "";
-                bus.Post(new DeactivateTextInputSignal());
-                plannerState.NeedsRedraw = true;
-            };
-
-            plannerState.SearchInput.OnTextChanged = text =>
-            {
-                if (_autoCompleteCache is not null)
-                {
-                    PlannerActions.UpdateSuggestions(plannerState, _autoCompleteCache, text);
-                }
-            };
-
-            // Autocomplete navigation: Up/Down/Return/Escape when suggestions are visible
-            plannerState.SearchInput.OnKeyOverride = key =>
-            {
-                if (plannerState.Suggestions.Count == 0)
-                {
-                    return false;
-                }
-
-                switch (key)
-                {
-                    case TextInputKey.Backspace or TextInputKey.Delete:
-                        return false; // Let the text input handle it, OnTextChanged will update suggestions
-
-                    case TextInputKey.Enter when plannerState.SuggestionIndex >= 0:
-                        CommitSuggestion(plannerState.Suggestions[plannerState.SuggestionIndex]);
-                        return true;
-
-                    case TextInputKey.Escape:
-                        plannerState.Suggestions.Clear();
-                        plannerState.SuggestionIndex = -1;
-                        plannerState.LastSuggestionQuery = "";
-                        appState.NeedsRedraw = true;
-                        return true;
-
-                    default:
-                        return false;
-                }
-            };
-
-            // Local helper captured by the search-input closures above.
-            void CommitSuggestion(string suggestion)
-            {
-                plannerState.SearchInput.Text = suggestion;
-                plannerState.SearchInput.CursorPos = suggestion.Length;
-                plannerState.Suggestions.Clear();
-                plannerState.SuggestionIndex = -1;
-                plannerState.LastSuggestionQuery = suggestion;
-
-                if (appState.ActiveProfile is not null)
-                {
-                    var transform = TransformFactory.FromProfile(appState.ActiveProfile, _timeProvider, out _);
-                    if (transform is not null)
-                    {
-                        var db = sp.GetRequiredService<TianWen.Lib.Astrometry.Catalogs.ICelestialObjectDB>();
-                        var resultIdx = PlannerActions.CommitSuggestion(plannerState, db, transform, suggestion, plannerState.Comets);
-                        if (resultIdx >= 0)
-                        {
-                            plannerState.SelectedTargetIndex = resultIdx;
-                            OnPlannerEnsureVisible?.Invoke(resultIdx);
-                        }
-                    }
-                }
-                appState.NeedsRedraw = true;
-            }
+            PlannerSearchInteraction.Wire(
+                _plannerState, db,
+                createTransform: () => appState.ActiveProfile is { } profile
+                    ? TransformFactory.FromProfile(profile, _timeProvider, out _)
+                    : null,
+                autoComplete: () => _autoCompleteCache,
+                ensureVisible: idx => OnPlannerEnsureVisible?.Invoke(idx),
+                deactivate: () => bus.Post(new DeactivateTextInputSignal()),
+                requestRedraw: () => appState.NeedsRedraw = true);
         }
 
         /// <summary>Wires schedule building (shared between planner preview and session start).</summary>

--- a/src/TianWen.UI.Abstractions/GuiEventHandlerBase.cs
+++ b/src/TianWen.UI.Abstractions/GuiEventHandlerBase.cs
@@ -138,43 +138,16 @@ namespace TianWen.UI.Abstractions
                 return true;
             }
 
-            // Slider drag start + selection (clicked directly on a slider handle)
-            if (hit is HitResult.SliderHit { SliderIndex: var sliderIdx })
+            // Handoff-slider drag start / click-to-place / deselect - shared with the web host
+            // (replaces the old click-empty-chart-to-deselect). Click-to-place is gated on the
+            // planner tab being active so a stray press elsewhere can't move a slider through a
+            // stale chart rect.
+            if (PlannerSliderInteraction.HandleMouseDown(
+                    _plannerState, hit, _chrome.PlannerChartRect, px, py,
+                    allowClickToPlace: _appState.ActiveTab == GuiTab.Planner))
             {
-                _plannerState.DraggingSliderIndex = sliderIdx;
-                PlannerActions.SelectSlider(_plannerState, sliderIdx);
+                _appState.NeedsRedraw = true;
                 return true;
-            }
-
-            // Click-to-place: a click anywhere in the planner chart (but not directly on a
-            // slider handle) moves the nearest handoff slider to that time and begins a drag,
-            // so the same press can refine it. Selecting it also makes Left/Right step the
-            // slider (which trumps date-switching). Replaces the old click-empty-chart-to-deselect.
-            if (hit is null
-                && _appState.ActiveTab == GuiTab.Planner
-                && _plannerState.HandoffSliders.Length > 0)
-            {
-                var chartRect = _chrome.PlannerChartRect;
-                var (tStart, tEnd, plotX, plotY, plotW, plotH) = AltitudeChartRenderer.GetChartPlotLayout(
-                    _plannerState, (int)chartRect.X, (int)chartRect.Y, (int)chartRect.Width, (int)chartRect.Height);
-                // Only inside the PLOT area -- a click on the weather band / icons above the plot
-                // (or the legend / axis below it) must NOT move a handoff divider.
-                if (px >= plotX && px <= plotX + plotW && py >= plotY && py <= plotY + plotH)
-                {
-                    var clickedTime = AltitudeChartRenderer.XToTime(px, tStart, tEnd, plotX, plotW);
-                    if (PlannerActions.PlaceNearestSlider(_plannerState, clickedTime) is var moved && moved >= 0)
-                    {
-                        _plannerState.DraggingSliderIndex = moved;
-                        _appState.NeedsRedraw = true;
-                        return true;
-                    }
-                }
-            }
-
-            // Clicking outside a slider and outside the chart → deselect
-            if (_plannerState.SelectedSliderIndex >= 0)
-            {
-                PlannerActions.SelectSlider(_plannerState, -1);
             }
 
             // Clicking outside text input → deactivate
@@ -221,26 +194,14 @@ namespace TianWen.UI.Abstractions
                 _appState.NeedsRedraw = true;
             }
 
-            var idx = _plannerState.DraggingSliderIndex;
-            if (idx < 0)
+            // Active slider drag consumes the move; otherwise forward to the active tab
+            // (e.g. live session drag pan).
+            if (PlannerSliderInteraction.HandleMouseMove(_plannerState, _chrome.PlannerChartRect, px))
             {
-                // Forward to active tab (e.g. live session drag pan)
-                return _chrome.ActiveTab?.HandleInput(new InputEvent.MouseMove(px, py)) ?? false;
+                return true;
             }
 
-            if (idx >= _plannerState.HandoffSliders.Length)
-            {
-                _plannerState.DraggingSliderIndex = -1;
-                return false;
-            }
-
-            var chartRect = _chrome.PlannerChartRect;
-            var (tStart, tEnd, plotX, plotW) = AltitudeChartRenderer.GetChartTimeLayout(
-                _plannerState, (int)chartRect.X, (int)chartRect.Width);
-
-            var newTime = AltitudeChartRenderer.XToTime(px, tStart, tEnd, plotX, plotW);
-            PlannerActions.MoveSlider(_plannerState, idx, newTime);
-            return true;
+            return _chrome.ActiveTab?.HandleInput(new InputEvent.MouseMove(px, py)) ?? false;
         }
 
         private bool HandleMouseUp(float x, float y)
@@ -248,9 +209,8 @@ namespace TianWen.UI.Abstractions
             // Forward to active tab first (e.g. live session drag pan release, sky-map click-select)
             _chrome.ActiveTab?.HandleInput(new InputEvent.MouseUp(x, y));
 
-            if (_plannerState.DraggingSliderIndex >= 0)
+            if (PlannerSliderInteraction.HandleMouseUp(_plannerState))
             {
-                _plannerState.DraggingSliderIndex = -1;
                 _appState.NeedsRedraw = true;
                 return true;
             }

--- a/src/TianWen.UI.Abstractions/GuiEventHandlerBase.cs
+++ b/src/TianWen.UI.Abstractions/GuiEventHandlerBase.cs
@@ -173,9 +173,7 @@ namespace TianWen.UI.Abstractions
                 return false;
             }
 
-            target.InsertText(text);
-            target.OnTextChanged?.Invoke(target.Text);
-            return true;
+            return TextInputInteraction.HandleText(target, text);
         }
 
         private bool HandleMouseMove(float px, float py)
@@ -313,134 +311,22 @@ namespace TianWen.UI.Abstractions
         private void DeactivateTextInput()
             => _chrome.Bus?.Post(new DeactivateTextInputSignal());
 
+        // The key machinery lives in the host-agnostic TextInputInteraction (shared with the
+        // web host); this supplies the desktop-flavoured context (signal-based focus release,
+        // SDL clipboard delegates, GuiAppState redraw flag).
         private bool HandleTextInputKey(TextInputState activeInput, InputKey key, InputModifier modifiers)
         {
-            // Autocomplete arrow navigation
-            if (activeInput == _plannerState.SearchInput && _plannerState.Suggestions.Count > 0)
-            {
-                if (key == InputKey.Down)
-                {
-                    _plannerState.SuggestionIndex = Math.Min(
-                        _plannerState.SuggestionIndex + 1, _plannerState.Suggestions.Count - 1);
-                    _appState.NeedsRedraw = true;
-                    return true;
-                }
-
-                if (key == InputKey.Up && _plannerState.SuggestionIndex >= 0)
-                {
-                    _plannerState.SuggestionIndex--;
-                    _appState.NeedsRedraw = true;
-                    return true;
-                }
-            }
-
-            // Sky-map F3 search: arrow keys navigate the result list. The tab's own
-            // TryHandleSearchKey only runs when NO text input is active, but the search input IS
-            // active here -- and this method swallows all keys (see the final return) -- so the
-            // navigation has to happen here too, mirroring the planner block above. Without this,
-            // Up/Down never reach the result list while the user is typing in the search box.
-            var skySearch = _chrome.SkyMapState.Search;
-            if (activeInput == skySearch.SearchInput && skySearch.Results.Length > 0)
-            {
-                if (key == InputKey.Down)
-                {
-                    skySearch.SelectedResultIndex = Math.Min(
-                        skySearch.SelectedResultIndex + 1, skySearch.Results.Length - 1);
-                    _appState.NeedsRedraw = true;
-                    return true;
-                }
-                if (key == InputKey.Up)
-                {
-                    skySearch.SelectedResultIndex = Math.Max(
-                        skySearch.SelectedResultIndex - 1, 0);
-                    _appState.NeedsRedraw = true;
-                    return true;
-                }
-            }
-
-            var textKey = key.ToTextInputKey(modifiers);
-
-            // Tab cycling through text inputs on the active tab
-            if (key == InputKey.Tab)
-            {
-                var shift = (modifiers & InputModifier.Shift) != 0;
-                var inputs = _chrome.ActiveTab?.GetRegisteredTextInputs();
-                if (inputs is { Count: > 1 } && _appState.ActiveTextInput is { } current)
-                {
-                    var idx = inputs.IndexOf(current);
-                    if (idx >= 0)
-                    {
-                        var next = shift
-                            ? inputs[(idx - 1 + inputs.Count) % inputs.Count]
-                            : inputs[(idx + 1) % inputs.Count];
-                        current.Deactivate();
-                        next.Activate();
-                        _appState.ActiveTextInput = next;
-                        _appState.NeedsRedraw = true;
-                        return true;
-                    }
-                }
-            }
-
-            // Let the input's OnKeyOverride handle it first (autocomplete, etc.)
-            if (textKey.HasValue && activeInput.OnKeyOverride?.Invoke(textKey.Value) == true)
-            {
-                _appState.NeedsRedraw = true;
-                return true;
-            }
-
-            // Handle Ctrl+V paste via platform clipboard
-            if (textKey == TextInputKey.Paste)
-            {
-                var clipboardText = GetClipboardText?.Invoke();
-                if (!string.IsNullOrEmpty(clipboardText))
-                {
-                    activeInput.InsertText(clipboardText);
-                    activeInput.OnTextChanged?.Invoke(activeInput.Text);
-                }
-                _appState.NeedsRedraw = true;
-                return true;
-            }
-
-            // Handle Ctrl+C copy via platform clipboard
-            if (textKey == TextInputKey.Copy)
-            {
-                if (activeInput.HasSelection)
-                {
-                    SetClipboardText?.Invoke(activeInput.Text[activeInput.SelectionStart..activeInput.SelectionEnd]);
-                }
-                return true;
-            }
-
-            if (textKey.HasValue && activeInput.HandleKey(textKey.Value))
-            {
-                // Notify text change on modifying keys
-                if (textKey.Value is TextInputKey.Backspace or TextInputKey.Delete)
-                {
-                    activeInput.OnTextChanged?.Invoke(activeInput.Text);
-                }
-
-                if (activeInput.IsCommitted)
-                {
-                    if (activeInput.OnCommit is { } onCommit)
-                    {
-                        var text = activeInput.Text;
-                        _tracker.Run(() => onCommit(text), "Text input commit");
-                    }
-                    activeInput.IsCommitted = false;
-                }
-                else if (activeInput.IsCancelled)
-                {
-                    activeInput.OnCancel?.Invoke();
-                    activeInput.IsCancelled = false;
-                    DeactivateTextInput();
-                }
-
-                _appState.NeedsRedraw = true;
-                return true;
-            }
-
-            return true; // Swallow all keys when text input active
+            return TextInputInteraction.HandleKey(activeInput, key, modifiers,
+                new TextInputInteraction.KeyContext(
+                    Tracker: _tracker,
+                    Deactivate: DeactivateTextInput,
+                    SetActive: next => _appState.ActiveTextInput = next,
+                    RequestRedraw: () => _appState.NeedsRedraw = true,
+                    Planner: _plannerState,
+                    SkySearch: _chrome.SkyMapState.Search,
+                    ActiveTab: _chrome.ActiveTab,
+                    GetClipboardText: GetClipboardText,
+                    SetClipboardText: SetClipboardText));
         }
     }
 }

--- a/src/TianWen.UI.Abstractions/PlannerPersistence.cs
+++ b/src/TianWen.UI.Abstractions/PlannerPersistence.cs
@@ -84,6 +84,45 @@ public static class PlannerPersistence
 
         logger.LogInformation("PlannerPersistence: loaded {Count} proposals from {FilePath}", dto.Proposals.Length, loadedFromPath);
 
+        return TryRestoreFromDto(state, dto, logger);
+    }
+
+    /// <summary>
+    /// Serializes the current planner session (pins, sliders, settings, site) to JSON using the
+    /// same DTO the file store writes. Storage-agnostic counterpart of <see cref="SaveAsync"/> for
+    /// hosts without a profile/file store (the browser host persists this string to localStorage).
+    /// </summary>
+    public static string SerializeToJson(PlannerState state)
+        => System.Text.Json.JsonSerializer.Serialize(CreateDto(state), PlannerJsonContext.Default.PlannerSessionDto);
+
+    /// <summary>
+    /// Restores a planner session from a JSON string produced by <see cref="SerializeToJson"/>.
+    /// Returns true if state was restored. Storage-agnostic counterpart of <see cref="TryLoadAsync"/>.
+    /// </summary>
+    public static bool TryRestoreFromJson(PlannerState state, string json, ILogger logger)
+    {
+        PlannerSessionDto? dto;
+        try
+        {
+            dto = System.Text.Json.JsonSerializer.Deserialize(json, PlannerJsonContext.Default.PlannerSessionDto);
+        }
+        catch (System.Text.Json.JsonException ex)
+        {
+            logger.LogWarning(ex, "PlannerPersistence: discarding unparseable saved session");
+            return false;
+        }
+
+        return dto is not null && TryRestoreFromDto(state, dto, logger);
+    }
+
+    /// <summary>
+    /// Applies a loaded session DTO to the planner state: validates the site, matches saved
+    /// proposals against the current target lists / object DB, and restores slider positions
+    /// that still fall inside tonight's window. Requires <see cref="PlannerState.TonightsBest"/>
+    /// and the night window to be computed first. Returns true if state was restored.
+    /// </summary>
+    public static bool TryRestoreFromDto(PlannerState state, PlannerSessionDto dto, ILogger logger)
+    {
         // Site invalidation: if saved site differs by >1° from current, discard
         if (Math.Abs(dto.SiteLatitude - state.SiteLatitude) > SiteInvalidationThreshold
             || Math.Abs(dto.SiteLongitude - state.SiteLongitude) > SiteInvalidationThreshold)

--- a/src/TianWen.UI.Abstractions/PlannerSearchInteraction.cs
+++ b/src/TianWen.UI.Abstractions/PlannerSearchInteraction.cs
@@ -1,0 +1,127 @@
+using System;
+using System.Threading.Tasks;
+using DIR.Lib;
+using TianWen.Lib.Astrometry.Catalogs;
+using TianWen.Lib.Astrometry.SOFA;
+
+namespace TianWen.UI.Abstractions
+{
+    /// <summary>
+    /// Wires the planner search-input callbacks (search commit, autocomplete suggestions,
+    /// suggestion commit) onto <see cref="PlannerState.SearchInput"/>. Shared by
+    /// <see cref="AppSignalHandler"/> (desktop/TUI hosts) and the web host - the callback
+    /// bodies used to live only in AppSignalHandler, which the web host never constructs
+    /// (it has no device stack), so the search box was inert in the browser.
+    /// </summary>
+    public static class PlannerSearchInteraction
+    {
+        /// <summary>
+        /// <paramref name="createTransform"/> returns a site-initialised transform, or null when
+        /// no site is configured yet (desktop: from the active profile; web: from the lat/lon
+        /// fields). <paramref name="autoComplete"/> returns the candidate cache - null until the
+        /// host finishes the catalog load (see <see cref="PlannerActions.BuildAutoCompleteList"/>).
+        /// <paramref name="deactivate"/> releases input focus the host's way (desktop posts
+        /// DeactivateTextInputSignal). <paramref name="ensureVisible"/> scrolls the target list.
+        /// </summary>
+        public static void Wire(
+            PlannerState plannerState,
+            ICelestialObjectDB db,
+            Func<Transform?> createTransform,
+            Func<string[]?> autoComplete,
+            Action<int>? ensureVisible,
+            Action deactivate,
+            Action requestRedraw)
+        {
+            plannerState.SearchInput.OnCommit = text =>
+            {
+                plannerState.Suggestions.Clear();
+                plannerState.SuggestionIndex = -1;
+                plannerState.LastSuggestionQuery = "";
+
+                if (text.Length > 0 && createTransform() is { } transform)
+                {
+                    var resultIdx = PlannerActions.SearchTargets(
+                        plannerState, db, transform, text, plannerState.Comets);
+                    if (resultIdx >= 0)
+                    {
+                        plannerState.SelectedTargetIndex = resultIdx;
+                        ensureVisible?.Invoke(resultIdx);
+                    }
+                }
+                requestRedraw();
+                return Task.CompletedTask;
+            };
+
+            plannerState.SearchInput.OnCancel = () =>
+            {
+                plannerState.SearchInput.Clear();
+                plannerState.SearchResults = [];
+                plannerState.Suggestions.Clear();
+                plannerState.SuggestionIndex = -1;
+                plannerState.LastSuggestionQuery = "";
+                deactivate();
+                plannerState.NeedsRedraw = true;
+                requestRedraw();
+            };
+
+            plannerState.SearchInput.OnTextChanged = text =>
+            {
+                if (autoComplete() is { } cache)
+                {
+                    PlannerActions.UpdateSuggestions(plannerState, cache, text);
+                }
+            };
+
+            // Autocomplete navigation: Up/Down/Return/Escape when suggestions are visible
+            plannerState.SearchInput.OnKeyOverride = key =>
+            {
+                if (plannerState.Suggestions.Count == 0)
+                {
+                    return false;
+                }
+
+                switch (key)
+                {
+                    case TextInputKey.Backspace or TextInputKey.Delete:
+                        return false; // Let the text input handle it, OnTextChanged will update suggestions
+
+                    case TextInputKey.Enter when plannerState.SuggestionIndex >= 0:
+                        CommitSuggestion(plannerState.Suggestions[plannerState.SuggestionIndex]);
+                        return true;
+
+                    case TextInputKey.Escape:
+                        plannerState.Suggestions.Clear();
+                        plannerState.SuggestionIndex = -1;
+                        plannerState.LastSuggestionQuery = "";
+                        requestRedraw();
+                        return true;
+
+                    default:
+                        return false;
+                }
+            };
+
+            // Local helper captured by the search-input closures above.
+            void CommitSuggestion(string suggestion)
+            {
+                plannerState.SearchInput.Text = suggestion;
+                plannerState.SearchInput.CursorPos = suggestion.Length;
+                plannerState.Suggestions.Clear();
+                plannerState.SuggestionIndex = -1;
+                plannerState.LastSuggestionQuery = suggestion;
+
+                if (createTransform() is { } transform)
+                {
+                    var resultIdx = PlannerActions.CommitSuggestion(
+                        plannerState, db, transform, suggestion, plannerState.Comets);
+                    if (resultIdx >= 0)
+                    {
+                        plannerState.SelectedTargetIndex = resultIdx;
+                        ensureVisible?.Invoke(resultIdx);
+                    }
+                }
+                requestRedraw();
+            }
+        }
+    }
+}

--- a/src/TianWen.UI.Abstractions/PlannerSliderInteraction.cs
+++ b/src/TianWen.UI.Abstractions/PlannerSliderInteraction.cs
@@ -1,0 +1,107 @@
+using DIR.Lib;
+
+namespace TianWen.UI.Abstractions
+{
+    /// <summary>
+    /// The handoff-slider (divider) mouse interaction on the planner altitude chart: grab a
+    /// handle (or click-to-place the nearest one), drag it along the time axis, release.
+    /// Single source of truth shared by every host - the SDL GUI routes through
+    /// <see cref="GuiEventHandlerBase"/> and the Blazor/WebGL host calls these directly -
+    /// so the drag state machine can never fork per host.
+    /// </summary>
+    public static class PlannerSliderInteraction
+    {
+        /// <summary>
+        /// Handles a primary-button press after hit testing. A press directly on a slider
+        /// handle (<see cref="HitResult.SliderHit"/>) selects it and starts a drag; a press on
+        /// empty chart plot area moves the nearest slider there (click-to-place) and starts a
+        /// drag so the same press can refine it. Any other press deselects a selected slider.
+        /// Returns true when a drag started (the press is consumed).
+        /// </summary>
+        /// <param name="allowClickToPlace">
+        /// False when the planner chart is not the active surface (e.g. another GUI tab is
+        /// shown), so a stray press cannot move a slider through a stale chart rect.
+        /// </param>
+        public static bool HandleMouseDown(
+            PlannerState state, HitResult? hit, RectF32 chartRect, float px, float py,
+            bool allowClickToPlace = true)
+        {
+            // Drag start + selection (clicked directly on a slider handle)
+            if (hit is HitResult.SliderHit { SliderIndex: var sliderIdx })
+            {
+                state.DraggingSliderIndex = sliderIdx;
+                PlannerActions.SelectSlider(state, sliderIdx);
+                return true;
+            }
+
+            // Click-to-place: a click anywhere in the planner chart (but not directly on a
+            // slider handle) moves the nearest handoff slider to that time and begins a drag,
+            // so the same press can refine it. Selecting it also makes Left/Right step the
+            // slider (which trumps date-switching).
+            if (allowClickToPlace && hit is null && state.HandoffSliders.Length > 0)
+            {
+                var (tStart, tEnd, plotX, plotY, plotW, plotH) = AltitudeChartRenderer.GetChartPlotLayout(
+                    state, (int)chartRect.X, (int)chartRect.Y, (int)chartRect.Width, (int)chartRect.Height);
+                // Only inside the PLOT area -- a click on the weather band / icons above the plot
+                // (or the legend / axis below it) must NOT move a handoff divider.
+                if (px >= plotX && px <= plotX + plotW && py >= plotY && py <= plotY + plotH)
+                {
+                    var clickedTime = AltitudeChartRenderer.XToTime(px, tStart, tEnd, plotX, plotW);
+                    if (PlannerActions.PlaceNearestSlider(state, clickedTime) is var moved && moved >= 0)
+                    {
+                        state.DraggingSliderIndex = moved;
+                        return true;
+                    }
+                }
+            }
+
+            // Clicking outside a slider and outside the chart -> deselect
+            if (state.SelectedSliderIndex >= 0)
+            {
+                PlannerActions.SelectSlider(state, -1);
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Handles a mouse move while a slider drag may be active. Returns true when a drag is
+        /// active and the move was consumed (the caller must NOT forward the move to the tab);
+        /// false when no drag is active.
+        /// </summary>
+        public static bool HandleMouseMove(PlannerState state, RectF32 chartRect, float px)
+        {
+            var idx = state.DraggingSliderIndex;
+            if (idx < 0)
+            {
+                return false;
+            }
+
+            if (idx >= state.HandoffSliders.Length)
+            {
+                // Sliders were rebuilt mid-drag (recompute) - abandon the drag but still own the move.
+                state.DraggingSliderIndex = -1;
+                return true;
+            }
+
+            var (tStart, tEnd, plotX, plotW) = AltitudeChartRenderer.GetChartTimeLayout(
+                state, (int)chartRect.X, (int)chartRect.Width);
+
+            var newTime = AltitudeChartRenderer.XToTime(px, tStart, tEnd, plotX, plotW);
+            PlannerActions.MoveSlider(state, idx, newTime);
+            return true;
+        }
+
+        /// <summary>Ends an active slider drag. Returns true when a drag was in progress.</summary>
+        public static bool HandleMouseUp(PlannerState state)
+        {
+            if (state.DraggingSliderIndex >= 0)
+            {
+                state.DraggingSliderIndex = -1;
+                return true;
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/TianWen.UI.Abstractions/PlannerState.cs
+++ b/src/TianWen.UI.Abstractions/PlannerState.cs
@@ -203,6 +203,14 @@ public class PlannerState
     }
     private bool _isDirty;
 
+    /// <summary>
+    /// Clears the dirty flag once the host has persisted the session. The flag's setter is
+    /// internal (mutations go through <see cref="PlannerActions"/>), so out-of-assembly hosts —
+    /// e.g. the browser host's localStorage store — call this from their
+    /// <see cref="SavePlannerSessionSignal"/> subscriber, mirroring the desktop handler.
+    /// </summary>
+    public void MarkSessionSaved() => _isDirty = false;
+
     /// <summary>Whether the display needs a redraw.</summary>
     public bool NeedsRedraw { get; set; }
 

--- a/src/TianWen.UI.Abstractions/SkyMapGpuGeometry.cs
+++ b/src/TianWen.UI.Abstractions/SkyMapGpuGeometry.cs
@@ -1,0 +1,419 @@
+using System;
+using System.Collections.Generic;
+using TianWen.Lib.Astrometry;
+using TianWen.Lib.Astrometry.Catalogs;
+using TianWen.Lib.Astrometry.SOFA;
+
+namespace TianWen.UI.Abstractions
+{
+    /// <summary>
+    /// Backend-agnostic geometry builders for the GPU sky map: pure float-list construction of
+    /// J2000 unit-vector line lists (constellation figures/boundaries, RA/Dec grid, ecliptic,
+    /// horizon, meridian, Alt/Az grid) and the 5-float star instance stream
+    /// (<see cref="SkyMapState.FloatsPerStar"/>). The Vulkan pipeline (TianWen.UI.Shared) and the
+    /// WebGL pipeline (TianWen.UI.Web) both upload these into their own persistent GPU buffers —
+    /// the geometry math has exactly one implementation here.
+    /// </summary>
+    public static class SkyMapGpuGeometry
+    {
+        /// <summary>Grid scale definitions: (raStepHours, decStepDeg, minFov, maxFov). A scale
+        /// draws only the lines coarser scales don't already draw; renderers overlay every scale
+        /// whose FOV window contains the current field of view.</summary>
+        public static readonly (double RaStep, double DecStep, double MinFov, double MaxFov)[] GridScales =
+        [
+            (6.0,  30.0,  30.0, 999.0),
+            (3.0,  15.0,  10.0, 120.0),
+            (1.0,  10.0,   3.0,  40.0),
+            (0.5,   5.0,   1.0,  15.0),
+            (10.0 / 60.0, 1.0, 0.2, 5.0),
+        ];
+
+        /// <summary>
+        /// The bright-star seed: 5 floats per star (unit x/y/z, vMag, B-V) for the ~1000
+        /// constellation-figure HIP stars — the buffer the Vulkan pipeline shows while the full
+        /// Tycho-2 build runs, and the WHOLE star field for the Lightweight/browser build
+        /// (naked-eye sky; tyc2 is stripped there).
+        /// </summary>
+        public static List<float> BuildFigureStarInstances(ICelestialObjectDB db)
+        {
+            var hipNumbers = ConstellationFigures.AllFigureStarHipNumbers;
+            var floats = new List<float>(hipNumbers.Count * SkyMapState.FloatsPerStar);
+
+            foreach (var hip in hipNumbers)
+            {
+                // Lite lookup: ra/dec/mag/bv straight from the catalog arrays, skipping the
+                // per-star constellation polygon test + cross-ref/type machinery a plotted seed
+                // dot never needs.
+                if (!db.TryGetHipStarLite(hip, out var ra, out var dec, out var vMag, out var bv)
+                    || float.IsNaN(vMag))
+                {
+                    continue;
+                }
+
+                var (x, y, z) = SkyMapState.RaDecToUnitVec(ra, dec);
+                floats.Add(x);
+                floats.Add(y);
+                floats.Add(z);
+                floats.Add(vMag);
+                floats.Add(float.IsNaN(bv) ? 0.65f : bv); // default to solar B-V if unknown
+            }
+
+            return floats;
+        }
+
+        /// <summary>
+        /// The full HR (Bright Star) catalog as star instances (~9k stars, the naked-eye sky) —
+        /// the browser star field. Unlike the HIP-keyed figure seed this needs no cross-identity
+        /// resolution (a Lightweight build has no Tycho-2), just catalog enumeration. Do NOT
+        /// combine with <see cref="BuildFigureStarInstances"/> in one buffer: the figure stars
+        /// resolve to the same bright stars, and the additive star blend would double them.
+        /// </summary>
+        public static List<float> BuildHrStarInstances(ICelestialObjectDB db)
+        {
+            var floats = new List<float>(9200 * SkyMapState.FloatsPerStar);
+            foreach (var idx in db.AllObjectIndices)
+            {
+                if (idx.ToCatalog() != Catalog.HR
+                    || !db.TryLookupByIndex(idx, out var obj)
+                    || Half.IsNaN(obj.V_Mag))
+                {
+                    continue;
+                }
+
+                var (x, y, z) = SkyMapState.RaDecToUnitVec(obj.RA, obj.Dec);
+                floats.Add(x);
+                floats.Add(y);
+                floats.Add(z);
+                floats.Add((float)obj.V_Mag);
+                floats.Add(Half.IsNaN(obj.BMinusV) ? 0.65f : (float)obj.BMinusV);
+            }
+
+            return floats;
+        }
+
+        /// <summary>Constellation stick figures as a line list (6 floats per segment).</summary>
+        public static List<float> BuildConstellationFigureLines(ICelestialObjectDB db)
+        {
+            var floats = new List<float>(4096);
+
+            foreach (var constellation in Enum.GetValues<Constellation>())
+            {
+                if (constellation is Constellation.SerpensCaput or Constellation.SerpensCauda)
+                {
+                    continue;
+                }
+
+                var figure = constellation.Figure;
+                if (figure.IsDefaultOrEmpty)
+                {
+                    continue;
+                }
+
+                foreach (var polyline in figure)
+                {
+                    float prevX = 0, prevY = 0, prevZ = 0;
+                    var hasPrev = false;
+
+                    foreach (var hip in polyline)
+                    {
+                        if (!db.TryLookupHIP(hip, out var ra, out var dec, out _, out _))
+                        {
+                            hasPrev = false;
+                            continue;
+                        }
+
+                        var (x, y, z) = SkyMapState.RaDecToUnitVec(ra, dec);
+
+                        if (hasPrev)
+                        {
+                            floats.Add(prevX); floats.Add(prevY); floats.Add(prevZ);
+                            floats.Add(x); floats.Add(y); floats.Add(z);
+                        }
+
+                        prevX = x; prevY = y; prevZ = z;
+                        hasPrev = true;
+                    }
+                }
+            }
+
+            return floats;
+        }
+
+        /// <summary>
+        /// IAU constellation boundaries as a line list. Boundaries are defined in B1875
+        /// (Delporte 1930 standard) while stars + grid are J2000; each tessellated point is
+        /// precessed B1875 -> J2000 or the boundaries sit ~1.74 deg off the stars they delimit
+        /// (and pan at a visibly different speed under the stereographic projection).
+        /// </summary>
+        public static List<float> BuildConstellationBoundaryLines()
+        {
+            var floats = new List<float>(65536);
+
+            const double FromEpoch = 1875.0;
+            const double ToEpoch = 2000.0;
+
+            static (double RA, double Dec) Precess1875ToJ2000(double ra, double dec)
+                => CoordinateUtils.Precess(ra, dec, FromEpoch, ToEpoch);
+
+            foreach (var edge in ConstellationEdges.Edges)
+            {
+                if (edge.Type == ConstellationEdges.EdgeType.Parallel)
+                {
+                    // Constant B1875 Dec arc from RA1 to RA2, tessellated in B1875 (the shape is
+                    // correct there), each point precessed to J2000.
+                    var raRange = edge.RA2 - edge.RA1;
+                    if (raRange < -12) raRange += 24;
+                    if (raRange > 12) raRange -= 24;
+                    var steps = Math.Max(5, (int)(Math.Abs(raRange) * 8));
+                    TessellateArc(floats, steps, i =>
+                        Precess1875ToJ2000(edge.RA1 + i * raRange / steps, edge.Dec1));
+                }
+                else if (edge.Type == ConstellationEdges.EdgeType.Meridian)
+                {
+                    // Constant B1875 RA arc from Dec1 to Dec2 — precessed per step.
+                    var decRange = edge.Dec2 - edge.Dec1;
+                    var steps = Math.Max(5, (int)(Math.Abs(decRange) / 2));
+                    TessellateArc(floats, steps, i =>
+                        Precess1875ToJ2000(edge.RA1, edge.Dec1 + i * decRange / steps));
+                }
+                else
+                {
+                    // Straight segment: just two endpoints, both precessed.
+                    var (p1RA, p1Dec) = Precess1875ToJ2000(edge.RA1, edge.Dec1);
+                    var (p2RA, p2Dec) = Precess1875ToJ2000(edge.RA2, edge.Dec2);
+                    var (x1, y1, z1) = SkyMapState.RaDecToUnitVec(p1RA, p1Dec);
+                    var (x2, y2, z2) = SkyMapState.RaDecToUnitVec(p2RA, p2Dec);
+                    floats.Add(x1); floats.Add(y1); floats.Add(z1);
+                    floats.Add(x2); floats.Add(y2); floats.Add(z2);
+                }
+            }
+
+            return floats;
+        }
+
+        /// <summary>
+        /// One grid scale's RA/Dec line list, skipping lines a coarser scale already draws
+        /// (renderers stack the active scales, so shared lines must not double-draw).
+        /// </summary>
+        public static List<float> BuildGridLines(int scaleIndex)
+        {
+            var (raStep, decStep, _, _) = GridScales[scaleIndex];
+            var floats = new List<float>(32768);
+
+            // RA lines (constant RA, varying Dec — great circles)
+            var lineSteps = Math.Max(60, Math.Min(200, (int)(180.0 / decStep * 2)));
+            for (var ra = 0.0; ra < 24.0; ra += raStep)
+            {
+                if (IsCoarserRaLine(ra, scaleIndex))
+                {
+                    continue;
+                }
+                TessellateArc(floats, lineSteps, j => (ra, -90.0 + j * 180.0 / lineSteps));
+            }
+
+            // Dec lines (constant Dec, varying RA — small circles)
+            var raSteps = Math.Max(60, Math.Min(200, (int)(24.0 / raStep * 2)));
+            for (var dec = -90.0 + decStep; dec < 90.0; dec += decStep)
+            {
+                if (IsCoarserDecLine(dec, scaleIndex))
+                {
+                    continue;
+                }
+                TessellateArc(floats, raSteps, j => (j * 24.0 / raSteps, dec));
+            }
+
+            return floats;
+        }
+
+        /// <summary>
+        /// The ecliptic great circle (the Sun's annual path), tessellated as a line list of
+        /// J2000 unit vectors. Inclination is the mean obliquity at J2000.0 (IAU 2006 / SOFA).
+        /// </summary>
+        public static List<float> BuildEclipticLine()
+        {
+            const double obliquityJ2000Deg = 23.4392911;
+            var (sinE, cosE) = Math.SinCos(double.DegreesToRadians(obliquityJ2000Deg));
+
+            const int steps = 360;
+            var floats = new List<float>(steps * 6);
+            float prevX = 0, prevY = 0, prevZ = 0;
+            for (var i = 0; i <= steps; i++)
+            {
+                // lambda = ecliptic longitude in radians, sweeping the full circle.
+                var lambda = i * (2.0 * Math.PI / steps);
+                var (sinL, cosL) = Math.SinCos(lambda);
+                // J2000 unit vector for ecliptic-longitude lambda, latitude 0.
+                var x = (float)cosL;
+                var y = (float)(sinL * cosE);
+                var z = (float)(sinL * sinE);
+
+                if (i > 0)
+                {
+                    floats.Add(prevX); floats.Add(prevY); floats.Add(prevZ);
+                    floats.Add(x); floats.Add(y); floats.Add(z);
+                }
+                prevX = x; prevY = y; prevZ = z;
+            }
+
+            return floats;
+        }
+
+        /// <summary>Dynamic horizon curve for the site (line list of unit vectors).</summary>
+        public static void BuildHorizonLine(SiteContext site, List<float> floats)
+        {
+            if (!site.IsValid)
+            {
+                return;
+            }
+
+            const int steps = 120;
+            float prevX = 0, prevY = 0, prevZ = 0;
+            var hasPrev = false;
+
+            for (var i = 0; i <= steps; i++)
+            {
+                var ra = i * 24.0 / steps;
+                var decHorizon = site.HorizonDec(ra);
+                var (x, y, z) = SkyMapState.RaDecToUnitVec(ra, decHorizon);
+
+                if (hasPrev)
+                {
+                    floats.Add(prevX); floats.Add(prevY); floats.Add(prevZ);
+                    floats.Add(x); floats.Add(y); floats.Add(z);
+                }
+
+                prevX = x; prevY = y; prevZ = z;
+                hasPrev = true;
+            }
+        }
+
+        /// <summary>Dynamic meridian line (the LST great circle).</summary>
+        public static void BuildMeridianLine(double lst, List<float> floats)
+        {
+            const int steps = 200;
+            var antiLst = (lst + 12.0) % 24.0;
+
+            // First half: LST line from south pole to north pole
+            TessellateArc(floats, steps / 2, i => (lst, -90.0 + i * 180.0 / (steps / 2)));
+            // Second half: anti-LST line from north pole to south pole
+            TessellateArc(floats, steps / 2, i => (antiLst, 90.0 - i * 180.0 / (steps / 2)));
+        }
+
+        /// <summary>
+        /// Dynamic Alt/Az grid: altitude circles at 10/20/30/45/60/80 degrees, azimuth lines
+        /// every 30 degrees, converted to J2000 unit vectors for the observer's latitude + LST.
+        /// </summary>
+        public static void BuildAltAzGrid(SiteContext site, List<float> floats)
+        {
+            if (!site.IsValid)
+            {
+                return;
+            }
+
+            // Altitude circles: constant altitude, sweep azimuth 0..360
+            double[] altitudes = [10, 20, 30, 45, 60, 80];
+            const int azSteps = 120;
+
+            foreach (var alt in altitudes)
+            {
+                TessellateArc(floats, azSteps, i =>
+                {
+                    var az = i * 360.0 / azSteps;
+                    AltAzToRaDec(alt, az, site, out var ra, out var dec);
+                    return (ra, dec);
+                });
+            }
+
+            // Azimuth lines: constant azimuth, sweep altitude 0..89
+            const int altSteps = 60;
+            for (var az = 0.0; az < 360.0; az += 30.0)
+            {
+                TessellateArc(floats, altSteps, i =>
+                {
+                    var a = i * 89.0 / altSteps;
+                    AltAzToRaDec(a, az, site, out var ra, out var dec);
+                    return (ra, dec);
+                });
+            }
+        }
+
+        /// <summary>
+        /// Convert horizontal coordinates (Alt, Az in degrees) to equatorial (RA in hours,
+        /// Dec in degrees) at the site's latitude + LST.
+        /// </summary>
+        public static void AltAzToRaDec(
+            double altDeg, double azDeg, SiteContext site,
+            out double raHours, out double decDeg)
+        {
+            var (sinAlt, cosAlt) = Math.SinCos(double.DegreesToRadians(altDeg));
+            var (sinAz, cosAz) = Math.SinCos(double.DegreesToRadians(azDeg));
+
+            var sinDec = site.SinLat * sinAlt + site.CosLat * cosAlt * cosAz;
+            decDeg = double.RadiansToDegrees(Math.Asin(sinDec));
+
+            var cosDec = Math.Cos(Math.Asin(sinDec));
+            if (Math.Abs(cosDec) < 1e-12)
+            {
+                raHours = site.LST;
+                return;
+            }
+
+            var sinHA = -sinAz * cosAlt / cosDec;
+            var cosHA = (sinAlt - site.SinLat * sinDec) / (site.CosLat * cosDec);
+            var ha = Math.Atan2(sinHA, cosHA); // radians
+
+            raHours = (site.LST - ha / (Math.PI / 12.0)) % 24.0;
+            if (raHours < 0) raHours += 24.0;
+        }
+
+        /// <summary>Tessellate an arc into line segments (line list: 2 vertices per segment).</summary>
+        public static void TessellateArc(List<float> floats, int steps, Func<int, (double RA, double Dec)> coordFunc)
+        {
+            float prevX = 0, prevY = 0, prevZ = 0;
+            var hasPrev = false;
+
+            for (var i = 0; i <= steps; i++)
+            {
+                var (ra, dec) = coordFunc(i);
+                var (x, y, z) = SkyMapState.RaDecToUnitVec(ra, dec);
+
+                if (hasPrev)
+                {
+                    floats.Add(prevX); floats.Add(prevY); floats.Add(prevZ);
+                    floats.Add(x); floats.Add(y); floats.Add(z);
+                }
+
+                prevX = x; prevY = y; prevZ = z;
+                hasPrev = true;
+            }
+        }
+
+        private static bool IsCoarserRaLine(double ra, int scaleIndex)
+        {
+            for (var j = 0; j < scaleIndex; j++)
+            {
+                var coarserStep = GridScales[j].RaStep;
+                var remainder = ra % coarserStep;
+                if (remainder < 1e-9 || coarserStep - remainder < 1e-9)
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        private static bool IsCoarserDecLine(double dec, int scaleIndex)
+        {
+            for (var j = 0; j < scaleIndex; j++)
+            {
+                var coarserStep = GridScales[j].DecStep;
+                var remainder = Math.Abs(dec) % coarserStep;
+                if (remainder < 1e-9 || coarserStep - remainder < 1e-9)
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+    }
+}

--- a/src/TianWen.UI.Abstractions/SkyMapUbo.cs
+++ b/src/TianWen.UI.Abstractions/SkyMapUbo.cs
@@ -1,0 +1,79 @@
+using System;
+using System.Numerics;
+using System.Runtime.InteropServices;
+using TianWen.Lib.Astrometry.SOFA;
+
+namespace TianWen.UI.Abstractions
+{
+    /// <summary>
+    /// The GPU sky map's per-frame view uniform block (std140, 112 bytes) — one writer shared by
+    /// the Vulkan pipeline (copies into its mapped per-frame slot) and the WebGL pipeline
+    /// (uploads via SetUniformBlock). Layout (see the shader-side SkyMapUBO declarations):
+    /// <code>
+    /// mat4  viewMatrix       offset  0  (64 bytes, column-major - transposed on write)
+    /// vec2  viewportCenter   offset 64
+    /// float pixelsPerRadian  offset 72
+    /// float magnitudeLimit   offset 76
+    /// float fovDeg           offset 80
+    /// float sinLat           offset 84
+    /// vec2  viewportSize     offset 88
+    /// float cosLat           offset 96
+    /// float sinLST           offset 100
+    /// float cosLST           offset 104
+    /// int   horizonClip      offset 108
+    /// </code>
+    /// </summary>
+    public static class SkyMapUbo
+    {
+        public const int Size = 112;
+
+        /// <summary>
+        /// Composes the block into <paramref name="dst"/> (must be at least <see cref="Size"/>
+        /// bytes) and stamps <see cref="SkyMapState.CurrentViewMatrix"/> as a side effect — the
+        /// CPU label/overlay projection must agree with what the GPU renders this frame.
+        /// <paramref name="offsetX"/>/<paramref name="offsetY"/> locate the map viewport inside
+        /// the window; <paramref name="viewportWidth"/>/<paramref name="viewportHeight"/> are the
+        /// NDC divisor the shaders use (the Vulkan path sets the map sub-rect via vkCmdSetViewport,
+        /// the WebGL path passes the full canvas size and window-absolute center).
+        /// </summary>
+        public static void Write(
+            Span<byte> dst, SkyMapState state,
+            float viewportWidth, float viewportHeight,
+            float offsetX, float offsetY,
+            SiteContext site)
+        {
+            // LST trig + zenith direction in J2000 for Alt/Az mode
+            var (fSinLST, fCosLST) = site.IsValid
+                ? Math.SinCos(site.LST * (Math.PI / 12.0))
+                : (0.0, 1.0);
+            var zenithX = (float)(site.CosLat * fCosLST);
+            var zenithY = (float)(site.CosLat * fSinLST);
+            var zenithZ = (float)site.SinLat;
+            var viewMatrix = state.ComputeViewMatrix(zenithX, zenithY, zenithZ);
+            state.CurrentViewMatrix = viewMatrix;
+            var ppr = (float)SkyMapProjection.PixelsPerRadian(viewportHeight, state.FieldOfViewDeg);
+
+            // Matrix4x4 is row-major in memory but GLSL mat4 expects column-major - transpose.
+            var transposed = Matrix4x4.Transpose(viewMatrix);
+            MemoryMarshal.Write(dst, in transposed);
+
+            WriteF(dst, 64, offsetX + viewportWidth * 0.5f);
+            WriteF(dst, 68, offsetY + viewportHeight * 0.5f);
+            WriteF(dst, 72, ppr);
+            // FOV-aware effective limit so zooming in reveals fainter stars (Stellarium computeRCMag idea).
+            WriteF(dst, 76, state.EffectiveMagnitudeLimit);
+            WriteF(dst, 80, (float)state.FieldOfViewDeg);
+            WriteF(dst, 84, (float)site.SinLat);
+            WriteF(dst, 88, viewportWidth);
+            WriteF(dst, 92, viewportHeight);
+            WriteF(dst, 96, (float)site.CosLat);
+            WriteF(dst, 100, (float)fSinLST);
+            WriteF(dst, 104, (float)fCosLST);
+            var horizonClip = state.ShowHorizon && site.IsValid ? 1 : 0;
+            MemoryMarshal.Write(dst[108..], in horizonClip);
+        }
+
+        private static void WriteF(Span<byte> dst, int offset, float value)
+            => MemoryMarshal.Write(dst[offset..], in value);
+    }
+}

--- a/src/TianWen.UI.Abstractions/TextInputInteraction.cs
+++ b/src/TianWen.UI.Abstractions/TextInputInteraction.cs
@@ -1,0 +1,185 @@
+using System;
+using DIR.Lib;
+
+namespace TianWen.UI.Abstractions
+{
+    /// <summary>
+    /// Host-agnostic text-input key/text machinery, shared by the desktop event handler
+    /// (<see cref="GuiEventHandlerBase"/>) and the web host (Planner.razor) - the same pattern as
+    /// <see cref="PlannerSliderInteraction"/>: this logic used to live only in
+    /// GuiEventHandlerBase, which the web host never routes through, so clicking/typing into a
+    /// text input was a no-op in the browser.
+    ///
+    /// Focus BOOKKEEPING deliberately stays host-owned (desktop: ActivateTextInputSignal ->
+    /// GuiAppState.ActiveTextInput + SDL StartTextInput; web: a field on the page) because
+    /// activation has platform side effects; this class owns the per-keystroke decision logic,
+    /// which is identical everywhere.
+    /// </summary>
+    public static class TextInputInteraction
+    {
+        /// <summary>Host callbacks + optional per-app state <see cref="HandleKey"/> needs.
+        /// <see cref="Planner"/>/<see cref="SkySearch"/> enable the suggestion/result arrow
+        /// navigation when the respective search input is the active one; either may be null.
+        /// <see cref="Deactivate"/> must clear the host's active-input tracking (desktop posts
+        /// DeactivateTextInputSignal); <see cref="SetActive"/> must update it to an
+        /// already-activated input (Tab cycling).</summary>
+        public readonly record struct KeyContext(
+            BackgroundTaskTracker Tracker,
+            Action Deactivate,
+            Action<TextInputState> SetActive,
+            Action RequestRedraw,
+            PlannerState? Planner = null,
+            SkyMapSearchState? SkySearch = null,
+            IPixelWidget? ActiveTab = null,
+            Func<string?>? GetClipboardText = null,
+            Action<string>? SetClipboardText = null);
+
+        /// <summary>Inserts typed text into the active input (the TextInput-event path on
+        /// desktop; the printable-keydown path on web) and fires OnTextChanged.</summary>
+        public static bool HandleText(TextInputState activeInput, string text)
+        {
+            activeInput.InsertText(text);
+            activeInput.OnTextChanged?.Invoke(activeInput.Text);
+            return true;
+        }
+
+        /// <summary>
+        /// Routes a key press to the active text input: suggestion/result navigation, Tab
+        /// cycling, OnKeyOverride, clipboard, then the input's own key handling with
+        /// commit/cancel dispatch. Swallows every key while an input is active (returns true),
+        /// mirroring the historical desktop behaviour.
+        /// </summary>
+        public static bool HandleKey(
+            TextInputState activeInput, InputKey key, InputModifier modifiers, in KeyContext ctx)
+        {
+            // Autocomplete arrow navigation (planner search box)
+            if (ctx.Planner is { } planner
+                && activeInput == planner.SearchInput && planner.Suggestions.Count > 0)
+            {
+                if (key == InputKey.Down)
+                {
+                    planner.SuggestionIndex = Math.Min(
+                        planner.SuggestionIndex + 1, planner.Suggestions.Count - 1);
+                    ctx.RequestRedraw();
+                    return true;
+                }
+
+                if (key == InputKey.Up && planner.SuggestionIndex >= 0)
+                {
+                    planner.SuggestionIndex--;
+                    ctx.RequestRedraw();
+                    return true;
+                }
+            }
+
+            // Sky-map F3 search: arrow keys navigate the result list. The tab's own
+            // TryHandleSearchKey only runs when NO text input is active, but the search input IS
+            // active here -- and this method swallows all keys (see the final return) -- so the
+            // navigation has to happen here too, mirroring the planner block above. Without this,
+            // Up/Down never reach the result list while the user is typing in the search box.
+            if (ctx.SkySearch is { } skySearch
+                && activeInput == skySearch.SearchInput && skySearch.Results.Length > 0)
+            {
+                if (key == InputKey.Down)
+                {
+                    skySearch.SelectedResultIndex = Math.Min(
+                        skySearch.SelectedResultIndex + 1, skySearch.Results.Length - 1);
+                    ctx.RequestRedraw();
+                    return true;
+                }
+                if (key == InputKey.Up)
+                {
+                    skySearch.SelectedResultIndex = Math.Max(
+                        skySearch.SelectedResultIndex - 1, 0);
+                    ctx.RequestRedraw();
+                    return true;
+                }
+            }
+
+            var textKey = key.ToTextInputKey(modifiers);
+
+            // Tab cycling through text inputs on the active tab
+            if (key == InputKey.Tab)
+            {
+                var shift = (modifiers & InputModifier.Shift) != 0;
+                var inputs = ctx.ActiveTab?.GetRegisteredTextInputs();
+                if (inputs is { Count: > 1 })
+                {
+                    var idx = inputs.IndexOf(activeInput);
+                    if (idx >= 0)
+                    {
+                        var next = shift
+                            ? inputs[(idx - 1 + inputs.Count) % inputs.Count]
+                            : inputs[(idx + 1) % inputs.Count];
+                        activeInput.Deactivate();
+                        next.Activate();
+                        ctx.SetActive(next);
+                        ctx.RequestRedraw();
+                        return true;
+                    }
+                }
+            }
+
+            // Let the input's OnKeyOverride handle it first (autocomplete, etc.)
+            if (textKey.HasValue && activeInput.OnKeyOverride?.Invoke(textKey.Value) == true)
+            {
+                ctx.RequestRedraw();
+                return true;
+            }
+
+            // Handle Ctrl+V paste via platform clipboard
+            if (textKey == TextInputKey.Paste)
+            {
+                var clipboardText = ctx.GetClipboardText?.Invoke();
+                if (!string.IsNullOrEmpty(clipboardText))
+                {
+                    activeInput.InsertText(clipboardText);
+                    activeInput.OnTextChanged?.Invoke(activeInput.Text);
+                }
+                ctx.RequestRedraw();
+                return true;
+            }
+
+            // Handle Ctrl+C copy via platform clipboard
+            if (textKey == TextInputKey.Copy)
+            {
+                if (activeInput.HasSelection)
+                {
+                    ctx.SetClipboardText?.Invoke(
+                        activeInput.Text[activeInput.SelectionStart..activeInput.SelectionEnd]);
+                }
+                return true;
+            }
+
+            if (textKey.HasValue && activeInput.HandleKey(textKey.Value))
+            {
+                // Notify text change on modifying keys
+                if (textKey.Value is TextInputKey.Backspace or TextInputKey.Delete)
+                {
+                    activeInput.OnTextChanged?.Invoke(activeInput.Text);
+                }
+
+                if (activeInput.IsCommitted)
+                {
+                    if (activeInput.OnCommit is { } onCommit)
+                    {
+                        var text = activeInput.Text;
+                        ctx.Tracker.Run(() => onCommit(text), "Text input commit");
+                    }
+                    activeInput.IsCommitted = false;
+                }
+                else if (activeInput.IsCancelled)
+                {
+                    activeInput.OnCancel?.Invoke();
+                    activeInput.IsCancelled = false;
+                    ctx.Deactivate();
+                }
+
+                ctx.RequestRedraw();
+                return true;
+            }
+
+            return true; // Swallow all keys when text input active
+        }
+    }
+}

--- a/src/TianWen.UI.Shared/VkSkyMapPipeline.cs
+++ b/src/TianWen.UI.Shared/VkSkyMapPipeline.cs
@@ -1031,55 +1031,12 @@ public sealed unsafe class VkSkyMapPipeline : IDisposable
         Lib.Astrometry.SOFA.SiteContext site,
         int frameIndex)
     {
-        // Compute LST trig + zenith direction in J2000 for Alt/Az mode
-        var (fSinLST, fCosLST) = site.IsValid
-            ? Math.SinCos(site.LST * (Math.PI / 12.0))
-            : (0.0, 1.0);
-        float zenithX = (float)(site.CosLat * fCosLST);
-        float zenithY = (float)(site.CosLat * fSinLST);
-        float zenithZ = (float)site.SinLat;
-        var viewMatrix = state.ComputeViewMatrix(zenithX, zenithY, zenithZ);
-        state.CurrentViewMatrix = viewMatrix;
-        var ppr = (float)SkyMapProjection.PixelsPerRadian(viewportHeight, state.FieldOfViewDeg);
-
+        // Composition (incl. the CurrentViewMatrix stamp) lives in the shared SkyMapUbo writer
+        // (one layout for both GPU backends); this method only targets the mapped frame slot.
         _currentUboFrame = frameIndex;
-        var p = _uboMapped[frameIndex];
-
-        // mat4 viewMatrix at offset 0 (64 bytes) — Matrix4x4 is row-major in memory,
-        // but GLSL mat4 expects column-major. Transpose before writing.
-        var transposed = Matrix4x4.Transpose(viewMatrix);
-        Unsafe.CopyBlock(p, Unsafe.AsPointer(ref transposed), 64);
-
-        // vec2 viewportCenter at offset 64
-        WriteFloat(p, 64, offsetX + viewportWidth * 0.5f);
-        WriteFloat(p, 68, offsetY + viewportHeight * 0.5f);
-
-        // float pixelsPerRadian at offset 72
-        WriteFloat(p, 72, ppr);
-
-        // float magnitudeLimit at offset 76 — use the FOV-aware effective limit so
-        // zooming in automatically reveals fainter stars (Stellarium computeRCMag idea).
-        WriteFloat(p, 76, state.EffectiveMagnitudeLimit);
-
-        // float fovDeg at offset 80
-        WriteFloat(p, 80, (float)state.FieldOfViewDeg);
-
-        // float sinLat at offset 84
-        WriteFloat(p, 84, (float)site.SinLat);
-
-        // vec2 viewportSize at offset 88
-        WriteFloat(p, 88, viewportWidth);
-        WriteFloat(p, 92, viewportHeight);
-
-        // float cosLat at offset 96
-        WriteFloat(p, 96, (float)site.CosLat);
-
-        // float sinLST, cosLST at offset 100, 104
-        WriteFloat(p, 100, (float)fSinLST);
-        WriteFloat(p, 104, (float)fCosLST);
-
-        // int horizonClip at offset 108
-        WriteInt(p, 108, state.ShowHorizon && site.IsValid ? 1 : 0);
+        Span<byte> block = stackalloc byte[SkyMapUbo.Size];
+        SkyMapUbo.Write(block, state, viewportWidth, viewportHeight, offsetX, offsetY, site);
+        block.CopyTo(new Span<byte>(_uboMapped[frameIndex], SkyMapUbo.Size));
     }
 
     /// <summary>
@@ -1292,15 +1249,9 @@ public sealed unsafe class VkSkyMapPipeline : IDisposable
 
     // ────────────────────────────────────────────────── Grid drawing
 
-    // Grid scale definitions: (raStepHours, decStepDeg, minFov, maxFov)
-    private static readonly (double RaStep, double DecStep, double MinFov, double MaxFov)[] GridScales =
-    [
-        (6.0,  30.0,  30.0, 999.0),
-        (3.0,  15.0,  10.0, 120.0),
-        (1.0,  10.0,   3.0,  40.0),
-        (0.5,   5.0,   1.0,  15.0),
-        (10.0 / 60.0, 1.0, 0.2, 5.0),
-    ];
+    // Grid scale definitions live in the shared SkyMapGpuGeometry (one source for both backends).
+    private static (double RaStep, double DecStep, double MinFov, double MaxFov)[] GridScales
+        => SkyMapGpuGeometry.GridScales;
 
     private void DrawGrid(VkCommandBuffer cmd, SkyMapState state)
     {
@@ -1597,85 +1548,21 @@ public sealed unsafe class VkSkyMapPipeline : IDisposable
     /// cost ~hundreds of ms; ~1000 lookups is a couple ms. The async build swaps in the full
     /// ~2.5M-star Tycho-2 catalogue a beat later (<see cref="StartStarBufferRebuildAsync"/>).
     /// </summary>
+    // Geometry math lives in the backend-agnostic SkyMapGpuGeometry (shared with the WebGL
+    // pipeline); these methods only upload the built float lists into Vulkan buffers.
+
     private void BuildStarBufferFromHip(ICelestialObjectDB db)
     {
-        var hipNumbers = ConstellationFigures.AllFigureStarHipNumbers;
-        var floats = new List<float>(hipNumbers.Count * 5);
-
-        foreach (var hip in hipNumbers)
-        {
-            // Lite lookup: ra/dec/mag/bv straight from the Tycho-2 array, skipping the per-star
-            // constellation polygon test + cross-ref/type machinery that TryLookupHIP runs. A
-            // plotted seed dot needs none of it.
-            if (!db.TryGetHipStarLite(hip, out var ra, out var dec, out var vMag, out var bv))
-            {
-                continue;
-            }
-
-            if (float.IsNaN(vMag))
-            {
-                continue;
-            }
-
-            var (x, y, z) = SkyMapState.RaDecToUnitVec(ra, dec);
-            floats.Add(x);
-            floats.Add(y);
-            floats.Add(z);
-            floats.Add(vMag);
-            floats.Add(float.IsNaN(bv) ? 0.65f : bv); // default to solar B-V if unknown
-        }
-
-        _starCount = (uint)(floats.Count / 5);
+        var floats = SkyMapGpuGeometry.BuildFigureStarInstances(db);
+        _starCount = (uint)(floats.Count / SkyMapState.FloatsPerStar);
         var floatsSpan = System.Runtime.InteropServices.CollectionsMarshal.AsSpan(floats);
-        _starChunks = ChunkAndSortStars(floatsSpan, 5);
+        _starChunks = ChunkAndSortStars(floatsSpan, SkyMapState.FloatsPerStar);
         (_starBuffer, _starMemory) = _ctx.CreatePersistentVertexBuffer(floatsSpan);
     }
 
     private void BuildConstellationFigureBuffer(ICelestialObjectDB db)
     {
-        var floats = new List<float>(4096);
-
-        foreach (var constellation in Enum.GetValues<Constellation>())
-        {
-            if (constellation is Constellation.SerpensCaput or Constellation.SerpensCauda)
-            {
-                continue;
-            }
-
-            var figure = constellation.Figure;
-            if (figure.IsDefaultOrEmpty)
-            {
-                continue;
-            }
-
-            foreach (var polyline in figure)
-            {
-                float prevX = 0, prevY = 0, prevZ = 0;
-                var hasPrev = false;
-
-                foreach (var hip in polyline)
-                {
-                    if (!db.TryLookupHIP(hip, out var ra, out var dec, out _, out _))
-                    {
-                        hasPrev = false;
-                        continue;
-                    }
-
-                    var (x, y, z) = SkyMapState.RaDecToUnitVec(ra, dec);
-
-                    if (hasPrev)
-                    {
-                        // Emit line segment: prev → current
-                        floats.Add(prevX); floats.Add(prevY); floats.Add(prevZ);
-                        floats.Add(x); floats.Add(y); floats.Add(z);
-                    }
-
-                    prevX = x; prevY = y; prevZ = z;
-                    hasPrev = true;
-                }
-            }
-        }
-
+        var floats = SkyMapGpuGeometry.BuildConstellationFigureLines(db);
         _figureVertexCount = (uint)(floats.Count / 3);
         if (_figureVertexCount > 0)
         {
@@ -1686,54 +1573,7 @@ public sealed unsafe class VkSkyMapPipeline : IDisposable
 
     private void BuildConstellationBoundaryBuffer()
     {
-        var floats = new List<float>(65536);
-
-        // IAU constellation boundaries are defined in B1875 (Delporte 1930 standard).
-        // Our stars + RA/Dec grid are J2000. Without precession the boundaries sit
-        // ~1.74 degrees offset from the stars they delimit, and the stereographic
-        // projection amplifies that offset non-uniformly across the screen — which
-        // the user perceives as boundaries and stars moving at different speeds
-        // during pan. Precess each tessellated point from B1875 -> J2000.
-        const double FromEpoch = 1875.0;
-        const double ToEpoch = 2000.0;
-
-        static (double RA, double Dec) Precess1875ToJ2000(double ra, double dec)
-            => CoordinateUtils.Precess(ra, dec, FromEpoch, ToEpoch);
-
-        foreach (var edge in ConstellationEdges.Edges)
-        {
-            if (edge.Type == ConstellationEdges.EdgeType.Parallel)
-            {
-                // Constant B1875 Dec arc from RA1 to RA2. We tessellate in B1875
-                // (the shape is correct there) and precess each point to J2000
-                // before mapping to the unit sphere.
-                var raRange = edge.RA2 - edge.RA1;
-                if (raRange < -12) raRange += 24;
-                if (raRange > 12) raRange -= 24;
-                var steps = Math.Max(5, (int)(Math.Abs(raRange) * 8));
-                TessellateArc(floats, steps, i =>
-                    Precess1875ToJ2000(edge.RA1 + i * raRange / steps, edge.Dec1));
-            }
-            else if (edge.Type == ConstellationEdges.EdgeType.Meridian)
-            {
-                // Constant B1875 RA arc from Dec1 to Dec2 — precessed per step.
-                var decRange = edge.Dec2 - edge.Dec1;
-                var steps = Math.Max(5, (int)(Math.Abs(decRange) / 2));
-                TessellateArc(floats, steps, i =>
-                    Precess1875ToJ2000(edge.RA1, edge.Dec1 + i * decRange / steps));
-            }
-            else
-            {
-                // Straight segment: just two endpoints, both precessed.
-                var (p1RA, p1Dec) = Precess1875ToJ2000(edge.RA1, edge.Dec1);
-                var (p2RA, p2Dec) = Precess1875ToJ2000(edge.RA2, edge.Dec2);
-                var (x1, y1, z1) = SkyMapState.RaDecToUnitVec(p1RA, p1Dec);
-                var (x2, y2, z2) = SkyMapState.RaDecToUnitVec(p2RA, p2Dec);
-                floats.Add(x1); floats.Add(y1); floats.Add(z1);
-                floats.Add(x2); floats.Add(y2); floats.Add(z2);
-            }
-        }
-
+        var floats = SkyMapGpuGeometry.BuildConstellationBoundaryLines();
         _boundaryVertexCount = (uint)(floats.Count / 3);
         if (_boundaryVertexCount > 0)
         {
@@ -1746,33 +1586,7 @@ public sealed unsafe class VkSkyMapPipeline : IDisposable
     {
         for (var i = 0; i < GridScales.Length; i++)
         {
-            var (raStep, decStep, _, _) = GridScales[i];
-            var floats = new List<float>(32768);
-
-            // RA lines (constant RA, varying Dec — great circles)
-            // Skip values already drawn by coarser scales
-            var lineSteps = Math.Max(60, Math.Min(200, (int)(180.0 / decStep * 2)));
-            for (var ra = 0.0; ra < 24.0; ra += raStep)
-            {
-                if (IsCoarserRaLine(ra, i))
-                {
-                    continue;
-                }
-                TessellateArc(floats, lineSteps, j => (ra, -90.0 + j * 180.0 / lineSteps));
-            }
-
-            // Dec lines (constant Dec, varying RA — small circles)
-            // Skip values already drawn by coarser scales
-            var raSteps = Math.Max(60, Math.Min(200, (int)(24.0 / raStep * 2)));
-            for (var dec = -90.0 + decStep; dec < 90.0; dec += decStep)
-            {
-                if (IsCoarserDecLine(dec, i))
-                {
-                    continue;
-                }
-                TessellateArc(floats, raSteps, j => (j * 24.0 / raSteps, dec));
-            }
-
+            var floats = SkyMapGpuGeometry.BuildGridLines(i);
             var vertexCount = (uint)(floats.Count / 3);
             if (vertexCount > 0)
             {
@@ -1783,178 +1597,26 @@ public sealed unsafe class VkSkyMapPipeline : IDisposable
         }
     }
 
-    /// <summary>True if this RA value is already drawn by a coarser grid scale.</summary>
-    private static bool IsCoarserRaLine(double ra, int scaleIndex)
-    {
-        for (var j = 0; j < scaleIndex; j++)
-        {
-            var coarserStep = GridScales[j].RaStep;
-            // Check if ra is an exact multiple of the coarser step (within tolerance)
-            var remainder = ra % coarserStep;
-            if (remainder < 1e-9 || coarserStep - remainder < 1e-9)
-            {
-                return true;
-            }
-        }
-        return false;
-    }
+    // Dynamic-line builders + Alt/Az conversion moved to the shared SkyMapGpuGeometry;
+    // thin delegating wrappers keep VkSkyMapTab's existing call sites stable.
 
-    /// <summary>True if this Dec value is already drawn by a coarser grid scale.</summary>
-    private static bool IsCoarserDecLine(double dec, int scaleIndex)
-    {
-        for (var j = 0; j < scaleIndex; j++)
-        {
-            var coarserStep = GridScales[j].DecStep;
-            var remainder = Math.Abs(dec) % coarserStep;
-            if (remainder < 1e-9 || coarserStep - remainder < 1e-9)
-            {
-                return true;
-            }
-        }
-        return false;
-    }
+    /// <inheritdoc cref="SkyMapGpuGeometry.BuildHorizonLine"/>
+    public static void BuildHorizonLine(Lib.Astrometry.SOFA.SiteContext site, List<float> floats)
+        => SkyMapGpuGeometry.BuildHorizonLine(site, floats);
 
-    /// <summary>
-    /// Tessellate an arc into line segments (line list topology: 2 vertices per segment).
-    /// </summary>
-    private static void TessellateArc(List<float> floats, int steps, Func<int, (double RA, double Dec)> coordFunc)
-    {
-        float prevX = 0, prevY = 0, prevZ = 0;
-        var hasPrev = false;
-
-        for (var i = 0; i <= steps; i++)
-        {
-            var (ra, dec) = coordFunc(i);
-            var (x, y, z) = SkyMapState.RaDecToUnitVec(ra, dec);
-
-            if (hasPrev)
-            {
-                floats.Add(prevX); floats.Add(prevY); floats.Add(prevZ);
-                floats.Add(x); floats.Add(y); floats.Add(z);
-            }
-
-            prevX = x; prevY = y; prevZ = z;
-            hasPrev = true;
-        }
-    }
-
-    /// <summary>
-    /// Build dynamic line geometry for the horizon curve. Returns floats for a line list
-    /// of unit vectors. Caller writes these to the ring buffer via <c>ctx.WriteVertices</c>.
-    /// </summary>
-    public static void BuildHorizonLine(
-        Lib.Astrometry.SOFA.SiteContext site,
-        List<float> floats)
-    {
-        if (!site.IsValid)
-        {
-            return;
-        }
-
-        const int steps = 120;
-        float prevX = 0, prevY = 0, prevZ = 0;
-        var hasPrev = false;
-
-        for (var i = 0; i <= steps; i++)
-        {
-            var ra = i * 24.0 / steps;
-            var decHorizon = site.HorizonDec(ra);
-            var (x, y, z) = SkyMapState.RaDecToUnitVec(ra, decHorizon);
-
-            if (hasPrev)
-            {
-                floats.Add(prevX); floats.Add(prevY); floats.Add(prevZ);
-                floats.Add(x); floats.Add(y); floats.Add(z);
-            }
-
-            prevX = x; prevY = y; prevZ = z;
-            hasPrev = true;
-        }
-    }
-
-    /// <summary>
-    /// Build dynamic line geometry for the meridian (LST great circle).
-    /// </summary>
+    /// <inheritdoc cref="SkyMapGpuGeometry.BuildMeridianLine"/>
     public static void BuildMeridianLine(double lst, List<float> floats)
-    {
-        const int steps = 200;
-        var antiLst = (lst + 12.0) % 24.0;
+        => SkyMapGpuGeometry.BuildMeridianLine(lst, floats);
 
-        // First half: LST line from south pole to north pole
-        TessellateArc(floats, steps / 2, i => (lst, -90.0 + i * 180.0 / (steps / 2)));
-        // Second half: anti-LST line from north pole to south pole
-        TessellateArc(floats, steps / 2, i => (antiLst, 90.0 - i * 180.0 / (steps / 2)));
-    }
+    /// <inheritdoc cref="SkyMapGpuGeometry.BuildAltAzGrid"/>
+    public static void BuildAltAzGrid(Lib.Astrometry.SOFA.SiteContext site, List<float> floats)
+        => SkyMapGpuGeometry.BuildAltAzGrid(site, floats);
 
-    /// <summary>
-    /// Build dynamic Alt/Az grid lines. Altitude circles at 10/20/30/45/60/80 degrees,
-    /// azimuth lines every 30 degrees. Converts (Alt, Az) to J2000 unit vectors using
-    /// the observer's latitude and LST.
-    /// </summary>
-    public static void BuildAltAzGrid(
-        Lib.Astrometry.SOFA.SiteContext site,
-        List<float> floats)
-    {
-        if (!site.IsValid)
-        {
-            return;
-        }
-
-        // Altitude circles: constant altitude, sweep azimuth 0..360
-        double[] altitudes = [10, 20, 30, 45, 60, 80];
-        const int azSteps = 120;
-
-        foreach (var alt in altitudes)
-        {
-            TessellateArc(floats, azSteps, i =>
-            {
-                var az = i * 360.0 / azSteps;
-                AltAzToRaDec(alt, az, site, out var ra, out var dec);
-                return (ra, dec);
-            });
-        }
-
-        // Azimuth lines: constant azimuth, sweep altitude 0..89
-        const int altSteps = 60;
-        for (var az = 0.0; az < 360.0; az += 30.0)
-        {
-            TessellateArc(floats, altSteps, i =>
-            {
-                var a = i * 89.0 / altSteps;
-                AltAzToRaDec(a, az, site, out var ra, out var dec);
-                return (ra, dec);
-            });
-        }
-    }
-
-    /// <summary>
-    /// Convert horizontal coordinates (Alt, Az in degrees) to equatorial (RA in hours, Dec in degrees).
-    /// </summary>
+    /// <inheritdoc cref="SkyMapGpuGeometry.AltAzToRaDec"/>
     public static void AltAzToRaDec(
-        double altDeg, double azDeg,
-        Lib.Astrometry.SOFA.SiteContext site,
+        double altDeg, double azDeg, Lib.Astrometry.SOFA.SiteContext site,
         out double raHours, out double decDeg)
-    {
-        var (sinAlt, cosAlt) = Math.SinCos(double.DegreesToRadians(altDeg));
-        var (sinAz, cosAz) = Math.SinCos(double.DegreesToRadians(azDeg));
-
-        var sinDec = site.SinLat * sinAlt + site.CosLat * cosAlt * cosAz;
-        decDeg = double.RadiansToDegrees(Math.Asin(sinDec));
-
-        var cosDec = Math.Cos(Math.Asin(sinDec));
-        if (Math.Abs(cosDec) < 1e-12)
-        {
-            raHours = site.LST;
-            return;
-        }
-
-        var sinHA = -sinAz * cosAlt / cosDec;
-        var cosHA = (sinAlt - site.SinLat * sinDec) / (site.CosLat * cosDec);
-        var ha = Math.Atan2(sinHA, cosHA); // radians
-
-        raHours = (site.LST - ha / (Math.PI / 12.0)) % 24.0;
-        if (raHours < 0) raHours += 24.0;
-    }
+        => SkyMapGpuGeometry.AltAzToRaDec(altDeg, azDeg, site, out raHours, out decDeg);
 
     // ────────────────────────────────────────────────── Vulkan setup
 

--- a/src/TianWen.UI.Web/Devices/BrowserExternal.cs
+++ b/src/TianWen.UI.Web/Devices/BrowserExternal.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using TianWen.Lib;
+using TianWen.Lib.Astrometry.Catalogs;
+using TianWen.Lib.Connections;
+using TianWen.Lib.Devices;
+using TianWen.Lib.Imaging;
+
+namespace TianWen.UI.Web.Devices
+{
+    /// <summary>
+    /// Browser/WASM implementation of <see cref="IExternal"/> for the in-browser planner + atlas.
+    /// <para>
+    /// The filesystem-shaped members (<see cref="AppDataFolder"/> et al. and the default
+    /// atomic-JSON helpers on the interface) resolve against the emscripten in-memory filesystem
+    /// (MEMFS) that .NET WASM provides: <see cref="Directory"/>/<see cref="File"/> work, they are
+    /// simply not persistent across a page reload (fine for a showcase - planner pins survive a
+    /// session; localStorage/IndexedDB persistence is a later refinement).
+    /// </para>
+    /// <para>
+    /// Serial ports, the guider TCP socket, and FITS writing do not exist in the browser sandbox and
+    /// are never reached by the planner or the atlas, so those members throw
+    /// <see cref="PlatformNotSupportedException"/> rather than pretending to work.
+    /// </para>
+    /// </summary>
+    public sealed class BrowserExternal(ICelestialObjectDB celestialObjectDB) : IExternal
+    {
+        private readonly ICelestialObjectDB _celestialObjectDB = celestialObjectDB;
+        private DirectoryInfo? _appData;
+        private DirectoryInfo? _images;
+        private DirectoryInfo? _profiles;
+
+        // All under the WASM MEMFS base dir; created on first access.
+        public DirectoryInfo AppDataFolder => _appData ??= Directory.CreateDirectory(
+            Path.Combine(AppContext.BaseDirectory, "appdata"));
+
+        public DirectoryInfo ImageOutputFolder => _images ??= Directory.CreateDirectory(
+            Path.Combine(AppContext.BaseDirectory, "appdata", "images"));
+
+        public DirectoryInfo ProfileFolder => _profiles ??= Directory.CreateDirectory(
+            Path.Combine(AppContext.BaseDirectory, "appdata", "profiles"));
+
+        public async ValueTask<ICelestialObjectDB> GetCelestialObjectDBAsync(CancellationToken cancellationToken = default)
+        {
+            await _celestialObjectDB.InitDBAsync(cancellationToken: cancellationToken);
+            return _celestialObjectDB;
+        }
+
+        public ValueTask WriteFitsFileAsync(Image image, string fileName)
+            => throw new PlatformNotSupportedException("FITS writing is unavailable in the browser.");
+
+        public ValueTask<ResourceLock> WaitForSerialPortEnumerationAsync(CancellationToken cancellationToken)
+            => throw new PlatformNotSupportedException("Serial ports are unavailable in the browser.");
+
+        public IReadOnlyList<string> EnumerateAvailableSerialPorts(ResourceLock resourceLock) => [];
+
+        public ValueTask<ISerialConnection> OpenSerialDeviceAsync(string address, int baud, Encoding encoding,
+            bool assertControlLines = false, CancellationToken cancellationToken = default)
+            => throw new PlatformNotSupportedException("Serial ports are unavailable in the browser.");
+
+        public Task<IUtf8TextBasedConnection> ConnectGuiderAsync(EndPoint address,
+            CommunicationProtocol protocol = CommunicationProtocol.JsonRPC, CancellationToken cancellationToken = default)
+            => throw new PlatformNotSupportedException("Guider connections are unavailable in the browser.");
+    }
+}

--- a/src/TianWen.UI.Web/Pages/Planner.razor
+++ b/src/TianWen.UI.Web/Pages/Planner.razor
@@ -1,5 +1,4 @@
 @page "/"
-@implements IDisposable
 @using System.Globalization
 @using DIR.Lib
 @using TianWen.Lib.Astrometry.Catalogs
@@ -35,9 +34,13 @@
     </div>
 
     <div class="canvas-host">
-        <canvas id="planner" tabindex="0" width="@_w" height="@_h"
-                @onmousedown="OnMouseDown" @onmousemove="OnMouseMove" @onmouseup="OnMouseUp"
-                @onwheel="OnWheel" @onkeydown="OnKeyDown"></canvas>
+        @* WebGlCanvas (1.2) owns the hi-dpi plumbing: backing-buffer sizing, resize/dpr watching,
+           backing-space input mapping, pointer capture (drags survive leaving the canvas), and
+           focus - the JS helpers this host used to carry. *@
+        <WebGlCanvas Id="planner" TabIndex="0" AutoFocus="true"
+                     OnReady="OnCanvasReady" OnResized="OnCanvasResized"
+                     OnPointerDown="OnPointerDown" OnPointerMove="OnPointerMove"
+                     OnPointerUp="OnPointerUp" OnWheel="OnWheel" OnKeyDown="OnKeyDown" />
     </div>
 </div>
 
@@ -53,19 +56,17 @@
     readonly SignalBus _bus = new SignalBus();
     readonly BackgroundTaskTracker _tracker = new BackgroundTaskTracker();
     PlannerState _state = new();
-    DotNetObjectReference<Planner>? _selfRef;
+    // First-metrics gate: WebGlCanvas's OnReady can fire while OnInitializedAsync is still staging
+    // the font, so init awaits this instead of racing the component (the Chess.Web pattern).
+    readonly TaskCompletionSource<CanvasMetrics> _firstMetrics = new();
+    // Latest canvas metrics: backing size feeds the GL projection + content rect,
+    // DevicePixelRatio is the tab's dpiScale. Input arrives pre-mapped to backing space.
+    CanvasMetrics _metrics;
     string _fontPath = "monospace";
     string _status = "Loading…";
     (float X, float Y) _mouse;
     bool _ready;
     bool _busy;
-    bool _resizePending;
-
-    // Canvas drawing-buffer size in device pixels (kept = CSS size x devicePixelRatio so the UI is
-    // crisp on hi-dpi displays); _dpr doubles as the tab's dpiScale and the mouse-coordinate scale.
-    int _w = 1280;
-    int _h = 800;
-    float _dpr = 1f;
 
     // Sensible default dark-ish mid-northern site; geolocation / manual entry override it.
     double _lat = 47.5;
@@ -93,12 +94,6 @@
             await TryGeolocateAsync(waitForPrompt: false);
         }
 
-        // Size the drawing buffer to the element's real on-screen size before creating the GL
-        // surface, so the first frame is already full-viewport + hi-dpi crisp.
-        await MeasureCanvasAsync();
-        StateHasChanged();
-        await Task.Delay(1); // let Blazor apply the width/height attributes
-
         // Dirty-flag driven persistence, mirroring AppSignalHandler's subscriber on desktop.
         _state.Bus = _bus;
         _bus.Subscribe<SavePlannerSessionSignal>(async _ =>
@@ -108,9 +103,12 @@
             await SavePlannerSessionAsync();
         });
 
+        // The canvas is laid out + measured once WebGlCanvas reports (canvas-in-DOM gate).
+        _metrics = await _firstMetrics.Task;
+
         try
         {
-            _webGl = await WebGlRenderer.CreateAsync("planner", (uint)_w, (uint)_h);
+            _webGl = await WebGlRenderer.CreateAsync("planner", _metrics.BackingWidth, _metrics.BackingHeight);
             _tab = new PlannerTab<WebGlContext>(_webGl) { Bus = _bus };
         }
         catch (Exception ex)
@@ -128,13 +126,6 @@
         RenderFrame();
         StateHasChanged();
 
-        // Window-resize tracking + keyboard focus on the canvas + pointer capture (keeps a
-        // divider/scrollbar drag alive when the pointer leaves the canvas, like SDL's capture).
-        _selfRef = DotNetObjectReference.Create(this);
-        await JS.InvokeVoidAsync("tianwenWatchResize", _selfRef);
-        await JS.InvokeVoidAsync("tianwenFocus", "planner");
-        await JS.InvokeVoidAsync("tianwenDragCapture", "planner");
-
         // Comets load after first paint, off the critical path (fire-and-forget; logs its own failures).
         _ = LoadCometsInBackgroundAsync();
 
@@ -146,44 +137,14 @@
         }
     }
 
-    protected override void OnAfterRender(bool firstRender)
-    {
-        // Deferred resize: the new canvas width/height attributes must be applied to the DOM before
-        // the GL viewport/projection switch, or one frame renders into a stale drawing buffer.
-        if (_resizePending && _webGl is not null)
-        {
-            _resizePending = false;
-            _webGl.Resize((uint)_w, (uint)_h);
-            RenderFrame();
-        }
-    }
+    void OnCanvasReady(CanvasMetrics m) => _firstMetrics.TrySetResult(m);
 
-    [JSInvokable]
-    public async Task OnBrowserResize()
+    void OnCanvasResized(CanvasMetrics m)
     {
-        if (await MeasureCanvasAsync())
-        {
-            _resizePending = true;
-            StateHasChanged();
-        }
-    }
-
-    async Task<bool> MeasureCanvasAsync()
-    {
-        var m = await JS.InvokeAsync<double[]?>("tianwenCanvasMetrics", "planner");
-        if (m is not { Length: 3 } || m[0] <= 0 || m[1] <= 0)
-        {
-            return false;
-        }
-        var dpr = (float)m[2];
-        var w = (int)Math.Round(m[0] * dpr);
-        var h = (int)Math.Round(m[1] * dpr);
-        if (w == _w && h == _h && dpr == _dpr)
-        {
-            return false;
-        }
-        (_w, _h, _dpr) = (w, h, dpr);
-        return true;
+        _metrics = m;
+        if (_webGl is null) return;
+        _webGl.Resize(m.BackingWidth, m.BackingHeight);
+        RenderFrame();
     }
 
     async Task LoadFontAsync()
@@ -429,59 +390,55 @@
         _bus.ProcessPending(_tracker);
         _tracker.ProcessCompletions(Logger);
         _webGl.Clear(Background);
-        var content = new RectF32(0f, 0f, _w, _h);
-        _tab.Render(_state, content, _dpr, _fontPath, Time, _mouse, emojiFontPath: null);
+        var content = new RectF32(0f, 0f, _metrics.BackingWidth, _metrics.BackingHeight);
+        _tab.Render(_state, content, (float)_metrics.DevicePixelRatio, _fontPath, Time, _mouse, emojiFontPath: null);
         _webGl.Present();
     }
 
     // --- Input: routed through the tab's InputEvent handler, mirroring the desktop host ---------
-    // Browser mouse coordinates are CSS pixels; the drawing buffer is device pixels (x _dpr).
+    // WebGlCanvas delivers coordinates pre-mapped to backing space; no dpr scaling here.
 
-    (float X, float Y) ToCanvas(MouseEventArgs e) => ((float)(e.OffsetX * _dpr), (float)(e.OffsetY * _dpr));
-
-    void OnMouseDown(MouseEventArgs e)
+    void OnPointerDown(CanvasPointerEventArgs e)
     {
-        if (!_ready || _tab is null || e.Button != 0) return;
-        var (x, y) = ToCanvas(e);
-        var mods = ToModifiers(e);
-        if (!_tab.HandleInput(new InputEvent.MouseDown(x, y, Modifiers: mods, ClickCount: (int)e.Detail)))
+        if (!_ready || _tab is null || e.Original.Button != 0) return;
+        var mods = ToModifiers(e.Original);
+        if (!_tab.HandleInput(new InputEvent.MouseDown(e.X, e.Y, Modifiers: mods, ClickCount: (int)e.Original.Detail)))
         {
             // Mirrors GuiEventHandlerBase: the hit result feeds the shared handoff-divider
             // interaction (grab a handle / click-to-place the nearest one / deselect).
-            var hit = _tab.HitTestAndDispatch(x, y, mods);
-            PlannerSliderInteraction.HandleMouseDown(_state, hit, _tab.ChartRect, x, y);
+            var hit = _tab.HitTestAndDispatch(e.X, e.Y, mods);
+            PlannerSliderInteraction.HandleMouseDown(_state, hit, _tab.ChartRect, e.X, e.Y);
         }
         RenderFrame();
     }
 
-    void OnMouseMove(MouseEventArgs e)
+    void OnPointerMove(CanvasPointerEventArgs e)
     {
         if (!_ready || _tab is null) return;
-        _mouse = ToCanvas(e);
+        _mouse = (e.X, e.Y);
         // An active divider drag consumes the move (shared state machine with the desktop
         // event handler); otherwise the tab gets it for hover / scrollbar handling.
-        if (!PlannerSliderInteraction.HandleMouseMove(_state, _tab.ChartRect, _mouse.X))
+        if (!PlannerSliderInteraction.HandleMouseMove(_state, _tab.ChartRect, e.X))
         {
-            _tab.HandleInput(new InputEvent.MouseMove(_mouse.X, _mouse.Y));
+            _tab.HandleInput(new InputEvent.MouseMove(e.X, e.Y));
         }
         RenderFrame(); // mouse-follower on the altitude chart
     }
 
-    void OnMouseUp(MouseEventArgs e)
+    void OnPointerUp(CanvasPointerEventArgs e)
     {
         if (!_ready || _tab is null) return;
-        var (x, y) = ToCanvas(e);
-        _tab.HandleInput(new InputEvent.MouseUp(x, y));
+        _tab.HandleInput(new InputEvent.MouseUp(e.X, e.Y));
         PlannerSliderInteraction.HandleMouseUp(_state);
         RenderFrame();
     }
 
-    void OnWheel(WheelEventArgs e)
+    void OnWheel(CanvasWheelEventArgs e)
     {
         if (!_ready || _tab is null) return;
         // Browser deltaY > 0 = wheel down; the tab uses the SDL convention (positive = up).
         var scrollY = (float)(-e.DeltaY / 100.0);
-        _tab.HandleInput(new InputEvent.Scroll(scrollY, _mouse.X, _mouse.Y));
+        _tab.HandleInput(new InputEvent.Scroll(scrollY, e.X, e.Y));
         RenderFrame();
     }
 
@@ -547,6 +504,4 @@
         [var c] when c is >= '0' and <= '9' => InputKey.D0 + (c - '0'),
         _ => InputKey.None,
     };
-
-    public void Dispose() => _selfRef?.Dispose();
 }

--- a/src/TianWen.UI.Web/Pages/Planner.razor
+++ b/src/TianWen.UI.Web/Pages/Planner.razor
@@ -1,4 +1,5 @@
 @page "/"
+@page "/{ViewSlug}"
 @using System.Globalization
 @using DIR.Lib
 @using TianWen.Lib.Astrometry.Catalogs
@@ -13,21 +14,22 @@
 @inject ITimeProvider Time
 @inject HttpClient Http
 @inject IJSRuntime JS
+@inject NavigationManager Nav
 @inject ILogger<Planner> Logger
 
 @* The favicon is already the 🔭 emoji (inline SVG data URI in index.html) - keep the tab
    title text-only or the emoji shows twice next to the tab label. Web titles follow
-   "Astro - <view>" per view (Planner now; Sky Map etc. later). *@
-<PageTitle>@(_view == View.SkyMap ? "Astro - Sky Map" : "Astro - Planner")</PageTitle>
+   "Astro - <view>" per view. *@
+<PageTitle>@(_view == View.SkyMap ? "Astro - Sky Atlas" : "Astro - Planner")</PageTitle>
 
 <div class="app">
     <div class="titlebar">
-        <span class="title">🔭 TianWen</span>
-        <button class="subtitle chip @(_view == View.Planner ? "active" : null)" @onclick="() => SwitchView(View.Planner)">Planner</button>
+        <span class="title" title="tiānwén">🔭 天文</span>
+        <button class="subtitle chip @(_view == View.Planner ? "active" : null)" @onclick="() => SwitchView(View.Planner)">📅 Planner</button>
         @* Grayed out until the planner's catalog init + first compute finish - the sky map
            renders an empty "catalog loading" placeholder before that, which reads as broken. *@
         <button class="subtitle chip @(_view == View.SkyMap ? "active" : null)" disabled="@(!_ready)"
-                title="@(_ready ? null : "Loading catalog…")" @onclick="() => SwitchView(View.SkyMap)">Sky Map</button>
+                title="@(_ready ? null : "Loading catalog…")" @onclick="() => SwitchView(View.SkyMap)">🌌 Sky Atlas</button>
         <span class="spacer"></span>
         <span class="status" aria-live="polite">@_status</span>
     </div>
@@ -55,6 +57,12 @@
 
     enum View { Planner, SkyMap }
 
+    /// <summary>Deep-linkable views: "/" or "/planner", and "/sky-atlas" (aliases: skymap, sky).
+    /// The URL is the source of truth for the active view - the chips navigate, and
+    /// OnParametersSet syncs, which also covers browser back/forward for free.</summary>
+    [Parameter]
+    public string? ViewSlug { get; set; }
+
     WebGlRenderer? _webGl;
     PlannerTab<WebGlContext>? _tab;
     WebSkyMapTab? _skyTab;
@@ -77,6 +85,13 @@
     (float X, float Y) _mouse;
     bool _ready;
     bool _busy;
+    // Focused canvas text input - the web counterpart of GuiAppState.ActiveTextInput (the
+    // desktop tracks it via Activate/DeactivateTextInputSignal + SDL StartTextInput; the
+    // browser needs no platform IME step, so a field suffices).
+    TextInputState? _activeInput;
+    // Planner search autocomplete candidates; built after catalog init and rebuilt with comet
+    // designations once they load (mirrors AppSignalHandler.SetAutoCompleteCache on desktop).
+    string[]? _autoComplete;
 
     // Sensible default dark-ish mid-northern site; geolocation / manual entry override it.
     double _lat = 47.5;
@@ -127,6 +142,19 @@
             _status = $"WebGL2 unavailable: {ex.Message}";
             return;
         }
+
+        // Search wiring - the same shared interaction bodies AppSignalHandler wires on desktop,
+        // with web-flavoured context: transform from the lat/lon fields, focus release via the
+        // _activeInput field. requestRedraw paints directly because a committed search finishes
+        // on a task continuation AFTER the triggering event's RenderFrame already ran.
+        PlannerSearchInteraction.Wire(
+            _state, Db,
+            createTransform: CreateSiteTransform,
+            autoComplete: () => _autoComplete,
+            ensureVisible: idx => _tab?.EnsureVisible(idx),
+            deactivate: DeactivateTextInput,
+            requestRedraw: RenderFrame);
+        WireSkyMapSearch(_skyTab);
 
         await ComputeAsync();
         _ready = true;
@@ -233,15 +261,7 @@
         _state.SiteLatitude = _lat;
         _state.SiteLongitude = _lon;
 
-        var transform = new Transform(Time);
-        transform.SiteLatitude = _lat;
-        transform.SiteLongitude = _lon;
-        transform.SiteElevation = SiteElevationMeters;
-        // CalculateNightWindow (inside ComputeTonightsBestAsync) reads transform.DateTimeOffset, whose
-        // getter needs the Julian date initialised - an unset JD maps to year -4712 and throws
-        // Arg_OleAutDateInvalid via DateTime.FromOADate. Seed the clock from the time provider first
-        // (the public equivalent of the Lib-internal Transform.RefreshDateTimeFromTimeProvider).
-        transform.DateTime = Time.GetUtcNow().UtcDateTime;
+        var transform = CreateSiteTransform();
 
         var sw = System.Diagnostics.Stopwatch.StartNew();
         await SetStatusAsync("Reading the star catalog…");
@@ -351,6 +371,95 @@
         }
     }
 
+    // Site-initialised transform for the current lat/lon fields - the web analogue of the
+    // desktop's TransformFactory.FromProfile (there is no profile in the browser). Used by the
+    // planner compute AND the search interaction (createTransform).
+    // CalculateNightWindow (inside ComputeTonightsBestAsync) reads transform.DateTimeOffset, whose
+    // getter needs the Julian date initialised - an unset JD maps to year -4712 and throws
+    // Arg_OleAutDateInvalid via DateTime.FromOADate. Seed the clock from the time provider first
+    // (the public equivalent of the Lib-internal Transform.RefreshDateTimeFromTimeProvider).
+    Transform CreateSiteTransform()
+    {
+        var transform = new Transform(Time);
+        transform.SiteLatitude = _lat;
+        transform.SiteLongitude = _lon;
+        transform.SiteElevation = SiteElevationMeters;
+        transform.DateTime = Time.GetUtcNow().UtcDateTime;
+        return transform;
+    }
+
+    // --- Canvas text-input focus (web counterpart of the Activate/DeactivateTextInputSignal
+    // flow; the shared TextInputInteraction supplies the per-keystroke machinery) -----------
+
+    void ActivateTextInput(TextInputState input, int clicks)
+    {
+        if (_activeInput is { } prev && prev != input)
+        {
+            prev.Deactivate();
+        }
+        input.Activate();
+        _activeInput = input;
+        if (clicks >= 2 && input.Text.Length > 0)
+        {
+            input.SelectAll();
+        }
+    }
+
+    void DeactivateTextInput()
+    {
+        if (_activeInput is { IsActive: true } active)
+        {
+            active.Deactivate();
+        }
+        _activeInput = null;
+    }
+
+    // Sky-map F3 search: the tab posts Open/Close/Commit signals; route them to the same shared
+    // SkyMapSearchActions the desktop AppSignalHandler uses. Subscribers run inside RenderFrame's
+    // bus pump (before the paint), so they mutate state only - never re-enter RenderFrame.
+    void WireSkyMapSearch(WebSkyMapTab skyTab)
+    {
+        var skyState = skyTab.State;
+        var skySearch = skyState.Search;
+
+        skySearch.SearchInput.OnTextChanged = _ =>
+        {
+            SkyMapSearchActions.FilterResults(skySearch, Db);
+            skyState.NeedsRedraw = true;
+        };
+        skySearch.SearchInput.OnCommit = _ =>
+        {
+            _bus.Post(new SkyMapSearchCommitSignal());
+            return Task.CompletedTask;
+        };
+        skySearch.SearchInput.OnCancel = () => _bus.Post(new CloseSkyMapSearchSignal());
+
+        _bus.Subscribe<OpenSkyMapSearchSignal>(_ =>
+        {
+            SkyMapSearchActions.OpenSearch(skySearch, Db, _state.Comets);
+            ActivateTextInput(skySearch.SearchInput, clicks: 1);
+            skyState.NeedsRedraw = true;
+        });
+        _bus.Subscribe<CloseSkyMapSearchSignal>(_ =>
+        {
+            SkyMapSearchActions.CloseSearch(skySearch);
+            DeactivateTextInput();
+            skyState.NeedsRedraw = true;
+        });
+        _bus.Subscribe<SkyMapSearchCommitSignal>(_ =>
+        {
+            // Same viewing-time rule as the desktop handler: planning date (or now) + scrub offset,
+            // so a commit resolves the position the map is actually showing.
+            var viewingUtc = (_state.PlanningDate?.ToUniversalTime() ?? Time.GetUtcNow()) + skyState.TimeOffset;
+            var site = SiteContext.Create(_state.SiteLatitude, _state.SiteLongitude, viewingUtc);
+            SkyMapSearchActions.CommitResult(
+                skySearch, skyState, Db, _state.SiteLatitude, _state.SiteLongitude,
+                viewingUtc, site, _state.Comets);
+            DeactivateTextInput();
+            skyState.NeedsRedraw = true;
+        });
+    }
+
     // Sets the status line and yields long enough for Blazor + the browser to actually paint it
     // before a following synchronous compute block freezes the single thread.
     async Task SetStatusAsync(string status)
@@ -360,15 +469,27 @@
         await Task.Delay(30);
     }
 
-    // Comet ephemerides load off the critical path (mirrors the desktop, where the tracker loads
-    // them in the background and markers appear when ready). Best-effort: CORS/network failure
-    // leaves the session DSO-only.
+    // Comet ephemerides + the search autocomplete cache load off the critical path (mirrors the
+    // desktop, where the tracker loads them in the background and markers appear when ready).
+    // Best-effort: CORS/network failure leaves the session DSO-only. The autocomplete build walks
+    // every catalog designation (interpreter-expensive on a dev run), so it must never sit on the
+    // first-paint path; search commit works without it, suggestions just come online later.
     async Task LoadCometsInBackgroundAsync()
     {
         try
         {
+            // This "background" task runs inline on the single browser thread until its first
+            // await - yield so the first paint lands before the heavy build below.
+            await Task.Delay(30);
             var sw = System.Diagnostics.Stopwatch.StartNew();
+            _autoComplete = PlannerActions.BuildAutoCompleteList(Db, null);
+            Console.WriteLine($"[tianwen-web] search autocomplete: {sw.ElapsedMilliseconds} ms");
+
+            sw.Restart();
             await Comets.EnsureLoadedAsync();
+            // Fold comet designations/names into the search autocomplete (desktop parity:
+            // AppSignalHandler rebuilds the cache on comet load).
+            _autoComplete = PlannerActions.BuildAutoCompleteList(Db, Comets);
             Console.WriteLine($"[tianwen-web] comets loaded: {sw.ElapsedMilliseconds} ms");
         }
         catch (Exception ex)
@@ -416,11 +537,28 @@
     // Active view's widget for generic input routing (both are PixelWidgetBase<WebGlContext>).
     DIR.Lib.IPixelWidget? ActiveTab => _view == View.SkyMap ? _skyTab : _tab;
 
+    // All three routes map to this same component, so the router updates ViewSlug in place
+    // (no re-init); this runs both on the initial deep link and on every chip / back / forward
+    // navigation. RenderFrame is a safe no-op until the renderer exists - the init path paints
+    // explicitly once ready.
+    protected override void OnParametersSet()
+    {
+        var view = ViewSlug?.ToLowerInvariant() switch
+        {
+            "sky-atlas" or "skymap" or "sky" => View.SkyMap,
+            _ => View.Planner,
+        };
+        if (view != _view)
+        {
+            _view = view;
+            RenderFrame();
+        }
+    }
+
     void SwitchView(View view)
     {
         if (_view == view || !_ready) return;
-        _view = view;
-        RenderFrame();
+        Nav.NavigateTo(view == View.SkyMap ? "sky-atlas" : "planner");
     }
 
     // --- Input: routed through the tab's InputEvent handler, mirroring the desktop host ---------
@@ -436,9 +574,28 @@
         // HandleInput (drag-pan, scrollbar). The sky map's HandleInput consumes EVERY press for
         // drag tracking, so hit-testing last would make all its labels unclickable.
         var hit = tab.HitTestAndDispatch(e.X, e.Y, mods);
+
+        // Text-input focus management (desktop: GuiEventHandlerBase's TextInputHit branch).
+        if (hit is HitResult.TextInputHit { Input: { } clickedInput })
+        {
+            ActivateTextInput(clickedInput, (int)e.Original.Detail);
+            RenderFrame();
+            return;
+        }
+
         var sliderHandled = _view == View.Planner && _tab is not null
             && PlannerSliderInteraction.HandleMouseDown(_state, hit, _tab.ChartRect, e.X, e.Y);
-        if (hit is null && !sliderHandled)
+        if (sliderHandled)
+        {
+            RenderFrame();
+            return;
+        }
+
+        // Clicking outside a text input releases focus (after the slider branch, mirroring the
+        // desktop order - a slider grab keeps the focused input).
+        DeactivateTextInput();
+
+        if (hit is null)
         {
             tab.HandleInput(new InputEvent.MouseDown(e.X, e.Y, Modifiers: mods, ClickCount: (int)e.Original.Detail));
         }
@@ -483,8 +640,34 @@
     {
         if (!_ready || ActiveTab is not { } tab) return;
         var mods = (e.ShiftKey ? InputModifier.Shift : 0) | (e.CtrlKey ? InputModifier.Ctrl : 0) | (e.AltKey ? InputModifier.Alt : 0);
-
         var key = MapKey(e.Key);
+
+        // A focused text input swallows every key first (desktop: GuiEventHandlerBase's
+        // active-input branch). Printable characters then insert as text - the browser keydown
+        // carries the character itself, where the SDL host gets a separate TextInput event.
+        // Clipboard delegates stay null for now: the browser clipboard API is async-only, so
+        // Ctrl+V paste into canvas inputs is a deferred follow-up.
+        if (_activeInput is { IsActive: true } active)
+        {
+            if (key != InputKey.None)
+            {
+                TextInputInteraction.HandleKey(active, key, mods, new TextInputInteraction.KeyContext(
+                    Tracker: _tracker,
+                    Deactivate: DeactivateTextInput,
+                    SetActive: next => _activeInput = next,
+                    RequestRedraw: () => { }, // the RenderFrame below covers this event
+                    Planner: _state,
+                    SkySearch: _skyTab?.State.Search,
+                    ActiveTab: tab));
+            }
+            if (e.Key.Length == 1 && !e.CtrlKey && !e.AltKey)
+            {
+                TextInputInteraction.HandleText(active, e.Key);
+            }
+            RenderFrame();
+            return;
+        }
+
         var handled = key != InputKey.None && tab.HandleInput(new InputEvent.KeyDown(key, mods));
 
         // Printable characters additionally flow as text (the SDL host sends both KeyDown +

--- a/src/TianWen.UI.Web/Pages/Planner.razor
+++ b/src/TianWen.UI.Web/Pages/Planner.razor
@@ -15,8 +15,9 @@
 @inject ILogger<Planner> Logger
 
 @* The favicon is already the 🔭 emoji (inline SVG data URI in index.html) - keep the tab
-   title text-only or the emoji shows twice next to the tab label. *@
-<PageTitle>TianWen</PageTitle>
+   title text-only or the emoji shows twice next to the tab label. Web titles follow
+   "Astro - <view>" per view (Planner now; Sky Map etc. later). *@
+<PageTitle>Astro - Planner</PageTitle>
 
 <div class="app">
     <div class="titlebar">

--- a/src/TianWen.UI.Web/Pages/Planner.razor
+++ b/src/TianWen.UI.Web/Pages/Planner.razor
@@ -6,6 +6,7 @@
 @using TianWen.Lib.Astrometry.SOFA
 @using TianWen.Lib.Devices
 @using TianWen.UI.Abstractions
+@using TianWen.UI.Web.SkyMap
 @using WebGl.Renderer
 @inject ICelestialObjectDB Db
 @inject ICometRepository Comets
@@ -17,12 +18,16 @@
 @* The favicon is already the 🔭 emoji (inline SVG data URI in index.html) - keep the tab
    title text-only or the emoji shows twice next to the tab label. Web titles follow
    "Astro - <view>" per view (Planner now; Sky Map etc. later). *@
-<PageTitle>Astro - Planner</PageTitle>
+<PageTitle>@(_view == View.SkyMap ? "Astro - Sky Map" : "Astro - Planner")</PageTitle>
 
 <div class="app">
     <div class="titlebar">
         <span class="title">🔭 TianWen</span>
-        <span class="subtitle">Planner</span>
+        <button class="subtitle chip @(_view == View.Planner ? "active" : null)" @onclick="() => SwitchView(View.Planner)">Planner</button>
+        @* Grayed out until the planner's catalog init + first compute finish - the sky map
+           renders an empty "catalog loading" placeholder before that, which reads as broken. *@
+        <button class="subtitle chip @(_view == View.SkyMap ? "active" : null)" disabled="@(!_ready)"
+                title="@(_ready ? null : "Loading catalog…")" @onclick="() => SwitchView(View.SkyMap)">Sky Map</button>
         <span class="spacer"></span>
         <span class="status" aria-live="polite">@_status</span>
     </div>
@@ -48,8 +53,12 @@
 @code {
     static readonly RGBAColor32 Background = new(0x10, 0x10, 0x18, 0xff);
 
+    enum View { Planner, SkyMap }
+
     WebGlRenderer? _webGl;
     PlannerTab<WebGlContext>? _tab;
+    WebSkyMapTab? _skyTab;
+    View _view = View.Planner;
     // The state's IsDirty setter auto-posts SavePlannerSessionSignal on this bus (same wiring as
     // the desktop host); the subscriber below persists to localStorage. Pumped in RenderFrame.
     // The tracker is mandatory: ProcessPending THROWS on an async handler without one (the
@@ -111,6 +120,7 @@
         {
             _webGl = await WebGlRenderer.CreateAsync("planner", _metrics.BackingWidth, _metrics.BackingHeight);
             _tab = new PlannerTab<WebGlContext>(_webGl) { Bus = _bus };
+            _skyTab = new WebSkyMapTab(_webGl) { Bus = _bus };
         }
         catch (Exception ex)
         {
@@ -392,8 +402,25 @@
         _tracker.ProcessCompletions(Logger);
         _webGl.Clear(Background);
         var content = new RectF32(0f, 0f, _metrics.BackingWidth, _metrics.BackingHeight);
-        _tab.Render(_state, content, (float)_metrics.DevicePixelRatio, _fontPath, Time, _mouse, emojiFontPath: null);
+        if (_view == View.SkyMap && _skyTab is not null)
+        {
+            _skyTab.Render(_state, content, (float)_metrics.DevicePixelRatio, _fontPath, Time);
+        }
+        else
+        {
+            _tab.Render(_state, content, (float)_metrics.DevicePixelRatio, _fontPath, Time, _mouse, emojiFontPath: null);
+        }
         _webGl.Present();
+    }
+
+    // Active view's widget for generic input routing (both are PixelWidgetBase<WebGlContext>).
+    DIR.Lib.IPixelWidget? ActiveTab => _view == View.SkyMap ? _skyTab : _tab;
+
+    void SwitchView(View view)
+    {
+        if (_view == view || !_ready) return;
+        _view = view;
+        RenderFrame();
     }
 
     // --- Input: routed through the tab's InputEvent handler, mirroring the desktop host ---------
@@ -401,61 +428,70 @@
 
     void OnPointerDown(CanvasPointerEventArgs e)
     {
-        if (!_ready || _tab is null || e.Original.Button != 0) return;
+        if (!_ready || ActiveTab is not { } tab || e.Original.Button != 0) return;
         var mods = ToModifiers(e.Original);
-        if (!_tab.HandleInput(new InputEvent.MouseDown(e.X, e.Y, Modifiers: mods, ClickCount: (int)e.Original.Detail)))
+        // Desktop order (GuiEventHandlerBase): hit-test the registered clickable regions FIRST
+        // (planet/comet labels, reticles, planner rows), then feed the result to the shared
+        // handoff-divider interaction, and only forward an unclaimed press to the tab's
+        // HandleInput (drag-pan, scrollbar). The sky map's HandleInput consumes EVERY press for
+        // drag tracking, so hit-testing last would make all its labels unclickable.
+        var hit = tab.HitTestAndDispatch(e.X, e.Y, mods);
+        var sliderHandled = _view == View.Planner && _tab is not null
+            && PlannerSliderInteraction.HandleMouseDown(_state, hit, _tab.ChartRect, e.X, e.Y);
+        if (hit is null && !sliderHandled)
         {
-            // Mirrors GuiEventHandlerBase: the hit result feeds the shared handoff-divider
-            // interaction (grab a handle / click-to-place the nearest one / deselect).
-            var hit = _tab.HitTestAndDispatch(e.X, e.Y, mods);
-            PlannerSliderInteraction.HandleMouseDown(_state, hit, _tab.ChartRect, e.X, e.Y);
+            tab.HandleInput(new InputEvent.MouseDown(e.X, e.Y, Modifiers: mods, ClickCount: (int)e.Original.Detail));
         }
         RenderFrame();
     }
 
     void OnPointerMove(CanvasPointerEventArgs e)
     {
-        if (!_ready || _tab is null) return;
+        if (!_ready || ActiveTab is not { } tab) return;
         _mouse = (e.X, e.Y);
         // An active divider drag consumes the move (shared state machine with the desktop
-        // event handler); otherwise the tab gets it for hover / scrollbar handling.
-        if (!PlannerSliderInteraction.HandleMouseMove(_state, _tab.ChartRect, e.X))
+        // event handler); otherwise the tab gets it for hover / drag / scrollbar handling.
+        if (_view != View.Planner || _tab is null
+            || !PlannerSliderInteraction.HandleMouseMove(_state, _tab.ChartRect, e.X))
         {
-            _tab.HandleInput(new InputEvent.MouseMove(e.X, e.Y));
+            tab.HandleInput(new InputEvent.MouseMove(e.X, e.Y));
         }
-        RenderFrame(); // mouse-follower on the altitude chart
+        RenderFrame(); // mouse-follower / sky-map drag pan
     }
 
     void OnPointerUp(CanvasPointerEventArgs e)
     {
-        if (!_ready || _tab is null) return;
-        _tab.HandleInput(new InputEvent.MouseUp(e.X, e.Y));
-        PlannerSliderInteraction.HandleMouseUp(_state);
+        if (!_ready || ActiveTab is not { } tab) return;
+        tab.HandleInput(new InputEvent.MouseUp(e.X, e.Y));
+        if (_view == View.Planner)
+        {
+            PlannerSliderInteraction.HandleMouseUp(_state);
+        }
         RenderFrame();
     }
 
     void OnWheel(CanvasWheelEventArgs e)
     {
-        if (!_ready || _tab is null) return;
+        if (!_ready || ActiveTab is not { } tab) return;
         // Browser deltaY > 0 = wheel down; the tab uses the SDL convention (positive = up).
         var scrollY = (float)(-e.DeltaY / 100.0);
-        _tab.HandleInput(new InputEvent.Scroll(scrollY, e.X, e.Y));
+        tab.HandleInput(new InputEvent.Scroll(scrollY, e.X, e.Y));
         RenderFrame();
     }
 
     void OnKeyDown(KeyboardEventArgs e)
     {
-        if (!_ready || _tab is null) return;
+        if (!_ready || ActiveTab is not { } tab) return;
         var mods = (e.ShiftKey ? InputModifier.Shift : 0) | (e.CtrlKey ? InputModifier.Ctrl : 0) | (e.AltKey ? InputModifier.Alt : 0);
 
         var key = MapKey(e.Key);
-        var handled = key != InputKey.None && _tab.HandleInput(new InputEvent.KeyDown(key, mods));
+        var handled = key != InputKey.None && tab.HandleInput(new InputEvent.KeyDown(key, mods));
 
         // Printable characters additionally flow as text (the SDL host sends both KeyDown +
         // TextInput too; the tab's focused-text-input handling sorts out which one applies).
         if (e.Key.Length == 1 && !e.CtrlKey && !e.AltKey)
         {
-            handled |= _tab.HandleInput(new InputEvent.TextInput(e.Key));
+            handled |= tab.HandleInput(new InputEvent.TextInput(e.Key));
         }
 
         if (handled)

--- a/src/TianWen.UI.Web/Pages/Planner.razor
+++ b/src/TianWen.UI.Web/Pages/Planner.razor
@@ -1,0 +1,438 @@
+@page "/"
+@implements IDisposable
+@using DIR.Lib
+@using TianWen.Lib.Astrometry.Catalogs
+@using TianWen.Lib.Astrometry.Comets
+@using TianWen.Lib.Astrometry.SOFA
+@using TianWen.Lib.Devices
+@using TianWen.UI.Abstractions
+@using WebGl.Renderer
+@inject ICelestialObjectDB Db
+@inject ICometRepository Comets
+@inject ITimeProvider Time
+@inject HttpClient Http
+@inject IJSRuntime JS
+
+<PageTitle>🔭 TianWen</PageTitle>
+
+<div class="app">
+    <div class="titlebar">
+        <span class="title">🔭 TianWen</span>
+        <span class="subtitle">Planner</span>
+        <span class="spacer"></span>
+        <span class="status" aria-live="polite">@_status</span>
+    </div>
+
+    <div class="toolbar">
+        <label>Lat <input type="number" step="0.1" @bind="_lat" /></label>
+        <label>Lon <input type="number" step="0.1" @bind="_lon" /></label>
+        <button @onclick="RecomputeAsync" disabled="@_busy">Recompute</button>
+        <button @onclick="RelocateAsync" disabled="@_busy" title="Plan for my current location">📍 Locate</button>
+    </div>
+
+    <div class="canvas-host">
+        <canvas id="planner" tabindex="0" width="@_w" height="@_h"
+                @onmousedown="OnMouseDown" @onmousemove="OnMouseMove" @onmouseup="OnMouseUp"
+                @onwheel="OnWheel" @onkeydown="OnKeyDown"></canvas>
+    </div>
+</div>
+
+@code {
+    static readonly RGBAColor32 Background = new(0x10, 0x10, 0x18, 0xff);
+
+    WebGlRenderer? _webGl;
+    PlannerTab<WebGlContext>? _tab;
+    PlannerState _state = new();
+    DotNetObjectReference<Planner>? _selfRef;
+    string _fontPath = "monospace";
+    string _status = "Loading…";
+    (float X, float Y) _mouse;
+    bool _ready;
+    bool _busy;
+    bool _resizePending;
+
+    // Canvas drawing-buffer size in device pixels (kept = CSS size x devicePixelRatio so the UI is
+    // crisp on hi-dpi displays); _dpr doubles as the tab's dpiScale and the mouse-coordinate scale.
+    int _w = 1280;
+    int _h = 800;
+    float _dpr = 1f;
+
+    // Sensible default dark-ish mid-northern site; geolocation / manual entry override it.
+    double _lat = 47.5;
+    double _lon = 11.0;
+    const double SiteElevationMeters = 500d;
+
+    protected override async Task OnInitializedAsync()
+    {
+        // Stage the UI font into the WASM in-memory FS so ManagedFontRasterizer's file loader finds
+        // it. The await here also yields once so Blazor performs the first render (mounting the
+        // <canvas>) BEFORE we measure it / WebGlRenderer.CreateAsync runs getElementById on it.
+        await LoadFontAsync();
+
+        // Site resolution, two-phase: if geolocation is ALREADY granted, fetch it now (no prompt,
+        // fast) so the first compute uses the real site. If it would prompt, don't block init -
+        // compute with the default site and apply the position in the background whenever the user
+        // answers (see ApplyGeolocationLaterAsync).
+        var geoGranted = await JS.InvokeAsync<string>("tianwenGeoState") == "granted";
+        if (geoGranted)
+        {
+            await TryGeolocateAsync(waitForPrompt: false);
+        }
+
+        // Size the drawing buffer to the element's real on-screen size before creating the GL
+        // surface, so the first frame is already full-viewport + hi-dpi crisp.
+        await MeasureCanvasAsync();
+        StateHasChanged();
+        await Task.Delay(1); // let Blazor apply the width/height attributes
+
+        try
+        {
+            _webGl = await WebGlRenderer.CreateAsync("planner", (uint)_w, (uint)_h);
+            _tab = new PlannerTab<WebGlContext>(_webGl);
+        }
+        catch (Exception ex)
+        {
+            _status = $"WebGL2 unavailable: {ex.Message}";
+            return;
+        }
+
+        await ComputeAsync();
+        _ready = true;
+        // Paint explicitly: Blazor's firstRender already happened way back during the font fetch
+        // (the first await in OnInitializedAsync yields to the renderer), so an
+        // `if (firstRender && _ready)` guard in OnAfterRender never fires - the classic
+        // "board/menu doesn't show until the first click" init-ordering bug.
+        RenderFrame();
+        StateHasChanged();
+
+        // Window-resize tracking + keyboard focus on the canvas.
+        _selfRef = DotNetObjectReference.Create(this);
+        await JS.InvokeVoidAsync("tianwenWatchResize", _selfRef);
+        await JS.InvokeVoidAsync("tianwenFocus", "planner");
+
+        // Comets load after first paint, off the critical path (fire-and-forget; logs its own failures).
+        _ = LoadCometsInBackgroundAsync();
+
+        // First visit (permission prompt pending): wait for the user's decision in the background
+        // and recompute for their real site once granted.
+        if (!geoGranted)
+        {
+            _ = ApplyGeolocationLaterAsync();
+        }
+    }
+
+    protected override void OnAfterRender(bool firstRender)
+    {
+        // Deferred resize: the new canvas width/height attributes must be applied to the DOM before
+        // the GL viewport/projection switch, or one frame renders into a stale drawing buffer.
+        if (_resizePending && _webGl is not null)
+        {
+            _resizePending = false;
+            _webGl.Resize((uint)_w, (uint)_h);
+            RenderFrame();
+        }
+    }
+
+    [JSInvokable]
+    public async Task OnBrowserResize()
+    {
+        if (await MeasureCanvasAsync())
+        {
+            _resizePending = true;
+            StateHasChanged();
+        }
+    }
+
+    async Task<bool> MeasureCanvasAsync()
+    {
+        var m = await JS.InvokeAsync<double[]?>("tianwenCanvasMetrics", "planner");
+        if (m is not { Length: 3 } || m[0] <= 0 || m[1] <= 0)
+        {
+            return false;
+        }
+        var dpr = (float)m[2];
+        var w = (int)Math.Round(m[0] * dpr);
+        var h = (int)Math.Round(m[1] * dpr);
+        if (w == _w && h == _h && dpr == _dpr)
+        {
+            return false;
+        }
+        (_w, _h, _dpr) = (w, h, dpr);
+        return true;
+    }
+
+    async Task LoadFontAsync()
+    {
+        var dir = System.IO.Path.Combine(AppContext.BaseDirectory, "Fonts");
+        System.IO.Directory.CreateDirectory(dir);
+        _fontPath = System.IO.Path.Combine(dir, "DejaVuSans.ttf");
+        if (!System.IO.File.Exists(_fontPath))
+        {
+            var bytes = await Http.GetByteArrayAsync("Fonts/DejaVuSans.ttf");
+            await System.IO.File.WriteAllBytesAsync(_fontPath, bytes);
+        }
+    }
+
+    // Best-effort browser geolocation: if granted, use the real lat/lon instead of the default.
+    // Denied / unavailable / dismissed -> keep the default. A manual lat/lon edit + Recompute
+    // overrides this for the session (cross-reload persistence is a follow-up - localStorage).
+    // Returns true when a position was applied.
+    async Task<bool> TryGeolocateAsync(bool waitForPrompt)
+    {
+        try
+        {
+            var pos = await JS.InvokeAsync<double[]?>("tianwenGeo", waitForPrompt);
+            if (pos is { Length: 2 } && !double.IsNaN(pos[0]) && !double.IsNaN(pos[1]))
+            {
+                _lat = Math.Round(pos[0], 4);
+                _lon = Math.Round(pos[1], 4);
+                return true;
+            }
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"[tianwen-web] geolocation unavailable, using default site: {ex.Message}");
+        }
+        return false;
+    }
+
+    // First-visit path: the permission prompt is open (or about to be). Wait for the user's
+    // decision with NO timeout - the initial plan for the default site renders meanwhile - and when
+    // a position arrives, recompute for the real site. Runs strictly after the initial compute
+    // (single-threaded WASM queues the continuation), so it never races _busy.
+    async Task ApplyGeolocationLaterAsync()
+    {
+        if (await TryGeolocateAsync(waitForPrompt: true))
+        {
+            Console.WriteLine($"[tianwen-web] geolocation granted late - recomputing for {_lat}, {_lon}");
+            StateHasChanged();
+            await RecomputeAsync();
+        }
+    }
+
+    // Toolbar 📍: re-fetch the current position on demand (prompting if needed) and recompute.
+    async Task RelocateAsync()
+    {
+        if (_busy) return;
+        if (await TryGeolocateAsync(waitForPrompt: true))
+        {
+            StateHasChanged();
+            await RecomputeAsync();
+        }
+        else
+        {
+            await SetStatusAsync("Location unavailable - enter Lat/Lon manually");
+        }
+    }
+
+    // Builds the night window + tonight's-best plan for the current site. The catalog DB is embedded
+    // (InitDBAsync is idempotent). Comets are deliberately NOT passed here: ComputeTonightsBestAsync
+    // awaits the JPL SBDB fetch inline when a repository is given, which would put a multi-MB (or
+    // CORS-failing) network call on the first-paint critical path; they load in the background below.
+    async Task ComputeAsync()
+    {
+        _state.ObjectDb = Db;
+        _state.Comets = Comets;
+        _state.SiteLatitude = _lat;
+        _state.SiteLongitude = _lon;
+
+        var transform = new Transform(Time);
+        transform.SiteLatitude = _lat;
+        transform.SiteLongitude = _lon;
+        transform.SiteElevation = SiteElevationMeters;
+        // CalculateNightWindow (inside ComputeTonightsBestAsync) reads transform.DateTimeOffset, whose
+        // getter needs the Julian date initialised - an unset JD maps to year -4712 and throws
+        // Arg_OleAutDateInvalid via DateTime.FromOADate. Seed the clock from the time provider first
+        // (the public equivalent of the Lib-internal Transform.RefreshDateTimeFromTimeProvider).
+        transform.DateTime = Time.GetUtcNow().UtcDateTime;
+
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        await SetStatusAsync("Reading the star catalog…");
+        await Db.InitDBAsync();
+        Console.WriteLine($"[tianwen-web] catalog init: {sw.ElapsedMilliseconds} ms");
+
+        // The catalog sweep + altitude profiles are one long synchronous block; on the single
+        // browser thread nothing repaints while it runs. SetStatusAsync yields first so the status
+        // above actually paints before the block starts.
+        sw.Restart();
+        await SetStatusAsync("Scanning the sky for tonight's best…");
+        await PlannerActions.ComputeTonightsBestAsync(
+            _state, Db, transform, _state.MinHeightAboveHorizon, CancellationToken.None,
+            onProgress: msg => Console.WriteLine($"[tianwen-web] {msg}"));
+        Console.WriteLine($"[tianwen-web] tonight's best: {sw.ElapsedMilliseconds} ms");
+
+        // Resolve the display timezone AFTER the plan computes: CalculateNightWindow initialises the
+        // transform's Julian date (via EventTimes), so the DateTime/FromOADate read inside
+        // TryGetSiteTimeZone is valid. Any residual failure - e.g. an IANA zone id TimeZoneInfo can't
+        // resolve under InvariantGlobalization - falls back to UTC.
+        try
+        {
+            _state.SiteTimeZone = transform.TryGetSiteTimeZone(out var tz, out _) ? tz : TimeSpan.Zero;
+        }
+        catch (Exception ex)
+        {
+            _state.SiteTimeZone = TimeSpan.Zero;
+            Console.WriteLine($"[tianwen-web] timezone resolution failed, using UTC: {ex.Message}");
+        }
+
+        _state.SelectedTargetIndex = 0;
+        _status = $"{_state.TonightsBest.Length} targets · {_lat:0.0}°, {_lon:0.0}°";
+    }
+
+    // Sets the status line and yields long enough for Blazor + the browser to actually paint it
+    // before a following synchronous compute block freezes the single thread.
+    async Task SetStatusAsync(string status)
+    {
+        _status = status;
+        StateHasChanged();
+        await Task.Delay(30);
+    }
+
+    // Comet ephemerides load off the critical path (mirrors the desktop, where the tracker loads
+    // them in the background and markers appear when ready). Best-effort: CORS/network failure
+    // leaves the session DSO-only.
+    async Task LoadCometsInBackgroundAsync()
+    {
+        try
+        {
+            var sw = System.Diagnostics.Stopwatch.StartNew();
+            await Comets.EnsureLoadedAsync();
+            Console.WriteLine($"[tianwen-web] comets loaded: {sw.ElapsedMilliseconds} ms");
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"[tianwen-web] comets unavailable (DSO-only session): {ex.Message}");
+        }
+    }
+
+    async Task RecomputeAsync()
+    {
+        if (_busy || _webGl is null) return;
+        _busy = true;
+        try
+        {
+            await ComputeAsync();
+            RenderFrame();
+        }
+        finally
+        {
+            _busy = false;
+        }
+    }
+
+    void RenderFrame()
+    {
+        if (_webGl is null || _tab is null) return;
+        _webGl.Clear(Background);
+        var content = new RectF32(0f, 0f, _w, _h);
+        _tab.Render(_state, content, _dpr, _fontPath, Time, _mouse, emojiFontPath: null);
+        _webGl.Present();
+    }
+
+    // --- Input: routed through the tab's InputEvent handler, mirroring the desktop host ---------
+    // Browser mouse coordinates are CSS pixels; the drawing buffer is device pixels (x _dpr).
+
+    (float X, float Y) ToCanvas(MouseEventArgs e) => ((float)(e.OffsetX * _dpr), (float)(e.OffsetY * _dpr));
+
+    void OnMouseDown(MouseEventArgs e)
+    {
+        if (!_ready || _tab is null || e.Button != 0) return;
+        var (x, y) = ToCanvas(e);
+        var mods = ToModifiers(e);
+        if (!_tab.HandleInput(new InputEvent.MouseDown(x, y, Modifiers: mods, ClickCount: (int)e.Detail)))
+        {
+            _tab.HitTestAndDispatch(x, y, mods);
+        }
+        RenderFrame();
+    }
+
+    void OnMouseMove(MouseEventArgs e)
+    {
+        if (!_ready || _tab is null) return;
+        _mouse = ToCanvas(e);
+        _tab.HandleInput(new InputEvent.MouseMove(_mouse.X, _mouse.Y));
+        RenderFrame(); // mouse-follower on the altitude chart
+    }
+
+    void OnMouseUp(MouseEventArgs e)
+    {
+        if (!_ready || _tab is null) return;
+        var (x, y) = ToCanvas(e);
+        _tab.HandleInput(new InputEvent.MouseUp(x, y));
+        RenderFrame();
+    }
+
+    void OnWheel(WheelEventArgs e)
+    {
+        if (!_ready || _tab is null) return;
+        // Browser deltaY > 0 = wheel down; the tab uses the SDL convention (positive = up).
+        var scrollY = (float)(-e.DeltaY / 100.0);
+        _tab.HandleInput(new InputEvent.Scroll(scrollY, _mouse.X, _mouse.Y));
+        RenderFrame();
+    }
+
+    void OnKeyDown(KeyboardEventArgs e)
+    {
+        if (!_ready || _tab is null) return;
+        var mods = (e.ShiftKey ? InputModifier.Shift : 0) | (e.CtrlKey ? InputModifier.Ctrl : 0) | (e.AltKey ? InputModifier.Alt : 0);
+
+        var key = MapKey(e.Key);
+        var handled = key != InputKey.None && _tab.HandleInput(new InputEvent.KeyDown(key, mods));
+
+        // Printable characters additionally flow as text (the SDL host sends both KeyDown +
+        // TextInput too; the tab's focused-text-input handling sorts out which one applies).
+        if (e.Key.Length == 1 && !e.CtrlKey && !e.AltKey)
+        {
+            handled |= _tab.HandleInput(new InputEvent.TextInput(e.Key));
+        }
+
+        if (handled)
+        {
+            RenderFrame();
+        }
+    }
+
+    static InputModifier ToModifiers(MouseEventArgs e)
+        => (e.ShiftKey ? InputModifier.Shift : 0) | (e.CtrlKey ? InputModifier.Ctrl : 0) | (e.AltKey ? InputModifier.Alt : 0);
+
+    // Browser KeyboardEvent.Key -> the platform-agnostic InputKey (the web analogue of the SDL
+    // scancode map in TianWen.UI.Shared).
+    static InputKey MapKey(string key) => key switch
+    {
+        "ArrowUp" => InputKey.Up,
+        "ArrowDown" => InputKey.Down,
+        "ArrowLeft" => InputKey.Left,
+        "ArrowRight" => InputKey.Right,
+        "Home" => InputKey.Home,
+        "End" => InputKey.End,
+        "PageUp" => InputKey.PageUp,
+        "PageDown" => InputKey.PageDown,
+        "Enter" => InputKey.Enter,
+        "Escape" => InputKey.Escape,
+        "Tab" => InputKey.Tab,
+        " " => InputKey.Space,
+        "Backspace" => InputKey.Backspace,
+        "Delete" => InputKey.Delete,
+        "+" => InputKey.Plus,
+        "-" => InputKey.Minus,
+        "." => InputKey.Period,
+        "," => InputKey.Comma,
+        "/" => InputKey.Slash,
+        "\\" => InputKey.Backslash,
+        ";" => InputKey.Semicolon,
+        "'" => InputKey.Quote,
+        "[" => InputKey.BracketLeft,
+        "]" => InputKey.BracketRight,
+        "`" => InputKey.Grave,
+        ['F', var d] when d is >= '1' and <= '9' => InputKey.F1 + (d - '1'),
+        "F10" => InputKey.F10,
+        "F11" => InputKey.F11,
+        "F12" => InputKey.F12,
+        [var c] when c is >= 'a' and <= 'z' => InputKey.A + (c - 'a'),
+        [var c] when c is >= 'A' and <= 'Z' => InputKey.A + (c - 'A'),
+        [var c] when c is >= '0' and <= '9' => InputKey.D0 + (c - '0'),
+        _ => InputKey.None,
+    };
+
+    public void Dispose() => _selfRef?.Dispose();
+}

--- a/src/TianWen.UI.Web/Pages/Planner.razor
+++ b/src/TianWen.UI.Web/Pages/Planner.razor
@@ -1,5 +1,6 @@
 @page "/"
 @implements IDisposable
+@using System.Globalization
 @using DIR.Lib
 @using TianWen.Lib.Astrometry.Catalogs
 @using TianWen.Lib.Astrometry.Comets
@@ -12,8 +13,11 @@
 @inject ITimeProvider Time
 @inject HttpClient Http
 @inject IJSRuntime JS
+@inject ILogger<Planner> Logger
 
-<PageTitle>🔭 TianWen</PageTitle>
+@* The favicon is already the 🔭 emoji (inline SVG data URI in index.html) - keep the tab
+   title text-only or the emoji shows twice next to the tab label. *@
+<PageTitle>TianWen</PageTitle>
 
 <div class="app">
     <div class="titlebar">
@@ -42,6 +46,12 @@
 
     WebGlRenderer? _webGl;
     PlannerTab<WebGlContext>? _tab;
+    // The state's IsDirty setter auto-posts SavePlannerSessionSignal on this bus (same wiring as
+    // the desktop host); the subscriber below persists to localStorage. Pumped in RenderFrame.
+    // The tracker is mandatory: ProcessPending THROWS on an async handler without one (the
+    // localStorage save is async), and ProcessCompletions reaps + logs the finished saves.
+    readonly SignalBus _bus = new SignalBus();
+    readonly BackgroundTaskTracker _tracker = new BackgroundTaskTracker();
     PlannerState _state = new();
     DotNetObjectReference<Planner>? _selfRef;
     string _fontPath = "monospace";
@@ -64,6 +74,10 @@
 
     protected override async Task OnInitializedAsync()
     {
+        // Last-used site loads first (localStorage) so a reload shows it immediately instead of
+        // flashing the built-in default while geolocation resolves.
+        await LoadSavedSiteAsync();
+
         // Stage the UI font into the WASM in-memory FS so ManagedFontRasterizer's file loader finds
         // it. The await here also yields once so Blazor performs the first render (mounting the
         // <canvas>) BEFORE we measure it / WebGlRenderer.CreateAsync runs getElementById on it.
@@ -85,10 +99,19 @@
         StateHasChanged();
         await Task.Delay(1); // let Blazor apply the width/height attributes
 
+        // Dirty-flag driven persistence, mirroring AppSignalHandler's subscriber on desktop.
+        _state.Bus = _bus;
+        _bus.Subscribe<SavePlannerSessionSignal>(async _ =>
+        {
+            if (!_state.IsDirty) return;
+            _state.MarkSessionSaved();
+            await SavePlannerSessionAsync();
+        });
+
         try
         {
             _webGl = await WebGlRenderer.CreateAsync("planner", (uint)_w, (uint)_h);
-            _tab = new PlannerTab<WebGlContext>(_webGl);
+            _tab = new PlannerTab<WebGlContext>(_webGl) { Bus = _bus };
         }
         catch (Exception ex)
         {
@@ -105,10 +128,12 @@
         RenderFrame();
         StateHasChanged();
 
-        // Window-resize tracking + keyboard focus on the canvas.
+        // Window-resize tracking + keyboard focus on the canvas + pointer capture (keeps a
+        // divider/scrollbar drag alive when the pointer leaves the canvas, like SDL's capture).
         _selfRef = DotNetObjectReference.Create(this);
         await JS.InvokeVoidAsync("tianwenWatchResize", _selfRef);
         await JS.InvokeVoidAsync("tianwenFocus", "planner");
+        await JS.InvokeVoidAsync("tianwenDragCapture", "planner");
 
         // Comets load after first paint, off the critical path (fire-and-forget; logs its own failures).
         _ = LoadCometsInBackgroundAsync();
@@ -277,6 +302,81 @@
 
         _state.SelectedTargetIndex = 0;
         _status = $"{_state.TonightsBest.Length} targets · {_lat:0.0}°, {_lon:0.0}°";
+
+        // Re-apply the saved session (pins + handoff sliders) against the freshly computed
+        // TonightsBest. Runs after EVERY compute: the first compute may run on the default site
+        // (saved pins get site-invalidated), and the geolocation recompute then restores them.
+        await TryRestorePlannerSessionAsync();
+
+        // Remember the site this plan was computed for, so the next reload starts from it.
+        await SaveSiteAsync();
+    }
+
+    // --- Planner session persistence: pins + sliders survive F5 via localStorage --------------
+    // The web analogue of the desktop's PlannerPersistence file store (AppData/Planner/...):
+    // same DTO + restore logic (SerializeToJson / TryRestoreFromJson), different storage.
+
+    async Task TryRestorePlannerSessionAsync()
+    {
+        try
+        {
+            if (await JS.InvokeAsync<string?>("localStorage.getItem", "tianwen.planner") is { Length: > 0 } json
+                && PlannerPersistence.TryRestoreFromJson(_state, json, Logger))
+            {
+                _state.MarkSessionSaved(); // freshly restored == already persisted
+            }
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"[tianwen-web] saved planner session unavailable: {ex.Message}");
+        }
+    }
+
+    async Task SavePlannerSessionAsync()
+    {
+        try
+        {
+            await JS.InvokeVoidAsync("localStorage.setItem", "tianwen.planner",
+                PlannerPersistence.SerializeToJson(_state));
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"[tianwen-web] planner session save failed: {ex.Message}");
+        }
+    }
+
+    // --- Site persistence: last-used lat/lon survives F5 via localStorage --------------------
+
+    async Task LoadSavedSiteAsync()
+    {
+        try
+        {
+            var saved = await JS.InvokeAsync<string?>("localStorage.getItem", "tianwen.site");
+            if (saved?.Split(',') is [var lat, var lon]
+                && double.TryParse(lat, CultureInfo.InvariantCulture, out var la)
+                && double.TryParse(lon, CultureInfo.InvariantCulture, out var lo))
+            {
+                (_lat, _lon) = (la, lo);
+            }
+        }
+        catch (Exception ex)
+        {
+            // Best-effort: localStorage can throw in private-browsing / storage-blocked modes.
+            Console.WriteLine($"[tianwen-web] saved site unavailable: {ex.Message}");
+        }
+    }
+
+    async Task SaveSiteAsync()
+    {
+        try
+        {
+            await JS.InvokeVoidAsync("localStorage.setItem", "tianwen.site",
+                FormattableString.Invariant($"{_lat},{_lon}"));
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"[tianwen-web] site save failed: {ex.Message}");
+        }
     }
 
     // Sets the status line and yields long enough for Blazor + the browser to actually paint it
@@ -323,6 +423,11 @@
     void RenderFrame()
     {
         if (_webGl is null || _tab is null) return;
+        // Web has no per-frame loop; every event ends in a RenderFrame, so this is the bus pump
+        // (delivers the auto-posted SavePlannerSessionSignal after pin/slider mutations) and the
+        // completion reaper for the tracked async saves.
+        _bus.ProcessPending(_tracker);
+        _tracker.ProcessCompletions(Logger);
         _webGl.Clear(Background);
         var content = new RectF32(0f, 0f, _w, _h);
         _tab.Render(_state, content, _dpr, _fontPath, Time, _mouse, emojiFontPath: null);
@@ -341,7 +446,10 @@
         var mods = ToModifiers(e);
         if (!_tab.HandleInput(new InputEvent.MouseDown(x, y, Modifiers: mods, ClickCount: (int)e.Detail)))
         {
-            _tab.HitTestAndDispatch(x, y, mods);
+            // Mirrors GuiEventHandlerBase: the hit result feeds the shared handoff-divider
+            // interaction (grab a handle / click-to-place the nearest one / deselect).
+            var hit = _tab.HitTestAndDispatch(x, y, mods);
+            PlannerSliderInteraction.HandleMouseDown(_state, hit, _tab.ChartRect, x, y);
         }
         RenderFrame();
     }
@@ -350,7 +458,12 @@
     {
         if (!_ready || _tab is null) return;
         _mouse = ToCanvas(e);
-        _tab.HandleInput(new InputEvent.MouseMove(_mouse.X, _mouse.Y));
+        // An active divider drag consumes the move (shared state machine with the desktop
+        // event handler); otherwise the tab gets it for hover / scrollbar handling.
+        if (!PlannerSliderInteraction.HandleMouseMove(_state, _tab.ChartRect, _mouse.X))
+        {
+            _tab.HandleInput(new InputEvent.MouseMove(_mouse.X, _mouse.Y));
+        }
         RenderFrame(); // mouse-follower on the altitude chart
     }
 
@@ -359,6 +472,7 @@
         if (!_ready || _tab is null) return;
         var (x, y) = ToCanvas(e);
         _tab.HandleInput(new InputEvent.MouseUp(x, y));
+        PlannerSliderInteraction.HandleMouseUp(_state);
         RenderFrame();
     }
 

--- a/src/TianWen.UI.Web/Pages/Planner.razor
+++ b/src/TianWen.UI.Web/Pages/Planner.razor
@@ -49,6 +49,11 @@
                      OnReady="OnCanvasReady" OnResized="OnCanvasResized"
                      OnPointerDown="OnPointerDown" OnPointerMove="OnPointerMove"
                      OnPointerUp="OnPointerUp" OnWheel="OnWheel" OnKeyDown="OnKeyDown" />
+        @* A REAL focusable input floated over the active canvas text widget: native IME /
+           clipboard / autocorrect and the mobile soft keyboard, none of which a canvas-drawn
+           widget can provide. Shown/hidden by the ActivateTextInput/DeactivateTextInput flow. *@
+        <CanvasTextOverlay @ref="_textOverlay" Class="canvas-text-input"
+                           OnInput="OnOverlayInput" OnSpecialKey="OnOverlayKey" OnBlurred="OnOverlayBlurred" />
     </div>
 </div>
 
@@ -87,8 +92,15 @@
     bool _busy;
     // Focused canvas text input - the web counterpart of GuiAppState.ActiveTextInput (the
     // desktop tracks it via Activate/DeactivateTextInputSignal + SDL StartTextInput; the
-    // browser needs no platform IME step, so a field suffices).
+    // browser's platform step is the CanvasTextOverlay below).
     TextInputState? _activeInput;
+    // The real HTML <input> floated over the active widget (IME / clipboard / mobile keyboard).
+    CanvasTextOverlay? _textOverlay;
+    // Last CSS rect pushed to the overlay, so the per-frame sync only calls into JS on a move.
+    RectF32 _overlayRect;
+    // Bumped on every overlay Show; the deferred blur handler compares epochs so a blur that
+    // was immediately followed by a re-activation (click from one input to another) is ignored.
+    int _overlayEpoch;
     // Planner search autocomplete candidates; built after catalog init and rebuilt with comet
     // designations once they load (mirrors AppSignalHandler.SetAutoCompleteCache on desktop).
     string[]? _autoComplete;
@@ -403,6 +415,7 @@
         {
             input.SelectAll();
         }
+        ShowOverlayFor(input);
     }
 
     void DeactivateTextInput()
@@ -412,6 +425,131 @@
             active.Deactivate();
         }
         _activeInput = null;
+        if (_textOverlay is { IsVisible: true } overlay)
+        {
+            _tracker.Run(() => overlay.HideAsync().AsTask(), "Hide text overlay");
+        }
+    }
+
+    // The active view's widget as the concrete pixel-widget base, for the region-rect scan
+    // (GetRegisteredRegions is not on the IPixelWidget interface).
+    PixelWidgetBase<WebGlContext>? ActivePixelTab => _view == View.SkyMap ? _skyTab : _tab;
+
+    // The arranged rect of the widget's clickable region, converted backing px -> CSS px
+    // (the overlay positions in CSS space). Null when the widget didn't render this frame.
+    RectF32? FindInputRectCss(TextInputState input)
+    {
+        if (ActivePixelTab is not { } tab)
+        {
+            return null;
+        }
+        foreach (var region in tab.GetRegisteredRegions())
+        {
+            if (region.Result is HitResult.TextInputHit { Input: { } i } && ReferenceEquals(i, input))
+            {
+                var dpr = (float)(_metrics.DevicePixelRatio > 0 ? _metrics.DevicePixelRatio : 1);
+                return new RectF32(region.X / dpr, region.Y / dpr, region.Width / dpr, region.Height / dpr);
+            }
+        }
+        return null;
+    }
+
+    void ShowOverlayFor(TextInputState input)
+    {
+        if (_textOverlay is not { } overlay || FindInputRectCss(input) is not { } r)
+        {
+            return;
+        }
+        _overlayEpoch++;
+        _overlayRect = r;
+        var (text, caret) = (input.Text, input.CursorPos);
+        _tracker.Run(() => overlay.ShowAsync(text, caret, r.X, r.Y, r.Width, r.Height).AsTask(), "Show text overlay");
+    }
+
+    // Called at the end of RenderFrame: the tab re-registers its regions every paint, so a
+    // layout move (panel resize, dropdown reflow) re-anchors the overlay.
+    void SyncOverlayRect()
+    {
+        if (_activeInput is not { IsActive: true } active || _textOverlay is not { IsVisible: true } overlay)
+        {
+            return;
+        }
+        if (FindInputRectCss(active) is not { } r || r.Equals(_overlayRect))
+        {
+            return;
+        }
+        _overlayRect = r;
+        _tracker.Run(() => overlay.SetRectAsync(r.X, r.Y, r.Width, r.Height).AsTask(), "Sync text overlay rect");
+    }
+
+    // --- CanvasTextOverlay callbacks: the browser input owns the text while editing ---------
+
+    Task OnOverlayInput(CanvasOverlayInputArgs e)
+    {
+        if (_activeInput is not { IsActive: true } active)
+        {
+            return Task.CompletedTask;
+        }
+        active.Text = e.Value;
+        active.CursorPos = e.SelectionStart;
+        active.OnTextChanged?.Invoke(active.Text);
+        RenderFrame(); // suggestions dropdown updates under the overlay
+        return Task.CompletedTask;
+    }
+
+    Task OnOverlayKey(CanvasOverlayKeyArgs e)
+    {
+        if (_activeInput is not { IsActive: true } active)
+        {
+            return Task.CompletedTask;
+        }
+        var key = e.Key switch
+        {
+            "ArrowUp" => InputKey.Up,
+            "ArrowDown" => InputKey.Down,
+            "Enter" => InputKey.Enter,
+            "Escape" => InputKey.Escape,
+            "Tab" => InputKey.Tab,
+            _ => InputKey.None,
+        };
+        if (key == InputKey.None)
+        {
+            return Task.CompletedTask;
+        }
+        var mods = (e.Shift ? InputModifier.Shift : 0) | (e.Ctrl ? InputModifier.Ctrl : 0) | (e.Alt ? InputModifier.Alt : 0);
+        var before = active.Text;
+        TextInputInteraction.HandleKey(active, key, mods, new TextInputInteraction.KeyContext(
+            Tracker: _tracker,
+            Deactivate: DeactivateTextInput,
+            SetActive: next => { _activeInput = next; ShowOverlayFor(next); }, // Tab cycling re-anchors
+            RequestRedraw: () => { }, // the RenderFrame below covers this event
+            Planner: _state,
+            SkySearch: _skyTab?.State.Search,
+            ActiveTab: ActiveTab));
+        // A canvas-side rewrite (suggestion committed on Enter) pushes back into the input.
+        if (_activeInput is { IsActive: true } current && ReferenceEquals(current, active) && current.Text != before)
+        {
+            var (text, caret) = (current.Text, current.CursorPos);
+            _tracker.Run(() => _textOverlay is { } o ? o.SetValueAsync(text, caret).AsTask() : Task.CompletedTask,
+                "Sync text overlay value");
+        }
+        RenderFrame();
+        return Task.CompletedTask;
+    }
+
+    async Task OnOverlayBlurred()
+    {
+        // Deferred + epoch-guarded: when focus moves because the user clicked ANOTHER canvas
+        // input, the pointer handler re-shows the overlay (bumping the epoch) around the same
+        // time this blur arrives - deactivating here would kill the new focus. Only a blur that
+        // stays unanswered (tap on the toolbar, browser chrome, page background) deactivates.
+        var epoch = _overlayEpoch;
+        await Task.Delay(100);
+        if (epoch == _overlayEpoch && _activeInput is { IsActive: true })
+        {
+            DeactivateTextInput();
+            RenderFrame();
+        }
     }
 
     // Sky-map F3 search: the tab posts Open/Close/Commit signals; route them to the same shared
@@ -532,6 +670,7 @@
             _tab.Render(_state, content, (float)_metrics.DevicePixelRatio, _fontPath, Time, _mouse, emojiFontPath: null);
         }
         _webGl.Present();
+        SyncOverlayRect(); // regions were re-registered by the Render above
     }
 
     // Active view's widget for generic input routing (both are PixelWidgetBase<WebGlContext>).

--- a/src/TianWen.UI.Web/Program.cs
+++ b/src/TianWen.UI.Web/Program.cs
@@ -21,6 +21,11 @@ builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri(builder.
 builder.Services.AddLogging();
 builder.Services.AddTimeProvider();
 builder.Services.AddSingleton<IExternal, BrowserExternal>();
-builder.Services.AddAstrometry();
+// JPL sends no CORS headers, so the live SBDB API is permanently unreachable from a browser
+// origin. The Pages deploy bakes the SAME query response as a same-origin static asset
+// (comets-sbdb.json, curled in CI) and the comet source fetches that instead - the response
+// shape, parser, and cache layers are all unchanged. On a dev server without the baked file the
+// fetch 404s and the repository degrades to a DSO-only session exactly like the CORS failure did.
+builder.Services.AddAstrometry(cometQueryUri: new Uri(new Uri(builder.HostEnvironment.BaseAddress), "comets-sbdb.json"));
 
 await builder.Build().RunAsync();

--- a/src/TianWen.UI.Web/Program.cs
+++ b/src/TianWen.UI.Web/Program.cs
@@ -1,0 +1,26 @@
+using Microsoft.AspNetCore.Components.Web;
+using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using TianWen.Lib.Devices;
+using TianWen.Lib.Extensions;
+using TianWen.UI.Web.Devices;
+using TianWen.UI.Web.Pages;
+
+var builder = WebAssemblyHostBuilder.CreateDefault(args);
+builder.RootComponents.Add<Planner>("#app");
+builder.RootComponents.Add<HeadOutlet>("head::after");
+
+// The comet repository fetches JPL SBDB over HTTP; the catalog DB is fully embedded. An HttpClient
+// scoped to the app base address covers the wwwroot font fetch at startup and the SBDB call.
+builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri(builder.HostEnvironment.BaseAddress) });
+
+// Minimal browser service graph: the shared clock + a browser IExternal (MEMFS / no serial / no TCP)
+// + astrometry (embedded catalog DB + JPL comet repository). Everything else in the desktop
+// Program.cs (native camera/mount SDKs, serial mounts, ASCOM/Alpaca, session factory) is either
+// inherently non-browser or irrelevant to the planner + atlas.
+builder.Services.AddLogging();
+builder.Services.AddTimeProvider();
+builder.Services.AddSingleton<IExternal, BrowserExternal>();
+builder.Services.AddAstrometry();
+
+await builder.Build().RunAsync();

--- a/src/TianWen.UI.Web/Properties/launchSettings.json
+++ b/src/TianWen.UI.Web/Properties/launchSettings.json
@@ -1,0 +1,12 @@
+{
+  "profiles": {
+    "TianWen.UI.Web": {
+      "commandName": "Project",
+      "launchBrowser": false,
+      "applicationUrl": "http://localhost:5099",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/src/TianWen.UI.Web/SkyMap/WebGlSkyMapPipeline.cs
+++ b/src/TianWen.UI.Web/SkyMap/WebGlSkyMapPipeline.cs
@@ -1,0 +1,542 @@
+using System;
+using System.Runtime.InteropServices;
+using DIR.Lib;
+using TianWen.Lib.Astrometry.Catalogs;
+using TianWen.Lib.Astrometry.SOFA;
+using TianWen.UI.Abstractions;
+using WebGl.Renderer;
+
+namespace TianWen.UI.Web.SkyMap
+{
+    /// <summary>
+    /// WebGL2 sky-map pipeline over WebGl.Renderer 1.3's custom-pipeline seam - the browser
+    /// mirror of <c>VkSkyMapPipeline</c> (TianWen.UI.Shared). Stars are instanced quads from a
+    /// persistent buffer of J2000 unit vectors (the HR/HIP bright-star seed: the Lightweight
+    /// build has no Tycho-2); lines (constellation figures/boundaries, grid, ecliptic, horizon,
+    /// meridian, Alt/Az) share one LINES pipeline with a per-draw uColor. All geometry comes
+    /// from the shared <see cref="SkyMapGpuGeometry"/> builders; the per-frame view state is the
+    /// shared 112-byte <see cref="SkyMapUbo"/> block - pan/zoom re-uploads only that.
+    ///
+    /// <para>Shader delta vs the Vulkan sources (transcribed, ASCII-only per the GLSL rule):
+    /// GLSL ES 3.00, the push-constant color becomes <c>uniform vec4 uColor</c>, and the final
+    /// NDC mapping negates Y (GL NDC Y is up; screen + Vulkan NDC Y are down). The web map draws
+    /// full-canvas, so viewportCenter == canvas centre and viewportSize == canvas size.</para>
+    /// </summary>
+    internal sealed class WebGlSkyMapPipeline
+    {
+        private const string ProjectionGlsl = """
+            // Stereographic projection: camera-space unit vector to screen pixel position.
+            // Returns vec3(screenX, screenY, cosD) where cosD <= -0.99 means antipode.
+            vec3 stereoProject(vec3 camPos) {
+                float cosD = -camPos.z;  // camera looks along -Z
+                if (cosD <= -0.99) return vec3(0.0, 0.0, -2.0);
+                float k = 2.0 / (1.0 + cosD);
+                float sx = viewportCenter.x + camPos.x * k * pixelsPerRadian;
+                float sy = viewportCenter.y - camPos.y * k * pixelsPerRadian;
+                return vec3(sx, sy, cosD);
+            }
+            """;
+
+        private const string UboGlsl = """
+            layout(std140) uniform SkyMapUBO {
+                mat4  viewMatrix;
+                vec2  viewportCenter;
+                float pixelsPerRadian;
+                float magnitudeLimit;
+                float fovDeg;
+                float sinLat;
+                vec2  viewportSize;
+                float cosLat;
+                float sinLST;
+                float cosLST;
+                int   horizonClip;
+            };
+            """;
+
+        private static readonly string StarVertexSource = $$"""
+            #version 300 es
+            precision highp float;
+            precision highp int;
+
+            layout(location = 0) in vec2 aCorner;      // per-vertex quad corner (-1,-1)..(1,1)
+            layout(location = 1) in vec3 aUnitPos;     // per-instance J2000 unit vector
+            layout(location = 2) in float aMagnitude;  // per-instance
+            layout(location = 3) in float aBvColor;    // per-instance
+
+            {{UboGlsl}}
+
+            out vec2 vCorner;
+            out vec3 vColor;
+            out float vAlpha;
+
+            {{ProjectionGlsl}}
+
+            // B-V color index to approximate RGB (piecewise linear, matches SkyMapProjection.StarColor)
+            vec3 bvToRgb(float bv) {
+                bv = clamp(bv, -0.4, 2.0);
+                if (bv < 0.0) {
+                    float t = (bv + 0.4) / 0.4;
+                    return vec3(155.0 + 100.0 * t, 175.0 + 80.0 * t, 255.0) / 255.0;
+                } else if (bv < 0.4) {
+                    float t = bv / 0.4;
+                    return vec3(255.0, 255.0 - 25.0 * t, 255.0 - 55.0 * t) / 255.0;
+                } else if (bv < 0.8) {
+                    float t = (bv - 0.4) / 0.4;
+                    return vec3(255.0, 230.0 - 40.0 * t, 200.0 - 80.0 * t) / 255.0;
+                } else if (bv < 1.2) {
+                    float t = (bv - 0.8) / 0.4;
+                    return vec3(255.0, 190.0 - 50.0 * t, 120.0 - 60.0 * t) / 255.0;
+                } else {
+                    float t = min((bv - 1.2) / 0.8, 1.0);
+                    return vec3(255.0, 140.0 - 40.0 * t, 60.0 - 40.0 * t) / 255.0;
+                }
+            }
+
+            float rawStarRadius(float vMag, float fov) {
+                float r = 4.0 * pow(10.0, -0.14 * vMag);
+                float zoomScale = sqrt(60.0 / max(1.0, fov));
+                return min(r * zoomScale, 15.0);
+            }
+
+            void main() {
+                if (aMagnitude > magnitudeLimit) {
+                    gl_Position = vec4(0.0, 0.0, 0.0, 0.0);
+                    return;
+                }
+
+                if (horizonClip != 0) {
+                    float sinAlt = sinLat * aUnitPos.z
+                        + cosLat * (cosLST * aUnitPos.x + sinLST * aUnitPos.y);
+                    if (sinAlt < 0.0) {
+                        gl_Position = vec4(0.0, 0.0, 0.0, 0.0);
+                        return;
+                    }
+                }
+
+                vec3 camPos = (viewMatrix * vec4(aUnitPos, 1.0)).xyz;
+                vec3 proj = stereoProject(camPos);
+                if (proj.z <= -0.99) {
+                    gl_Position = vec4(0.0, 0.0, 0.0, 0.0);
+                    return;
+                }
+
+                float rawR = rawStarRadius(aMagnitude, fovDeg);
+                float kMin = 1.0;
+                float subPixelFade = clamp(rawR / kMin, 0.35, 1.0);
+                float radius = max(rawR, kMin);
+
+                float magFadeWidth = 0.8;
+                float magFade = clamp((magnitudeLimit - aMagnitude) / magFadeWidth, 0.0, 1.0);
+
+                vec2 screenPos = proj.xy + aCorner * (radius + 3.0);
+
+                // Window-absolute pixels -> GL NDC (Y negated vs the Vulkan shader: GL NDC Y is
+                // up; the web map draws full-canvas so viewportCenter/Size describe the canvas).
+                gl_Position = vec4(
+                    (screenPos.x - viewportCenter.x) / (viewportSize.x * 0.5),
+                    -(screenPos.y - viewportCenter.y) / (viewportSize.y * 0.5),
+                    0.0, 1.0);
+
+                vCorner = aCorner;
+                vColor = bvToRgb(aBvColor);
+
+                float brightness = clamp(1.0 - aMagnitude / magnitudeLimit, 0.0, 1.0);
+                vAlpha = (0.75 + 0.25 * brightness) * subPixelFade * magFade;
+            }
+            """;
+
+        private const string StarFragmentSource = """
+            #version 300 es
+            precision highp float;
+            precision highp int;
+
+            in vec2 vCorner;
+            in vec3 vColor;
+            in float vAlpha;
+
+            out vec4 FragColor;
+
+            void main() {
+                float dist = length(vCorner);
+                // Analytic PSF - flat core + Gaussian-like halo (see the Vulkan source's tuning notes).
+                float core  = 1.0 - smoothstep(0.32, 0.55, dist);
+                float halo  = exp(-dist * dist * 3.2);
+                float alpha = max(core, halo);
+                if (alpha < 0.005) discard;
+
+                FragColor = vec4(vColor * alpha * vAlpha, alpha * vAlpha);
+            }
+            """;
+
+        private static readonly string LineVertexSource = $$"""
+            #version 300 es
+            precision highp float;
+            precision highp int;
+
+            layout(location = 0) in vec3 aUnitPos;
+
+            {{UboGlsl}}
+
+            uniform vec4 uColor;  // the push-constant color analog
+
+            out vec4 vColor;
+
+            {{ProjectionGlsl}}
+
+            void main() {
+                vec3 camPos = (viewMatrix * vec4(aUnitPos, 1.0)).xyz;
+                vec3 proj = stereoProject(camPos);
+                if (proj.z <= -0.99) {
+                    gl_Position = vec4(2.0, 2.0, 0.0, 1.0);
+                    vColor = vec4(0.0);
+                    return;
+                }
+
+                gl_Position = vec4(
+                    (proj.x - viewportCenter.x) / (viewportSize.x * 0.5),
+                    -(proj.y - viewportCenter.y) / (viewportSize.y * 0.5),
+                    0.0, 1.0);
+                vColor = uColor;
+            }
+            """;
+
+        private const string LineFragmentSource = """
+            #version 300 es
+            precision highp float;
+            precision highp int;
+
+            in vec4 vColor;
+            out vec4 FragColor;
+
+            void main() {
+                FragColor = vColor;
+            }
+            """;
+
+        // Horizon ground shading: an attributeless full-screen pass (gl_VertexID generates the
+        // quad; no vertex data consumed) whose FS inverse-stereographic-projects each pixel and
+        // tints below-horizon directions with depth-scaled alpha - the port of the Vulkan
+        // HorizonFill pipeline (gl_VertexIndex -> gl_VertexID; NDC Y flipped for GL).
+        private static readonly string HorizonFillVertexSource = $$"""
+            #version 300 es
+            precision highp float;
+            precision highp int;
+
+            {{UboGlsl}}
+
+            out vec2 vScreenPos;
+
+            void main() {
+                vec2 pos;
+                if (gl_VertexID == 0)      pos = vec2(0.0, 0.0);
+                else if (gl_VertexID == 1) pos = vec2(viewportSize.x, 0.0);
+                else if (gl_VertexID == 2) pos = vec2(0.0, viewportSize.y);
+                else if (gl_VertexID == 3) pos = vec2(viewportSize.x, 0.0);
+                else if (gl_VertexID == 4) pos = vec2(viewportSize.x, viewportSize.y);
+                else                       pos = vec2(0.0, viewportSize.y);
+
+                // Screen-pixel position for the fragment shader (window-absolute, top-left origin).
+                vScreenPos = pos + vec2(viewportCenter.x - viewportSize.x * 0.5,
+                                        viewportCenter.y - viewportSize.y * 0.5);
+
+                // Map to NDC - GL Y up, so the top of the screen (pos.y = 0) is +1.
+                gl_Position = vec4(
+                    pos.x / viewportSize.x * 2.0 - 1.0,
+                    1.0 - pos.y / viewportSize.y * 2.0,
+                    0.0, 1.0);
+            }
+            """;
+
+        private static readonly string HorizonFillFragmentSource = $$"""
+            #version 300 es
+            precision highp float;
+            precision highp int;
+
+            {{UboGlsl}}
+
+            in vec2 vScreenPos;
+            out vec4 FragColor;
+
+            void main() {
+                // Inverse stereographic projection: screen pixel -> camera-space unit vector
+                float x = (vScreenPos.x - viewportCenter.x) / pixelsPerRadian;
+                float y = -(vScreenPos.y - viewportCenter.y) / pixelsPerRadian;
+
+                // Warm earthy-brown tint for the below-horizon region. Mixed on top of
+                // the sky background with depth-scaled alpha so pixels just below the
+                // horizon are lightly hazed, and pixels deep below are mostly ground.
+                vec3 groundTint = vec3(0.18, 0.11, 0.06);
+
+                float rho = length(vec2(x, y));
+                if (rho < 0.00001) {
+                    vec3 j2000 = transpose(mat3(viewMatrix)) * vec3(0.0, 0.0, -1.0);
+                    float sinAlt = sinLat * j2000.z
+                        + cosLat * (cosLST * j2000.x + sinLST * j2000.y);
+                    if (sinAlt >= 0.0) discard;
+                    FragColor = vec4(groundTint, 0.85);
+                    return;
+                }
+
+                float c = 2.0 * atan(rho * 0.5);
+                float sinC = sin(c);
+                float cosC = cos(c);
+
+                // Camera-space unit vector
+                vec3 camDir = vec3(
+                    sinC * x / rho,
+                    sinC * y / rho,
+                    -cosC
+                );
+
+                // Rotate back to J2000 (view matrix is orthogonal, inverse = transpose)
+                vec3 j2000 = transpose(mat3(viewMatrix)) * camDir;
+
+                float sinAlt = sinLat * j2000.z
+                    + cosLat * (cosLST * j2000.x + sinLST * j2000.y);
+
+                if (sinAlt >= 0.0) discard;
+
+                // Fade from 0.45 at horizon to 0.88 at -10 degrees (sin(10deg) ~ 0.17)
+                float depth = clamp(-sinAlt / 0.17, 0.0, 1.0);
+                float alpha = 0.45 + 0.43 * depth;
+                FragColor = vec4(groundTint, alpha);
+            }
+            """;
+
+        // Line colors mirror VkSkyMapPipeline.Draw's PushLineColor constants.
+        private static readonly RGBAColor32 GridColor = new(0x30, 0x60, 0xA0, 0x70);
+        private static readonly RGBAColor32 AltAzColor = new(0x80, 0xA0, 0x30, 0x80);
+        private static readonly RGBAColor32 MeridianColor = new(0x30, 0xDD, 0x30, 0xA0);
+        private static readonly RGBAColor32 EclipticColor = new(0xE0, 0xC0, 0x40, 0xB0);
+        private static readonly RGBAColor32 BoundaryColor = new(0xAA, 0x44, 0x44, 0x80);
+        private static readonly RGBAColor32 FigureColor = new(0x40, 0x80, 0xDD, 0x90);
+        private static readonly RGBAColor32 HorizonColor = new(0x80, 0x40, 0x20, 0xFF);
+
+        private readonly WebGlRenderer _renderer;
+        private readonly PipelineHandle _starPipeline;
+        private readonly PipelineHandle _linePipeline;
+        private readonly PipelineHandle _horizonFillPipeline;
+
+        private bool _geometryBuilt;
+        private GpuBufferHandle _cornerQuad;
+        private GpuBufferHandle _stars;
+        private int _starCount;
+        private GpuBufferHandle _figures;
+        private int _figureVertexCount;
+        private GpuBufferHandle _boundaries;
+        private int _boundaryVertexCount;
+        private GpuBufferHandle _ecliptic;
+        private int _eclipticVertexCount;
+        private readonly (GpuBufferHandle Buffer, int VertexCount)[] _grids
+            = new (GpuBufferHandle, int)[SkyMapGpuGeometry.GridScales.Length];
+
+        // Site/time-dependent line sets, rebuilt only when their inputs move (render is
+        // event-driven; an idle frame re-uploads nothing).
+        private GpuBufferHandle _horizon;
+        private int _horizonVertexCount = -1;
+        private GpuBufferHandle _meridianAltAz;
+        private int _meridianAltAzVertexCount = -1;
+        private double _dynamicLstKey = double.NaN;
+        private double _dynamicLatKey = double.NaN;
+
+        public WebGlSkyMapPipeline(WebGlRenderer renderer)
+        {
+            _renderer = renderer;
+            _starPipeline = renderer.RegisterPipeline(new CustomPipelineDescriptor(
+                StarVertexSource, StarFragmentSource,
+                Attribs:
+                [
+                    new VertexAttrib(0, 2),
+                    new VertexAttrib(1, 3, PerInstance: true),
+                    new VertexAttrib(2, 1, PerInstance: true),
+                    new VertexAttrib(3, 1, PerInstance: true),
+                ],
+                Blend: PipelineBlend.Additive,
+                UniformBlockName: "SkyMapUBO"));
+            _linePipeline = renderer.RegisterPipeline(new CustomPipelineDescriptor(
+                LineVertexSource, LineFragmentSource,
+                Attribs: [new VertexAttrib(0, 3)],
+                Topology: PipelineTopology.Lines,
+                UniformBlockName: "SkyMapUBO"));
+            // Attributeless (gl_VertexID) - the empty layout means DrawBuffer enables nothing.
+            _horizonFillPipeline = renderer.RegisterPipeline(new CustomPipelineDescriptor(
+                HorizonFillVertexSource, HorizonFillFragmentSource,
+                Attribs: [],
+                UniformBlockName: "SkyMapUBO"));
+        }
+
+        /// <summary>Builds the persistent static geometry once (bright stars + figures +
+        /// boundaries + grid scales + ecliptic). Cheap no-op afterwards.</summary>
+        public void EnsureGeometry(ICelestialObjectDB db)
+        {
+            if (_geometryBuilt)
+            {
+                return;
+            }
+
+            // Unit quad corners as two triangles (per-vertex stream of the instanced star draw).
+            _cornerQuad = _renderer.CreateBuffer([-1f, -1f, 1f, -1f, 1f, 1f, -1f, -1f, 1f, 1f, -1f, 1f]);
+
+            // The HR bright-star catalog is the browser star field (~9k naked-eye stars; the
+            // Lightweight build has no Tycho-2, and HR needs no HIP cross-identity resolution).
+            var stars = SkyMapGpuGeometry.BuildHrStarInstances(db);
+            _starCount = stars.Count / SkyMapState.FloatsPerStar;
+            _stars = _renderer.CreateBuffer(CollectionsMarshal.AsSpan(stars));
+
+            var figures = SkyMapGpuGeometry.BuildConstellationFigureLines(db);
+            _figureVertexCount = figures.Count / 3;
+            _figures = _renderer.CreateBuffer(CollectionsMarshal.AsSpan(figures));
+
+            var boundaries = SkyMapGpuGeometry.BuildConstellationBoundaryLines();
+            _boundaryVertexCount = boundaries.Count / 3;
+            _boundaries = _renderer.CreateBuffer(CollectionsMarshal.AsSpan(boundaries));
+
+            var ecliptic = SkyMapGpuGeometry.BuildEclipticLine();
+            _eclipticVertexCount = ecliptic.Count / 3;
+            _ecliptic = _renderer.CreateBuffer(CollectionsMarshal.AsSpan(ecliptic));
+
+            for (var i = 0; i < _grids.Length; i++)
+            {
+                var grid = SkyMapGpuGeometry.BuildGridLines(i);
+                _grids[i] = (_renderer.CreateBuffer(CollectionsMarshal.AsSpan(grid)), grid.Count / 3);
+            }
+
+            Console.WriteLine(
+                $"[tianwen-web] sky geometry: {_starCount} HR stars, {_figureVertexCount / 2} figure segments, "
+                + $"{_boundaryVertexCount / 2} boundary segments, buffers star={_stars.Id} corner={_cornerQuad.Id}");
+            _geometryBuilt = true;
+        }
+
+        /// <summary>Uploads the shared 112-byte view block to both pipelines (each has its own
+        /// UBO binding point) and refreshes the site/time-dependent line sets when LST/latitude
+        /// moved. Call once per frame before <see cref="Draw"/>.</summary>
+        public void UpdateFrame(SkyMapState state, float canvasWidth, float canvasHeight, SiteContext site)
+        {
+            Span<byte> block = stackalloc byte[SkyMapUbo.Size];
+            SkyMapUbo.Write(block, state, canvasWidth, canvasHeight, offsetX: 0f, offsetY: 0f, site);
+            _renderer.SetUniformBlock(_starPipeline, block);
+            _renderer.SetUniformBlock(_linePipeline, block);
+            _renderer.SetUniformBlock(_horizonFillPipeline, block);
+
+            // Horizon + meridian + Alt/Az geometry depends on (LST, latitude). LST moves ~15
+            // arcsec/s of RA; a 30-second bucket keeps the lines visually glued to real time
+            // while idle frames (pan/zoom bursts) re-upload nothing.
+            var lstKey = site.IsValid ? Math.Round(site.LST * 120.0) / 120.0 : 0.0;
+            var latKey = site.IsValid ? site.SinLat : 0.0;
+            if (lstKey == _dynamicLstKey && latKey == _dynamicLatKey)
+            {
+                return;
+            }
+            _dynamicLstKey = lstKey;
+            _dynamicLatKey = latKey;
+
+            var horizon = new System.Collections.Generic.List<float>(768);
+            SkyMapGpuGeometry.BuildHorizonLine(site, horizon);
+            var horizonSpan = CollectionsMarshal.AsSpan(horizon);
+            if (_horizonVertexCount < 0)
+            {
+                _horizon = _renderer.CreateBuffer(horizonSpan);
+            }
+            else
+            {
+                _renderer.UpdateBuffer(_horizon, horizonSpan);
+            }
+            _horizonVertexCount = horizon.Count / 3;
+
+            // Meridian + Alt/Az share one dynamic buffer: [meridian | altAz] with draw offsets.
+            var dyn = new System.Collections.Generic.List<float>(8192);
+            SkyMapGpuGeometry.BuildMeridianLine(site.IsValid ? site.LST : 0.0, dyn);
+            var meridianFloats = dyn.Count;
+            SkyMapGpuGeometry.BuildAltAzGrid(site, dyn);
+            var dynSpan = CollectionsMarshal.AsSpan(dyn);
+            if (_meridianAltAzVertexCount < 0)
+            {
+                _meridianAltAz = _renderer.CreateBuffer(dynSpan);
+            }
+            else
+            {
+                _renderer.UpdateBuffer(_meridianAltAz, dynSpan);
+            }
+            _meridianVertexCount = meridianFloats / 3;
+            _meridianAltAzVertexCount = dyn.Count / 3;
+        }
+
+        private int _meridianVertexCount;
+
+        /// <summary>Records the frame's sky draws: lines back-to-front (grid, Alt/Az, meridian,
+        /// ecliptic, boundaries, figures, horizon), then the instanced star field on top.</summary>
+        public void Draw(SkyMapState state, SiteContext site)
+        {
+            if (!_geometryBuilt)
+            {
+                return;
+            }
+
+            // Ground shading first, so lines/stars draw on top of it (the desktop order).
+            if (state.ShowHorizon && site.IsValid)
+            {
+                _renderer.UsePipeline(_horizonFillPipeline);
+                // The buffer satisfies the record's slot; the attributeless pipeline reads none of it.
+                _renderer.DrawBuffer(_cornerQuad, 0, 6);
+            }
+
+            _renderer.UsePipeline(_linePipeline);
+
+            if (state.ShowGrid)
+            {
+                var fov = state.FieldOfViewDeg;
+                for (var i = 0; i < _grids.Length; i++)
+                {
+                    var (_, _, minFov, maxFov) = SkyMapGpuGeometry.GridScales[i];
+                    if (fov >= minFov && fov <= maxFov && _grids[i].VertexCount > 0)
+                    {
+                        _renderer.SetPipelineColor(GridColor);
+                        _renderer.DrawBuffer(_grids[i].Buffer, 0, _grids[i].VertexCount);
+                    }
+                }
+            }
+
+            if (state.ShowAltAzGrid && site.IsValid && _meridianAltAzVertexCount > _meridianVertexCount)
+            {
+                _renderer.SetPipelineColor(AltAzColor);
+                _renderer.DrawBuffer(_meridianAltAz, _meridianVertexCount, _meridianAltAzVertexCount - _meridianVertexCount);
+            }
+
+            if (site.IsValid && _meridianVertexCount > 0)
+            {
+                _renderer.SetPipelineColor(MeridianColor);
+                _renderer.DrawBuffer(_meridianAltAz, 0, _meridianVertexCount);
+            }
+
+            if (_eclipticVertexCount > 0)
+            {
+                _renderer.SetPipelineColor(EclipticColor);
+                _renderer.DrawBuffer(_ecliptic, 0, _eclipticVertexCount);
+            }
+
+            if (state.ShowConstellationBoundaries && _boundaryVertexCount > 0)
+            {
+                _renderer.SetPipelineColor(BoundaryColor);
+                _renderer.DrawBuffer(_boundaries, 0, _boundaryVertexCount);
+            }
+
+            if (state.ShowConstellationFigures && _figureVertexCount > 0)
+            {
+                _renderer.SetPipelineColor(FigureColor);
+                _renderer.DrawBuffer(_figures, 0, _figureVertexCount);
+            }
+
+            if (state.ShowHorizon && _horizonVertexCount > 0)
+            {
+                _renderer.SetPipelineColor(HorizonColor);
+                _renderer.DrawBuffer(_horizon, 0, _horizonVertexCount);
+            }
+
+            if (_starCount > 0)
+            {
+                _renderer.UsePipeline(_starPipeline);
+                _renderer.DrawInstanced(_cornerQuad, 6, _stars, _starCount);
+            }
+        }
+    }
+}

--- a/src/TianWen.UI.Web/SkyMap/WebSkyMapTab.cs
+++ b/src/TianWen.UI.Web/SkyMap/WebSkyMapTab.cs
@@ -1,0 +1,34 @@
+using TianWen.Lib.Astrometry.Catalogs;
+using TianWen.Lib.Astrometry.SOFA;
+using TianWen.UI.Abstractions;
+using DIR.Lib;
+using WebGl.Renderer;
+
+namespace TianWen.UI.Web.SkyMap
+{
+    /// <summary>
+    /// The browser sky map: <see cref="SkyMapTab{TSurface}"/> (all labels, search, info panel,
+    /// input, planet/comet markers - drawn via the generic renderer primitives) over
+    /// <see cref="WebGlSkyMapPipeline"/> for the GPU star field + line work, mirroring
+    /// VkSkyMapTab's split on desktop. v1 scope: stars (HR/HIP bright seed) + lines; the
+    /// object-overlay / mount / schedule-marker hooks stay at their no-op base until needed.
+    /// </summary>
+    internal sealed class WebSkyMapTab(WebGlRenderer renderer) : SkyMapTab<WebGlContext>(renderer)
+    {
+        private readonly WebGlSkyMapPipeline _pipeline = new(renderer);
+
+        protected override void RenderSkyMap(
+            ICelestialObjectDB db, RectF32 contentRect, string fontPath,
+            System.DateTimeOffset viewingTime, double siteLat, double siteLon, SiteContext site)
+        {
+            // Sun-altitude-tinted sky background (the base implementation).
+            base.RenderSkyMap(db, contentRect, fontPath, viewingTime, siteLat, siteLon, site);
+
+            _pipeline.EnsureGeometry(db);
+            // The web map draws full-canvas: viewport == canvas == contentRect (the razor host
+            // hands the whole drawing buffer to the active tab).
+            _pipeline.UpdateFrame(State, contentRect.Width, contentRect.Height, site);
+            _pipeline.Draw(State, site);
+        }
+    }
+}

--- a/src/TianWen.UI.Web/TianWen.UI.Web.csproj
+++ b/src/TianWen.UI.Web/TianWen.UI.Web.csproj
@@ -52,7 +52,7 @@
     <ProjectReference Include="..\..\..\WebGl.Renderer\src\WebGl.Renderer\WebGl.Renderer.csproj" />
   </ItemGroup>
   <ItemGroup Condition="'$(UseLocalSiblings)' != 'true'">
-    <PackageReference Include="WebGl.Renderer" Version="1.0.*" />
+    <PackageReference Include="WebGl.Renderer" Version="1.2.*" />
   </ItemGroup>
 
 

--- a/src/TianWen.UI.Web/TianWen.UI.Web.csproj
+++ b/src/TianWen.UI.Web/TianWen.UI.Web.csproj
@@ -1,0 +1,59 @@
+<Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <OverrideHtmlAssetPlaceholders>true</OverrideHtmlAssetPlaceholders>
+    <!-- The in-browser app is a consumer of TianWen.Lib / TianWen.UI.Abstractions, not a shipped
+         package and not part of the desktop test/release chain. It lives OUTSIDE TianWen.slnx and
+         opts out of Central Package Management so the Blazor deps carry their own versions without
+         touching Directory.Packages.props. Mirrors ../../sebgod/chess/Chess.Web. -->
+    <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
+    <IsPackable>false</IsPackable>
+    <!-- No culture data needed; dropping ICU trims the payload. Site timezone resolves via the
+         bundled wasm tzdata (TimeZoneInfo), which is independent of ICU; the planner falls back to
+         UTC if a zone id cannot be resolved (Transform.TryGetSiteTimeZone). -->
+    <InvariantGlobalization>true</InvariantGlobalization>
+    <!-- Default (full) trimming: TianWen.Lib is IsTrimmable + IsAotCompatible (the native binaries
+         already publish AOT), and embedded catalog resources survive trimming regardless (they are
+         resources, not IL), so the catalog DB + planner load fine under a trimmed build - no
+         TrimmerRootAssembly rooting needed. Keeps the WASM download small. -->
+    <!-- This is a lightweight build: the ~30 MB Tycho-2 catalog is dropped via the GLOBAL publish
+         property -p:Lightweight=true (see TianWen.Lib.csproj) - the pages.yml deploy passes it, same
+         slot as -p:UseLocalSiblings=false. A property set HERE would not flow across the
+         ProjectReference into TianWen.Lib's own build, so it must ride the publish command line. -->
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.9" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.9" PrivateAssets="all" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\TianWen.UI.Abstractions\TianWen.UI.Abstractions.csproj" />
+  </ItemGroup>
+
+  <!-- AOT (RunAOTCompilation=true on the deploy publish): the mono AOT cross-compiler fail-fasts
+       (sgen assertion, 0xC0000409) on these P/Invoke-dense vendor SDK assemblies - and they are
+       dead weight in a browser anyway (no native device I/O). Keep them interpreted; the rest of
+       the app AOTs. Item identity must be the .dll name so MSBuild's %(Filename) batching matches
+       the aot-in file names. Why the trimmer keeps them in the bundle at all is a tracked
+       follow-up - once they trim away, this list can go. -->
+  <ItemGroup>
+    <_AOT_InternalForceInterpretAssemblies Include="ZWOptical.SDK.dll" />
+    <_AOT_InternalForceInterpretAssemblies Include="QHYCCD.SDK.dll" />
+    <_AOT_InternalForceInterpretAssemblies Include="LibUsbDotNet.LibUsbDotNet.dll" />
+  </ItemGroup>
+
+  <!-- WebGL backend: sibling working copy for local iteration, NuGet in CI (same UseLocalSiblings
+       switch the desktop projects use; the web project opts out of CPM so the version rides inline). -->
+  <ItemGroup Condition="'$(UseLocalSiblings)' == 'true'">
+    <ProjectReference Include="..\..\..\WebGl.Renderer\src\WebGl.Renderer\WebGl.Renderer.csproj" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(UseLocalSiblings)' != 'true'">
+    <PackageReference Include="WebGl.Renderer" Version="1.0.*" />
+  </ItemGroup>
+
+
+</Project>

--- a/src/TianWen.UI.Web/TianWen.UI.Web.csproj
+++ b/src/TianWen.UI.Web/TianWen.UI.Web.csproj
@@ -52,7 +52,7 @@
     <ProjectReference Include="..\..\..\WebGl.Renderer\src\WebGl.Renderer\WebGl.Renderer.csproj" />
   </ItemGroup>
   <ItemGroup Condition="'$(UseLocalSiblings)' != 'true'">
-    <PackageReference Include="WebGl.Renderer" Version="1.2.*" />
+    <PackageReference Include="WebGl.Renderer" Version="1.3.*" />
   </ItemGroup>
 
 

--- a/src/TianWen.UI.Web/TianWen.UI.Web.csproj
+++ b/src/TianWen.UI.Web/TianWen.UI.Web.csproj
@@ -52,7 +52,7 @@
     <ProjectReference Include="..\..\..\WebGl.Renderer\src\WebGl.Renderer\WebGl.Renderer.csproj" />
   </ItemGroup>
   <ItemGroup Condition="'$(UseLocalSiblings)' != 'true'">
-    <PackageReference Include="WebGl.Renderer" Version="1.3.*" />
+    <PackageReference Include="WebGl.Renderer" Version="1.4.*" />
   </ItemGroup>
 
 

--- a/src/TianWen.UI.Web/_Imports.razor
+++ b/src/TianWen.UI.Web/_Imports.razor
@@ -1,0 +1,6 @@
+@using System.Threading.Tasks
+@using Microsoft.AspNetCore.Components
+@using Microsoft.AspNetCore.Components.Web
+@using Microsoft.JSInterop
+@using TianWen.UI.Web
+@using TianWen.UI.Web.Pages

--- a/src/TianWen.UI.Web/wwwroot/Fonts/DejaVuSans.ttf
+++ b/src/TianWen.UI.Web/wwwroot/Fonts/DejaVuSans.ttf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7da195a74c55bef988d0d48f9508bd5d849425c1770dba5d7bfc6ce9ed848954
+size 757076

--- a/src/TianWen.UI.Web/wwwroot/css/app.css
+++ b/src/TianWen.UI.Web/wwwroot/css/app.css
@@ -130,10 +130,26 @@ button.chip:disabled {
 }
 
 /* The planner surface fills everything below the chrome. The canvas element is sized by CSS;
-   the drawing buffer is set to element-size x devicePixelRatio from the app (hi-dpi crisp). */
+   the drawing buffer is set to element-size x devicePixelRatio from the app (hi-dpi crisp).
+   position:relative anchors the CanvasTextOverlay input, which is absolutely positioned over
+   the active canvas text widget's rect. */
 .canvas-host {
     flex: 1;
     min-height: 0;
+    position: relative;
+}
+
+/* The CanvasTextOverlay input - a real focusable <input> covering the active canvas text
+   widget (native IME / clipboard / mobile keyboard). Styled to sit flush with the dark canvas
+   chrome; mechanics (absolute positioning, show/hide) are inline in the component. */
+.canvas-text-input {
+    background: var(--bg);
+    color: var(--text);
+    border: 1px solid var(--accent);
+    border-radius: 2px;
+    padding: 0 6px;
+    font-family: system-ui, "Segoe UI", Roboto, sans-serif;
+    outline: none;
 }
 
 canvas {

--- a/src/TianWen.UI.Web/wwwroot/css/app.css
+++ b/src/TianWen.UI.Web/wwwroot/css/app.css
@@ -1,0 +1,162 @@
+/* Chrome styled after the desktop SDL GUI: dark slate panels (#1a1a22 header, #101018 content),
+   teal accent (#66ddcc - the GUI's pinned-target colour), minimal text. The app is a fixed
+   full-viewport layout like a native window: no page scroll, no overscroll bounce, no text
+   selection dragging the document around while interacting with the canvas. */
+:root {
+    color-scheme: dark;
+    --bg: #101018;
+    --chrome: #1a1a22;
+    --border: #26263a;
+    --text: #dddddd;
+    --dim: #9a9aab;
+    --accent: #66ddcc;
+}
+
+* { box-sizing: border-box; }
+
+html, body {
+    margin: 0;
+    height: 100%;
+    overflow: hidden;            /* the app IS the window - never scroll the document */
+    overscroll-behavior: none;   /* no rubber-band bounce when drags hit the edge */
+    background: var(--bg);
+    color: var(--text);
+    font-family: system-ui, "Segoe UI", Roboto, sans-serif;
+}
+
+#app { height: 100%; }
+
+.app {
+    height: 100vh;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+}
+
+/* Title bar - mirrors the desktop window chrome. */
+.titlebar {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    background: var(--chrome);
+    border-bottom: 1px solid var(--border);
+    padding: 8px 14px;
+    flex: none;
+}
+
+.titlebar .title {
+    font-size: 1.05rem;
+    font-weight: 600;
+    letter-spacing: 0.02em;
+}
+
+.titlebar .subtitle {
+    color: var(--accent);
+    font-size: 0.85rem;
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    padding: 1px 8px;
+}
+
+.titlebar .spacer { flex: 1; }
+
+.titlebar .status {
+    color: var(--dim);
+    font-size: 0.85rem;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+/* Toolbar - site entry + recompute, styled like a GUI panel row. */
+.toolbar {
+    display: flex;
+    gap: 14px;
+    align-items: center;
+    flex-wrap: wrap;
+    background: var(--chrome);
+    border-bottom: 1px solid var(--border);
+    padding: 6px 14px;
+    flex: none;
+}
+
+.toolbar label {
+    color: var(--dim);
+    font-size: 0.85rem;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+}
+
+.toolbar input {
+    width: 6.5rem;
+    background: var(--bg);
+    color: var(--text);
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    padding: 4px 6px;
+    font-size: 0.85rem;
+}
+
+.toolbar button {
+    background: var(--bg);
+    color: var(--text);
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    padding: 4px 14px;
+    font-size: 0.85rem;
+    cursor: pointer;
+}
+
+.toolbar button:hover:not(:disabled) { border-color: var(--accent); color: var(--accent); }
+.toolbar button:disabled { opacity: 0.5; cursor: default; }
+
+/* The planner surface fills everything below the chrome. The canvas element is sized by CSS;
+   the drawing buffer is set to element-size x devicePixelRatio from the app (hi-dpi crisp). */
+.canvas-host {
+    flex: 1;
+    min-height: 0;
+}
+
+canvas {
+    display: block;
+    width: 100%;
+    height: 100%;
+    background: var(--bg);
+    user-select: none;        /* a list-drag must never start a document text selection */
+    touch-action: none;       /* pointer gestures belong to the app, not the browser */
+    outline: none;            /* focus ring off - the canvas is the whole workspace */
+}
+
+/* Boot splash shown until Blazor mounts the app. */
+.boot {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    height: 100vh;
+    gap: 16px;
+    color: var(--dim);
+}
+
+.boot-spinner {
+    width: 36px;
+    height: 36px;
+    border: 3px solid var(--border);
+    border-top-color: var(--accent);
+    border-radius: 50%;
+    animation: spin 0.9s linear infinite;
+}
+
+@keyframes spin { to { transform: rotate(360deg); } }
+
+#blazor-error-ui {
+    display: none;
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    padding: 10px 16px;
+    background: #7a1f1f;
+    color: #fff;
+}

--- a/src/TianWen.UI.Web/wwwroot/css/app.css
+++ b/src/TianWen.UI.Web/wwwroot/css/app.css
@@ -111,6 +111,24 @@ html, body {
 .toolbar button:hover:not(:disabled) { border-color: var(--accent); color: var(--accent); }
 .toolbar button:disabled { opacity: 0.5; cursor: default; }
 
+/* View-switcher chips in the titlebar (Planner / Sky Map). */
+button.chip {
+    background: transparent;
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    padding: 2px 10px;
+    cursor: pointer;
+}
+
+button.chip.active {
+    border-color: var(--accent, #66ddcc);
+}
+
+button.chip:disabled {
+    opacity: 0.4;
+    cursor: default;
+}
+
 /* The planner surface fills everything below the chrome. The canvas element is sized by CSS;
    the drawing buffer is set to element-size x devicePixelRatio from the app (hi-dpi crisp). */
 .canvas-host {

--- a/src/TianWen.UI.Web/wwwroot/index.html
+++ b/src/TianWen.UI.Web/wwwroot/index.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>🔭 TianWen</title>
+    <base href="/" />
+    <!-- Publish-time fingerprinting (OverrideHtmlAssetPlaceholders): the preload id, the importmap
+         element, and the #[.{fingerprint}] marker below are rewritten to the hashed asset names.
+         Without them the published page 404s on _framework/blazor.webassembly.js (only the
+         fingerprinted file exists). Mirrors Chess.Web. -->
+    <link rel="preload" id="webassembly" />
+    <link rel="stylesheet" href="css/app.css" />
+    <!-- Zero-asset favicon: the 🔭 the app is named for, as an inline SVG data URI. -->
+    <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🔭</text></svg>" />
+    <script type="importmap"></script>
+</head>
+
+<body>
+    <div id="app">
+        <div class="boot">
+            <div class="boot-spinner"></div>
+            <div class="boot-text">Loading TianWen...</div>
+        </div>
+    </div>
+
+    <div id="blazor-error-ui">
+        An unhandled error has occurred.
+        <a href="." class="reload">Reload</a>
+        <span class="dismiss">&#x1F5D9;</span>
+    </div>
+
+    <!-- The WebGl.Renderer JS module (_content/WebGl.Renderer/webgl-renderer.js) is imported by the
+         library itself via JSHost.ImportAsync - no script tag needed here. -->
+
+    <!-- Best-effort browser geolocation for the observing site.
+         tianwenGeoState: the Permissions-API state ('granted' | 'prompt' | 'denied' | 'unknown') so
+         the app can decide whether a position fetch is instant or will open a permission prompt.
+         tianwenGeo(waitForPrompt): resolves [lat, lon] or null. With waitForPrompt=true there is NO
+         timeout - the promise waits for the user's prompt decision (a fixed timeout here is exactly
+         what made "Allow" appear dead: it expired while the prompt was still open, so the grant
+         landed after the app had given up until the next refresh). -->
+    <script>
+        window.tianwenGeoState = function () {
+            if (!navigator.permissions || !navigator.geolocation) return Promise.resolve("unknown");
+            return navigator.permissions.query({ name: "geolocation" })
+                .then(function (s) { return s.state; })
+                .catch(function () { return "unknown"; });
+        };
+        // Canvas sizing: CSS-pixel size of the element + devicePixelRatio, so the app can size the
+        // drawing buffer to the real device pixels (crisp on hi-dpi) and scale mouse coordinates.
+        window.tianwenCanvasMetrics = function (id) {
+            var el = document.getElementById(id);
+            if (!el) return null;
+            var r = el.getBoundingClientRect();
+            return [r.width, r.height, window.devicePixelRatio || 1];
+        };
+        // Debounced window-resize notifications into .NET.
+        window.tianwenWatchResize = function (ref) {
+            var t = null;
+            window.addEventListener('resize', function () {
+                clearTimeout(t);
+                t = setTimeout(function () { ref.invokeMethodAsync('OnBrowserResize'); }, 150);
+            });
+        };
+        // Give the canvas keyboard focus (it carries tabindex="0").
+        window.tianwenFocus = function (id) {
+            var el = document.getElementById(id);
+            if (el) el.focus();
+        };
+        window.tianwenGeo = function (waitForPrompt) {
+            return new Promise(function (resolve) {
+                if (!navigator.geolocation) { resolve(null); return; }
+                var opts = waitForPrompt
+                    ? { maximumAge: 600000 }
+                    : { timeout: 10000, maximumAge: 600000 };
+                navigator.geolocation.getCurrentPosition(
+                    function (p) { resolve([p.coords.latitude, p.coords.longitude]); },
+                    function () { resolve(null); },
+                    opts);
+            });
+        };
+    </script>
+
+    <script src="_framework/blazor.webassembly#[.{fingerprint}].js"></script>
+</body>
+
+</html>

--- a/src/TianWen.UI.Web/wwwroot/index.html
+++ b/src/TianWen.UI.Web/wwwroot/index.html
@@ -5,8 +5,8 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <!-- Text-only: the favicon below is already the telescope emoji, so an emoji here would
-         show twice next to the tab label. -->
-    <title>TianWen</title>
+         show twice next to the tab label. Boot-time fallback; each view sets "Astro - <view>". -->
+    <title>Astro - Planner</title>
     <base href="/" />
     <!-- Publish-time fingerprinting (OverrideHtmlAssetPlaceholders): the preload id, the importmap
          element, and the #[.{fingerprint}] marker below are rewritten to the hashed asset names.

--- a/src/TianWen.UI.Web/wwwroot/index.html
+++ b/src/TianWen.UI.Web/wwwroot/index.html
@@ -4,7 +4,9 @@
 <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>🔭 TianWen</title>
+    <!-- Text-only: the favicon below is already the telescope emoji, so an emoji here would
+         show twice next to the tab label. -->
+    <title>TianWen</title>
     <base href="/" />
     <!-- Publish-time fingerprinting (OverrideHtmlAssetPlaceholders): the preload id, the importmap
          element, and the #[.{fingerprint}] marker below are rewritten to the hashed asset names.
@@ -68,6 +70,18 @@
         window.tianwenFocus = function (id) {
             var el = document.getElementById(id);
             if (el) el.focus();
+        };
+        // Capture the pointer on press so drags (handoff divider, list scrollbar) keep receiving
+        // mousemove/mouseup after the pointer leaves the canvas - capturing retargets the
+        // compatibility mouse events back to the capturing element, mirroring SDL's mouse capture.
+        window.tianwenDragCapture = function (id) {
+            var el = document.getElementById(id);
+            if (!el || !el.setPointerCapture) return;
+            el.addEventListener('pointerdown', function (e) {
+                if (e.button === 0) {
+                    try { el.setPointerCapture(e.pointerId); } catch (ignored) { }
+                }
+            });
         };
         window.tianwenGeo = function (waitForPrompt) {
             return new Promise(function (resolve) {

--- a/src/TianWen.UI.Web/wwwroot/index.html
+++ b/src/TianWen.UI.Web/wwwroot/index.html
@@ -50,39 +50,8 @@
                 .then(function (s) { return s.state; })
                 .catch(function () { return "unknown"; });
         };
-        // Canvas sizing: CSS-pixel size of the element + devicePixelRatio, so the app can size the
-        // drawing buffer to the real device pixels (crisp on hi-dpi) and scale mouse coordinates.
-        window.tianwenCanvasMetrics = function (id) {
-            var el = document.getElementById(id);
-            if (!el) return null;
-            var r = el.getBoundingClientRect();
-            return [r.width, r.height, window.devicePixelRatio || 1];
-        };
-        // Debounced window-resize notifications into .NET.
-        window.tianwenWatchResize = function (ref) {
-            var t = null;
-            window.addEventListener('resize', function () {
-                clearTimeout(t);
-                t = setTimeout(function () { ref.invokeMethodAsync('OnBrowserResize'); }, 150);
-            });
-        };
-        // Give the canvas keyboard focus (it carries tabindex="0").
-        window.tianwenFocus = function (id) {
-            var el = document.getElementById(id);
-            if (el) el.focus();
-        };
-        // Capture the pointer on press so drags (handoff divider, list scrollbar) keep receiving
-        // mousemove/mouseup after the pointer leaves the canvas - capturing retargets the
-        // compatibility mouse events back to the capturing element, mirroring SDL's mouse capture.
-        window.tianwenDragCapture = function (id) {
-            var el = document.getElementById(id);
-            if (!el || !el.setPointerCapture) return;
-            el.addEventListener('pointerdown', function (e) {
-                if (e.button === 0) {
-                    try { el.setPointerCapture(e.pointerId); } catch (ignored) { }
-                }
-            });
-        };
+        // Canvas metrics / resize watching / focus / drag pointer-capture all moved into
+        // WebGl.Renderer 1.2's <WebGlCanvas> component - only the geolocation helpers remain.
         window.tianwenGeo = function (waitForPrompt) {
             return new Promise(function (resolve) {
                 if (!navigator.geolocation) { resolve(null); return; }


### PR DESCRIPTION
## Summary

Brings TianWen's planner into the browser and deploys it to GitHub Pages:
**https://sharpastro.github.io/tianwen/** (live).

- **P0+P1 — `TianWen.UI.Web`**: standalone Blazor WASM host (outside slnx/CPM) running
  `PlannerTab<WebGlContext>` via the WebGl.Renderer backend with ZERO changes to the tab/chart
  code. Browser `IExternal` (MEMFS), minimal DI graph, geolocation two-phase site resolution,
  localStorage persistence for the site + planner session (pins/sliders survive F5).
- **Shared input path**: the handoff-divider drag state machine extracted from
  `GuiEventHandlerBase` into `PlannerSliderInteraction` (desktop delegates; web calls it) — the
  divider was desktop-only before.
- **`Lightweight` build gate** (`TianWen.Lib`): strips the 30 MB Tycho-2 catalog for the web
  payload (45 → 16 MB brotli); hd-hip-cross snapshot applies unverified in Lightweight builds
  (full builds still verify).
- **P5 — `pages.yml`**: ubuntu **Mono WASM AOT** publish (measured 24-42x on catalog init +
  planner sweep vs interpreted; no WasmDedup workarounds needed on linux), narrow LFS pull with
  the shared object cache, `/tianwen/` base-href rewrite, SPA 404 + `.nojekyll`, weekly cron.
- **Comets without CORS**: JPL SBDB sends no CORS headers, so CI curls the exact query into
  `wwwroot/comets-sbdb.json` and the new optional `AddAstrometry(cometQueryUri:)` points the
  unchanged source/parser/cache stack at the same-origin snapshot (null = live API, desktop
  registration byte-identical).
- **WebGlCanvas 1.2 migration**: the host's hand-rolled hi-dpi/resize/capture JS helpers deleted
  in favour of WebGl.Renderer 1.2's `<WebGlCanvas>` (which upstreamed the pattern + adds the full
  pointer surface).

Design + measured findings: `docs/plans/web-showcase.md`.

## Test plan

- [x] Full unit suite green (3358 passed / 0 failed) — twice, at both Abstractions-touching commits
- [x] Desktop GUI + solution build clean (divider refactor is behavior-preserving, gated identically)
- [x] Manual browser checklist on the dev server: divider grab / click-to-place / drag-out-of-canvas,
      hover follower, list scroll, double-click select-all, keyboard, F5 persistence (site + pins)
- [x] Live Pages deploy verified end-to-end incl. baked comets (424 KB served same-origin)
- [x] AOT publish proven on ubuntu-x64 CI and (with documented workarounds) win-arm64 locally

## Post-merge

- Drop the temporary `feat/web-showcase` push trigger + environment branch allowance (main-only)
- Chess repin to WebGl.Renderer `1.2.*` (its own repo/session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ATx1GGJ6CyDBF2yjTqrvm7