### PR TITLE
feat(web): touch pan + two-finger pinch-zoom in the sky atlas (WebGl.Renderer 1.5)

### DIFF
--- a/src/TianWen.UI.Web/Pages/Planner.razor
+++ b/src/TianWen.UI.Web/Pages/Planner.razor
@@ -62,7 +62,8 @@
         <WebGlCanvas Id="planner" TabIndex="0" AutoFocus="true"
                      OnReady="OnCanvasReady" OnResized="OnCanvasResized"
                      OnPointerDown="OnPointerDown" OnPointerMove="OnPointerMove"
-                     OnPointerUp="OnPointerUp" OnWheel="OnWheel" OnKeyDown="OnKeyDown" />
+                     OnPointerUp="OnPointerUp" OnWheel="OnWheel" OnKeyDown="OnKeyDown"
+                     OnPinch="OnPinch" OnPinchEnd="OnPinchEnd" />
         @* A REAL focusable input floated over the active canvas text widget: native IME /
            clipboard / autocorrect and the mobile soft keyboard, none of which a canvas-drawn
            widget can provide. Shown/hidden by the ActivateTextInput/DeactivateTextInput flow. *@
@@ -974,6 +975,25 @@
         // Browser deltaY > 0 = wheel down; the tab uses the SDL convention (positive = up).
         var scrollY = (float)(-e.DeltaY / 100.0);
         tab.HandleInput(new InputEvent.Scroll(scrollY, e.X, e.Y));
+        RenderFrame();
+    }
+
+    // Two-finger pinch (touchscreen): drive the shared sky-map zoom the same way the desktop SDL host
+    // does (TianWen.UI.Gui Program.cs OnPinch). WebGlCanvas already anchors at the finger midpoint in
+    // backing space; Source=Touchscreen tells SkyMapTab to zoom around that point (not the view centre).
+    // SINGLE-finger pan needs no handler here - WebGlCanvas bridges a lone finger to OnPointerDown/Move/Up,
+    // so the existing drag-pan handles it for free.
+    void OnPinch(CanvasPinchEventArgs e)
+    {
+        if (ActiveTab is not { } tab) return;
+        tab.HandleInput(new InputEvent.Pinch((float)e.Scale, e.X, e.Y) { Source = PinchSource.Touchscreen });
+        RenderFrame();
+    }
+
+    void OnPinchEnd()
+    {
+        if (ActiveTab is not { } tab) return;
+        tab.HandleInput(new InputEvent.PinchEnd());
         RenderFrame();
     }
 

--- a/src/TianWen.UI.Web/TianWen.UI.Web.csproj
+++ b/src/TianWen.UI.Web/TianWen.UI.Web.csproj
@@ -52,7 +52,7 @@
     <ProjectReference Include="..\..\..\WebGl.Renderer\src\WebGl.Renderer\WebGl.Renderer.csproj" />
   </ItemGroup>
   <ItemGroup Condition="'$(UseLocalSiblings)' != 'true'">
-    <PackageReference Include="WebGl.Renderer" Version="1.4.*" />
+    <PackageReference Include="WebGl.Renderer" Version="1.5.*" />
   </ItemGroup>
 
 


### PR DESCRIPTION
## What

Brings the in-browser sky atlas to **desktop input parity on tablets/phones**: single-finger drag **pans**, two-finger **pinch** zooms.

## Why it was needed

`WebGlCanvas` sets `touch-action:none` (so the page doesn't scroll/zoom under the canvas), which *also* suppresses the browser's compatibility mouse events — so on a touchscreen a finger produced **no input at all** (no pan, no zoom, nothing).

## How

Depends on **WebGl.Renderer 1.5** (published 1.5.81), which teaches `WebGlCanvas` to bridge raw touch:

- **One finger** → the existing `OnPointerDown`/`Move`/`Up` callbacks (a synthesized left press), so drag-pan **and** tap-to-select work with zero new code here.
- **Two fingers** → new `OnPinch`/`OnPinchEnd` callbacks → the shared `SkyMapTab.HandlePinchZoom`, anchored at the finger midpoint — the *same* handler the desktop SDL touchscreen path drives, so pinch behaves identically on both.

TianWen change is small: wire the two callbacks in `Planner.razor` (mirroring `TianWen.UI.Gui/Program.cs`) + bump `WebGl.Renderer 1.4.* → 1.5.*`.

## Verification

- Compiles via the **PackageReference path** (`-p:UseLocalSiblings=false`, the CI path) against the published 1.5.81 — confirms the package carries the new API.
- Canvas-boot smoke test (E2E `CatalogLoads`) passes against a dev server built on the new WebGl.Renderer — confirms the JS `attach()` touch listeners don't break canvas startup.
- Pan reuses the already-tested pointer path; pinch drives the already-tested `SkyMapTab.HandlePinchZoom` (desktop-covered).

**Follow-up:** a real touch/pinch E2E test — I'm evaluating a canvas-gesture + state-assertion pattern to model it on. Hardware (actual tablet) is the final check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)