### PR TITLE
feat(ui): planner details name links to Wikipedia (web + SDL desktop)

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -120,7 +120,7 @@
          reflow builds on. The Sizing ctor/Star/WStar signatures gained optional parameters
          (binary-breaking), so the whole sibling family rebuilt: lockstep with Console.Lib 3.8 +
          SdlVulkan.Renderer 6.25 + WebGl.Renderer 1.8. -->
-    <PackageVersion Include="DIR.Lib" Version="6.15.*" />
+    <PackageVersion Include="DIR.Lib" Version="6.16.*" />
     <!-- DIR.Lib 3.0 extracted its codec layer to these sibling packages, which
          ship as a lockstep family from the Codecs repo. 3.0 brought a
          binary-breaking SharpAstro.Tiff change (TiffPageOptions.IccProfile is
@@ -184,7 +184,7 @@
          migration (Console.Lib references SharpAstro.Codecs for image decode). 3.8 is the current
          pin: the no-code lockstep rebuild against DIR.Lib 6.14 (its Sizing/Star signatures are
          binary-breaking, so the 3.5 binary would MissingMethodException at runtime). -->
-    <PackageVersion Include="Console.Lib" Version="3.9.*" />
+    <PackageVersion Include="Console.Lib" Version="3.10.*" />
     <!-- SdlVulkan.Renderer 5.0 adds a multi-page SDF glyph atlas (no more grow
          stall / Adreno submit-wedge) on top of 4.1's SetSystemCursor + anisotropic
          glyph xScale. 5.1 implements DIR.Lib 4.4's PushClip/PopClip via Vulkan
@@ -232,7 +232,7 @@
          opt-in even in Debug (CompiledDebug and SDLVK_VALIDATION=1). 6.27 is the current pin: batched
          DrawPolyline/DrawPolylineDashed overrides (whole polyline into one Flat-pipeline draw); see
          docs/plans/render-batching.md. -->
-    <PackageVersion Include="SdlVulkan.Renderer" Version="6.28.*" />
+    <PackageVersion Include="SdlVulkan.Renderer" Version="6.29.*" />
     <PackageVersion Include="SDL3-CS" Version="3.5.0-preview.20260213-150035" />
     <PackageVersion Include="SDL3-CS.Native" Version="3.5.0-preview.20260205-174353" />
     <!-- Canon DSLR -->

--- a/src/TianWen.Lib.Tests/PlannerDetailsTests.cs
+++ b/src/TianWen.Lib.Tests/PlannerDetailsTests.cs
@@ -107,4 +107,36 @@ public class PlannerDetailsTests
         var one = PlannerDetails.GetLines(state, [Scored(target, obj.ObjectType)], maxLines: 1);
         one.ShouldBe([obj.DisplayName]);
     }
+
+    [Fact]
+    public async Task GivenCataloguedTargetWhenGetWikipediaUrlThenLinksMainCatalogName()
+    {
+        var db = await SharedCatalogDB.InitAsync(TestContext.Current.CancellationToken);
+        db.TryLookupByIndex("M31", out var obj).ShouldBeTrue();
+
+        var target = new Target(obj.RA, obj.Dec, obj.DisplayName, obj.Index);
+        var scored = Scored(target, obj.ObjectType);
+
+        var url = PlannerDetails.GetWikipediaUrl(BuildState(scored, db), [scored]);
+
+        // The link points at en.wikipedia.org and uses the MAIN catalog designation, NOT the display
+        // name: decoding the path (and '_' -> ' ') must reproduce Index.ToCanonical(). No raw spaces.
+        url.ShouldNotBeNull();
+        url.ShouldStartWith("https://en.wikipedia.org/wiki/");
+        url.ShouldNotContain(" ");
+        var slug = url["https://en.wikipedia.org/wiki/".Length..];
+        Uri.UnescapeDataString(slug).Replace('_', ' ').ShouldBe(obj.Index.ToCanonical());
+    }
+
+    [Fact]
+    public void GivenNoCatalogIndexOrNoSelectionWhenGetWikipediaUrlThenNull()
+    {
+        // Bare position (no catalog index) -> nothing to link.
+        var bare = new Target(1.23, 45.6, "Custom position", null);
+        var scored = Scored(bare);
+        PlannerDetails.GetWikipediaUrl(BuildState(scored, db: null), [scored]).ShouldBeNull();
+
+        // Selection out of range (empty filtered list) -> null.
+        PlannerDetails.GetWikipediaUrl(BuildState(scored, db: null), []).ShouldBeNull();
+    }
 }

--- a/src/TianWen.Lib.Tests/PlannerTabLayoutTests.cs
+++ b/src/TianWen.Lib.Tests/PlannerTabLayoutTests.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using DIR.Lib;
 using SharpAstro.Png;
 using Shouldly;
+using TianWen.Lib.Astrometry.Catalogs;
 using TianWen.Lib.Astrometry.SOFA;
 using TianWen.Lib.Devices;
 using TianWen.Lib.Sequencing;
@@ -29,8 +30,9 @@ namespace TianWen.Lib.Tests
         private static readonly DateTimeOffset NightEnd = new(2025, 12, 16, 6, 0, 0, TimeSpan.Zero);
 
         /// <summary>A planner state with two selectable targets so the chart, list rows, and details
-        /// panel all have real content to paint.</summary>
-        private static PlannerState BuildState()
+        /// panel all have real content to paint. <paramref name="firstIndex"/> optionally gives the first
+        /// target a catalog index (so the details name line becomes a Wikipedia link).</summary>
+        private static PlannerState BuildState(CatalogIndex? firstIndex = null)
         {
             var state = new PlannerState
             {
@@ -45,7 +47,7 @@ namespace TianWen.Lib.Tests
             var tonightsBuilder = ImmutableArray.CreateBuilder<ScoredTarget>();
             for (var i = 0; i < 2; i++)
             {
-                var target = new Target(i * 2.0, 45, $"T{i}", null);
+                var target = new Target(i * 2.0, 45, $"T{i}", i == 0 ? firstIndex : null);
                 var peak = NightStart + TimeSpan.FromHours(3 + i * 2);
                 var scored = new ScoredTarget(target, (Half)1.0, (Half)1.0,
                     new Dictionary<RaDecEventTime, RaDecEventInfo>(),
@@ -273,6 +275,33 @@ namespace TianWen.Lib.Tests
 
             hit.ShouldBeOfType<HitResult.ListItemHit>().Index.ShouldBe(1);
             committed.ShouldBe([1]);
+        }
+
+        /// <summary>
+        /// The details name line for a catalogued target is a Wikipedia link: it registers a
+        /// <see cref="HitResult.LinkHit"/> carrying the article URL built from the MAIN catalog
+        /// designation. The host decides what a link does (the SDL/Vulkan chrome maps LinkHit ->
+        /// open the OS browser + a pointer cursor on hover; the web renders a real &lt;a&gt;), so this
+        /// pins only the tab's contract -- that the region exists with the right URL.
+        /// </summary>
+        [Fact]
+        public void DetailsName_ForCataloguedTarget_RegistersWikipediaLinkHit()
+        {
+            using var renderer = new RgbaImageRenderer(1600, 1000);
+            var tab = new PlannerTab<RgbaImage>(renderer) { FontPath = FontResolver.ResolveSystemFont() };
+
+            // A catalogued selected target (IC 1000) -> the name line carries the link.
+            var state = BuildState(CatalogIndex.IC1000);
+
+            var time = new FakeTimeProviderWrapper(new DateTimeOffset(2025, 12, 15, 22, 0, 0, TimeSpan.Zero));
+            tab.Render(state, new RectF32(0, 0, 1600, 1000), time);
+
+            // The name registers a LinkHit; a click on it returns that hit with the article URL built
+            // from the canonical designation (IC 1000 -> IC_1000), spaces mapped to '_'.
+            var region = tab.GetRegisteredRegions().First(r => r.Result is HitResult.LinkHit);
+            var hit = tab.HitTestAndDispatch(region.X + region.Width / 2f, region.Y + region.Height / 2f);
+
+            hit.ShouldBeOfType<HitResult.LinkHit>().Url.ShouldBe("https://en.wikipedia.org/wiki/IC_1000");
         }
     }
 }

--- a/src/TianWen.UI.Abstractions/GuiEventHandlerBase.cs
+++ b/src/TianWen.UI.Abstractions/GuiEventHandlerBase.cs
@@ -127,6 +127,17 @@ namespace TianWen.UI.Abstractions
                 hit = _chrome.ActiveTab?.HitTestAndDispatch(px, py, modifiers);
             }
 
+            // A hyperlink (planner details -> Wikipedia): open it via the host. Centralized here so every
+            // LinkHit behaves identically, with no per-region wiring. The desktop host subscribes to
+            // OpenUrlSignal and opens the OS browser; on the web the DOM <a> handles the click before the
+            // canvas ever sees it, so this path is desktop-only in practice (and a no-op with no subscriber).
+            if (hit is HitResult.LinkHit { Url: var url })
+            {
+                _chrome.Bus?.Post(new OpenUrlSignal(url));
+                _appState.NeedsRedraw = true;
+                return true;
+            }
+
             // Text input focus management (via ActivateTextInputSignal/DeactivateTextInputSignal)
             if (hit is HitResult.TextInputHit { Input: { } clickedInput })
             {

--- a/src/TianWen.UI.Abstractions/GuiSignals.cs
+++ b/src/TianWen.UI.Abstractions/GuiSignals.cs
@@ -65,6 +65,13 @@ public readonly record struct BuildScheduleSignal;
 /// <summary>Toggle fullscreen mode.</summary>
 public readonly record struct ToggleFullscreenSignal;
 
+/// <summary>
+/// Open an external URL in the user's default browser. Posted by desktop (SDL/Vulkan) hosts, which have
+/// no DOM and handle it through the OS shell; the web host renders links as real &lt;a&gt; elements and
+/// never posts this. A host with no subscriber simply drops it (no-op), so it is safe to post anywhere.
+/// </summary>
+public readonly record struct OpenUrlSignal(string Url);
+
 /// <summary>Request plate solving the current image.</summary>
 public readonly record struct PlateSolveSignal;
 

--- a/src/TianWen.UI.Abstractions/PlannerDetails.cs
+++ b/src/TianWen.UI.Abstractions/PlannerDetails.cs
@@ -125,6 +125,36 @@ public static class PlannerDetails
         return lines;
     }
 
+    private const string WikipediaArticleBase = "https://en.wikipedia.org/wiki/";
+
+    /// <summary>
+    /// The Wikipedia article URL for the currently selected target, built from its MAIN catalog
+    /// designation (e.g. "NGC 6523" -> https://en.wikipedia.org/wiki/NGC_6523). Returns null when nothing
+    /// is selected or the target carries no catalog index (bare positions). Spaces map to '_' (the
+    /// MediaWiki title convention) and the rest is percent-encoded -- MediaWiki decodes encoded titles, so
+    /// the link stays correct even for designations containing '/', '(' or an en-dash (comets, named DSOs).
+    /// The name line rendered in the details panel is the display name; the LINK deliberately uses the
+    /// canonical catalog designation so it resolves regardless of which common name we happen to show.
+    /// </summary>
+    public static string? GetWikipediaUrl(PlannerState state, IReadOnlyList<ScoredTarget> filteredTargets)
+    {
+        var idx = state.SelectedTargetIndex;
+        if (idx < 0 || idx >= filteredTargets.Count)
+        {
+            return null;
+        }
+        if (filteredTargets[idx].Target.CatalogIndex is not { } index)
+        {
+            return null;
+        }
+        var name = index.ToCanonical();
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            return null;
+        }
+        return WikipediaArticleBase + Uri.EscapeDataString(name.Replace(' ', '_'));
+    }
+
     /// <summary>
     /// Formats the coordinate + altitude + peak-time + window line for a scored target. Extracted
     /// so the CLI inline prompt can render exactly this line without depending on its positional

--- a/src/TianWen.UI.Abstractions/PlannerTab.cs
+++ b/src/TianWen.UI.Abstractions/PlannerTab.cs
@@ -521,6 +521,11 @@ namespace TianWen.UI.Abstractions
 
             var lineH = rect.Height / lines.Count;
 
+            // The name line links to the object's Wikipedia article (built from its MAIN catalog
+            // designation). Web-only affordance: the DOM text layer renders it as a real <a href>; the
+            // desktop raster path ignores the href and draws the name as before. Null for bare positions.
+            var nameHref = PlannerDetails.GetWikipediaUrl(state, _lastFilteredTargets);
+
             for (var i = 0; i < lines.Count; i++)
             {
                 var line = lines[i];
@@ -536,10 +541,23 @@ namespace TianWen.UI.Abstractions
 
                 // Selectable: these are the stable, copy-worthy detail lines (designations, coords,
                 // photometry). Rasters exactly like DrawText on desktop; on the web a DOM text layer
-                // renders them as real selectable text instead (Renderer.HostRendersSelectableText).
+                // renders them as real selectable text instead (Renderer.HostRendersSelectableText). The
+                // name line additionally carries the Wikipedia href -> a real <a> on the web host.
                 DrawSelectableText(line, fontPath,
                     rect.X + padding, y, rect.Width - padding * 2f, lineH,
-                    fs, color, TextAlign.Near, TextAlign.Center);
+                    fs, color, TextAlign.Near, TextAlign.Center,
+                    i == 0 ? nameHref : null);
+
+                // Desktop realization of the same link: register the name as a LinkHit region. The host
+                // owns what a link does -- the SDL/Vulkan chrome opens the OS browser on click and shows a
+                // pointer cursor on hover; on the web the DOM <a> sits on top and intercepts the click, so
+                // this canvas region never dispatches there (no double open). No per-region OnClick: the
+                // host's central dispatch maps LinkHit uniformly, so every link behaves the same.
+                if (i == 0 && nameHref is { } href)
+                {
+                    RegisterClickable(rect.X + padding, y, rect.Width - padding * 2f, lineH,
+                        new HitResult.LinkHit(href));
+                }
             }
         }
 

--- a/src/TianWen.UI.Gui/Program.cs
+++ b/src/TianWen.UI.Gui/Program.cs
@@ -153,6 +153,21 @@ bus.Subscribe<DeactivateTextInputSignal>(_ =>
         appState.NeedsRedraw = true;
     }
 });
+// Open an external URL in the OS default browser (planner details -> Wikipedia link). Host-level +
+// desktop-only on purpose: UseShellExecute routes a URL through the shell (ShellExecute on Windows,
+// xdg-open/open on Linux/macOS), which the WASM-shared abstraction layer cannot do. Best-effort.
+bus.Subscribe<OpenUrlSignal>(sig =>
+{
+    try
+    {
+        using var _ = System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(sig.Url) { UseShellExecute = true });
+    }
+    catch (Exception ex)
+    {
+        logger.LogWarning(ex, "Failed to open URL {Url}", sig.Url);
+    }
+});
+
 // BuildScheduleSignal is now handled inside AppSignalHandler — no host-level subscription needed
 
 // Load saved session configuration + initialize planner (shared logic in AppSignalHandler)
@@ -236,10 +251,23 @@ var loop = new SdlEventLoop(sdlWindow, renderer)
     // on MouseUp (the previous hand-wired OnMouseUp reconstructed them from a cached position —
     // without them the click-vs-drag detection in SkyMapTab compared (0, 0) to the real mouse-down
     // position). Presses route left-button only, as before; everything else flows through.
-    OnPointerInput = evt => evt switch
+    OnPointerInput = evt =>
     {
-        InputEvent.MouseDown { Button: not MouseButton.Left } => true,
-        _ => handlers.HandleInput(evt),
+        // Hand cursor over a hyperlink (planner details -> Wikipedia). Non-dispatching HitTest against
+        // the last frame's regions (active tab, then chrome) so hover never fires a click handler. Cheap
+        // and idempotent -- SetSystemCursor no-ops when the cursor is unchanged, so this is safe per move.
+        if (evt is InputEvent.MouseMove(var mx, var my))
+        {
+            var overLink = guiRenderer.ActiveTab?.HitTest(mx, my) is HitResult.LinkHit
+                || guiRenderer.HitTest(mx, my) is HitResult.LinkHit;
+            sdlWindow.SetSystemCursor(overLink ? SystemCursor.Pointer : SystemCursor.Default);
+        }
+
+        return evt switch
+        {
+            InputEvent.MouseDown { Button: not MouseButton.Left } => true,
+            _ => handlers.HandleInput(evt),
+        };
     },
 
     OnPinch = (scale, mx, my, source) =>

--- a/src/TianWen.UI.Web/Pages/Planner.razor
+++ b/src/TianWen.UI.Web/Pages/Planner.razor
@@ -954,7 +954,7 @@
             ref readonly var r = ref regions[i];
             var run = new OverlayTextRun(
                 r.X / dpr, r.Y / dpr, r.Width / dpr, r.Height / dpr,
-                r.Text, r.FontSize / dpr, r.Color, r.HorizontalAlign, r.VerticalAlign);
+                r.Text, r.FontSize / dpr, r.Color, r.HorizontalAlign, r.VerticalAlign, r.Href);
             if (!changed && run != _textRuns[i]) changed = true;
             _textRunsScratch.Add(run);
         }

--- a/src/TianWen.UI.Web/TianWen.UI.Web.csproj
+++ b/src/TianWen.UI.Web/TianWen.UI.Web.csproj
@@ -52,7 +52,7 @@
     <ProjectReference Include="..\..\..\WebGl.Renderer\src\WebGl.Renderer\WebGl.Renderer.csproj" />
   </ItemGroup>
   <ItemGroup Condition="'$(UseLocalSiblings)' != 'true'">
-    <PackageReference Include="WebGl.Renderer" Version="1.10.*" />
+    <PackageReference Include="WebGl.Renderer" Version="1.11.*" />
   </ItemGroup>
 
 


### PR DESCRIPTION
The selected target's name in the planner details panel becomes a link to its Wikipedia article, built from the MAIN catalog designation (Target.CatalogIndex.ToCanonical(), spaces to underscores, percent-encoded) via PlannerDetails.GetWikipediaUrl.

## Behavior
- Web: DrawSelectableText carries an href, so WebGl.Renderer's CanvasTextLayer renders a real anchor element (target=_blank, rel=noopener) with a pointer cursor + underline. Native new-tab / copy-link / hover-preview.
- Desktop (SDL/Vulkan): the name registers a HitResult.LinkHit(url). GuiEventHandlerBase maps any LinkHit to OpenUrlSignal centrally; the GUI host opens the OS browser (Process.Start, UseShellExecute) and shows a hand cursor on hover (SystemCursor.Pointer, via a non-dispatching HitTest each mouse-move).

Bare positions (no catalog index) get no link. Catalogued DSOs link via their NGC/IC designation (Messier numbers are cross-index aliases of the NGC primary), which Wikipedia has redirects for.

## Design (LinkHit)
One general primitive rather than per-widget wiring: DIR.Lib gains SelectableTextRegion.Href + HitResult.LinkHit; the host decides what a link does. Verified in the running GUI (the details name shows as a LinkHit region) and by unit tests (PlannerDetails.GetWikipediaUrl + the LinkHit contract).

## Sibling releases this rides
- DIR.Lib 6.16 (SelectableTextRegion.Href + DrawSelectableText href overload + HitResult.LinkHit)
- WebGl.Renderer 1.11 (OverlayTextRun.Href + anchor rendering)
- Console.Lib 3.10 + SdlVulkan.Renderer 6.29 (lockstep rebuilds against DIR.Lib 6.16; SdlVulkan 6.29 also carries the merged lavapipe teardown-flake test fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)