### PR TITLE
test(gpu): fix lavapipe exit-139 flake (shared Vulkan fixture) + in-job crash symbolication

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -99,8 +99,12 @@ jobs:
     # whenever this package list changes -- it controls the apt cache key.
     - uses: SharpAstro/cache-apt-pkgs-action@v1
       with:
-        packages: ghostscript fonts-urw-base35 fontconfig mesa-vulkan-drivers libvulkan1 vulkan-tools vulkan-validationlayers
-        version: 1.3
+        # lldb: on a native testhost crash, symbolicate the runtime minidump on THIS runner (where
+        # the crashed process's .so files still exist) so the "Symbolicate crash dump" step below
+        # resolves module names -- the offline analyze-crash-dump workflow can't (a fresh runner
+        # lacks those .so, hence lldb's "no associated executable images").
+        packages: ghostscript fonts-urw-base35 fontconfig mesa-vulkan-drivers libvulkan1 vulkan-tools vulkan-validationlayers lldb
+        version: 1.4
     - name: Rebuild fontconfig cache
       run: fc-cache -f
     # Sanity-check that the Vulkan loader can enumerate at least one ICD before
@@ -175,6 +179,30 @@ jobs:
         DOTNET_DbgMiniDumpName: /tmp/coredump-%e-%p-%t.dmp
       run: dotnet test TianWen.Lib.Tests -c $BUILD_CONF --no-build --logger "console;verbosity=detailed" --blame-crash --blame-hang --blame-hang-timeout 5min --results-directory test-results/
       working-directory: src
+    # On a native testhost crash (SIGSEGV -> exit 139), symbolicate the runtime minidump HERE, on
+    # the same runner, while the crashed process's shared libraries are still on disk -- lldb reads
+    # the minidump's module list and loads those .so from their recorded paths, so the backtrace
+    # names the culprit (e.g. the lavapipe software-Vulkan .so) directly in this run's log. The
+    # offline analyze-crash-dump workflow only gets bare addresses (its runner lacks the .so).
+    # Best-effort + capped: never let analysis failure mask the real test failure.
+    - name: Symbolicate crash dump (native stacks)
+      if: failure()
+      run: |
+        set +e
+        shopt -s nullglob
+        dumps=(/tmp/coredump-*.dmp)
+        if [ ${#dumps[@]} -eq 0 ]; then
+          echo "no runtime minidump (/tmp/coredump-*.dmp) -- the failure was not a native crash"
+          exit 0
+        fi
+        for d in "${dumps[@]}"; do
+          echo "==== lldb backtrace ($d, $(du -h "$d" | cut -f1)) ===="
+          lldb --batch -c "$d" \
+            -o "thread backtrace all" \
+            -o "image list" \
+            -o "quit" 2>&1 | head -c 500000
+          echo "(lldb exit $?)"
+        done
     # Upload test temp output (cpu.tiff / gpu.tiff / diff.tiff and other test
     # fixtures) when tests fail, so CPU/GPU divergences in GpuStretchPipelineTests
     # can be diagnosed without re-running CI to add diagnostics.

--- a/src/TianWen.Lib.Tests/OffscreenGpuFixture.cs
+++ b/src/TianWen.Lib.Tests/OffscreenGpuFixture.cs
@@ -7,33 +7,26 @@ using static Vortice.Vulkan.Vulkan;
 namespace TianWen.Lib.Tests;
 
 /// <summary>
-/// xUnit class fixture that owns a single offscreen Vulkan stack (VkInstance +
+/// Base xUnit fixture that owns a single offscreen Vulkan stack (VkInstance +
 /// <see cref="VulkanContext"/> + <see cref="VkRenderer"/> + <see cref="VkFitsImagePipeline"/>)
-/// shared across every test in <see cref="GpuStretchPipelineTests"/>. Created once, disposed
-/// once. Mirrors docs/plans/gpu-stretch-tests.md Phase 1's "Class fixture so all theory cases share
-/// one context" recommendation.
+/// at a fixed size, created once and disposed once. Concrete size-specific fixtures derive from
+/// it (see <see cref="OffscreenGpuFixture"/>, <see cref="VkPrimitiveGpuFixture"/>,
+/// <see cref="VkHistogramGpuFixture"/>); each is wired as an <c>IClassFixture&lt;T&gt;</c> so a
+/// GPU test class creates its Vulkan stack ONCE, not per test method.
 ///
-/// Why: without this, every [Theory] case (and every [Fact]) used to call vkInitialize +
-/// vkCreateInstance + vkCreateDebugUtilsMessengerEXT and tear it all down again. Mesa lavapipe
-/// + the Khronos validation layer + libvulkan loader accumulate enough TLS / process-global
-/// state across repeated init/destroy that the runtime SIGSEGVs during process exit (xUnit
-/// reports "Catastrophic failure: Test process crashed with exit code 139"). The accumulation
-/// is the antipattern; this fixture removes it.
+/// Why this must be a fixture, not per-test setup: xUnit constructs a fresh test-class instance
+/// per test method, so any Vulkan init in a test method's body (or the class ctor) runs on EVERY
+/// method. Repeated vkInitialize + vkCreateInstance + vkCreateDebugUtilsMessengerEXT + teardown
+/// makes Mesa lavapipe + the Khronos validation layer + the libvulkan loader accumulate enough
+/// TLS / process-global state that the runtime SIGSEGVs during process exit -- xUnit reports
+/// "Catastrophic failure: Test process crashed with exit code 139". Hoisting the stack into a
+/// class fixture removes the churn (one init/destroy per class instead of per method).
 ///
-/// The framebuffer is sized to the largest expected test image (Vela_SNR_Panel = 1310x1291).
-/// Smaller tests (Phase 1 synthetic SPCC field, 1280x1024) render into the top-left
-/// sub-rectangle and the helper extracts the meaningful slice from the readback.
-///
-/// Channel textures inside <see cref="VkFitsImagePipeline"/> resize automatically per upload
-/// (<see cref="VkFitsImagePipeline.UploadChannelTexture"/> calls DestroyChannelTexture +
-/// CreateChannelTexture when dimensions change), so the shared pipeline handles arbitrary
-/// per-test image dimensions transparently.
+/// Channel/histogram textures inside <see cref="VkFitsImagePipeline"/> resize automatically per
+/// upload, so the shared pipeline handles arbitrary per-test image dimensions transparently.
 /// </summary>
-public sealed unsafe class OffscreenGpuFixture : IDisposable
+public abstract unsafe class OffscreenGpuFixtureBase : IDisposable
 {
-    public const int Width = 1310;
-    public const int Height = 1291;
-
     public bool VulkanAvailable { get; }
     public string? UnavailableReason { get; }
 
@@ -43,7 +36,7 @@ public sealed unsafe class OffscreenGpuFixture : IDisposable
     public VkRenderer? Renderer { get; }
     public VkFitsImagePipeline? Pipeline { get; }
 
-    public OffscreenGpuFixture()
+    protected OffscreenGpuFixtureBase(int width, int height)
     {
         try
         {
@@ -54,8 +47,8 @@ public sealed unsafe class OffscreenGpuFixture : IDisposable
             // VulkanContext.Dispose() destroys the instance at teardown, so the fixture
             // doesn't separately track it -- Ctx.Dispose() in the fixture's Dispose covers
             // both the device + instance lifecycle.
-            Ctx = VulkanContext.CreateOffscreen(instance, Width, Height);
-            Renderer = new VkRenderer(Ctx, Width, Height);
+            Ctx = VulkanContext.CreateOffscreen(instance, (uint)width, (uint)height);
+            Renderer = new VkRenderer(Ctx, (uint)width, (uint)height);
             Pipeline = new VkFitsImagePipeline(Ctx);
             VulkanAvailable = true;
         }
@@ -73,4 +66,31 @@ public sealed unsafe class OffscreenGpuFixture : IDisposable
         Renderer?.Dispose();
         Ctx?.Dispose();
     }
+}
+
+/// <summary>
+/// Offscreen Vulkan stack sized to the largest expected stacking/stretch test image
+/// (Vela_SNR_Panel = 1310x1291); shared across every test in <see cref="GpuStretchPipelineTests"/>.
+/// Smaller tests render into the top-left sub-rectangle and the helper extracts the meaningful
+/// slice from the readback. The <see cref="Width"/> / <see cref="Height"/> consts stay so callers
+/// keep referencing <c>OffscreenGpuFixture.Width</c> unchanged.
+/// </summary>
+public sealed class OffscreenGpuFixture : OffscreenGpuFixtureBase
+{
+    public const int Width = 1310;
+    public const int Height = 1291;
+
+    public OffscreenGpuFixture() : base(Width, Height) { }
+}
+
+/// <summary>Offscreen Vulkan stack sized for <see cref="VkRendererPrimitiveTests"/> (256x256).</summary>
+public sealed class VkPrimitiveGpuFixture : OffscreenGpuFixtureBase
+{
+    public VkPrimitiveGpuFixture() : base(256, 256) { }
+}
+
+/// <summary>Offscreen Vulkan stack sized for <see cref="VkHistogramPipelineTests"/> (512x64).</summary>
+public sealed class VkHistogramGpuFixture : OffscreenGpuFixtureBase
+{
+    public VkHistogramGpuFixture() : base(512, 64) { }
 }

--- a/src/TianWen.Lib.Tests/VkHistogramPipelineTests.cs
+++ b/src/TianWen.Lib.Tests/VkHistogramPipelineTests.cs
@@ -22,7 +22,8 @@ namespace TianWen.Lib.Tests;
 /// clear color.
 /// </summary>
 [Collection("Imaging")]
-public sealed class VkHistogramPipelineTests(ITestOutputHelper output)
+public sealed class VkHistogramPipelineTests(VkHistogramGpuFixture gpuFixture, ITestOutputHelper output)
+    : IClassFixture<VkHistogramGpuFixture>
 {
     // Match the pipeline's HistogramBins constant so each pixel column corresponds to one
     // bin (no linear-interpolation noise from sub-texel sampling).
@@ -44,17 +45,13 @@ public sealed class VkHistogramPipelineTests(ITestOutputHelper output)
         hist1[250] = 0.5f;  // G: half-height bar
         hist2[400] = 0.25f; // B: quarter-height bar
 
-        byte[] gpu;
-        try
+        if (!gpuFixture.VulkanAvailable)
         {
-            gpu = RenderHistogramGpu(hist0, hist1, hist2);
-        }
-        catch (Exception ex) when (IsVulkanInitFailure(ex))
-        {
-            output.WriteLine($"Vulkan unavailable, skipping: {ex.GetType().Name}: {ex.Message}");
-            Assert.Skip($"Vulkan runtime not available ({ex.Message})");
+            output.WriteLine($"Vulkan unavailable, skipping: {gpuFixture.UnavailableReason}");
+            Assert.Skip($"Vulkan runtime not available ({gpuFixture.UnavailableReason})");
             return;
         }
+        var gpu = RenderHistogramGpu(hist0, hist1, hist2);
 
         // Spike columns: the column containing the spike should have a colored bar of the
         // right height (h * H rows tall, anchored at the bottom of the framebuffer because
@@ -76,16 +73,12 @@ public sealed class VkHistogramPipelineTests(ITestOutputHelper output)
         // All zeros -> shader sees scaled=0 for every column -> no fragment is coloured ->
         // framebuffer stays at the clear color everywhere.
         var empty = new float[HistogramBins];
-        byte[] gpu;
-        try
+        if (!gpuFixture.VulkanAvailable)
         {
-            gpu = RenderHistogramGpu(empty, empty, empty);
-        }
-        catch (Exception ex) when (IsVulkanInitFailure(ex))
-        {
-            Assert.Skip($"Vulkan runtime not available ({ex.Message})");
+            Assert.Skip($"Vulkan runtime not available ({gpuFixture.UnavailableReason})");
             return;
         }
+        var gpu = RenderHistogramGpu(empty, empty, empty);
 
         // Every pixel should be the clear color (0, 0, 0, 255).
         var firstDiff = -1;
@@ -107,13 +100,10 @@ public sealed class VkHistogramPipelineTests(ITestOutputHelper output)
 
     private unsafe byte[] RenderHistogramGpu(float[] hist0, float[] hist1, float[] hist2)
     {
-        vkInitialize().CheckResult();
-        VkInstanceCreateInfo ici = new();
-        vkCreateInstance(&ici, null, out var instance).CheckResult();
-
-        using var ctx = VulkanContext.CreateOffscreen(instance, Width, Height);
-        using var renderer = new VkRenderer(ctx, Width, Height);
-        using var pipeline = new VkFitsImagePipeline(ctx);
+        // Reuse the class fixture's single Vulkan stack (created once; see VkHistogramGpuFixture).
+        var ctx = gpuFixture.Ctx!;
+        var renderer = gpuFixture.Renderer!;
+        var pipeline = gpuFixture.Pipeline!;
 
         ctx.InstanceApi.vkGetPhysicalDeviceProperties(ctx.PhysicalDevice, out var props);
         var deviceName = System.Text.Encoding.UTF8.GetString(
@@ -182,16 +172,5 @@ public sealed class VkHistogramPipelineTests(ITestOutputHelper output)
             rgba[i + 2].ShouldBe((byte)0, $"{label} py={py}: B should be clear");
             rgba[i + 3].ShouldBe((byte)255, $"{label} py={py}: A should stay opaque");
         }
-    }
-
-    private static bool IsVulkanInitFailure(Exception ex)
-    {
-        return ex is DllNotFoundException
-            || ex is TypeInitializationException
-            || ex.Message.Contains("vkCreateInstance", StringComparison.OrdinalIgnoreCase)
-            || ex.Message.Contains("vkInitialize", StringComparison.OrdinalIgnoreCase)
-            || ex.Message.Contains("Vulkan", StringComparison.OrdinalIgnoreCase)
-            || ex.Message.Contains("VK_ERROR", StringComparison.Ordinal)
-            || ex.Message.Contains("ICD", StringComparison.Ordinal);
     }
 }

--- a/src/TianWen.Lib.Tests/VkRendererPrimitiveTests.cs
+++ b/src/TianWen.Lib.Tests/VkRendererPrimitiveTests.cs
@@ -27,7 +27,8 @@ namespace TianWen.Lib.Tests;
 /// Skips when Vulkan is unavailable (no driver / no ICD).
 /// </summary>
 [Collection("Imaging")]
-public sealed class VkRendererPrimitiveTests(ITestOutputHelper output)
+public sealed class VkRendererPrimitiveTests(VkPrimitiveGpuFixture gpuFixture, ITestOutputHelper output)
+    : IClassFixture<VkPrimitiveGpuFixture>
 {
     private const int Width = 256;
     private const int Height = 256;
@@ -160,35 +161,26 @@ public sealed class VkRendererPrimitiveTests(ITestOutputHelper output)
         using var cpu = new RgbaImageRenderer((uint)Width, (uint)Height);
         cpu.Surface.Clear(Black);
 
-        // GPU side -- pay Vulkan init cost per test (~200ms). If init fails (no ICD, etc.)
-        // skip the comparison.
-        byte[]? gpuRgba;
-        try
+        // GPU side -- the shared class fixture creates the Vulkan stack once (see
+        // VkPrimitiveGpuFixture). When init failed (no ICD, etc.) still run the CPU side so a
+        // CPU-only regression stays visible, then skip the parity check.
+        if (!gpuFixture.VulkanAvailable)
         {
-            gpuRgba = RenderViaOffscreenGpu(gpuR =>
-            {
-                draw(cpu, gpuR);
-            });
-        }
-        catch (Exception ex) when (IsVulkanInitFailure(ex))
-        {
-            output.WriteLine($"Vulkan unavailable, skipping GPU comparison: {ex.GetType().Name}: {ex.Message}");
-            // Still run the CPU side so any CPU-only regression is visible, then skip the
-            // parity check.
-            Assert.Skip($"Vulkan runtime not available on this host ({ex.Message})");
+            output.WriteLine($"Vulkan unavailable, skipping GPU comparison: {gpuFixture.UnavailableReason}");
+            Assert.Skip($"Vulkan runtime not available on this host ({gpuFixture.UnavailableReason})");
             return (cpu.Surface.Pixels, null);
         }
+
+        var gpuRgba = RenderViaOffscreenGpu(gpuR => draw(cpu, gpuR));
         return (cpu.Surface.Pixels, gpuRgba);
     }
 
     private unsafe byte[] RenderViaOffscreenGpu(Action<VkRenderer> draw)
     {
-        vkInitialize().CheckResult();
-        VkInstanceCreateInfo ici = new();
-        vkCreateInstance(&ici, null, out var instance).CheckResult();
-
-        using var ctx = VulkanContext.CreateOffscreen(instance, Width, Height);
-        using var renderer = new VkRenderer(ctx, Width, Height);
+        // Reuse the class fixture's single Vulkan stack -- BeginOffscreenFrame clears to Black on
+        // every call, so tests never leak state into one another.
+        var ctx = gpuFixture.Ctx!;
+        var renderer = gpuFixture.Renderer!;
 
         ctx.InstanceApi.vkGetPhysicalDeviceProperties(ctx.PhysicalDevice, out var props);
         var deviceName = System.Text.Encoding.UTF8.GetString(
@@ -255,16 +247,5 @@ public sealed class VkRendererPrimitiveTests(ITestOutputHelper output)
             diff[i + 3] = 255;
         }
         return DisplayImageWriter.WriteTiffAsync(diff, width, height, path);
-    }
-
-    private static bool IsVulkanInitFailure(Exception ex)
-    {
-        return ex is DllNotFoundException
-            || ex is TypeInitializationException
-            || ex.Message.Contains("vkCreateInstance", StringComparison.OrdinalIgnoreCase)
-            || ex.Message.Contains("vkInitialize", StringComparison.OrdinalIgnoreCase)
-            || ex.Message.Contains("Vulkan", StringComparison.OrdinalIgnoreCase)
-            || ex.Message.Contains("VK_ERROR", StringComparison.Ordinal)
-            || ex.Message.Contains("ICD", StringComparison.Ordinal);
     }
 }


### PR DESCRIPTION
## What

Hardens the flaky Vulkan GPU tests + makes future native crashes self-diagnosing in CI. Grew out of the crash-dump analysis of the `test-unit (ubuntu-latest)` **exit-139 (SIGSEGV)** flake on PR #99.

## Root cause (from the dump, not a guess)

The reusable `analyze-crash-dump` workflow's blame Sequence pinned the crash to **`VkRendererPrimitiveTests.DrawLine_AxisAligned`** — a Vulkan offscreen-render test under Mesa lavapipe, *not* the catalog memory pressure I'd first guessed. The `OffscreenGpuFixture` docstring already named the mechanism: repeated `vkInitialize` + `vkCreateInstance` + teardown makes lavapipe + the validation layer + the libvulkan loader accumulate process-global/TLS state until the runtime SIGSEGVs at process exit.

`GpuStretchPipelineTests` avoided this with a per-class fixture; **`VkRendererPrimitiveTests` and `VkHistogramPipelineTests` never were migrated** — they created and destroyed a full Vulkan instance *inline per test method* (xUnit constructs the test class per method).

## (b) Shared Vulkan stack per GPU test class

- Extract the fixture into a size-parameterized `OffscreenGpuFixtureBase`; give each GPU class its own `IClassFixture` at its **native** size — `OffscreenGpuFixture` 1310×1291, `VkPrimitiveGpuFixture` 256×256, `VkHistogramGpuFixture` 512×64.
- One instance **per class** instead of per method drops ~13 instance lifecycles → **3** across the run (the proven `GpuStretchPipelineTests` pattern, applied uniformly).
- Native sizes mean **no** sub-rect rendering changes, so the tuned pixel-parity / column assertions are untouched.
- `GpuStretchPipelineTests` is unchanged (its fixture just re-parents onto the base; the `OffscreenGpuFixture.Width/Height` consts stay).

**Validated: all 26 GPU tests pass on a real GPU, 0 skipped.**

## (c) In-job native symbolication

- On a native crash, run `lldb` on the runtime minidump **in the test job**, on the runner where the crashed process's `.so` files still exist — so the backtrace names the culprit library (e.g. the lavapipe `.so`) directly in the failed run's log.
- The offline `analyze-crash-dump` workflow can't: a fresh runner lacks those binaries, so lldb reports "no associated executable images" and prints bare addresses (exactly what happened here).
- Pre-installs `lldb` via the apt cache (version key bumped); the step is `if: failure()` + best-effort so it never masks the real failure.

## Notes

- The `[Collection("Catalog")]` change from #99 was based on the wrong (memory-pressure) hypothesis — harmless and kept (heavy catalog tests should serialize), but (b) here is the actual fix.
- The `analyze-crash-dump` workflow (already on main) stays useful for the blame Sequence / managed stacks / re-analysis; (c) is the fast path for native frames.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ATx1GGJ6CyDBF2yjTqrvm7
