### PR TITLE
test(web): fix the E2E auto-start dev server (wrong port + pipe deadlock)

### DIFF
--- a/src/TianWen.UI.Web.E2E/TianWenWebFixture.cs
+++ b/src/TianWen.UI.Web.E2E/TianWenWebFixture.cs
@@ -82,10 +82,15 @@ public sealed class TianWenWebFixture : IAsyncLifetime
         // collides with one a developer already has up.
         const string url = "http://127.0.0.1:5188";
 
+        // --no-launch-profile is load-bearing: TianWen.UI.Web's launchSettings.json pins
+        // applicationUrl to :5099, and `dotnet run` applies that OVER our ASPNETCORE_URLS/--urls, so
+        // without this the dev server comes up on :5099 while WaitForServerAsync polls :5188 -> a
+        // guaranteed 5-minute timeout. Skipping the profile lets the explicit --urls (passed as an app
+        // arg after --) win. ASPNETCORE_URLS is kept as a belt-and-suspenders fallback.
         _server = new Process
         {
             StartInfo = new ProcessStartInfo("dotnet",
-                $"run --project \"{Path.Combine(repoRoot, "src", "TianWen.UI.Web")}\" -c Release -p:Lightweight=true")
+                $"run --project \"{Path.Combine(repoRoot, "src", "TianWen.UI.Web")}\" -c Release -p:Lightweight=true --no-launch-profile -- --urls {url}")
             {
                 WorkingDirectory = repoRoot,
                 UseShellExecute = false,
@@ -94,9 +99,32 @@ public sealed class TianWenWebFixture : IAsyncLifetime
             },
         };
         _server.StartInfo.Environment["ASPNETCORE_URLS"] = url;
-        _server.Start();
 
-        await WaitForServerAsync(url, TimeSpan.FromMinutes(5));
+        // Drain stdout+stderr. RedirectStandard* fills a ~4 KB OS pipe buffer and then BLOCKS the child
+        // until someone reads it; a WASM `dotnet run` prints far more than that during its build, so an
+        // undrained pipe wedges the server before it ever listens -> the other way this used to time out.
+        // Keep a bounded tail so a genuine startup failure surfaces in the exception, not a bare timeout.
+        var tail = new System.Collections.Concurrent.ConcurrentQueue<string>();
+        void Capture(string? line)
+        {
+            if (line is null) return;
+            tail.Enqueue(line);
+            while (tail.Count > 80) tail.TryDequeue(out _);
+        }
+        _server.OutputDataReceived += (_, e) => Capture(e.Data);
+        _server.ErrorDataReceived += (_, e) => Capture(e.Data);
+        _server.Start();
+        _server.BeginOutputReadLine();
+        _server.BeginErrorReadLine();
+
+        try
+        {
+            await WaitForServerAsync(url, TimeSpan.FromMinutes(5));
+        }
+        catch (TimeoutException ex)
+        {
+            throw new TimeoutException($"{ex.Message}\n--- last dev server output ---\n{string.Join('\n', tail)}", ex);
+        }
         return url;
     }
 


### PR DESCRIPTION
## Bug

The E2E fixture's self-contained `StartServerAsync` could **never** bring up its dev server, so every local E2E run needed a hand-started server + `TIANWEN_WEB_BASEURL`. Two independent bugs, either fatal:

1. **Wrong port.** It set `ASPNETCORE_URLS=:5188`, but `dotnet run` applies `launchSettings.json`'s `applicationUrl` (`:5099`) *over* the env var — so the server listened on `:5099` while `WaitForServerAsync` polled `:5188` → a guaranteed 5-minute timeout.
2. **Pipe deadlock.** `RedirectStandardOutput`/`Error` were `true` but never read. Once the ~4 KB OS pipe buffer fills — and a WASM `dotnet run` build prints far more — the child **blocks** before it ever listens.

## Fix

- `--no-launch-profile` so the `:5099` profile stops overriding us, plus an explicit `-- --urls http://127.0.0.1:5188` (app arg) that then wins.
- Drain stdout/stderr via `BeginOutputReadLine`/`BeginErrorReadLine`, keeping a bounded 80-line tail that's folded into the `TimeoutException` — so a genuine startup failure is visible instead of a bare timeout.

## Verification

`dotnet test --filter CatalogLoads` with **no** `TIANWEN_WEB_BASEURL` (the auto-start path) now boots its own server on `:5188` and passes — **1/1, 52s**. The hand-started-server path (`TIANWEN_WEB_BASEURL=...`) still works unchanged.

## Notes

E2E stays dispatch-only in CI (interpreted-WASM boot is too slow for the push path), so this doesn't add a CI job — it just makes the self-contained local/dispatch path actually work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
