### PR TITLE
feat(ui): U2 search-control unification (DIR.Lib SearchInteraction) + sibling repin to 6.18

### DIFF
--- a/docs/plans/controls-upstreaming.md
+++ b/docs/plans/controls-upstreaming.md
@@ -1,6 +1,6 @@
 # Controls upstreaming: promote generic controls to DIR.Lib
 
-**Status: PLANNED (2026-07-21).** Follow-on to
+**Status: U1 + U5 SHIPPED; U2 DESIGN SIGNED OFF (2026-07-23), implementation next.** Follow-on to
 [interaction-primitives.md](interaction-primitives.md); taxonomy + inventory in
 [../architecture/widgets-and-controls.md](../architecture/widgets-and-controls.md).
 
@@ -10,11 +10,16 @@ belong in DIR.Lib next to `PixelWidgetBase`/`TextInputState`. Two of them (the s
 a duplication: the planner autocomplete and the sky-map F3 modal hand-roll the same
 input + suggestion-list + key-nav + commit machinery around `TextInputState`.
 
-**Release vehicle: DIR.Lib 6.16 (a minor AFTER the pending 6.15 lockstep chain ships).** Do NOT grow
-the P2 release -- 6.15 is frozen (primitives + fits-again re-pin) and tianwen is already stacked on
-it. Each U-phase below is independently shippable.
+**Release-slot history (IMPORTANT -- the 6.16 earmark is stale):** U1 + U5 shipped as part of the
+DIR.Lib **6.15/6.16** line (they landed on `feat/interaction-primitives`, released with the P2 chain and
+consumed by tianwen PR #110). The 6.16 minor this plan originally earmarked for U2 was then **consumed
+by an unrelated feature** (the planner Wikipedia-link channel, tianwen PR #111). DIR.Lib `main` is now at
+**6.17.0** (an in-progress `DeviceTransform` feature). So **U2 rides the next DIR.Lib minor after
+DeviceTransform's 6.17** -- 6.17 if that isn't published to NuGet yet, else 6.18 -- + the Console.Lib /
+SdlVulkan.Renderer / WebGl lockstep rebuilds + a tianwen repin. Each U-phase is independently shippable;
+"no push before NuGet" applies.
 
-## U1 -- `TrackSlider` -> DIR.Lib  **(DONE in branch, rides 6.16)**
+## U1 -- `TrackSlider` -> DIR.Lib  **(DONE + SHIPPED, DIR.Lib 6.15/6.16)**
 
 `ImageRendererBase.TrackSlider.cs` was ~50 lines with zero domain dependencies: `DrawTrackSlider`
 uses `FillRect`/`RegisterClickable` (`PixelWidgetBase` members) + `RectF32`/`RGBAColor32`/`HitResult`
@@ -38,6 +43,15 @@ were tianwen's.
 
 ## U2 -- `SearchInteraction` base -> DIR.Lib, tianwen searches become subclasses
 
+**Status: IMPLEMENTED locally + smoke-verified (2026-07-23); pending release + commit.** On uncommitted
+branches `feat/search-interaction` (DIR.Lib) + `feat/controls-upstreaming-u2` (tianwen). DIR.Lib suite
+549/0 (20 new `SearchInteractionTests`); tianwen solution builds 0/0, 128 Planner/SkyMap/TextInput/
+Equipment tests green. Live GUI smoke (inspector): planner autocomplete (type -> dropdown -> Down -> Enter
+commits + resets, no auto-highlight) and sky-map F3 (open -> results with first auto-highlighted -> Escape
+closes) both behave per their preserved policies; no stderr exceptions. Remaining: the DIR.Lib release
+chain (next minor after DeviceTransform's 6.17) + lockstep rebuilds + tianwen repin, then commit/PR
+("no push before NuGet"). The 6 U5 residue casts are an easy tail to fold into the tianwen repin.
+
 The planner search (`PlannerSearchInteraction` + suggestion state spread over `PlannerState`) and the
 sky-map F3 search (`SkyMapSearchState` + inline key-nav in `SkyMapTab.Search.cs:762-768`) are the
 same control with different domain resolution:
@@ -50,24 +64,98 @@ same control with different domain resolution:
 | commit-identical mouse path (`CommitSuggestionAt(index)` == keyboard Enter) | deactivate via `DeactivateTextInputSignal` | close modal |
 | clear/dismiss reset (text, list, index, focus release) | | |
 
-Design: `DIR.Lib.SearchInteraction<TResult>` (abstract class next to `TextInputState`):
+### Design (SIGNED OFF 2026-07-23)
 
-- Owns `TextInputState Input`, `ImmutableArray<TResult> Results`, `int SelectedIndex`,
-  `string LastQuery`; wires the four `TextInputState` callbacks in its ctor.
-- Abstract seams: `UpdateResults(string query)` (domain resolve), `CommitResult(TResult)`,
-  `DisplayText(TResult)`; virtual `OnDismissed()`. Host callbacks (`deactivateFocus`,
-  `requestRedraw`) passed in, like `PlannerSearchInteraction.Wire` today.
-- The key-nav protocol lives ONCE in the base (today it is split three ways:
-  `TextInputInteraction`'s suggestion cycling, `PlannerSearchInteraction.OnKeyOverride`, and the
-  sky map's inline Up/Down).
-- tianwen: `PlannerSearchInteraction : SearchInteraction<string>`,
-  `SkyMapSearchInteraction : SearchInteraction<SkyMapSearchResult>`; the per-widget rendering
-  (dropdown rows vs modal rows) stays in the widgets -- the base is interaction state, not paint.
-- Evaluate during U2: `TextInputInteraction` itself (key routing + clipboard over `TextInputState`,
-  `TextInputKey` is DIR.Lib) looks promotable wholesale -- decide when the seams are cut; anything
-  signal-bus-flavoured stays behind the host callbacks.
-- Web note: the `CanvasTextOverlay` binds to `TextInputState` and already serves both searches --
-  unchanged by this refactor.
+**Two-level base in DIR.Lib.** `TextInputKey` has no Up/Down (verified), and mapping arrows into
+`ToTextInputKey` would change key routing for *every* text input (incl. the TUI equipment tab) -- too
+broad. So Up/Down nav stays an explicit `InputKey` seam the host key-router calls, which means the host
+needs a `TResult`-free handle. Hence a non-generic base carrying the protocol + selected-index, and a
+generic subclass carrying the typed results:
+
+```csharp
+namespace DIR.Lib;
+
+// TResult-free: input wiring + key-nav protocol + selected-index. Hosts (KeyContext) hold THIS.
+public abstract class SearchInteraction
+{
+    protected SearchInteraction(TextInputState input, Action requestRedraw, Action? releaseFocus = null);
+    public TextInputState Input { get; }
+    public int SelectedIndex { get; set; } = -1;
+    public string LastQuery { get; protected set; } = "";
+    public abstract int ResultCount { get; }
+    public bool HandleNavKey(InputKey key);   // Up/Down over [0, ResultCount); replaces the 2 KeyContext blocks
+    public void CommitAt(int index);          // mouse click == keyboard Enter-on-highlight
+    protected abstract void Requery(string text);        // OnTextChanged -> resolve results
+    protected abstract void CommitSelected();            // Enter-on-highlight / CommitAt
+    protected abstract void CommitRawQuery(string text); // Enter with no highlight
+    protected virtual  void Dismiss();                   // Escape / OnCancel cleanup
+}
+
+// Adds typed results; seals Requery/CommitSelected onto the typed seams.
+public abstract class SearchInteraction<TResult> : SearchInteraction
+{
+    public ImmutableArray<TResult> Results { get; protected set; } = [];
+    public sealed override int ResultCount => Results.Length;
+    protected sealed override void Requery(string t) => Results = Query(t);
+    protected sealed override void CommitSelected() => Commit(Results[SelectedIndex]);
+    protected abstract ImmutableArray<TResult> Query(string text);
+    protected abstract void Commit(TResult result);
+}
+```
+
+The ctor wires all four `TextInputState` callbacks **once**: `OnTextChanged` -> set `LastQuery` +
+`Requery` + redraw; `OnCommit` (Enter, no highlight) -> `CommitRawQuery`; `OnCancel` -> `Dismiss` +
+releaseFocus + redraw; `OnKeyOverride` -> Enter-on-highlight -> `CommitSelected`, Escape -> `Dismiss`,
+Backspace/Delete -> `false` (fall through to text edit, `Requery` fires via `OnTextChanged`).
+
+**Host key-router change (one struct field, one production site).** `TextInputInteraction.KeyContext`
+drops `PlannerState? Planner` + `SkyMapSearchState? SkySearch`, gains `SearchInteraction? ActiveSearch`.
+The two hardcoded Up/Down blocks (`HandleKey` L55-97) collapse to one polymorphic call:
+
+```csharp
+if (ctx.ActiveSearch is { } s && activeInput == s.Input && s.HandleNavKey(key)) { ctx.RequestRedraw(); return true; }
+```
+
+`TextInputInteraction` thereby loses its `PlannerState`/`SkyMapSearchState` dependency entirely. The only
+production `KeyContext` site is `GuiEventHandlerBase:331` (resolve `ActiveSearch` = whichever search's
+`Input` is the active one, else null); verify the web host key path (`Planner.razor`) builds the same
+context. `SkyMapTab.TryHandleSearchKey`'s Up/Down fallback (L753-767) is already dead while the modal's
+input is active (`HandleKey` swallows all keys) -- delete it, keep the F3 toggle.
+
+**tianwen subclasses (thin: protocol in the base, domain callbacks injected).** Commit needs
+per-invocation host context (planner: transform/db/ensureVisible; sky: db/site/viewingUtc/comets, resolved
+in the signal handler with DI), so the subclasses hold host-supplied callbacks and forward -- exactly the
+shape `PlannerSearchInteraction.Wire` + `AppSignalHandler.SkyMap` already inject:
+
+- `PlannerSearchInteraction : SearchInteraction<string>` -- `Query` = the pure part of
+  `PlannerActions.UpdateSuggestions` (extract `ComputeSuggestions(cache, text)`); `Commit` =
+  `CommitSuggestion`; `CommitRawQuery` = `SearchTargets`; `Dismiss` = clear + deactivate. ctor takes
+  today's `Wire` params (db, createTransform, autoComplete, ensureVisible, deactivate, requestRedraw).
+- `SkyMapSearchInteraction : SearchInteraction<SkyMapSearchResult>` -- `Query` = pure `FilterResults`;
+  `Commit`/`CommitRawQuery` post `SkyMapSearchCommitSignal` (DI/context resolution stays in the handler);
+  `Dismiss` = `CloseSearch` + deactivate. `AppSignalHandler.SkyMap`'s three `SearchInput.On*` assignments
+  disappear (ctor-wired); the Open/Close/Commit signal subscribers stay.
+
+**State migration = FULL (decision A, 2026-07-23).** The base OWNS `Results`/`SelectedIndex`/`LastQuery`;
+`PlannerState`/`SkyMapSearchState` expose the interaction instance and the old fields go away rather than
+becoming shims (shims would perpetuate the split U2 exists to remove). Blast radius is bounded:
+`PlannerState.Suggestions`/`SuggestionIndex`/`LastSuggestionQuery`/`CommitSuggestionAt` -> `Search.Results`
+(`ImmutableArray<string>`)/`Search.SelectedIndex`/`Search.LastQuery`/`Search.CommitAt`, read by
+`PlannerTab.cs:443/457/479`; `SkyMapSearchState.Results`/`SelectedResultIndex` -> `Search.Results`/
+`.SelectedIndex`, read across `SkyMapTab.Search.cs`. Test updates: `PlannerSearchInteractionTests`,
+`SkyMapSearchActionsTests`, `PlannerTabLayoutTests`.
+
+- Web note: the `CanvasTextOverlay` binds to `TextInputState` (which the base still owns as `Input`) and
+  already serves both searches -- unchanged by this refactor.
+
+## U6 -- `TextInputInteraction` -> DIR.Lib (DEFERRED, decision 2026-07-23)
+
+After U2, `TextInputInteraction` has NO TianWen-domain deps left (the `PlannerState`/`SkyMapSearchState`
+special-cases become the single `SearchInteraction? ActiveSearch` seam), so it becomes a clean DIR.Lib
+promotion candidate -- key routing + clipboard + Tab-cycling over `TextInputState`, with `IPixelWidget`
+(`GetRegisteredTextInputs`) + `BackgroundTaskTracker` already DIR.Lib types. **Deliberately deferred** to
+keep U2 focused: promote it as a separate follow-on once `SearchInteraction` has proven out, cutting the
+`IPixelWidget`/`BackgroundTaskTracker`/clipboard seams carefully. Rides its own DIR.Lib minor.
 
 ## U3 -- `DropdownMenuState` overflow scrolling (opportunistic)
 
@@ -88,7 +176,7 @@ lets every `DIR.Lib.Layout` consumer (incl. the web port) drop hand-drawn gauge 
 tianwen `ProgressBarLayoutTests`; the same arrange assertions move to DIR.Lib headless tests on promotion.
 No behaviour change, pixel-identical. Not scheduled; recorded so the door stays marked.
 
-## U5 -- `RenderTextInput(RectF32)` overload (DONE in branch, rides 6.16)
+## U5 -- `RenderTextInput(RectF32)` overload (DONE + SHIPPED, DIR.Lib 6.15/6.16; small residue)
 
 The layout-driven refactor left every arranged-rect text-input call site repeating a four-way
 `(int)r.X, (int)r.Y, (int)r.Width, (int)r.Height` cast because `PixelWidgetBase.RenderTextInput` was
@@ -100,8 +188,14 @@ boundary and forwards to the int path -- rounding, not truncating, so a fraction
 the 1px border centred on the intended edge. tianwen: the four arranged-rect callers (SkyMap F3 search,
 Session exposure editor, LiveSession focuser goto, Equipment create-profile) drop the cast and pass the
 Fill rect directly; PlannerTab's search strip stays on the int signature (still hand-computed cursor
-code, not an arranged Fill). Already in the DIR.Lib branch -- rides the same 6.16 release + tianwen
-repin; "no push before NuGet" applies.
+code, not an arranged Fill). Shipped in the DIR.Lib 6.15/6.16 line with a tianwen repin.
+
+- **Residue (2026-07-23):** 6 MORE arranged-Fill callers -- all in `EquipmentTab.*` (`DeviceSettings.cs:123`,
+  `FilterTable.cs:89`, `ProfilePanel.cs:171/246/460`, `Telemetry.cs:87`) -- still do the four-way
+  `(int)r.X, (int)r.Y, (int)r.Width, (int)r.Height` cast. They were added later, during the
+  layout-driven-ui L2 EquipmentTab split, after the U5 cut. Each takes a `RectF32 r` inside a Fill
+  dispatch lambda, so they qualify for the same overload. Pure tianwen-only cleanup (no DIR.Lib release);
+  drop the casts, pass `r` directly. Fold in as the tail of the U2 tianwen repin, or a standalone commit.
 
 ## Explicit non-moves
 
@@ -117,4 +211,5 @@ repin; "no push before NuGet" applies.
 - U2: DIR.Lib headless tests for the key-nav protocol (cycle/commit/dismiss/backspace-passthrough,
   mouse-commit == keyboard-commit); tianwen planner + F3 behaviour pinned by existing search tests
   before the cut, re-run after; web overlay smoke (planner search + F3 through `CanvasTextOverlay`).
-- Both ride DIR.Lib 6.16 + a tianwen repin; "no push before NuGet" applies as usual.
+- U1 + U5 shipped in the DIR.Lib 6.15/6.16 line. U2 rides the next DIR.Lib minor after DeviceTransform's
+  6.17 (6.17 if unpublished, else 6.18) + a tianwen repin; "no push before NuGet" applies as usual.

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -120,7 +120,7 @@
          reflow builds on. The Sizing ctor/Star/WStar signatures gained optional parameters
          (binary-breaking), so the whole sibling family rebuilt: lockstep with Console.Lib 3.8 +
          SdlVulkan.Renderer 6.25 + WebGl.Renderer 1.8. -->
-    <PackageVersion Include="DIR.Lib" Version="6.16.*" />
+    <PackageVersion Include="DIR.Lib" Version="6.18.*" />
     <!-- DIR.Lib 3.0 extracted its codec layer to these sibling packages, which
          ship as a lockstep family from the Codecs repo. 3.0 brought a
          binary-breaking SharpAstro.Tiff change (TiffPageOptions.IccProfile is
@@ -184,7 +184,7 @@
          migration (Console.Lib references SharpAstro.Codecs for image decode). 3.8 is the current
          pin: the no-code lockstep rebuild against DIR.Lib 6.14 (its Sizing/Star signatures are
          binary-breaking, so the 3.5 binary would MissingMethodException at runtime). -->
-    <PackageVersion Include="Console.Lib" Version="3.10.*" />
+    <PackageVersion Include="Console.Lib" Version="3.11.*" />
     <!-- SdlVulkan.Renderer 5.0 adds a multi-page SDF glyph atlas (no more grow
          stall / Adreno submit-wedge) on top of 4.1's SetSystemCursor + anisotropic
          glyph xScale. 5.1 implements DIR.Lib 4.4's PushClip/PopClip via Vulkan
@@ -232,7 +232,7 @@
          opt-in even in Debug (CompiledDebug and SDLVK_VALIDATION=1). 6.27 is the current pin: batched
          DrawPolyline/DrawPolylineDashed overrides (whole polyline into one Flat-pipeline draw); see
          docs/plans/render-batching.md. -->
-    <PackageVersion Include="SdlVulkan.Renderer" Version="6.29.*" />
+    <PackageVersion Include="SdlVulkan.Renderer" Version="6.31.*" />
     <PackageVersion Include="SDL3-CS" Version="3.5.0-preview.20260213-150035" />
     <PackageVersion Include="SDL3-CS.Native" Version="3.5.0-preview.20260205-174353" />
     <!-- Canon DSLR -->

--- a/src/TianWen.Lib.Tests/PlannerSearchInteractionTests.cs
+++ b/src/TianWen.Lib.Tests/PlannerSearchInteractionTests.cs
@@ -10,8 +10,8 @@ public class PlannerSearchInteractionTests
     /// Committing a suggestion must RESET the search box (clear the text, drop the dropdown) and release
     /// focus -- the fix for "clicking a suggestion left the committed name in the box and the floating
     /// &lt;input&gt; overlay lingered onto the sky atlas" (the overlay only hides on deactivate). Both the
-    /// keyboard Enter-on-suggestion and the dropdown mouse-click go through the same CommitSuggestion, so
-    /// this exercises the shared reset via <see cref="PlannerState.CommitSuggestionAt"/> (the mouse entry).
+    /// keyboard Enter-on-suggestion and the dropdown mouse-click go through the same commit path, so this
+    /// exercises the shared reset via <see cref="DIR.Lib.SearchInteraction.CommitAt"/> (the mouse entry).
     /// A null transform skips the DB resolution so the test isolates the reset/deactivate contract.
     /// </summary>
     [Fact]
@@ -19,28 +19,30 @@ public class PlannerSearchInteractionTests
     {
         var state = new PlannerState();
         state.SearchInput.Activate("Androm");
-        state.Suggestions.Add("Andromeda Galaxy");
-        state.Suggestions.Add("Andromeda I");
-        state.SuggestionIndex = 0;
-        state.LastSuggestionQuery = "Androm";
         var deactivated = 0;
 
-        PlannerSearchInteraction.Wire(
+        var search = new PlannerSearchInteraction(
             state,
             db: null!,                    // unreached: createTransform returns null, skipping resolution
             createTransform: () => null,
-            autoComplete: () => null,
+            autoComplete: () => ["Andromeda Galaxy", "Andromeda I"],
             ensureVisible: null,
             deactivate: () => deactivated++,
             requestRedraw: () => { });
+        state.Search = search;
 
-        state.CommitSuggestionAt.ShouldNotBeNull();
-        state.CommitSuggestionAt!(0);
+        // Populate the dropdown the way a keystroke would (base OnTextChanged -> Query).
+        state.SearchInput.OnTextChanged!("Androm");
+        search.Results.Length.ShouldBe(2);
+        search.SelectedIndex.ShouldBe(-1); // planner does not auto-highlight
+
+        // Mouse-click commit of the first suggestion (== keyboard Enter-on-highlight).
+        search.CommitAt(0);
 
         state.SearchInput.Text.ShouldBe("");            // was left as the committed name before the fix
-        state.Suggestions.ShouldBeEmpty();
-        state.SuggestionIndex.ShouldBe(-1);
-        state.LastSuggestionQuery.ShouldBe("");
+        search.Results.ShouldBeEmpty();
+        search.SelectedIndex.ShouldBe(-1);
+        search.LastQuery.ShouldBe("");
         deactivated.ShouldBe(1);                        // focus released -> the overlay hides on the host
     }
 }

--- a/src/TianWen.Lib.Tests/PlannerTabLayoutTests.cs
+++ b/src/TianWen.Lib.Tests/PlannerTabLayoutTests.cs
@@ -247,9 +247,11 @@ namespace TianWen.Lib.Tests
         /// <summary>
         /// Regression for "arrow+enter on the search box works, mouse+click doesn't": the autocomplete
         /// dropdown row is clickable but had NO OnClick, so only the keyboard could commit a suggestion.
-        /// The row now dispatches to <see cref="PlannerState.CommitSuggestionAt"/> (wired by
-        /// <see cref="PlannerSearchInteraction"/> to the same commit path the keyboard uses), so a click
-        /// commits identically. Asserts a click on the dropdown row invokes it with the row's index.
+        /// The row now dispatches to <see cref="DIR.Lib.SearchInteraction.CommitAt"/> on
+        /// <see cref="PlannerState.Search"/> (the same commit path the keyboard Enter-on-highlight uses),
+        /// so a click commits identically. Asserts a click on the second dropdown row reaches the commit
+        /// (box reset + focus released); the index->suggestion binding is unit-pinned in DIR.Lib's
+        /// SearchInteractionTests.
         /// </summary>
         [Fact]
         public void SuggestionDropdown_MouseClick_CommitsTheClickedSuggestion()
@@ -257,24 +259,32 @@ namespace TianWen.Lib.Tests
             using var renderer = new RgbaImageRenderer(1600, 1000);
             var tab = new PlannerTab<RgbaImage>(renderer) { FontPath = FontResolver.ResolveSystemFont() };
             var state = BuildState();
-            // The dropdown only renders when the search input is active with suggestions present.
-            state.SearchInput.Activate();
-            state.Suggestions.Add("M31");
-            state.Suggestions.Add("M42");
-            var committed = new List<int>();
-            state.CommitSuggestionAt = i => committed.Add(i);
+            // The dropdown only renders when the search input is active with suggestions present. A null
+            // transform makes the commit skip DB resolution and just reset the box (the observable effect).
+            state.SearchInput.Activate("M3");
+            var deactivated = 0;
+            state.Search = new PlannerSearchInteraction(
+                state, db: null!, createTransform: () => null,
+                autoComplete: () => ["M31", "M32"],
+                ensureVisible: null, deactivate: () => deactivated++, requestRedraw: () => { });
+            state.SearchInput.OnTextChanged!("M3"); // populate the dropdown (2 rows) the way a keystroke would
+            state.Search.Results.Length.ShouldBe(2);
 
             var time = new FakeTimeProviderWrapper(new DateTimeOffset(2025, 12, 15, 22, 0, 0, TimeSpan.Zero));
             tab.Render(state, new RectF32(0, 0, 1600, 1000), time);
 
             // The dropdown is painted last, so its rows are the topmost regions at their pixels -- a click
-            // on the second row's centre dispatches that row (HitTestAndDispatch returns topmost-first).
+            // on the second row's centre dispatches that row (HitTestAndDispatch returns topmost-first),
+            // invoking search.CommitAt(1).
             var region = tab.GetRegisteredRegions()
                 .First(r => r.Result is HitResult.ListItemHit { ListId: "Suggestion", Index: 1 });
             var hit = tab.HitTestAndDispatch(region.X + region.Width / 2f, region.Y + region.Height / 2f);
 
             hit.ShouldBeOfType<HitResult.ListItemHit>().Index.ShouldBe(1);
-            committed.ShouldBe([1]);
+            // CommitAt(1) reached the commit path: the box reset (text + dropdown cleared) and focus released.
+            deactivated.ShouldBe(1);
+            state.SearchInput.Text.ShouldBe("");
+            state.Search.Results.ShouldBeEmpty();
         }
 
         /// <summary>

--- a/src/TianWen.Lib.Tests/SkyMapSearchActionsTests.cs
+++ b/src/TianWen.Lib.Tests/SkyMapSearchActionsTests.cs
@@ -22,15 +22,13 @@ public class SkyMapSearchActionsTests
     public void FilterResultsWithEmptyIndexReturnsEmpty()
     {
         var search = new SkyMapSearchState();
-        search.SearchInput.Text = "M31";
         // No SearchIndex set — simulating "catalog not loaded yet".
         search.SearchIndex = [];
 
         // Should not throw, just return no results.
-        SkyMapSearchActions.FilterResults(search, new EmptyDb());
+        var results = SkyMapSearchActions.FilterResults(search, new EmptyDb(), "M31");
 
-        search.Results.ShouldBeEmpty();
-        search.SelectedResultIndex.ShouldBe(-1);
+        results.ShouldBeEmpty();
     }
 
     [Fact]
@@ -39,10 +37,9 @@ public class SkyMapSearchActionsTests
         var search = new SkyMapSearchState();
         search.SearchIndex = ["M31", "Andromeda"];
 
-        search.SearchInput.Text = "M";
-        SkyMapSearchActions.FilterResults(search, new EmptyDb());
+        var results = SkyMapSearchActions.FilterResults(search, new EmptyDb(), "M");
 
-        search.Results.ShouldBeEmpty();
+        results.ShouldBeEmpty();
     }
 
     [Fact]
@@ -59,14 +56,15 @@ public class SkyMapSearchActionsTests
     }
 
     [Fact]
-    public void CommitResultWithNoSelectionReturnsFalse()
+    public void CommitResultWithNoIndexReturnsFalse()
     {
         var search = new SkyMapSearchState();
         var skyMap = new SkyMapState();
-        search.SelectedResultIndex = -1;
 
+        // A result carrying no catalog index cannot resolve to a position -> false.
         var ok = SkyMapSearchActions.CommitResult(
             search, skyMap, new EmptyDb(),
+            new SkyMapSearchResult("nothing", Index: null, ObjType: default, VMag: float.NaN),
             siteLat: 0, siteLon: 0,
             viewingUtc: DateTimeOffset.UtcNow,
             site: default);
@@ -338,15 +336,11 @@ public class SkyMapSearchActionsTests
 
         // The catalog returns the planet as a NaN-coord solar-system stub (as the real DB does).
         var db = new PlanetStubDb(planetIdx, "TestPlanet");
-        var search = new SkyMapSearchState
-        {
-            IsOpen = true,
-            Results = [new SkyMapSearchResult(Display: "TestPlanet", Index: planetIdx, ObjType: ObjectType.Unknown, VMag: float.NaN)],
-            SelectedResultIndex = 0,
-        };
+        var search = new SkyMapSearchState { IsOpen = true };
+        var result = new SkyMapSearchResult(Display: "TestPlanet", Index: planetIdx, ObjType: ObjectType.Unknown, VMag: float.NaN);
 
         var site = SiteContext.Create(0, 0, viewingUtc);
-        SkyMapSearchActions.CommitResult(search, skyMap, db, 0, 0, viewingUtc, site).ShouldBeTrue();
+        SkyMapSearchActions.CommitResult(search, skyMap, db, result, 0, 0, viewingUtc, site).ShouldBeTrue();
 
         var info = search.InfoPanel.ShouldNotBeNull();
         info.Name.ShouldBe("TestPlanet");

--- a/src/TianWen.UI.Abstractions/AppSignalHandler.Planner.cs
+++ b/src/TianWen.UI.Abstractions/AppSignalHandler.Planner.cs
@@ -46,7 +46,7 @@ namespace TianWen.UI.Abstractions
             var appState = _appState;
             var db = _sp.GetRequiredService<TianWen.Lib.Astrometry.Catalogs.ICelestialObjectDB>();
 
-            PlannerSearchInteraction.Wire(
+            _plannerState.Search = new PlannerSearchInteraction(
                 _plannerState, db,
                 createTransform: () => appState.ActiveProfile is { } profile
                     ? TransformFactory.FromProfile(profile, _timeProvider, out _)

--- a/src/TianWen.UI.Abstractions/AppSignalHandler.SkyMap.cs
+++ b/src/TianWen.UI.Abstractions/AppSignalHandler.SkyMap.cs
@@ -63,21 +63,20 @@ namespace TianWen.UI.Abstractions
             // ---------------------------------------------------------------
             var skySearch = skyMapState.Search;
 
-            skySearch.SearchInput.OnTextChanged = _ =>
-            {
-                var db = sp.GetRequiredService<ICelestialObjectDB>();
-                SkyMapSearchActions.FilterResults(skySearch, db);
-                skyMapState.NeedsRedraw = true;
-                appState.NeedsRedraw = true;
-            };
-
-            skySearch.SearchInput.OnCommit = _ =>
-            {
-                bus.Post(new SkyMapSearchCommitSignal());
-                return Task.CompletedTask;
-            };
-
-            skySearch.SearchInput.OnCancel = () => bus.Post(new CloseSkyMapSearchSignal());
+            // The search-box interaction (input wiring + Up/Down/Enter/Escape protocol + the result list) is
+            // the shared DIR.Lib SearchInteraction; construct it with the desktop-flavoured dispatch. Commit
+            // + close go through the signal bus so the per-invocation DI context (catalog / comets / viewing
+            // time / site) resolves in the handlers below. Replaces the three SearchInput.On* assignments.
+            skySearch.Interaction = new SkyMapSearchInteraction(
+                skySearch,
+                sp.GetRequiredService<ICelestialObjectDB>(),
+                commit: () => bus.Post(new SkyMapSearchCommitSignal()),
+                close: () => bus.Post(new CloseSkyMapSearchSignal()),
+                requestRedraw: () =>
+                {
+                    skyMapState.NeedsRedraw = true;
+                    appState.NeedsRedraw = true;
+                });
 
             bus.Subscribe<OpenSkyMapSearchSignal>(_ =>
             {
@@ -98,6 +97,14 @@ namespace TianWen.UI.Abstractions
 
             bus.Subscribe<SkyMapSearchCommitSignal>(_ =>
             {
+                // The interaction holds the highlighted row (keyboard Enter or a CommitAt mouse click set
+                // SelectedIndex before posting this); resolve it and hand it to the commit helper.
+                if (skySearch.Interaction is not { } interaction
+                    || interaction.SelectedIndex < 0
+                    || interaction.SelectedIndex >= interaction.Results.Length)
+                {
+                    return;
+                }
                 var db = sp.GetRequiredService<ICelestialObjectDB>();
                 // Include the sky-map scrub offset so a planet commit resolves the SAME live position
                 // the map is showing (and reads the render's planet cache without thrashing it).
@@ -105,6 +112,7 @@ namespace TianWen.UI.Abstractions
                 var site = SiteContext.Create(plannerState.SiteLatitude, plannerState.SiteLongitude, viewingUtc);
                 SkyMapSearchActions.CommitResult(
                     skySearch, skyMapState, db,
+                    interaction.Results[interaction.SelectedIndex],
                     plannerState.SiteLatitude, plannerState.SiteLongitude,
                     viewingUtc, site, plannerState.Comets);
                 bus.Post(new DeactivateTextInputSignal());

--- a/src/TianWen.UI.Abstractions/EquipmentTab.DeviceSettings.cs
+++ b/src/TianWen.UI.Abstractions/EquipmentTab.DeviceSettings.cs
@@ -120,7 +120,7 @@ namespace TianWen.UI.Abstractions
                         if (desc.Placeholder is { } placeholder) State.StringSettingInput.Placeholder = placeholder;
                         var editFillKey = $"setting:{desc.Key}";
                         _profilePanelFills[editFillKey] =
-                            r => RenderTextInput(State.StringSettingInput, (int)r.X, (int)r.Y, (int)r.Width, (int)r.Height, fontPath, fontSize * 0.85f);
+                            r => RenderTextInput(State.StringSettingInput, r, fontPath, fontSize * 0.85f);
                         control = Layout.Builder.Fill(key: editFillKey);
                         break;
 

--- a/src/TianWen.UI.Abstractions/EquipmentTab.FilterTable.cs
+++ b/src/TianWen.UI.Abstractions/EquipmentTab.FilterTable.cs
@@ -86,7 +86,7 @@ namespace TianWen.UI.Abstractions
                 {
                     var inputKey = $"filterNameInput:{otaIndex}:{f}";
                     _profilePanelFills[inputKey] =
-                        r => RenderTextInput(State.CustomFilterNameInput, (int)r.X, (int)r.Y, (int)r.Width, (int)r.Height, fontPath, fontSize * 0.8f);
+                        r => RenderTextInput(State.CustomFilterNameInput, r, fontPath, fontSize * 0.8f);
                     nameCell = Layout.Builder.Fill(key: inputKey);
                 }
                 else

--- a/src/TianWen.UI.Abstractions/EquipmentTab.ProfilePanel.cs
+++ b/src/TianWen.UI.Abstractions/EquipmentTab.ProfilePanel.cs
@@ -168,7 +168,7 @@ namespace TianWen.UI.Abstractions
 
                 Layout.Node InputRow(string label, string key, TextInputState input)
                 {
-                    _profilePanelFills[key] = r => RenderTextInput(input, (int)r.X, (int)r.Y, (int)r.Width, (int)r.Height, fontPath, fontSize * 0.9f);
+                    _profilePanelFills[key] = r => RenderTextInput(input, r, fontPath, fontSize * 0.9f);
                     return FormRowLayout.LabeledInputRow(label, labelW, fieldH, 0f, BaseFontSize * 0.85f, DimText, fillKey: key);
                 }
 
@@ -243,7 +243,7 @@ namespace TianWen.UI.Abstractions
             }
 
             _profilePanelFills["guideFl"] =
-                r => RenderTextInput(State.GuiderFocalLengthInput, (int)r.X, (int)r.Y, (int)r.Width, (int)r.Height, fontPath, fontSize * 0.9f);
+                r => RenderTextInput(State.GuiderFocalLengthInput, r, fontPath, fontSize * 0.9f);
             return FormRowLayout.LabeledInputRow("Guide FL (mm):", labelWDesign, fieldH, 0f, BaseFontSize * 0.85f, DimText, fillKey: "guideFl");
         }
 
@@ -457,7 +457,7 @@ namespace TianWen.UI.Abstractions
 
             Layout.Node InputRow(string label, string key, TextInputState input)
             {
-                _profilePanelFills[key] = r => RenderTextInput(input, (int)r.X, (int)r.Y, (int)r.Width, (int)r.Height, fontPath, fontSize * 0.9f);
+                _profilePanelFills[key] = r => RenderTextInput(input, r, fontPath, fontSize * 0.9f);
                 return FormRowLayout.LabeledInputRow(label, labelW, fieldH, 0f, BaseFontSize * 0.85f, DimText, fillKey: key);
             }
 

--- a/src/TianWen.UI.Abstractions/EquipmentTab.Telemetry.cs
+++ b/src/TianWen.UI.Abstractions/EquipmentTab.Telemetry.cs
@@ -84,7 +84,7 @@ namespace TianWen.UI.Abstractions
             var coolerUnsafe = latest is { } l && l.CoolerOn;
             var setpointFillKey = $"coolerSetpoint:{key}";
             _profilePanelFills[setpointFillKey] =
-                r => RenderTextInput(setpointInput, (int)r.X, (int)r.Y, (int)r.Width, (int)r.Height, fontPath, fontSize * 0.85f);
+                r => RenderTextInput(setpointInput, r, fontPath, fontSize * 0.85f);
 
             rows.Add(Layout.Builder.HStack(
                     Layout.Builder.Text("    Setpoint:", BaseFontSize * 0.85f, DimText).WFixed(80f).HStar(),

--- a/src/TianWen.UI.Abstractions/GuiEventHandlerBase.cs
+++ b/src/TianWen.UI.Abstractions/GuiEventHandlerBase.cs
@@ -327,14 +327,21 @@ namespace TianWen.UI.Abstractions
         // SDL clipboard delegates, GuiAppState redraw flag).
         private bool HandleTextInputKey(TextInputState activeInput, InputKey key, InputModifier modifiers)
         {
+            // The active search interaction (planner autocomplete or sky-map F3) when the active input is
+            // one of their boxes -- gives TextInputInteraction the Up/Down result nav without knowing the
+            // concrete search types.
+            SearchInteraction? activeSearch =
+                activeInput == _plannerState.SearchInput ? _plannerState.Search
+                : activeInput == _chrome.SkyMapState.Search.SearchInput ? _chrome.SkyMapState.Search.Interaction
+                : null;
+
             return TextInputInteraction.HandleKey(activeInput, key, modifiers,
                 new TextInputInteraction.KeyContext(
                     Tracker: _tracker,
                     Deactivate: DeactivateTextInput,
                     SetActive: next => _appState.ActiveTextInput = next,
                     RequestRedraw: () => _appState.NeedsRedraw = true,
-                    Planner: _plannerState,
-                    SkySearch: _chrome.SkyMapState.Search,
+                    ActiveSearch: activeSearch,
                     ActiveTab: _chrome.ActiveTab,
                     GetClipboardText: GetClipboardText,
                     SetClipboardText: SetClipboardText));

--- a/src/TianWen.UI.Abstractions/PlannerActions.cs
+++ b/src/TianWen.UI.Abstractions/PlannerActions.cs
@@ -959,21 +959,18 @@ public static class PlannerActions
     /// Updates the autocomplete suggestions based on the current search query.
     /// Runs synchronously — ~200K string comparisons takes ~2ms.
     /// </summary>
-    public static void UpdateSuggestions(PlannerState state, string[] autoCompleteList, string query)
+    /// <summary>
+    /// Pure autocomplete resolve: fuzzy-scores <paramref name="autoCompleteList"/> against
+    /// <paramref name="query"/> and returns up to <see cref="PlannerState.MaxSuggestions"/> best matches,
+    /// score DESC. Returns empty for a query under 2 characters. Extracted from the old state-mutating
+    /// <c>UpdateSuggestions</c> so it can back <c>PlannerSearchInteraction.Query</c> (the shared
+    /// <see cref="DIR.Lib.SearchInteraction{TResult}"/> owns the result list + last-query dedup + redraw).
+    /// </summary>
+    public static ImmutableArray<string> ComputeSuggestions(string[] autoCompleteList, string query)
     {
-        if (query == state.LastSuggestionQuery)
-        {
-            return;
-        }
-
-        state.LastSuggestionQuery = query;
-        state.Suggestions.Clear();
-        state.SuggestionIndex = -1;
-
         if (query.Length < 2)
         {
-            state.NeedsRedraw = true;
-            return;
+            return [];
         }
 
         var candidates = new List<(string Entry, int Score)>();
@@ -1002,12 +999,12 @@ public static class PlannerActions
         candidates.Sort(static (a, b) => b.Score.CompareTo(a.Score));
 
         var count = Math.Min(candidates.Count, PlannerState.MaxSuggestions);
+        var builder = ImmutableArray.CreateBuilder<string>(count);
         for (var i = 0; i < count; i++)
         {
-            state.Suggestions.Add(candidates[i].Entry);
+            builder.Add(candidates[i].Entry);
         }
-
-        state.NeedsRedraw = true;
+        return builder.MoveToImmutable();
     }
 
     private static int FuzzyMatchScore(string query, string entry)

--- a/src/TianWen.UI.Abstractions/PlannerSearchInteraction.cs
+++ b/src/TianWen.UI.Abstractions/PlannerSearchInteraction.cs
@@ -1,5 +1,5 @@
 using System;
-using System.Threading.Tasks;
+using System.Collections.Immutable;
 using DIR.Lib;
 using TianWen.Lib.Astrometry.Catalogs;
 using TianWen.Lib.Astrometry.SOFA;
@@ -7,138 +7,109 @@ using TianWen.Lib.Astrometry.SOFA;
 namespace TianWen.UI.Abstractions
 {
     /// <summary>
-    /// Wires the planner search-input callbacks (search commit, autocomplete suggestions,
-    /// suggestion commit) onto <see cref="PlannerState.SearchInput"/>. Shared by
-    /// <see cref="AppSignalHandler"/> (desktop/TUI hosts) and the web host - the callback
-    /// bodies used to live only in AppSignalHandler, which the web host never constructs
-    /// (it has no device stack), so the search box was inert in the browser.
+    /// The planner search box as a <see cref="SearchInteraction{TResult}"/> (TResult = a suggestion
+    /// string): input wiring + the Up/Down/Enter/Escape protocol + the suggestion list all come from the
+    /// DIR.Lib base; this subclass supplies only the domain resolution (autocomplete + target search /
+    /// commit). It replaces the old static <c>Wire</c> helper, which spread the same machinery across
+    /// <see cref="PlannerState"/> fields + <c>TextInputInteraction</c>'s arrow-nav block.
+    ///
+    /// <para>Behaviour preserved from the old wiring, via base policy overrides: no auto-highlight (Enter
+    /// searches the raw text until the user arrows down -> <see cref="AutoSelectFirstResult"/> false), Up at
+    /// index 0 deselects back to raw-query mode (<see cref="AllowDeselectOnUp"/>), and the first Escape
+    /// collapses the dropdown while a second cancels the box (<see cref="CollapseResultsOnEscape"/>).</para>
+    ///
+    /// Constructed by the host (desktop <see cref="AppSignalHandler"/> / web Planner.razor) with
+    /// host-flavoured context (profile/site transform, focus release, redraw). The standalone <c>plan</c>
+    /// CLI never constructs one, so <see cref="PlannerState.Search"/> stays null there and the box is inert
+    /// -- the same contract the old nullable <c>CommitSuggestionAt</c> carried.
     /// </summary>
-    public static class PlannerSearchInteraction
+    public sealed class PlannerSearchInteraction : SearchInteraction<string>
     {
-        /// <summary>
-        /// <paramref name="createTransform"/> returns a site-initialised transform, or null when
-        /// no site is configured yet (desktop: from the active profile; web: from the lat/lon
-        /// fields). <paramref name="autoComplete"/> returns the candidate cache - null until the
-        /// host finishes the catalog load (see <see cref="PlannerActions.BuildAutoCompleteList"/>).
-        /// <paramref name="deactivate"/> releases input focus the host's way (desktop posts
-        /// DeactivateTextInputSignal). <paramref name="ensureVisible"/> scrolls the target list.
-        /// </summary>
-        public static void Wire(
-            PlannerState plannerState,
+        private readonly PlannerState _state;
+        private readonly ICelestialObjectDB _db;
+        private readonly Func<Transform?> _createTransform;
+        private readonly Func<string[]?> _autoComplete;
+        private readonly Action<int>? _ensureVisible;
+
+        /// <param name="state">The planner state; the box wraps <see cref="PlannerState.SearchInput"/>.</param>
+        /// <param name="db">Catalog DB for target resolution.</param>
+        /// <param name="createTransform">Site-initialised transform, or null when no site is configured yet.</param>
+        /// <param name="autoComplete">The candidate cache, or null until the host finishes the catalog load.</param>
+        /// <param name="ensureVisible">Scrolls the resolved target into the planner list.</param>
+        /// <param name="deactivate">Releases input focus the host's way (desktop posts DeactivateTextInputSignal).</param>
+        /// <param name="requestRedraw">Marks the host surface dirty.</param>
+        public PlannerSearchInteraction(
+            PlannerState state,
             ICelestialObjectDB db,
             Func<Transform?> createTransform,
             Func<string[]?> autoComplete,
             Action<int>? ensureVisible,
             Action deactivate,
             Action requestRedraw)
+            : base(state.SearchInput, requestRedraw, releaseFocus: deactivate)
         {
-            plannerState.SearchInput.OnCommit = text =>
+            _state = state;
+            _db = db;
+            _createTransform = createTransform;
+            _autoComplete = autoComplete;
+            _ensureVisible = ensureVisible;
+        }
+
+        protected override bool AutoSelectFirstResult => false;
+        protected override bool AllowDeselectOnUp => true;
+        protected override bool CollapseResultsOnEscape => true;
+
+        protected override ImmutableArray<string> Query(string text)
+            => _autoComplete() is { } cache ? PlannerActions.ComputeSuggestions(cache, text) : [];
+
+        // Enter on a highlighted suggestion (or a dropdown click via CommitAt): resolve + select WITHOUT
+        // re-searching, then reset the box (clear text, drop the dropdown, release focus).
+        protected override void Commit(string suggestion)
+        {
+            if (_createTransform() is { } transform)
             {
-                plannerState.Suggestions.Clear();
-                plannerState.SuggestionIndex = -1;
-                plannerState.LastSuggestionQuery = "";
-
-                if (text.Length > 0 && createTransform() is { } transform)
+                var idx = PlannerActions.CommitSuggestion(_state, _db, transform, suggestion, _state.Comets);
+                if (idx >= 0)
                 {
-                    var resultIdx = PlannerActions.SearchTargets(
-                        plannerState, db, transform, text, plannerState.Comets);
-                    if (resultIdx >= 0)
-                    {
-                        plannerState.SelectedTargetIndex = resultIdx;
-                        ensureVisible?.Invoke(resultIdx);
-                    }
+                    _state.SelectedTargetIndex = idx;
+                    _ensureVisible?.Invoke(idx);
                 }
-                requestRedraw();
-                return Task.CompletedTask;
-            };
-
-            plannerState.SearchInput.OnCancel = () =>
-            {
-                plannerState.SearchInput.Clear();
-                plannerState.SearchResults = [];
-                plannerState.Suggestions.Clear();
-                plannerState.SuggestionIndex = -1;
-                plannerState.LastSuggestionQuery = "";
-                deactivate();
-                plannerState.NeedsRedraw = true;
-                requestRedraw();
-            };
-
-            plannerState.SearchInput.OnTextChanged = text =>
-            {
-                if (autoComplete() is { } cache)
-                {
-                    PlannerActions.UpdateSuggestions(plannerState, cache, text);
-                }
-            };
-
-            // Autocomplete navigation: Up/Down/Return/Escape when suggestions are visible
-            plannerState.SearchInput.OnKeyOverride = key =>
-            {
-                if (plannerState.Suggestions.Count == 0)
-                {
-                    return false;
-                }
-
-                switch (key)
-                {
-                    case TextInputKey.Backspace or TextInputKey.Delete:
-                        return false; // Let the text input handle it, OnTextChanged will update suggestions
-
-                    case TextInputKey.Enter when plannerState.SuggestionIndex >= 0:
-                        CommitSuggestion(plannerState.Suggestions[plannerState.SuggestionIndex]);
-                        return true;
-
-                    case TextInputKey.Escape:
-                        plannerState.Suggestions.Clear();
-                        plannerState.SuggestionIndex = -1;
-                        plannerState.LastSuggestionQuery = "";
-                        requestRedraw();
-                        return true;
-
-                    default:
-                        return false;
-                }
-            };
-
-            // Mouse counterpart of the keyboard Enter-on-highlighted-suggestion path (OnKeyOverride
-            // above): the dropdown row's OnClick calls this so a click commits IDENTICALLY. Before this
-            // the suggestion click had no handler at all -- only the keyboard could commit a suggestion
-            // ("arrow+enter works, mouse doesn't"). Routes through the same local CommitSuggestion.
-            plannerState.CommitSuggestionAt = index =>
-            {
-                if (index >= 0 && index < plannerState.Suggestions.Count)
-                {
-                    CommitSuggestion(plannerState.Suggestions[index]);
-                }
-            };
-
-            // Local helper captured by the search-input closures above (keyboard Enter-on-suggestion
-            // AND the dropdown mouse-click, via CommitSuggestionAt -- one path, so both behave identically).
-            void CommitSuggestion(string suggestion)
-            {
-                // Resolve + select the target first (it needs the suggestion text), then RESET the box:
-                // clear the text, drop the dropdown, and release focus. Without the reset the search input
-                // lingered showing the committed name and -- on the web -- the floating <input> overlay
-                // stayed visible (it only hides on deactivate), including after switching to the sky atlas.
-                if (createTransform() is { } transform)
-                {
-                    var resultIdx = PlannerActions.CommitSuggestion(
-                        plannerState, db, transform, suggestion, plannerState.Comets);
-                    if (resultIdx >= 0)
-                    {
-                        plannerState.SelectedTargetIndex = resultIdx;
-                        ensureVisible?.Invoke(resultIdx);
-                    }
-                }
-
-                plannerState.SearchInput.Clear();
-                plannerState.Suggestions.Clear();
-                plannerState.SuggestionIndex = -1;
-                plannerState.LastSuggestionQuery = "";
-                deactivate();
-                requestRedraw();
             }
+            ResetBox();
+            ReleaseFocus?.Invoke();
+            RequestRedraw();
+        }
+
+        // Enter with no highlighted suggestion: search targets by the raw text. Matches the old OnCommit,
+        // which cleared only the dropdown state (not the text) and left the box active.
+        protected override void CommitRawQuery(string text)
+        {
+            if (text.Length > 0 && _createTransform() is { } transform)
+            {
+                var idx = PlannerActions.SearchTargets(_state, _db, transform, text, _state.Comets);
+                if (idx >= 0)
+                {
+                    _state.SelectedTargetIndex = idx;
+                    _ensureVisible?.Invoke(idx);
+                }
+            }
+            CollapseResults(); // clears Results + SelectedIndex + LastQuery; leaves the text
+            RequestRedraw();
+        }
+
+        // Escape with nothing to collapse, or the field's own cancel: clear the box + release focus.
+        protected override void Dismiss()
+        {
+            ResetBox();
+            base.Dismiss(); // ReleaseFocus?.Invoke()
+        }
+
+        private void ResetBox()
+        {
+            Input.Clear();
+            Results = [];
+            SelectedIndex = -1;
+            LastQuery = "";
         }
     }
 }

--- a/src/TianWen.UI.Abstractions/PlannerState.cs
+++ b/src/TianWen.UI.Abstractions/PlannerState.cs
@@ -143,25 +143,17 @@ public class PlannerState
     /// <see cref="ImmutableArray{T}.Add"/> and replace the property atomically.</summary>
     public ImmutableArray<ScoredTarget> SearchResults { get; set; } = [];
 
-    /// <summary>Current autocomplete suggestions for the search bar (max <see cref="MaxSuggestions"/>).</summary>
-    public List<string> Suggestions { get; } = [];
-
-    /// <summary>Index of the highlighted suggestion (-1 = none).</summary>
-    public int SuggestionIndex { get; set; } = -1;
-
     /// <summary>
-    /// Commits the autocomplete suggestion at a dropdown index -- the MOUSE-click counterpart of the
-    /// keyboard Enter-on-highlighted-suggestion path. Both route through the SAME CommitSuggestion in
-    /// <see cref="PlannerSearchInteraction"/>, so a dropdown click and a keypress land identically.
-    /// Set by <see cref="PlannerSearchInteraction.Wire"/>; null until a host wires the search box (the
-    /// standalone <c>plan</c> CLI never does). The dropdown row's OnClick invokes this -- before it was
-    /// wired the suggestion click had no handler, so only the keyboard could commit a suggestion (the
-    /// "arrow+enter works, mouse doesn't" bug).
+    /// The planner search-box interaction (autocomplete + target search / commit): a
+    /// <see cref="PlannerSearchInteraction"/> over <see cref="SearchInput"/>. Owns the suggestion list
+    /// (<c>Search.Results</c>), the highlighted index (<c>Search.SelectedIndex</c>), and the last-query
+    /// dedup -- state that used to live directly on this type (Suggestions / SuggestionIndex /
+    /// LastSuggestionQuery / CommitSuggestionAt). Set by the host (desktop <see cref="AppSignalHandler"/> /
+    /// web Planner.razor); null in the standalone <c>plan</c> CLI, where the search box is inert -- the
+    /// same nullable contract the old CommitSuggestionAt carried. The dropdown's mouse-click commit goes
+    /// through <c>Search.CommitAt(index)</c>, identical to the keyboard Enter-on-highlighted path.
     /// </summary>
-    public Action<int>? CommitSuggestionAt { get; set; }
-
-    /// <summary>The query that produced the current <see cref="Suggestions"/> list (avoids re-scanning on arrow keys).</summary>
-    public string LastSuggestionQuery { get; set; } = "";
+    public PlannerSearchInteraction? Search { get; set; }
 
     /// <summary>Maximum number of autocomplete suggestions to show.</summary>
     public const int MaxSuggestions = 8;

--- a/src/TianWen.UI.Abstractions/PlannerTab.cs
+++ b/src/TianWen.UI.Abstractions/PlannerTab.cs
@@ -440,7 +440,7 @@ namespace TianWen.UI.Abstractions
             _targetScroll.DrawScrollBar(FillRect);
 
             // Autocomplete dropdown (overlay, painted last so it's on top)
-            if (state.Suggestions.Count > 0 && state.SearchInput.IsActive)
+            if (state.Search is { Results.Length: > 0 } && state.SearchInput.IsActive)
             {
                 RenderSuggestionDropdown(state, itemHeight, fontSize, padding);
             }
@@ -454,8 +454,14 @@ namespace TianWen.UI.Abstractions
             PlannerState state,
             float itemHeight, float fontSize, float padding)
         {
-            var suggestions = state.Suggestions;
-            var dropdownH = suggestions.Count * itemHeight;
+            // Guarded by the caller (state.Search is { Results.Length: > 0 }); re-checked so this method is
+            // safe to call standalone. Suggestion list + highlight now live on the DIR.Lib SearchInteraction.
+            if (state.Search is not { } search)
+            {
+                return;
+            }
+            var suggestions = search.Results;
+            var dropdownH = suggestions.Length * itemHeight;
             var dropdownY = _searchBarBottom;
 
             // Clamp to not extend past the target list panel
@@ -473,10 +479,10 @@ namespace TianWen.UI.Abstractions
             // the keyboard Enter-on-highlighted path -- both go through PlannerState.CommitSuggestionAt.
             var rowFs = fontSize * 0.9f;
             var maxRows = itemHeight > 0 ? (int)(dropdownH / itemHeight) : 0;
-            var rows = new List<Layout.Node>(Math.Min(suggestions.Count, maxRows));
-            for (var i = 0; i < suggestions.Count && i < maxRows; i++)
+            var rows = new List<Layout.Node>(Math.Min(suggestions.Length, maxRows));
+            for (var i = 0; i < suggestions.Length && i < maxRows; i++)
             {
-                var isHighlighted = i == state.SuggestionIndex;
+                var isHighlighted = i == search.SelectedIndex;
                 var capturedSuggestion = i;
                 var row = Layout.Builder.HStack(
                         Layout.Builder.Spacer().WFixed(padding).HStar(),
@@ -484,7 +490,7 @@ namespace TianWen.UI.Abstractions
                         Layout.Builder.Spacer().WFixed(padding).HStar())
                     .RowH(itemHeight)
                     .Clickable(new HitResult.ListItemHit("Suggestion", capturedSuggestion),
-                        _ => state.CommitSuggestionAt?.Invoke(capturedSuggestion));
+                        _ => search.CommitAt(capturedSuggestion));
                 if (isHighlighted) row = row.Bg(DropdownSelBg);
                 rows.Add(row);
             }

--- a/src/TianWen.UI.Abstractions/SkyMapSearchActions.cs
+++ b/src/TianWen.UI.Abstractions/SkyMapSearchActions.cs
@@ -86,25 +86,21 @@ public static class SkyMapSearchActions
     }
 
     /// <summary>
-    /// Recompute <see cref="SkyMapSearchState.Results"/> from the current
-    /// <see cref="SkyMapSearchState.SearchInput"/> text. With Tycho-2 in the
-    /// catalog the index is ~2.5M entries; we exploit the fact that
-    /// <see cref="ICelestialObjectDB.CreateAutoCompleteList"/> returns its
-    /// entries sorted ordinal-ignore-case to binary-search the prefix
-    /// range in O(log N), then scan the contiguous prefix run for matches.
-    /// A substring fallback runs only when the prefix scan returns nothing,
-    /// keeping the steady-state hot path off the full-array scan that used
-    /// to fire on every keystroke.
+    /// Resolve the search results for <paramref name="query"/> from the catalog + comet index. With
+    /// Tycho-2 in the catalog the index is ~2.5M entries; we exploit the fact that
+    /// <see cref="ICelestialObjectDB.CreateAutoCompleteList"/> returns its entries sorted
+    /// ordinal-ignore-case to binary-search the prefix range in O(log N), then scan the contiguous prefix
+    /// run for matches. A substring fallback runs only when the prefix scan returns nothing, keeping the
+    /// steady-state hot path off the full-array scan. Pure with respect to <paramref name="search"/> (reads
+    /// its index + comet map, returns the array) so it can back
+    /// <see cref="SkyMapSearchInteraction.Query"/>; the shared <see cref="DIR.Lib.SearchInteraction{TResult}"/>
+    /// owns the result list, selected index, and scroll reset.
     /// </summary>
-    public static void FilterResults(SkyMapSearchState search, ICelestialObjectDB db)
+    public static ImmutableArray<SkyMapSearchResult> FilterResults(SkyMapSearchState search, ICelestialObjectDB db, string query)
     {
-        var query = search.SearchInput.Text;
-
         if (string.IsNullOrWhiteSpace(query) || query.Length < 2)
         {
-            search.Results = [];
-            search.SelectedResultIndex = -1;
-            return;
+            return [];
         }
 
         // Virtual TYC path: the ~2.5M Tycho-2 stars deliberately don't appear in
@@ -112,9 +108,9 @@ public static class SkyMapSearchActions
         // of string allocations). Instead, queries that look like "TYC <digits>..."
         // are served by a direct byte[] walk over the catalogue, which decodes a
         // small destination buffer on-the-fly without materialising any noise stars.
-        if (TryHandleTycPrefix(search, db, query))
+        if (TryHandleTycPrefix(db, query, out var tycResults))
         {
-            return;
+            return tycResults;
         }
 
         var index = search.SearchIndex;
@@ -209,9 +205,7 @@ public static class SkyMapSearchActions
             }
         }
 
-        search.Results = results.ToImmutable();
-        search.SelectedResultIndex = search.Results.Length > 0 ? 0 : -1;
-        search.ResultsScrollOffset = 0;
+        return results.ToImmutable();
     }
 
     /// <summary>
@@ -242,12 +236,13 @@ public static class SkyMapSearchActions
     /// <summary>
     /// Detect a "TYC ..." (or "TYC..." / "TYC-...") query, strip the catalog tag,
     /// and route to <see cref="ICelestialObjectDB.FindTycho2ByCanonicalPrefix"/>.
-    /// Returns true when the query was TYC-shaped (results written to
-    /// <paramref name="search"/>); false to let the caller continue with the
+    /// Returns true when the query was TYC-shaped (results in <paramref name="results"/>);
+    /// false (with empty <paramref name="results"/>) to let the caller continue with the
     /// general autocomplete-list scan.
     /// </summary>
-    private static bool TryHandleTycPrefix(SkyMapSearchState search, ICelestialObjectDB db, string query)
+    private static bool TryHandleTycPrefix(ICelestialObjectDB db, string query, out ImmutableArray<SkyMapSearchResult> results)
     {
+        results = [];
         var trimmed = query.AsSpan().Trim();
         if (trimmed.Length < 4) return false;  // need at least "TYC" + 1 digit
         if (!trimmed.StartsWith("TYC", StringComparison.OrdinalIgnoreCase)) return false;
@@ -268,7 +263,7 @@ public static class SkyMapSearchActions
         var count = db.FindTycho2ByCanonicalPrefix(rest, buf);
 
         var take = Math.Min(count, MaxResults);
-        var results = ImmutableArray.CreateBuilder<SkyMapSearchResult>(take);
+        var builder = ImmutableArray.CreateBuilder<SkyMapSearchResult>(take);
         for (var i = 0; i < take; i++)
         {
             var m = buf[i];
@@ -281,38 +276,33 @@ public static class SkyMapSearchActions
             var display = string.Create(CultureInfo.InvariantCulture, $"TYC {m.Tyc1}-{m.Tyc2}-{m.Tyc3}");
             var encoded = CatalogUtils.EncodeTyc2CatalogIndex(Catalog.Tycho2, m.Tyc1, m.Tyc2, m.Tyc3);
             var idx = CatalogUtils.AbbreviationToCatalogIndex(encoded, isBase91Encoded: true);
-            results.Add(new SkyMapSearchResult(
+            builder.Add(new SkyMapSearchResult(
                 Display: display,
                 Index: idx,
                 ObjType: ObjectType.Star,
                 VMag: m.VMag));
         }
 
-        search.Results = results.ToImmutable();
-        search.SelectedResultIndex = search.Results.Length > 0 ? 0 : -1;
-        search.ResultsScrollOffset = 0;
+        results = builder.ToImmutable();
         return true;
     }
 
     /// <summary>
-    /// Commit the currently-selected result: slew the sky map to the object,
-    /// populate the info panel, and close the modal. Returns true on success.
+    /// Commit a chosen <paramref name="result"/>: slew the sky map to the object, populate the info panel,
+    /// and close the modal. Returns true on success. The caller (the commit-signal handler) resolves the
+    /// result from the search interaction's highlighted row; taking it explicitly keeps this helper
+    /// directly testable without an interaction.
     /// </summary>
     public static bool CommitResult(
         SkyMapSearchState search,
         SkyMapState skyMap,
         ICelestialObjectDB db,
+        SkyMapSearchResult result,
         double siteLat, double siteLon,
         DateTimeOffset viewingUtc,
         in SiteContext site,
         ICometRepository? comets = null)
     {
-        if (search.SelectedResultIndex < 0 || search.SelectedResultIndex >= search.Results.Length)
-        {
-            return false;
-        }
-
-        var result = search.Results[search.SelectedResultIndex];
         if (result.Index is not { } catIdx) return false;
 
         // Comet: resolve the LIVE ephemeris position + magnitude (it is not in the object DB), slew there,

--- a/src/TianWen.UI.Abstractions/SkyMapSearchInteraction.cs
+++ b/src/TianWen.UI.Abstractions/SkyMapSearchInteraction.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Collections.Immutable;
+using DIR.Lib;
+using TianWen.Lib.Astrometry.Catalogs;
+
+namespace TianWen.UI.Abstractions
+{
+    /// <summary>
+    /// The sky-map F3 search modal as a <see cref="SearchInteraction{TResult}"/> (TResult =
+    /// <see cref="SkyMapSearchResult"/>): input wiring + the Up/Down/Enter/Escape protocol + the result
+    /// list come from the DIR.Lib base; this subclass supplies only the catalog resolution
+    /// (<see cref="SkyMapSearchActions.FilterResults"/>) and dispatches commit / dismiss through the host's
+    /// signal bus. It replaces the three <c>SearchInput.On*</c> assignments + the arrow-nav block that were
+    /// spread across <c>AppSignalHandler.SkyMap</c> and <c>TextInputInteraction</c>.
+    ///
+    /// <para>Behaviour preserved via base policy overrides: the first result is auto-highlighted
+    /// (<see cref="AutoSelectFirstResult"/> so Enter commits it), Up clamps at 0
+    /// (<see cref="AllowDeselectOnUp"/> false), and Escape closes the modal on the first press
+    /// (<see cref="CollapseResultsOnEscape"/> false -> falls through to <see cref="Dismiss"/>).</para>
+    ///
+    /// Commit + close go through the signal bus (not directly) because they need per-invocation DI context
+    /// (catalog DB, comet repo, viewing time, site, sky-map mutation) that lives in the host handler.
+    /// </summary>
+    public sealed class SkyMapSearchInteraction : SearchInteraction<SkyMapSearchResult>
+    {
+        private readonly SkyMapSearchState _search;
+        private readonly ICelestialObjectDB _db;
+        private readonly Action _commit;
+        private readonly Action _close;
+
+        /// <param name="search">The F3 search state; the box wraps <see cref="SkyMapSearchState.SearchInput"/>.</param>
+        /// <param name="db">Catalog DB the result filter reads.</param>
+        /// <param name="commit">Posts the host's commit signal (resolves the highlighted row + slews / info-panels it).</param>
+        /// <param name="close">Posts the host's close-modal signal (also releases input focus).</param>
+        /// <param name="requestRedraw">Marks the host surface dirty.</param>
+        public SkyMapSearchInteraction(
+            SkyMapSearchState search,
+            ICelestialObjectDB db,
+            Action commit,
+            Action close,
+            Action requestRedraw)
+            : base(search.SearchInput, requestRedraw, releaseFocus: null) // focus release rides the close signal's handler
+        {
+            _search = search;
+            _db = db;
+            _commit = commit;
+            _close = close;
+        }
+
+        protected override bool AutoSelectFirstResult => true;
+        protected override bool AllowDeselectOnUp => false;
+        protected override bool CollapseResultsOnEscape => false;
+
+        protected override ImmutableArray<SkyMapSearchResult> Query(string text)
+            => SkyMapSearchActions.FilterResults(_search, _db, text);
+
+        protected override void OnResultsChanged() => _search.ResultsScrollOffset = 0;
+
+        // Commit the highlighted result. The base has already set SelectedIndex (keyboard Enter or a
+        // CommitAt mouse click), so the handler reads it back off this interaction.
+        protected override void Commit(SkyMapSearchResult result) => _commit();
+
+        // Escape (nothing to collapse) / OnCancel: close the modal via the host signal.
+        protected override void Dismiss() => _close();
+    }
+}

--- a/src/TianWen.UI.Abstractions/SkyMapSearchState.cs
+++ b/src/TianWen.UI.Abstractions/SkyMapSearchState.cs
@@ -31,13 +31,14 @@ public class SkyMapSearchState
     public TextInputState SearchInput { get; } = new() { Placeholder = "Type object name..." };
 
     /// <summary>
-    /// Live-filtered results for the current <see cref="SearchInput"/> text.
-    /// Atomically replaced on each query — readers snapshot into a local.
+    /// The F3 search interaction (input wiring + Up/Down/Enter/Escape protocol + the typed result list): a
+    /// <see cref="SkyMapSearchInteraction"/> over <see cref="SearchInput"/>. Owns the results
+    /// (<c>Interaction.Results</c>) and the highlighted index (<c>Interaction.SelectedIndex</c>) -- state
+    /// that used to live directly on this type. Set by the host (desktop <see cref="AppSignalHandler"/> /
+    /// web Planner.razor); the sky map only appears in those hosts, so it is non-null whenever the modal is
+    /// used (readers still null-guard defensively).
     /// </summary>
-    public ImmutableArray<SkyMapSearchResult> Results { get; set; } = [];
-
-    /// <summary>Index of the keyboard-highlighted row, -1 = none.</summary>
-    public int SelectedResultIndex { get; set; } = -1;
+    public SkyMapSearchInteraction? Interaction { get; set; }
 
     /// <summary>
     /// Flat prefix/substring search index built lazily on first open from

--- a/src/TianWen.UI.Abstractions/SkyMapTab.Search.cs
+++ b/src/TianWen.UI.Abstractions/SkyMapTab.Search.cs
@@ -180,7 +180,9 @@ namespace TianWen.UI.Abstractions
             var body = Layout.Builder.VStack(
                     Layout.Builder.Fill(key: "searchInput").RowH(inputHDesign),
                     Layout.Builder.Spacer().RowH(inputGap),
-                    BuildSearchResults(State.Search.Results, State.Search.SelectedResultIndex, visibleRows).Stretch())
+                    BuildSearchResults(
+                        State.Search.Interaction?.Results ?? [],
+                        State.Search.Interaction?.SelectedIndex ?? -1, visibleRows).Stretch())
                 .Stretch().Pad(bodyPad);
 
             // Panel (bg) inside a 1px border frame (an outer Box.Bg + Pad(1)); the whole card is ONE tree.
@@ -239,11 +241,10 @@ namespace TianWen.UI.Abstractions
 
                 var rowNode = Layout.Builder.HStack([.. rowChildren])
                     .RowH(SearchRowHeight)
-                    .Clickable(new HitResult.ListItemHit("SearchResult", capturedIndex), _ =>
-                    {
-                        State.Search.SelectedResultIndex = capturedIndex;
-                        PostSignal(new SkyMapSearchCommitSignal());
-                    });
+                    // Mouse commit == keyboard Enter-on-highlight: CommitAt sets the selected index AND
+                    // commits through the same base path (which posts SkyMapSearchCommitSignal).
+                    .Clickable(new HitResult.ListItemHit("SearchResult", capturedIndex),
+                        _ => State.Search.Interaction?.CommitAt(capturedIndex));
                 if (isSelected) rowNode = rowNode.Bg(SearchRowHover);
                 rows.Add(rowNode);
             }
@@ -746,25 +747,10 @@ namespace TianWen.UI.Abstractions
                 return true;
             }
 
-            // Arrow key navigation inside the result list (only when modal open and text
-            // input hasn't already handled the key — i.e. this is a fallback).
-            if (!State.Search.IsOpen) return false;
-
-            switch (key)
-            {
-                case InputKey.Down when State.Search.Results.Length > 0:
-                    State.Search.SelectedResultIndex = Math.Min(
-                        State.Search.SelectedResultIndex + 1, State.Search.Results.Length - 1);
-                    State.NeedsRedraw = true;
-                    return true;
-                case InputKey.Up when State.Search.Results.Length > 0:
-                    State.Search.SelectedResultIndex = Math.Max(
-                        State.Search.SelectedResultIndex - 1, 0);
-                    State.NeedsRedraw = true;
-                    return true;
-                default:
-                    return false;
-            }
+            // Up/Down over the result list is handled by SearchInteraction.HandleNavKey while the modal's
+            // input is active (the host key router routes it) -- the modal always activates the input on
+            // open, so the old "fallback" arrow-nav here was unreachable and has been removed.
+            return false;
         }
 
         /// <summary>

--- a/src/TianWen.UI.Abstractions/TextInputInteraction.cs
+++ b/src/TianWen.UI.Abstractions/TextInputInteraction.cs
@@ -18,18 +18,17 @@ namespace TianWen.UI.Abstractions
     public static class TextInputInteraction
     {
         /// <summary>Host callbacks + optional per-app state <see cref="HandleKey"/> needs.
-        /// <see cref="Planner"/>/<see cref="SkySearch"/> enable the suggestion/result arrow
-        /// navigation when the respective search input is the active one; either may be null.
-        /// <see cref="Deactivate"/> must clear the host's active-input tracking (desktop posts
-        /// DeactivateTextInputSignal); <see cref="SetActive"/> must update it to an
-        /// already-activated input (Tab cycling).</summary>
+        /// <see cref="ActiveSearch"/> is the search interaction whose input is currently active (planner
+        /// autocomplete or sky-map F3), enabling Up/Down result navigation; null when no search box is
+        /// active. <see cref="Deactivate"/> must clear the host's active-input tracking (desktop posts
+        /// DeactivateTextInputSignal); <see cref="SetActive"/> must update it to an already-activated input
+        /// (Tab cycling).</summary>
         public readonly record struct KeyContext(
             BackgroundTaskTracker Tracker,
             Action Deactivate,
             Action<TextInputState> SetActive,
             Action RequestRedraw,
-            PlannerState? Planner = null,
-            SkyMapSearchState? SkySearch = null,
+            SearchInteraction? ActiveSearch = null,
             IPixelWidget? ActiveTab = null,
             Func<string?>? GetClipboardText = null,
             Action<string>? SetClipboardText = null);
@@ -52,48 +51,14 @@ namespace TianWen.UI.Abstractions
         public static bool HandleKey(
             TextInputState activeInput, InputKey key, InputModifier modifiers, in KeyContext ctx)
         {
-            // Autocomplete arrow navigation (planner search box)
-            if (ctx.Planner is { } planner
-                && activeInput == planner.SearchInput && planner.Suggestions.Count > 0)
+            // Result-list navigation (planner autocomplete / sky-map F3) while its search box is the active
+            // input. The Up/Down protocol lives ONCE in SearchInteraction.HandleNavKey -- arrow keys are not
+            // TextInputKeys, so they cannot ride OnKeyOverride, and this method swallows all keys (see the
+            // final return), so the nav has to happen here before the key is consumed.
+            if (ctx.ActiveSearch is { } search && activeInput == search.Input && search.HandleNavKey(key))
             {
-                if (key == InputKey.Down)
-                {
-                    planner.SuggestionIndex = Math.Min(
-                        planner.SuggestionIndex + 1, planner.Suggestions.Count - 1);
-                    ctx.RequestRedraw();
-                    return true;
-                }
-
-                if (key == InputKey.Up && planner.SuggestionIndex >= 0)
-                {
-                    planner.SuggestionIndex--;
-                    ctx.RequestRedraw();
-                    return true;
-                }
-            }
-
-            // Sky-map F3 search: arrow keys navigate the result list. The tab's own
-            // TryHandleSearchKey only runs when NO text input is active, but the search input IS
-            // active here -- and this method swallows all keys (see the final return) -- so the
-            // navigation has to happen here too, mirroring the planner block above. Without this,
-            // Up/Down never reach the result list while the user is typing in the search box.
-            if (ctx.SkySearch is { } skySearch
-                && activeInput == skySearch.SearchInput && skySearch.Results.Length > 0)
-            {
-                if (key == InputKey.Down)
-                {
-                    skySearch.SelectedResultIndex = Math.Min(
-                        skySearch.SelectedResultIndex + 1, skySearch.Results.Length - 1);
-                    ctx.RequestRedraw();
-                    return true;
-                }
-                if (key == InputKey.Up)
-                {
-                    skySearch.SelectedResultIndex = Math.Max(
-                        skySearch.SelectedResultIndex - 1, 0);
-                    ctx.RequestRedraw();
-                    return true;
-                }
+                ctx.RequestRedraw();
+                return true;
             }
 
             var textKey = key.ToTextInputKey(modifiers);

--- a/src/TianWen.UI.Web/Pages/Planner.razor
+++ b/src/TianWen.UI.Web/Pages/Planner.razor
@@ -190,7 +190,7 @@
         // with web-flavoured context: transform from the lat/lon fields, focus release via the
         // _activeInput field. requestRedraw paints directly because a committed search finishes
         // on a task continuation AFTER the triggering event's RenderFrame already ran.
-        PlannerSearchInteraction.Wire(
+        _state.Search = new PlannerSearchInteraction(
             _state, Db,
             createTransform: CreateSiteTransform,
             autoComplete: () => _autoComplete,
@@ -564,6 +564,13 @@
         return Task.CompletedTask;
     }
 
+    // The active search interaction (planner autocomplete / sky-map F3) when `active` is one of their
+    // boxes -- feeds TextInputInteraction the Up/Down result nav (mirrors the desktop GuiEventHandlerBase).
+    SearchInteraction? ResolveActiveSearch(TextInputState active)
+        => active == _state.SearchInput ? _state.Search
+        : _skyTab is { } st && active == st.State.Search.SearchInput ? st.State.Search.Interaction
+        : null;
+
     Task OnOverlayKey(CanvasOverlayKeyArgs e)
     {
         if (_activeInput is not { IsActive: true } active)
@@ -590,8 +597,7 @@
             Deactivate: DeactivateTextInput,
             SetActive: next => { _activeInput = next; ShowOverlayFor(next); }, // Tab cycling re-anchors
             RequestRedraw: () => { }, // the RenderFrame below covers this event
-            Planner: _state,
-            SkySearch: _skyTab?.State.Search,
+            ActiveSearch: ResolveActiveSearch(active),
             ActiveTab: ActiveTab));
         // A canvas-side rewrite (suggestion committed on Enter) pushes back into the input.
         if (_activeInput is { IsActive: true } current && ReferenceEquals(current, active) && current.Text != before)
@@ -627,17 +633,14 @@
         var skyState = skyTab.State;
         var skySearch = skyState.Search;
 
-        skySearch.SearchInput.OnTextChanged = _ =>
-        {
-            SkyMapSearchActions.FilterResults(skySearch, Db);
-            skyState.NeedsRedraw = true;
-        };
-        skySearch.SearchInput.OnCommit = _ =>
-        {
-            _bus.Post(new SkyMapSearchCommitSignal());
-            return Task.CompletedTask;
-        };
-        skySearch.SearchInput.OnCancel = () => _bus.Post(new CloseSkyMapSearchSignal());
+        // The F3 search-box interaction (shared DIR.Lib SearchInteraction) with web-flavoured dispatch:
+        // commit + close post signals so the DI context resolves in the handlers below. Replaces the three
+        // SearchInput.On* assignments.
+        skySearch.Interaction = new SkyMapSearchInteraction(
+            skySearch, Db,
+            commit: () => _bus.Post(new SkyMapSearchCommitSignal()),
+            close: () => _bus.Post(new CloseSkyMapSearchSignal()),
+            requestRedraw: () => skyState.NeedsRedraw = true);
 
         _bus.Subscribe<OpenSkyMapSearchSignal>(_ =>
         {
@@ -653,12 +656,19 @@
         });
         _bus.Subscribe<SkyMapSearchCommitSignal>(_ =>
         {
+            if (skySearch.Interaction is not { } interaction
+                || interaction.SelectedIndex < 0
+                || interaction.SelectedIndex >= interaction.Results.Length)
+            {
+                return;
+            }
             // Same viewing-time rule as the desktop handler: planning date (or now) + scrub offset,
             // so a commit resolves the position the map is actually showing.
             var viewingUtc = (_state.PlanningDate?.ToUniversalTime() ?? Time.GetUtcNow()) + skyState.TimeOffset;
             var site = SiteContext.Create(_state.SiteLatitude, _state.SiteLongitude, viewingUtc);
             SkyMapSearchActions.CommitResult(
-                skySearch, skyState, Db, _state.SiteLatitude, _state.SiteLongitude,
+                skySearch, skyState, Db, interaction.Results[interaction.SelectedIndex],
+                _state.SiteLatitude, _state.SiteLongitude,
                 viewingUtc, site, _state.Comets);
             DeactivateTextInput();
             skyState.NeedsRedraw = true;
@@ -1224,8 +1234,7 @@
                     Deactivate: DeactivateTextInput,
                     SetActive: next => _activeInput = next,
                     RequestRedraw: () => { }, // the RenderFrame below covers this event
-                    Planner: _state,
-                    SkySearch: _skyTab?.State.Search,
+                    ActiveSearch: ResolveActiveSearch(active),
                     ActiveTab: tab));
             }
             if (e.Key.Length == 1 && !e.CtrlKey && !e.AltKey)


### PR DESCRIPTION
Completes **U2** of [controls-upstreaming](docs/plans/controls-upstreaming.md): rebases the planner autocomplete and the sky-map F3 search onto the new DIR.Lib `SearchInteraction<TResult>` base, collapsing the three-way-split key-nav protocol into one place. Also folds in the U5 residue and the sibling repin to the 6.18 line.

## U2 — search-control unification

Before, the "type → results → arrow to highlight → Enter/click to commit → Escape to dismiss" machinery was hand-rolled twice and split three ways (`TextInputInteraction` cycling + `PlannerSearchInteraction.OnKeyOverride` + the sky-map inline Up/Down).

- `PlannerSearchInteraction : SearchInteraction<string>` and new `SkyMapSearchInteraction : SearchInteraction<SkyMapSearchResult>` — thin subclasses that inject only the domain resolve/commit. Per-search behaviour differences ride base policy virtuals: planner = no auto-highlight (raw-Enter searches), Up-at-0 deselects, first Escape collapses the dropdown then cancels; sky-map = auto-highlight first result, Escape closes the modal.
- **Full state migration** (no shims): `PlannerState.Suggestions`/`SuggestionIndex`/`LastSuggestionQuery`/`CommitSuggestionAt` → `PlannerState.Search`; `SkyMapSearchState.Results`/`SelectedResultIndex` → `.Interaction`. Renderers + tests read through the interaction.
- `PlannerActions.UpdateSuggestions` → pure `ComputeSuggestions`; `SkyMapSearchActions.FilterResults` returns the array + takes the query; `CommitResult` takes the chosen result explicitly (both stay directly unit-testable).
- `TextInputInteraction.KeyContext` drops `Planner`/`SkySearch` for one `SearchInteraction? ActiveSearch`; the two hardcoded Up/Down blocks collapse to `s.HandleNavKey(key)`. Resolved at all three `KeyContext` sites (desktop `GuiEventHandlerBase` + web `Planner.razor` ×2). `TextInputInteraction` thereby loses its domain deps (a clean U6 promotion candidate — deferred).

## U5 residue

The 6 remaining `EquipmentTab.*` arranged-Fill callers drop the four-way `(int)r.X…` cast for the `RenderTextInput(RectF32)` overload (added later during the layout-driven-ui L2 split).

## Sibling repin → 6.18 line

- **DIR.Lib 6.18** — `SearchInteraction` base ([DIR.Lib #25](https://github.com/SharpAstro/DIR.Lib/pull/25))
- **Console.Lib 3.11**, **SdlVulkan.Renderer 6.31** — lockstep rebuilds
- Also folds in the already-published **DeviceTransform** (DIR.Lib 6.17 / SdlVkR 6.30) that main had not yet consumed (tianwen jumps 6.16→6.18 / 6.29→6.31).

## Verification

DIR.Lib 549/0 (20 new `SearchInteractionTests`). tianwen: 128 Planner/SkyMap/TextInput/Equipment tests green, full solution 0/0. Live GUI smoke via the inspector — planner autocomplete (type → dropdown → Down highlights → Enter commits + resets, no auto-highlight) and sky-map F3 (open → results with first auto-highlighted → Escape closes) both behave per their preserved policies; no stderr exceptions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)