### PR TITLE
fix(web): prevent native browser zoom from trackpad pinch (ctrl+wheel)

### DIFF
--- a/src/TianWen.UI.Web/wwwroot/index.html
+++ b/src/TianWen.UI.Web/wwwroot/index.html
@@ -76,6 +76,20 @@
                 e.preventDefault();
             }
         }, { capture: true });
+
+        // A trackpad pinch-zoom (and ctrl+scroll) reaches the page as ctrl+wheel; the browser's native
+        // default zooms the WHOLE PAGE (chrome and all). This showcase owns zoom itself -- the canvas
+        // pinch-zoom + the sky-map wheel-zoom -- so cancel the browser default page-wide. window-level +
+        // non-passive + capture so it wins over EVERY region (toolbar / title / the selectable-text DOM
+        // overlay), not just the canvas -- a canvas-only guard leaves a pinch over the chrome still zooming.
+        // preventDefault does not stop propagation, so the canvas's @onwheel still routes the delta to the
+        // app (SkyMap zooms toward the cursor). Keyboard ctrl +/-/0 is deliberately left alone (accessibility
+        // zoom). Same reason as the F3 guard above: a passive Blazor @onwheel can't preventDefault this.
+        window.addEventListener("wheel", function (e) {
+            if (e.ctrlKey) {
+                e.preventDefault();
+            }
+        }, { passive: false, capture: true });
 </script>
 
     <!-- IndexedDB cache for the decoded Tycho-2 star buffer (window.tyc2Cache). Loaded before


### PR DESCRIPTION
Touchpad pinch-zoom on the web showcase zoomed the whole browser page (chrome and all) instead of the atlas. A trackpad pinch reaches the browser as ctrl+wheel; touchscreen pinch was already correct (bridged to OnPinch in webgl-canvas.js), but wheel comes through Blazor's passive @onwheel binding, so the browser's native ctrl+wheel page-zoom was never prevented.

Fix: a window-level, non-passive, capture-phase wheel listener in index.html that preventDefaults ctrl+wheel across the ENTIRE planner page -- so a pinch over the toolbar / title / selectable-text DOM overlay is caught too, not just over the canvas (a canvas-only guard would leave the chrome areas zooming, hence page-wide). preventDefault does not stop propagation, so the canvas @onwheel still routes the delta to the app and the sky map zooms toward the cursor. Keyboard ctrl +/-/0 is deliberately left untouched (accessibility zoom). Same rationale + location as the existing F3 find-in-page guard.

Static-asset only (no sibling release); GitHub Pages redeploys on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)