### PR TITLE
test(web): E2E canvas gesture harness — pinch-zoom asserts the sky FOV changes

### DIFF
--- a/src/TianWen.UI.Web.E2E/CanvasGestureTests.cs
+++ b/src/TianWen.UI.Web.E2E/CanvasGestureTests.cs
@@ -1,0 +1,84 @@
+using System.Text.Json;
+using Microsoft.Playwright;
+using Xunit;
+using static Microsoft.Playwright.Assertions;
+
+namespace TianWen.UI.Web.E2E;
+
+/// <summary>
+/// Browser E2E for canvas touch gestures on the sky atlas. Unlike <see cref="NavigationTests"/> (which
+/// asserts on chrome DOM), these drive the WebGL canvas itself and assert the *view state* changed —
+/// impossible to read from the DOM of a single &lt;canvas&gt;, so they use the <c>?e2e=1</c> view-state
+/// hook (<c>window.__tianwenTest.getSkyView()</c>, wired in index.html + Planner.razor) to read the
+/// live field-of-view before/after a synthesized two-finger pinch (<see cref="CanvasGestures"/>, CDP).
+///
+/// This closes the gap the Drawboard canvas-E2E investigation surfaced: neither codebase tested
+/// touch/pinch, because a real canvas offers no DOM to assert on — the fix is a read-only view-state
+/// hook plus a CDP multi-touch helper.
+/// </summary>
+[Collection(TianWenWebCollection.Name)]
+public sealed class CanvasGestureTests(TianWenWebFixture fixture)
+{
+    private const float BootTimeout = 120_000;
+
+    // Opens the sky atlas directly (?view=sky) with the E2E view-state hook on (?e2e=1) and waits for
+    // the catalog to finish loading (the same readiness gate NavigationTests uses).
+    private async Task<IPage> OpenSkyAtlasAsync()
+    {
+        var page = await fixture.NewPageAsync();
+        await page.GotoAsync(fixture.BaseUrl + "?view=sky&e2e=1",
+            new PageGotoOptions { WaitUntil = WaitUntilState.DOMContentLoaded });
+        await Expect(page.Locator("[data-view=sky]")).ToBeVisibleAsync(new() { Timeout = BootTimeout });
+        await Expect(page.Locator(".catalog-loading")).ToHaveCountAsync(0, new() { Timeout = BootTimeout });
+        return page;
+    }
+
+    private static async Task<double> GetFovAsync(IPage page)
+    {
+        var json = await page.EvaluateAsync<string>("async () => await window.__tianwenTest.getSkyView()");
+        using var doc = JsonDocument.Parse(json);
+        return doc.RootElement.GetProperty("fovDeg").GetDouble();
+    }
+
+    // "Render idle" for the canvas: poll the view hook until the FOV stops changing (the Drawboard
+    // waitForBoundingBoxToStopChanging pattern, adapted from a bounding box to the view-state hook).
+    private static async Task WaitForFovToSettleAsync(IPage page)
+    {
+        var last = double.NaN;
+        for (var i = 0; i < 40; i++)
+        {
+            var fov = await GetFovAsync(page);
+            if (fov == last) return;
+            last = fov;
+            await page.WaitForTimeoutAsync(50);
+        }
+    }
+
+    [Fact]
+    public async Task PinchOut_ZoomsIn_ShrinksFieldOfView()
+    {
+        var page = await OpenSkyAtlasAsync();
+        var canvas = page.Locator("#planner");
+
+        var before = await GetFovAsync(page);
+        await CanvasGestures.PinchAsync(page, canvas, startGap: 60, endGap: 320); // spread fingers = zoom in
+        await WaitForFovToSettleAsync(page);
+        var after = await GetFovAsync(page);
+
+        Assert.True(after < before, $"pinch-out should shrink the FOV (zoom in); before={before}, after={after}");
+    }
+
+    [Fact]
+    public async Task PinchIn_ZoomsOut_GrowsFieldOfView()
+    {
+        var page = await OpenSkyAtlasAsync();
+        var canvas = page.Locator("#planner");
+
+        var before = await GetFovAsync(page);
+        await CanvasGestures.PinchAsync(page, canvas, startGap: 320, endGap: 60); // close fingers = zoom out
+        await WaitForFovToSettleAsync(page);
+        var after = await GetFovAsync(page);
+
+        Assert.True(after > before, $"pinch-in should grow the FOV (zoom out); before={before}, after={after}");
+    }
+}

--- a/src/TianWen.UI.Web.E2E/CanvasGestures.cs
+++ b/src/TianWen.UI.Web.E2E/CanvasGestures.cs
@@ -1,0 +1,59 @@
+using Microsoft.Playwright;
+
+namespace TianWen.UI.Web.E2E;
+
+/// <summary>
+/// Canvas gesture helpers for the WebGL sky atlas. The app is a single &lt;canvas&gt; with no DOM to
+/// drive, and Playwright has no public multi-touch API, so a two-finger pinch is synthesized over the
+/// Chrome DevTools Protocol (<c>Input.dispatchTouchEvent</c> with two <c>touchPoints</c>) — the
+/// technique the Drawboard canvas-E2E investigation surfaced as the genuine gap (both codebases
+/// lacked it). Coordinates are page (viewport) pixels, which CDP treats as clientX/clientY.
+/// </summary>
+internal static class CanvasGestures
+{
+    /// <summary>
+    /// A two-finger pinch centred on <paramref name="target"/>: two fingers on a horizontal line about
+    /// the centre, animating the inter-finger gap from <paramref name="startGap"/> to
+    /// <paramref name="endGap"/> over <paramref name="steps"/> moves. Spreading the fingers (end &gt;
+    /// start) zooms IN; closing them (end &lt; start) zooms OUT.
+    /// </summary>
+    public static async Task PinchAsync(
+        IPage page, ILocator target, double startGap, double endGap, int steps = 12)
+    {
+        var box = await target.BoundingBoxAsync()
+            ?? throw new InvalidOperationException("Pinch target has no bounding box (not visible).");
+        var cx = box.X + (box.Width / 2);
+        var cy = box.Y + (box.Height / 2);
+        var cdp = await page.Context.NewCDPSessionAsync(page);
+
+        // Two horizontal touch points `gap` apart, centred on (cx, cy).
+        static object[] Points(double cx, double cy, double gap) =>
+        [
+            new Dictionary<string, object> { ["x"] = cx - (gap / 2), ["y"] = cy },
+            new Dictionary<string, object> { ["x"] = cx + (gap / 2), ["y"] = cy },
+        ];
+
+        await cdp.SendAsync("Input.dispatchTouchEvent", new Dictionary<string, object>
+        {
+            ["type"] = "touchStart",
+            ["touchPoints"] = Points(cx, cy, startGap),
+        });
+
+        for (var i = 1; i <= steps; i++)
+        {
+            var gap = startGap + ((endGap - startGap) * i / steps);
+            await cdp.SendAsync("Input.dispatchTouchEvent", new Dictionary<string, object>
+            {
+                ["type"] = "touchMove",
+                ["touchPoints"] = Points(cx, cy, gap),
+            });
+            await page.WaitForTimeoutAsync(16); // ~1 frame between moves so each is processed
+        }
+
+        await cdp.SendAsync("Input.dispatchTouchEvent", new Dictionary<string, object>
+        {
+            ["type"] = "touchEnd",
+            ["touchPoints"] = Array.Empty<object>(), // release all fingers
+        });
+    }
+}

--- a/src/TianWen.UI.Web.E2E/TianWenWebFixture.cs
+++ b/src/TianWen.UI.Web.E2E/TianWenWebFixture.cs
@@ -65,6 +65,10 @@ public sealed class TianWenWebFixture : IAsyncLifetime
             // position so the tests are deterministic and never hit a permission prompt.
             Permissions = ["geolocation"],
             Geolocation = new Geolocation { Latitude = 47.5f, Longitude = 11.0f },
+            // Enable touch so the canvas gesture tests can synthesize touch events over CDP
+            // (the canvas touch listeners only fire when the browser reports touch support). The
+            // app doesn't branch on touch capability, so the mouse/DOM tests are unaffected.
+            HasTouch = true,
         });
         return await context.NewPageAsync();
     }

--- a/src/TianWen.UI.Web/Pages/Planner.razor
+++ b/src/TianWen.UI.Web/Pages/Planner.razor
@@ -118,6 +118,9 @@
     // bundle - the atlas shows the HR bright-star seed until it lands (and stays HR-only if the
     // fetch 404s, e.g. a dev server without the CI-baked asset).
     bool _tycho2Requested;
+    // E2E-only view-state hook (activated by ?e2e=1). Held so it can be disposed; null in a
+    // normal session (the hook is never registered).
+    DotNetObjectReference<Planner>? _testRef;
 
     // Sensible default dark-ish mid-northern site; geolocation / manual entry override it.
     double _lat = 47.5;
@@ -186,6 +189,16 @@
             deactivate: DeactivateTextInput,
             requestRedraw: RenderFrame);
         WireSkyMapSearch(_skyTab);
+
+        // E2E-only: when the app is opened with ?e2e=1, hand a .NET ref to the index.html shim so
+        // browser tests can read LIVE sky-map view state (FOV/centre) via window.__tianwenTest -
+        // the "assert canvas state without pixels" hook (a single WebGL canvas has no DOM to inspect).
+        // Inert in a normal session: the shim's getSkyView is never wired unless the flag is present.
+        if (IsE2ETestMode())
+        {
+            _testRef = DotNetObjectReference.Create(this);
+            await JS.InvokeVoidAsync("__tianwenTestInit", _testRef);
+        }
 
         await ComputeAsync();
         _ready = true;
@@ -898,9 +911,34 @@
         Nav.NavigateTo($"{Nav.BaseUri}?view={(view == View.SkyMap ? "sky" : "planner")}");
     }
 
+    // --- E2E view-state inspection hook (activated by ?e2e=1) --------------------------------
+    // The sky atlas is a single WebGL canvas with no DOM to inspect, so a browser test can't read
+    // zoom/pan the way a DOM-mirrored canvas app (e.g. Drawboard) can. This hook exposes the live
+    // view state to window.__tianwenTest.getSkyView() (wired by the index.html shim), gated on a URL
+    // flag so it is inert in a normal session. Read-only - it never mutates state.
+
+    bool IsE2ETestMode()
+        => Nav.ToAbsoluteUri(Nav.Uri).Query.Contains("e2e=1", StringComparison.OrdinalIgnoreCase);
+
+    // Live sky-map view state as JSON (fov + centre), invoked from the index.html test shim. Returns
+    // "null" before the sky tab exists. Hand-built JSON (no JsonSerializerContext) keeps it AOT-trivial.
+    [JSInvokable]
+    public string GetSkyViewJson()
+    {
+        if (_skyTab is not { State: { } s })
+        {
+            return "null";
+        }
+        var ci = CultureInfo.InvariantCulture;
+        return "{\"fovDeg\":" + s.FieldOfViewDeg.ToString(ci)
+            + ",\"centerRA\":" + s.CenterRA.ToString(ci)
+            + ",\"centerDec\":" + s.CenterDec.ToString(ci) + "}";
+    }
+
     public void Dispose()
     {
         Nav.LocationChanged -= OnLocationChanged;
+        _testRef?.Dispose();
     }
 
     // --- Input: routed through the tab's InputEvent handler, mirroring the desktop host ---------

--- a/src/TianWen.UI.Web/wwwroot/index.html
+++ b/src/TianWen.UI.Web/wwwroot/index.html
@@ -82,6 +82,18 @@
          Blazor so it's defined by the time the atlas first opens. -->
     <script src="tyc2-cache.js"></script>
 
+    <!-- E2E-only view-state hook. When the app is opened with ?e2e=1, Blazor calls __tianwenTestInit
+         with a .NET ref (see Planner.razor), so browser tests can read LIVE sky-map view state -
+         window.__tianwenTest.getSkyView() -> {fovDeg, centerRA, centerDec} - via page.evaluate. This
+         is how a single-WebGL-canvas app asserts "the gesture zoomed/panned" with no DOM to inspect
+         and no pixel reads. Defined always (a harmless no-op until called); never invoked in a normal
+         session because Planner only calls __tianwenTestInit behind the ?e2e=1 gate. -->
+    <script>
+        window.__tianwenTestInit = function (ref) {
+            window.__tianwenTest = { getSkyView: function () { return ref.invokeMethodAsync('GetSkyViewJson'); } };
+        };
+    </script>
+
     <script src="_framework/blazor.webassembly#[.{fingerprint}].js"></script>
 </body>
 


### PR DESCRIPTION
## What

Adds the reusable infrastructure to **test canvas interactions that have no DOM to inspect**, and uses it to actually test the touch pinch-zoom shipped in #106.

## Why

The Drawboard canvas-E2E investigation (their PDF app) surfaced that **neither codebase tested touch/pinch** — a single WebGL canvas offers no DOM to assert on the way a DOM-mirrored canvas app can. The fix is two reusable pieces:

1. **A read-only view-state hook** — `window.__tianwenTest.getSkyView()` → `{ fovDeg, centerRA, centerDec }`, gated behind **`?e2e=1`** so it's inert in a normal session (no build flag). Blazor hands a `DotNetObjectReference<Planner>` to a tiny `index.html` shim; `[JSInvokable] GetSkyViewJson()` returns the live `SkyMapState`. Drawboard has *write* hooks (setUser/setLicense) but no *read* hook — this is the missing direction, reusable for every future canvas assertion.
2. **A CDP multi-touch pinch helper** — `CanvasGestures.PinchAsync` uses `Input.dispatchTouchEvent` with two `touchPoints` (Playwright has no public multi-touch API). Fixture context gets `HasTouch = true` so the canvas touch listeners fire; harmless for the existing mouse/DOM tests.

## Tests

`CanvasGestureTests`: pinch-out asserts the FOV **shrinks** (zoom in); pinch-in asserts it **grows** (zoom out), with a hook-polling render-idle wait.

**Verified locally: 2/2 passing** against a dev server (msedge) — so this also proves the shipped touch feature genuinely zooms end-to-end, not just compiles.

## Notes

- E2E is dispatch-only in CI (interpreted-WASM dev-server boot is too slow for the push path), so these run on demand / locally, same as the existing `NavigationTests`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)