### PR TITLE
web(atlas): F3 fix + IndexedDB raw-bytes cache + clickable Tycho-2 stars

### DIFF
--- a/src/TianWen.Lib.Tests/Tycho2BulkInjectionTests.cs
+++ b/src/TianWen.Lib.Tests/Tycho2BulkInjectionTests.cs
@@ -91,4 +91,42 @@ public class Tycho2BulkInjectionTests
         db.TryLoadTycho2BulkFromCompressed(Array.Empty<byte>()).ShouldBeFalse();
         ((ICelestialObjectDB)db).Tycho2StarCount.ShouldBe(0);
     }
+
+    [Fact]
+    public void GivenAlreadyDecompressedBytesWhenInjectedThenCatalogIsAvailable()
+    {
+        // The browser caches the DECOMPRESSED buffer (IndexedDB); a repeat visit feeds it back
+        // through this path to skip the lzip decode. Exercise it with the raw bytes directly.
+        var raw = SharpAstro.Lzip.LzipDecoder.Decompress(ReadEmbeddedTyc2Lz());
+
+        var db = new CelestialObjectDB();
+        ((ICelestialObjectDB)db).Tycho2StarCount.ShouldBe(0);
+
+        db.TryLoadTycho2BulkFromDecoded(raw).ShouldBeTrue();
+        ((ICelestialObjectDB)db).Tycho2StarCount.ShouldBeGreaterThan(2_000_000);
+    }
+
+    [Fact]
+    public void GivenInjectedDBWhenQueryingCoordinateGridThenTychoStarsResolve()
+    {
+        // Injection now wires the GSC-bounds spatial index, so the composite CoordinateGrid answers
+        // FOV queries against Tycho-2 -- the exact path click-to-identify uses (SkyMapSearchActions).
+        var db = new CelestialObjectDB();
+        db.TryLoadTycho2BulkFromCompressed(ReadEmbeddedTyc2Lz()).ShouldBeTrue();
+        ICelestialObjectDB idb = db;
+
+        // Probe the spatial index at a real star's position (RA hours, Dec degrees).
+        var chunk = new Tycho2StarLite[256];
+        var n = db.CopyTycho2Stars(chunk, 0);
+        var star = chunk.Take(n).First(s => !float.IsNaN(s.VMag));
+
+        var cell = idb.CoordinateGrid[star.RaHours, star.DecDeg];
+        cell.ShouldContain(i => i.ToCatalog() == Catalog.Tycho2,
+            "the wired spatial index must surface Tycho-2 stars for the click-to-identify path");
+
+        // And a returned tyc2 index resolves to a real position (the identify step).
+        var tycIdx = cell.First(i => i.ToCatalog() == Catalog.Tycho2);
+        idb.TryLookupByIndex(tycIdx, out var o).ShouldBeTrue();
+        double.IsNaN(o.RA).ShouldBeFalse();
+    }
 }

--- a/src/TianWen.Lib/Astrometry/Catalogs/CelestialObjectDB.cs
+++ b/src/TianWen.Lib/Astrometry/Catalogs/CelestialObjectDB.cs
@@ -751,13 +751,60 @@ internal sealed partial class CelestialObjectDB : ICelestialObjectDB
             return false;
         }
 
-        // Display-only: the GSC-bounds spatial index (_tycho2RaDecIndex) and the high-pm sidecar
-        // (~11 stars, still embedded on the Lightweight build) are intentionally NOT wired here -
-        // the atlas plots dots, which need neither; CopyTycho2Stars falls back to the inline pm
-        // rail value for the handful of sidecar stars, invisible at plot scale. WireTycho2BulkData
-        // handles the decompress-buffer publish (torn-free) shared with the embedded path.
-        WireTycho2BulkData(LzipDecoder.Decompress(compressedLz));
+        return TryLoadTycho2BulkFromDecoded(LzipDecoder.Decompress(compressedLz));
+    }
+
+    /// <inheritdoc/>
+    public bool TryLoadTycho2BulkFromDecoded(byte[] decodedData)
+    {
+        // Already loaded (embedded desktop path, or a prior injection) - nothing to do.
+        if (_tycho2Data is not null)
+        {
+            return true;
+        }
+        if (decodedData is null || decodedData.Length < 4)
+        {
+            return false;
+        }
+
+        // Publish the bulk star records (torn-free), then build the GSC-bounds spatial index so the
+        // composite CoordinateGrid answers FOV queries against Tycho-2 - the click-to-identify /
+        // overlay-label path resolves individual TYC stars. The high-pm sidecar (~11 stars) is still
+        // NOT wired: it only refines proper motion, which a plotted/clicked dot doesn't need
+        // (CopyTycho2Stars falls back to the inline rail value for those).
+        WireTycho2BulkData(decodedData);
+        BuildTycho2SpatialIndexFromEmbeddedBounds();
         return true;
+    }
+
+    /// <summary>
+    /// Builds the Tycho-2 spatial index (<see cref="_tycho2RaDecIndex"/>) from the embedded
+    /// GSC-region bounds (<c>tyc2_gsc_bounds.bin.lz</c>, still embedded on the Lightweight build).
+    /// Requires <see cref="_tycho2Data"/> already set. Cheap: it indexes the ~9.5k GSC region
+    /// bounding boxes, not the 2.5M stars. Idempotent + a no-op when the bounds resource is absent.
+    /// </summary>
+    private void BuildTycho2SpatialIndexFromEmbeddedBounds()
+    {
+        var data = _tycho2Data;
+        if (data is null || _tycho2RaDecIndex is not null)
+        {
+            return;
+        }
+
+        var assembly = typeof(CelestialObjectDB).Assembly;
+        var boundsManifest = assembly.GetManifestResourceNames()
+            .FirstOrDefault(n => n.EndsWith(".tyc2_gsc_bounds.bin.lz", StringComparison.Ordinal));
+        if (boundsManifest is null)
+        {
+            return;
+        }
+        using var boundsStream = assembly.GetManifestResourceStream(boundsManifest);
+        if (boundsStream is null)
+        {
+            return;
+        }
+        var boundsData = LzipDecoder.Decompress(boundsStream);
+        _tycho2RaDecIndex = new Tycho2RaDecIndex(data, _tycho2StreamCount, boundsData);
     }
 
     /// <summary>

--- a/src/TianWen.Lib/Astrometry/Catalogs/ICelestialObjectDB.cs
+++ b/src/TianWen.Lib/Astrometry/Catalogs/ICelestialObjectDB.cs
@@ -164,20 +164,30 @@ public interface ICelestialObjectDB
 
     /// <summary>
     /// Injects an externally-fetched, still-lzip-compressed <c>tyc2.bin.lz</c> payload,
-    /// decompressing it and wiring the bulk Tycho-2 star data so <see cref="Tycho2StarCount"/> /
-    /// <see cref="CopyTycho2Stars"/> return the full catalog. This is the browser/Lightweight
-    /// path: the ~30 MB catalog is stripped from the WASM bundle (the embedded manifest entry is
-    /// absent), so the atlas fetches <c>tyc2.bin.lz</c> as a same-origin static asset and feeds
-    /// the bytes here. Idempotent (a no-op returning <c>true</c> once bulk data is present) and
-    /// deliberately <b>display-only</b>: it builds only the flat star records, NOT the searchable
-    /// spatial index or the HD/HIP cross maps (a plotted star dot needs neither). The default is a
-    /// no-op for hosts that never inject (the embedded desktop build, tests) - only
-    /// <c>CelestialObjectDB</c> performs the decode.
+    /// decompressing it (then delegating to <see cref="TryLoadTycho2BulkFromDecoded"/>). This is
+    /// the browser/Lightweight path: the ~30 MB catalog is stripped from the WASM bundle (the
+    /// embedded manifest entry is absent), so the atlas fetches <c>tyc2.bin.lz</c> as a same-origin
+    /// static asset and feeds the bytes here. Idempotent (a no-op returning <c>true</c> once bulk
+    /// data is present). The default is a no-op for hosts that never inject (the embedded desktop
+    /// build, tests) - only <c>CelestialObjectDB</c> performs the decode.
     /// </summary>
     /// <param name="compressedLz">The raw <c>tyc2.bin.lz</c> bytes as fetched over HTTP.</param>
     /// <returns><c>true</c> when the Tycho-2 catalog is available after the call
     /// (freshly injected, or already loaded); <c>false</c> on empty input or a no-op host.</returns>
     bool TryLoadTycho2BulkFromCompressed(byte[] compressedLz) => false;
+
+    /// <summary>
+    /// Injects an already-decompressed Tycho-2 bulk buffer (the plain byte[], no lzip layer) and
+    /// wires the star records + the GSC-bounds spatial index, so <see cref="Tycho2StarCount"/> /
+    /// <see cref="CopyTycho2Stars"/> return the full catalog AND <see cref="CoordinateGrid"/>
+    /// answers FOV queries against Tycho-2 (the click-to-identify / overlay-label path). The
+    /// browser caches this decompressed buffer (e.g. IndexedDB) so a repeat visit skips both the
+    /// download and the lzip decode. Idempotent; the default is a no-op for hosts that never inject.
+    /// </summary>
+    /// <param name="decodedData">The decompressed <c>tyc2.bin</c> bytes (the output of the lzip decode).</param>
+    /// <returns><c>true</c> when the Tycho-2 catalog is available after the call; <c>false</c> on
+    /// empty input or a no-op host.</returns>
+    bool TryLoadTycho2BulkFromDecoded(byte[] decodedData) => false;
 
     /// <summary>
     /// Single-star lookup by Tycho-2 catalog index. One walk through the

--- a/src/TianWen.UI.Web/Pages/Planner.razor
+++ b/src/TianWen.UI.Web/Pages/Planner.razor
@@ -659,9 +659,10 @@
     // HR field untouched - the atlas is a fine showcase either way. On single-threaded WASM the
     // decode + flatten are synchronous stalls, but they run after the atlas has already painted;
     // measuring the AOT wall-time here is what gates the P2 parallel-decode work (web-tycho2.md).
-    // Bump when tyc2.bin.lz content OR the float-instance layout (FloatsPerStar) changes, so a
-    // stale IndexedDB snapshot is discarded rather than rendering the wrong stars.
-    const string Tyc2CacheVersion = "tyc2-v1-5f";
+    // Bump when tyc2.bin.lz content OR the cached buffer format changes, so a stale IndexedDB
+    // snapshot is discarded rather than fed to the DB. v2 = raw decompressed bytes (v1 cached the
+    // flattened float buffer; raw enables clickable stars, which need the DB records + spatial index).
+    const string Tyc2CacheVersion = "tyc2-v2-raw";
 
     async Task EnsureTycho2AtlasAsync()
     {
@@ -671,38 +672,33 @@
             // paints before the heavy work below (mirrors LoadCometsInBackgroundAsync).
             await Task.Delay(30);
 
-            // Fast path: a decoded buffer cached in IndexedDB from a prior visit skips BOTH the
-            // ~30 MB fetch and the ~1.8 s decode/flatten. Streamed back (no JSON marshaling).
-            if (await TryLoadTycho2FromCacheAsync())
+            // Warm path: the raw decompressed catalog cached from a prior visit skips BOTH the
+            // ~30 MB fetch and the lzip decompress. It feeds the SAME DB path as the cold decode
+            // (records + spatial index), so click-to-identify works identically on a cached load.
+            var cachedRaw = await TryReadTycho2CacheAsync();
+            if (cachedRaw is { Length: > 0 } && Db.TryLoadTycho2BulkFromDecoded(cachedRaw))
             {
+                FlattenAndSubmitTycho2("IndexedDB cache");
                 return;
             }
 
-            // Cold path: fetch the compressed catalog, decode + flatten, then cache for next time.
+            // Cold path: fetch the compressed catalog, decompress, wire the DB + spatial index,
+            // flatten to the GPU, then cache the raw decompressed bytes for next time.
             var sw = System.Diagnostics.Stopwatch.StartNew();
-            var bytes = await Http.GetByteArrayAsync("tyc2.bin.lz");
-            Console.WriteLine($"[tianwen-web] tyc2 fetch: {bytes.Length / (1024 * 1024)} MB in {sw.ElapsedMilliseconds} ms");
+            var lz = await Http.GetByteArrayAsync("tyc2.bin.lz");
+            Console.WriteLine($"[tianwen-web] tyc2 fetch: {lz.Length / (1024 * 1024)} MB in {sw.ElapsedMilliseconds} ms");
 
             sw.Restart();
-            if (!Db.TryLoadTycho2BulkFromCompressed(bytes))
+            var raw = SharpAstro.Lzip.LzipDecoder.Decompress(lz);
+            if (!Db.TryLoadTycho2BulkFromDecoded(raw))
             {
                 Console.WriteLine("[tianwen-web] tyc2 decode produced no catalog; keeping the HR field");
                 return;
             }
+            Console.WriteLine($"[tianwen-web] tyc2 decompress: {raw.Length / (1024 * 1024)} MB in {sw.ElapsedMilliseconds} ms");
 
-            // Flatten to 5-float star instances via the shared builder the desktop pipeline uses
-            // (dt=0: render at J2000, no pm propagation - a plotted dot doesn't need it).
-            var count = Db.Tycho2StarCount;
-            var verts = new float[count * SkyMapState.FloatsPerStar];
-            var written = SkyMapState.FillTycho2StarVertices(Db, dtJulianYears: 0.0, verts);
-            Console.WriteLine($"[tianwen-web] tyc2 decode+flatten: {written} stars in {sw.ElapsedMilliseconds} ms");
-
-            _skyTab?.SubmitTycho2Stars(verts, written);
-            RenderFrame(); // swap it in on the next paint
-
-            // Persist the flattened buffer so the next visit takes the fast path (fire-and-forget;
-            // a cache-write failure is non-fatal).
-            _ = SaveTycho2ToCacheAsync(verts, written);
+            FlattenAndSubmitTycho2("decode");
+            _ = SaveTycho2ToCacheAsync(raw); // persist the raw buffer (fire-and-forget; non-fatal)
         }
         catch (Exception ex)
         {
@@ -710,10 +706,22 @@
         }
     }
 
-    // Reads the decoded float buffer from IndexedDB (a JS-to-.NET stream) and swaps it straight in,
-    // skipping the fetch + decode + flatten. Returns false on a miss / version mismatch / any error
-    // (an empty stream = miss), so the caller falls back to the cold path.
-    async Task<bool> TryLoadTycho2FromCacheAsync()
+    // Flattens the loaded Tycho-2 records to 5-float star instances (shared desktop builder, dt=0)
+    // and hands them to the GPU pipeline for the render-thread swap over the HR seed.
+    void FlattenAndSubmitTycho2(string source)
+    {
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        var count = Db.Tycho2StarCount;
+        var verts = new float[count * SkyMapState.FloatsPerStar];
+        var written = SkyMapState.FillTycho2StarVertices(Db, dtJulianYears: 0.0, verts);
+        Console.WriteLine($"[tianwen-web] tyc2 flatten ({source}): {written} stars in {sw.ElapsedMilliseconds} ms");
+        _skyTab?.SubmitTycho2Stars(verts, written);
+        RenderFrame(); // swap it in on the next paint
+    }
+
+    // Reads the raw decompressed catalog from IndexedDB (a JS-to-.NET stream). Returns null on a
+    // miss / version mismatch / any error (an empty stream = miss) so the caller fetches + decodes.
+    async Task<byte[]?> TryReadTycho2CacheAsync()
     {
         try
         {
@@ -722,41 +730,24 @@
             using var ms = new System.IO.MemoryStream();
             await s.CopyToAsync(ms);
             var bytes = ms.ToArray();
-
-            const int bytesPerStar = SkyMapState.FloatsPerStar * sizeof(float);
-            if (bytes.Length == 0 || bytes.Length % bytesPerStar != 0)
-            {
-                return false; // miss, or a corrupt/partial snapshot -> re-fetch
-            }
-
-            var floats = System.Runtime.InteropServices.MemoryMarshal.Cast<byte, float>(bytes).ToArray();
-            var starCount = bytes.Length / bytesPerStar;
-            Console.WriteLine($"[tianwen-web] tyc2 from IndexedDB cache: {starCount} stars ({bytes.Length / (1024 * 1024)} MB)");
-
-            _skyTab?.SubmitTycho2Stars(floats, starCount);
-            RenderFrame();
-            return true;
+            return bytes.Length == 0 ? null : bytes;
         }
         catch (Exception ex)
         {
             Console.WriteLine($"[tianwen-web] tyc2 cache read failed, will fetch: {ex.Message}");
-            return false;
+            return null;
         }
     }
 
-    // Streams the flattened float buffer into IndexedDB (a .NET-to-JS stream) under the version key.
-    async Task SaveTycho2ToCacheAsync(float[] verts, int written)
+    // Streams the raw decompressed catalog into IndexedDB (a .NET-to-JS stream) under the version key.
+    async Task SaveTycho2ToCacheAsync(byte[] raw)
     {
         try
         {
-            var byteLength = written * SkyMapState.FloatsPerStar * sizeof(float);
-            var bytes = new byte[byteLength];
-            System.Buffer.BlockCopy(verts, 0, bytes, 0, byteLength);
-
-            using var ms = new System.IO.MemoryStream(bytes, writable: false);
+            using var ms = new System.IO.MemoryStream(raw, writable: false);
             using var streamRef = new DotNetStreamReference(ms, leaveOpen: false);
             await JS.InvokeVoidAsync("tyc2Cache.save", Tyc2CacheVersion, streamRef);
-            Console.WriteLine($"[tianwen-web] tyc2 cached to IndexedDB ({byteLength / (1024 * 1024)} MB)");
+            Console.WriteLine($"[tianwen-web] tyc2 cached to IndexedDB ({raw.Length / (1024 * 1024)} MB)");
         }
         catch (Exception ex)
         {

--- a/src/TianWen.UI.Web/Pages/Planner.razor
+++ b/src/TianWen.UI.Web/Pages/Planner.razor
@@ -659,14 +659,26 @@
     // HR field untouched - the atlas is a fine showcase either way. On single-threaded WASM the
     // decode + flatten are synchronous stalls, but they run after the atlas has already painted;
     // measuring the AOT wall-time here is what gates the P2 parallel-decode work (web-tycho2.md).
+    // Bump when tyc2.bin.lz content OR the float-instance layout (FloatsPerStar) changes, so a
+    // stale IndexedDB snapshot is discarded rather than rendering the wrong stars.
+    const string Tyc2CacheVersion = "tyc2-v1-5f";
+
     async Task EnsureTycho2AtlasAsync()
     {
         try
         {
             // This "background" task runs inline until its first await; yield so the HR atlas
-            // paints before the heavy fetch/decode below (mirrors LoadCometsInBackgroundAsync).
+            // paints before the heavy work below (mirrors LoadCometsInBackgroundAsync).
             await Task.Delay(30);
 
+            // Fast path: a decoded buffer cached in IndexedDB from a prior visit skips BOTH the
+            // ~30 MB fetch and the ~1.8 s decode/flatten. Streamed back (no JSON marshaling).
+            if (await TryLoadTycho2FromCacheAsync())
+            {
+                return;
+            }
+
+            // Cold path: fetch the compressed catalog, decode + flatten, then cache for next time.
             var sw = System.Diagnostics.Stopwatch.StartNew();
             var bytes = await Http.GetByteArrayAsync("tyc2.bin.lz");
             Console.WriteLine($"[tianwen-web] tyc2 fetch: {bytes.Length / (1024 * 1024)} MB in {sw.ElapsedMilliseconds} ms");
@@ -687,10 +699,68 @@
 
             _skyTab?.SubmitTycho2Stars(verts, written);
             RenderFrame(); // swap it in on the next paint
+
+            // Persist the flattened buffer so the next visit takes the fast path (fire-and-forget;
+            // a cache-write failure is non-fatal).
+            _ = SaveTycho2ToCacheAsync(verts, written);
         }
         catch (Exception ex)
         {
             Console.WriteLine($"[tianwen-web] Tycho-2 catalog unavailable (HR-only atlas): {ex.Message}");
+        }
+    }
+
+    // Reads the decoded float buffer from IndexedDB (a JS-to-.NET stream) and swaps it straight in,
+    // skipping the fetch + decode + flatten. Returns false on a miss / version mismatch / any error
+    // (an empty stream = miss), so the caller falls back to the cold path.
+    async Task<bool> TryLoadTycho2FromCacheAsync()
+    {
+        try
+        {
+            var streamRef = await JS.InvokeAsync<IJSStreamReference>("tyc2Cache.load", Tyc2CacheVersion);
+            await using var s = await streamRef.OpenReadStreamAsync(maxAllowedSize: 128L * 1024 * 1024);
+            using var ms = new System.IO.MemoryStream();
+            await s.CopyToAsync(ms);
+            var bytes = ms.ToArray();
+
+            const int bytesPerStar = SkyMapState.FloatsPerStar * sizeof(float);
+            if (bytes.Length == 0 || bytes.Length % bytesPerStar != 0)
+            {
+                return false; // miss, or a corrupt/partial snapshot -> re-fetch
+            }
+
+            var floats = System.Runtime.InteropServices.MemoryMarshal.Cast<byte, float>(bytes).ToArray();
+            var starCount = bytes.Length / bytesPerStar;
+            Console.WriteLine($"[tianwen-web] tyc2 from IndexedDB cache: {starCount} stars ({bytes.Length / (1024 * 1024)} MB)");
+
+            _skyTab?.SubmitTycho2Stars(floats, starCount);
+            RenderFrame();
+            return true;
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"[tianwen-web] tyc2 cache read failed, will fetch: {ex.Message}");
+            return false;
+        }
+    }
+
+    // Streams the flattened float buffer into IndexedDB (a .NET-to-JS stream) under the version key.
+    async Task SaveTycho2ToCacheAsync(float[] verts, int written)
+    {
+        try
+        {
+            var byteLength = written * SkyMapState.FloatsPerStar * sizeof(float);
+            var bytes = new byte[byteLength];
+            System.Buffer.BlockCopy(verts, 0, bytes, 0, byteLength);
+
+            using var ms = new System.IO.MemoryStream(bytes, writable: false);
+            using var streamRef = new DotNetStreamReference(ms, leaveOpen: false);
+            await JS.InvokeVoidAsync("tyc2Cache.save", Tyc2CacheVersion, streamRef);
+            Console.WriteLine($"[tianwen-web] tyc2 cached to IndexedDB ({byteLength / (1024 * 1024)} MB)");
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"[tianwen-web] tyc2 cache write failed (non-fatal): {ex.Message}");
         }
     }
 

--- a/src/TianWen.UI.Web/wwwroot/index.html
+++ b/src/TianWen.UI.Web/wwwroot/index.html
@@ -64,7 +64,19 @@
                     opts);
             });
         };
-    </script>
+
+        // F3 opens the in-app catalog search (the sky atlas). The <canvas> keydown handler runs
+        // our search, but the browser ALSO fires its native find-in-page for F3 -- so both open at
+        // once. Cancel the browser default here (capture phase, so it wins before anything else);
+        // the canvas keydown listener still fires, so our search opens and the browser bar does
+        // not. The whole page is one canvas app, so there is nothing for browser find to match
+        // anyway. Blazor's plain @onkeydown can't preventDefault after the fact, hence this listener.
+        window.addEventListener("keydown", function (e) {
+            if (e.key === "F3") {
+                e.preventDefault();
+            }
+        }, { capture: true });
+</script>
 
     <script src="_framework/blazor.webassembly#[.{fingerprint}].js"></script>
 </body>

--- a/src/TianWen.UI.Web/wwwroot/index.html
+++ b/src/TianWen.UI.Web/wwwroot/index.html
@@ -78,6 +78,10 @@
         }, { capture: true });
 </script>
 
+    <!-- IndexedDB cache for the decoded Tycho-2 star buffer (window.tyc2Cache). Loaded before
+         Blazor so it's defined by the time the atlas first opens. -->
+    <script src="tyc2-cache.js"></script>
+
     <script src="_framework/blazor.webassembly#[.{fingerprint}].js"></script>
 </body>
 

--- a/src/TianWen.UI.Web/wwwroot/tyc2-cache.js
+++ b/src/TianWen.UI.Web/wwwroot/tyc2-cache.js
@@ -1,0 +1,65 @@
+// IndexedDB cache for the decoded Tycho-2 star buffer (~50 MB of float instances). Keyed by a
+// catalog version so a catalog change invalidates it. On a repeat visit this skips BOTH the ~30 MB
+// fetch AND the ~1.8 s decode/flatten -- the app reads the ready-to-upload float buffer straight
+// back. The 50 MB crosses the JS<->.NET boundary via Blazor's stream interop
+// (IJSStreamReference on load, DotNetStreamReference on save), never slow JSON marshaling.
+//
+// localStorage is unusable here (~5-10 MB, strings only); IndexedDB holds hundreds of MB async and
+// survives reloads/redeploys/eviction far better than the HTTP cache.
+window.tyc2Cache = (function () {
+    const DB_NAME = "tianwen-atlas";
+    const STORE = "tyc2";
+    const KEY = "stars";
+
+    function openDb() {
+        return new Promise(function (resolve, reject) {
+            const req = indexedDB.open(DB_NAME, 1);
+            req.onupgradeneeded = function () { req.result.createObjectStore(STORE); };
+            req.onsuccess = function () { resolve(req.result); };
+            req.onerror = function () { reject(req.error); };
+        });
+    }
+
+    return {
+        // Returns the cached bytes as a Uint8Array (Blazor hands it to C# as an IJSStreamReference)
+        // when a record for `version` exists, otherwise an EMPTY array -- the C# side reads a
+        // zero-length stream as a miss and falls back to fetch+decode. Returning empty rather than
+        // null keeps the return type a plain stream (no nullable-marshaling ambiguity).
+        load: async function (version) {
+            try {
+                const db = await openDb();
+                const rec = await new Promise(function (resolve, reject) {
+                    const req = db.transaction(STORE, "readonly").objectStore(STORE).get(KEY);
+                    req.onsuccess = function () { resolve(req.result); };
+                    req.onerror = function () { reject(req.error); };
+                });
+                db.close();
+                if (rec && rec.version === version && rec.bytes) {
+                    return new Uint8Array(rec.bytes);
+                }
+                return new Uint8Array(0);
+            } catch (e) {
+                console.warn("[tianwen-web] tyc2 cache load failed:", e);
+                return new Uint8Array(0);
+            }
+        },
+
+        // `streamRef` is a .NET DotNetStreamReference; read it fully and persist under `version`.
+        // Best-effort: a failure (private mode, quota) is swallowed so the atlas still works.
+        save: async function (version, streamRef) {
+            try {
+                const buf = await streamRef.arrayBuffer();
+                const db = await openDb();
+                await new Promise(function (resolve, reject) {
+                    const tx = db.transaction(STORE, "readwrite");
+                    tx.objectStore(STORE).put({ version: version, bytes: buf }, KEY);
+                    tx.oncomplete = function () { resolve(); };
+                    tx.onerror = function () { reject(tx.error); };
+                });
+                db.close();
+            } catch (e) {
+                console.warn("[tianwen-web] tyc2 cache save failed:", e);
+            }
+        }
+    };
+})();

--- a/src/TianWen.UI.Web/wwwroot/tyc2-cache.js
+++ b/src/TianWen.UI.Web/wwwroot/tyc2-cache.js
@@ -1,8 +1,9 @@
-// IndexedDB cache for the decoded Tycho-2 star buffer (~50 MB of float instances). Keyed by a
-// catalog version so a catalog change invalidates it. On a repeat visit this skips BOTH the ~30 MB
-// fetch AND the ~1.8 s decode/flatten -- the app reads the ready-to-upload float buffer straight
-// back. The 50 MB crosses the JS<->.NET boundary via Blazor's stream interop
-// (IJSStreamReference on load, DotNetStreamReference on save), never slow JSON marshaling.
+// IndexedDB cache for the RAW DECOMPRESSED Tycho-2 catalog (~42 MB). Keyed by a catalog version so
+// a catalog change invalidates it. On a repeat visit this skips BOTH the ~30 MB fetch AND the lzip
+// decompress -- the app feeds the cached bytes straight into the DB (star records + spatial index)
+// and re-flattens to the GPU, so clicking a star to identify it works on a cached load too. The
+// bytes cross the JS<->.NET boundary via Blazor's stream interop (IJSStreamReference on load,
+// DotNetStreamReference on save), never slow JSON marshaling.
 //
 // localStorage is unusable here (~5-10 MB, strings only); IndexedDB holds hundreds of MB async and
 // survives reloads/redeploys/eviction far better than the HTTP cache.


### PR DESCRIPTION
## What

Three web-atlas improvements found while testing the live Tycho-2 deploy: F3 fix, an IndexedDB cache to kill the repeat-visit re-decode, and clickable Tycho-2 stars.

## (1) F3 no longer double-opens

F3 opened the in-app catalog search **and** the browser's native find-in-page at once. A capture-phase `window` keydown listener in `index.html` cancels the browser default for F3; the canvas listener still fires, so only our search opens. Local fix, no `WebGl.Renderer` sibling release.

## (2) IndexedDB cache — no re-decode on repeat visits

Measured on the live AOT build: the atlas re-ran the ~1.8 s decode on every load (the HTTP cache only saves the download, and that 1.8 s is a synchronous WASM-thread freeze). Now the **raw decompressed catalog (~42 MB)** is cached in IndexedDB, keyed by a catalog version. A repeat visit streams it back and feeds the DB directly — skipping the ~30 MB fetch **and** the lzip decompress. Blazor stream interop (`IJSStreamReference`/`DotNetStreamReference`), not JSON marshaling. `localStorage` is unusable (~5–10 MB, strings).

## (3) Clickable Tycho-2 stars

Injection now wires the **GSC-bounds spatial index**, so the composite `CoordinateGrid` answers FOV queries against Tycho-2 — the shared `SkyMapSearchActions` click path (and Ctrl+click point-source pick) identifies individual TYC stars **with no new UI**. New `TryLoadTycho2BulkFromDecoded(byte[])` wires records + index; `TryLoadTycho2BulkFromCompressed` delegates to it after the decode.

Why P3 caches raw bytes (not the flattened float buffer): the click path needs the DB records + index, which a float-buffer cache bypassed — clicking would only work on the first cold visit. Caching raw makes both cold and warm loads feed the same DB path, so **clicking works identically on a cached load**. Cache version bumped v1→v2.

## Verification

- Lib + web **compile clean**; `tyc2-cache.js` syntax-checked.
- **Lib tests** cover the decoded-path method and the spatial-index contract (`CoordinateGrid` returns Tycho-2 + `TryLookupByIndex` resolves) — 5/5 green.
- ⚠️ **Runtime-unverified (need a browser):** the IndexedDB round-trip and the actual on-canvas click. Verify on the dev server / deploy: on a **second** load expect `[tianwen-web] tyc2 flatten (IndexedDB cache)` (no fetch/decompress lines); a click/Ctrl+click on a faint star should identify a `TYC …` designation; F3 opens only our search.
- **Safety:** every cache path is try/catch-wrapped with fallback to the cold fetch+decode, so if IndexedDB misbehaves the atlas still works exactly as now (P3 becomes a silent no-op, never a break).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ATx1GGJ6CyDBF2yjTqrvm7
