### PR TITLE
refactor(tui): every tab declares a layout tree, no docked Panel left

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -1,4 +1,4 @@
-<Project>
+﻿<Project>
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <!-- Allow floating versions (e.g. "3.0.*", "2.30.*") so sibling-tracked
@@ -124,8 +124,12 @@
          Auto/Star, Node.CollapseBelow, Node.Wrap flow container) that PlannerTab's portrait
          reflow builds on. The Sizing ctor/Star/WStar signatures gained optional parameters
          (binary-breaking), so the whole sibling family rebuilt: lockstep with Console.Lib 3.8 +
-         SdlVulkan.Renderer 6.25 + WebGl.Renderer 1.8. -->
-    <PackageVersion Include="DIR.Lib" Version="6.19.*" />
+         SdlVulkan.Renderer 6.25 + WebGl.Renderer 1.8.
+         6.20 is the current pin: it adds Renderer.FillRoundedRectangle (a base virtual, so every
+         backend gains rounded fills at once) and fixes per-vector alpha compositing in
+         RgbaImage.FillRect, where a translucent fill over an opaque surface now yields alpha 255 as
+         it always should have. RGB output is bit-identical, so no TianWen golden moved. -->
+    <PackageVersion Include="DIR.Lib" Version="6.20.*" />
     <!-- DIR.Lib 3.0 extracted its codec layer to these sibling packages, which
          ship as a lockstep family from the Codecs repo. 3.0 brought a
          binary-breaking SharpAstro.Tiff change (TiffPageOptions.IccProfile is
@@ -186,10 +190,14 @@
          3.2 is a no-code lockstep rebuild against DIR.Lib 5.2.
          3.3 is a no-code lockstep rebuild against DIR.Lib 6.0 (layout namespace + Layout.Builder DSL).
          3.4-3.5 continue the lockstep rebuilds against DIR.Lib 6.x; 3.5 also carries the codecs-facade
-         migration (Console.Lib references SharpAstro.Codecs for image decode). 3.8 is the current
-         pin: the no-code lockstep rebuild against DIR.Lib 6.14 (its Sizing/Star signatures are
-         binary-breaking, so the 3.5 binary would MissingMethodException at runtime). -->
-    <PackageVersion Include="Console.Lib" Version="3.12.*" />
+         migration (Console.Lib references SharpAstro.Codecs for image decode). 3.8 was the no-code
+         lockstep rebuild against DIR.Lib 6.14 (its Sizing/Star signatures are binary-breaking, so the
+         3.5 binary would MissingMethodException at runtime); 3.10-3.12 continue that lockstep.
+         3.13 is the current pin: it adds the shared TextTable + BorderStyle (markdown tables render
+         through it, so mdcat inherits the border vocabulary) and widens TerminalViewport.UpdateGeometry
+         to public so a layout tree can host a widget at a Fill leaf and re-point it at the arranged
+         rect each frame. That is the seam the TUI's CellLayout migration is built on. -->
+    <PackageVersion Include="Console.Lib" Version="3.13.*" />
     <!-- SdlVulkan.Renderer 5.0 adds a multi-page SDF glyph atlas (no more grow
          stall / Adreno submit-wedge) on top of 4.1's SetSystemCursor + anisotropic
          glyph xScale. 5.1 implements DIR.Lib 4.4's PushClip/PopClip via Vulkan

--- a/src/TianWen.Cli/GlobalUsings.cs
+++ b/src/TianWen.Cli/GlobalUsings.cs
@@ -1,0 +1,4 @@
+// Alias rather than `using DIR.Lib.Layout;` -- the namespace's bareword types (Node, Content, Size<T>)
+// collide readily, so the codebase writes the qualified Layout.Node / Layout.Builder instead. Matches
+// TianWen.UI.Abstractions, TianWen.UI.Gui and TianWen.Lib.Tests.
+global using Layout = DIR.Lib.Layout;

--- a/src/TianWen.Cli/Tui/ITuiTab.cs
+++ b/src/TianWen.Cli/Tui/ITuiTab.cs
@@ -5,7 +5,7 @@ namespace TianWen.Cli.Tui;
 
 /// <summary>
 /// Interface for a TUI tab that can be hosted in the tabbed <see cref="TuiSubCommand"/>.
-/// Each tab owns its own Console.Lib widget layout within a content viewport.
+/// Each tab declares its arrangement as a layout tree and hosts its widgets at that tree's leaves.
 /// </summary>
 internal interface ITuiTab
 {
@@ -13,11 +13,11 @@ internal interface ITuiTab
     bool NeedsRedraw { get; set; }
 
     /// <summary>
-    /// Builds the tab's Panel layout. The tab creates its own Panel from the terminal,
-    /// reserving <paramref name="topRows"/> for the tab bar and <paramref name="bottomRows"/> for the status bar.
-    /// Called on tab activation and terminal resize.
+    /// Binds the tab to a terminal and creates its widgets, reserving <paramref name="topRows"/> for the
+    /// tab bar and <paramref name="bottomRows"/> for the status bar so the tab's own tree is arranged in
+    /// what is left. Called on tab activation and terminal resize.
     /// </summary>
-    void BuildPanel(IVirtualTerminal terminal, int topRows = 1, int bottomRows = 1);
+    void Attach(IVirtualTerminal terminal, int topRows = 1, int bottomRows = 1);
 
     /// <summary>Renders the tab content. Called each frame when <see cref="NeedsRedraw"/> is true.</summary>
     void Render();

--- a/src/TianWen.Cli/Tui/TuiEquipmentTab.cs
+++ b/src/TianWen.Cli/Tui/TuiEquipmentTab.cs
@@ -66,20 +66,54 @@ internal sealed class TuiEquipmentTab(
     protected override bool IsReady =>
         _profileList is not null && _settingsList is not null && _siteBar is not null && _statusBar is not null;
 
+    // Fill-leaf keys. The tree names these; PaintHost draws them.
+    private const string ProfilesKey = "profiles";
+    private const string SettingsKey = "settings";
+    private const string SiteKey = "site";
+    private const string StatusKey = "status";
+
     [MemberNotNull(nameof(_profileList), nameof(_settingsList), nameof(_siteBar), nameof(_statusBar))]
-    protected override void CreateWidgets(Panel panel)
+    protected override void CreateWidgets()
     {
-        var bottomVp = panel.Dock(DockStyle.Bottom, 1);
-        var siteVp = panel.Dock(DockStyle.Bottom, 1);
-        var leftVp = panel.Dock(DockStyle.Left, 24);
-        var fillVp = panel.Fill();
+        _siteBar = new TextBar(Host(SiteKey));
+        _statusBar = new TextBar(Host(StatusKey));
+        _profileList = new ScrollableList<ProfilePickerItem>(Host(ProfilesKey));
+        _settingsList = new ScrollableList<EquipmentFieldItem>(Host(SettingsKey));
+    }
 
-        _siteBar = new TextBar(siteVp);
-        _statusBar = new TextBar(bottomVp);
-        _profileList = new ScrollableList<ProfilePickerItem>(leftVp);
-        _settingsList = new ScrollableList<EquipmentFieldItem>(fillVp);
+    /// <summary>
+    /// Profile picker left, settings right, with the site line above the status row -- the same
+    /// arrangement the docked Panel produced (its two Bottom 1 docks in that order are what put the
+    /// site line above the status bar).
+    /// </summary>
+    protected override Layout.Node BuildLayout() =>
+        Layout.Builder.VStack(
+            Layout.Builder.HStack(
+                Layout.Builder.Fill(key: ProfilesKey).WFixed(24),
+                Layout.Builder.Fill(key: SettingsKey).WStar()).Stretch(),
+            Layout.Builder.Fill(key: SiteKey).RowH(1),
+            Layout.Builder.Fill(key: StatusKey).RowH(1));
 
-        panel.Add(_siteBar).Add(_statusBar).Add(_profileList).Add(_settingsList);
+    protected override void PaintHost(string key, Rect<int> rect, bool geometryChanged)
+    {
+        switch (key)
+        {
+            case ProfilesKey:
+                _profileList?.Render();
+                break;
+
+            case SettingsKey:
+                _settingsList?.Render();
+                break;
+
+            case SiteKey:
+                _siteBar?.Render();
+                break;
+
+            case StatusKey:
+                _statusBar?.Render();
+                break;
+        }
     }
 
     private static readonly string[] FieldLabels = ["Lat", "Lon", "Elev"];

--- a/src/TianWen.Cli/Tui/TuiGuiderTab.cs
+++ b/src/TianWen.Cli/Tui/TuiGuiderTab.cs
@@ -29,7 +29,11 @@ internal sealed class TuiGuiderTab(
     private TextBar? _topBar;
     private TextBar? _statusBar;
 
-    // Sixel mode: single canvas with full graphical guider
+    // Sixel mode: single canvas with full graphical guider. All three are built on first placement and
+    // rebuilt on resize (PaintHost), because their pixel size is only known once the tree is arranged.
+    // Interface-typed: PixelSize is a default interface member, so it is only reachable through
+    // ITerminalViewport, and this is the one place the tab needs it.
+    private ITerminalViewport? _canvasViewport;
     private Canvas? _canvas;
     private SixelRgbaImageRenderer? _canvasRenderer;
     private GuiderTab<RgbaImage>? _guiderWidget;
@@ -41,42 +45,108 @@ internal sealed class TuiGuiderTab(
 
     private bool UseSixel => terminal.HasSixelSupport;
 
+    /// <summary>
+    /// Readiness covers only what <see cref="CreateWidgets"/> builds. The Sixel canvas is deliberately
+    /// absent: it cannot exist before the first arrange, so requiring it here would stop the tab ever
+    /// rendering the frame that would size it.
+    /// </summary>
     [MemberNotNullWhen(true, nameof(_topBar), nameof(_statusBar))]
     protected override bool IsReady => _topBar is not null && _statusBar is not null
-        && (UseSixel
-            ? _canvas is not null && _canvasRenderer is not null && _guiderWidget is not null
-            : _graphPanel is not null && _targetPanel is not null && _statsPanel is not null);
+        && (UseSixel || (_graphPanel is not null && _targetPanel is not null && _statsPanel is not null));
 
-    protected override void CreateWidgets(Panel panel)
+    // Fill-leaf keys. The tree names these; PaintHost draws them.
+    private const string TopKey = "top";
+    private const string StatusKey = "status";
+    private const string CanvasKey = "canvas";
+    private const string GraphKey = "graph";
+    private const string TargetKey = "target";
+    private const string StatsKey = "stats";
+
+    protected override void CreateWidgets()
     {
-        var topVp = panel.Dock(DockStyle.Top, 1);
-        var bottomVp = panel.Dock(DockStyle.Bottom, 1);
-
-        _topBar = new TextBar(topVp);
-        _statusBar = new TextBar(bottomVp);
+        _topBar = new TextBar(Host(TopKey));
+        _statusBar = new TextBar(Host(StatusKey));
 
         if (UseSixel)
         {
-            var fillVp = panel.Fill();
-            var canvasPixelSize = fillVp.PixelSize;
-            _canvasRenderer = new SixelRgbaImageRenderer((uint)canvasPixelSize.Width, (uint)canvasPixelSize.Height);
-            _canvas = new Canvas(fillVp, _canvasRenderer);
-            // The widget owns its font path (host-set once); a terminal Sixel canvas has no emoji font.
-            _guiderWidget = new GuiderTab<RgbaImage>(_canvasRenderer) { FontPath = fontPath };
-
-            panel.Add(_topBar).Add(_statusBar).Add(_canvas);
+            // Only the viewport. The renderer, canvas and guider widget all need a pixel size, which
+            // comes from the arranged rect -- PaintHost builds them on first placement and on resize.
+            _canvasViewport = Host(CanvasKey);
         }
         else
         {
-            var leftVp = panel.Dock(DockStyle.Left, 44);
-            var centerVp = panel.Dock(DockStyle.Left, 24);
-            var fillVp = panel.Fill();
+            _graphPanel = new MarkdownWidget(Host(GraphKey));
+            _targetPanel = new MarkdownWidget(Host(TargetKey));
+            _statsPanel = new MarkdownWidget(Host(StatsKey));
+        }
+    }
 
-            _graphPanel = new MarkdownWidget(leftVp);
-            _targetPanel = new MarkdownWidget(centerVp);
-            _statsPanel = new MarkdownWidget(fillVp);
+    /// <summary>
+    /// The arrangement: a one-row bar top and bottom with the content between them. The Sixel and text
+    /// variants are now two expressions of one tree rather than two widget-construction paths -- and
+    /// because the tree is rebuilt per frame, the fallback's fixed 44/24 columns can give way to Star
+    /// sizing on a narrow terminal without touching widget setup.
+    /// </summary>
+    protected override Layout.Node BuildLayout() =>
+        Layout.Builder.VStack(
+            Layout.Builder.Fill(key: TopKey).RowH(1),
+            UseSixel
+                ? Layout.Builder.Fill(key: CanvasKey).Stretch()
+                : Layout.Builder.HStack(
+                    Layout.Builder.Fill(key: GraphKey).WFixed(44),
+                    Layout.Builder.Fill(key: TargetKey).WFixed(24),
+                    Layout.Builder.Fill(key: StatsKey).WStar()).Stretch(),
+            Layout.Builder.Fill(key: StatusKey).RowH(1));
 
-            panel.Add(_topBar).Add(_statusBar).Add(_graphPanel).Add(_targetPanel).Add(_statsPanel);
+    /// <summary>
+    /// Draws one hosted widget. The Sixel canvas is the reason <paramref name="geometryChanged"/> exists:
+    /// its renderer is a fixed-size pixel buffer, so it is allocated on first placement and reallocated
+    /// whenever the cell rect resizes. The Panel-based version sized it once at construction and never
+    /// again, so a terminal resize left the guider rendering at the old pixel size.
+    /// </summary>
+    protected override void PaintHost(string key, Rect<int> rect, bool geometryChanged)
+    {
+        switch (key)
+        {
+            case TopKey:
+                _topBar?.Render();
+                break;
+
+            case StatusKey:
+                _statusBar?.Render();
+                break;
+
+            case CanvasKey when _canvasViewport is { } viewport:
+                if (geometryChanged)
+                {
+                    var (pixelWidth, pixelHeight) = viewport.PixelSize;
+                    _canvasRenderer?.Dispose();
+                    _canvasRenderer = new SixelRgbaImageRenderer(pixelWidth, pixelHeight);
+                    _guiderWidget = new GuiderTab<RgbaImage>(_canvasRenderer) { FontPath = fontPath };
+                    _canvas = new Canvas(viewport, _canvasRenderer);
+                }
+
+                if (_canvas is { } canvas && _guiderWidget is { } guiderWidget)
+                {
+                    // A terminal Sixel canvas has no DPI scaling; the widget's DpiScale stays at its
+                    // default 1. FontPath was set when the widget was built, not passed per render.
+                    var (pixelWidth, pixelHeight) = canvas.PixelSize;
+                    guiderWidget.Render(LiveState, new RectF32(0, 0, pixelWidth, pixelHeight), timeProvider);
+                    canvas.Render();
+                }
+                break;
+
+            case GraphKey:
+                _graphPanel?.Render();
+                break;
+
+            case TargetKey:
+                _targetPanel?.Render();
+                break;
+
+            case StatsKey:
+                _statsPanel?.Render();
+                break;
         }
     }
 
@@ -100,13 +170,11 @@ internal sealed class TuiGuiderTab(
             _topBar.RightText(GuiderActions.FormatRmsSummary(_state.LastGuideStats));
         }
 
-        // Main content. The null-checked widgets flow into the helpers as parameters so the
-        // non-null guarantee travels with them -- no null-forgiving '!' re-derefs inside.
-        if (UseSixel && _canvas is { } canvas && _guiderWidget is { } guiderWidget)
-        {
-            RenderSixelContent(canvas, guiderWidget);
-        }
-        else if (_graphPanel is { } graphPanel && _targetPanel is { } targetPanel && _statsPanel is { } statsPanel)
+        // Text-fallback content. The Sixel path has no data step -- the guider widget draws straight from
+        // LiveState during PaintHost, once its canvas has been sized by the arrange.
+        // The null-checked widgets flow into the helper as parameters so the non-null guarantee travels
+        // with them -- no null-forgiving '!' re-derefs inside.
+        if (!UseSixel && _graphPanel is { } graphPanel && _targetPanel is { } targetPanel && _statsPanel is { } statsPanel)
         {
             RenderTextContent(placeholder, graphPanel, targetPanel, statsPanel);
         }
@@ -115,16 +183,6 @@ internal sealed class TuiGuiderTab(
         var targetName = _state.ActiveObservation is { Target: var t } ? t.Name : "";
         _statusBar.Text(targetName.Length > 0 ? $" \u2192 {targetName}" : "");
         _statusBar.RightText(appState.StatusMessage ?? "");
-    }
-
-    private void RenderSixelContent(Canvas canvas, GuiderTab<RgbaImage> guiderWidget)
-    {
-        var canvasPixelSize = canvas.PixelSize;
-        var contentRect = new RectF32(0, 0, canvasPixelSize.Width, canvasPixelSize.Height);
-
-        // A terminal Sixel canvas has no DPI scaling; the widget's DpiScale stays at its default 1.
-        // FontPath was set on the widget in CreateWidgets, so it is not passed per-render any more.
-        guiderWidget.Render(LiveState, contentRect, timeProvider);
     }
 
     private void RenderTextContent(GuiderPlaceholder? placeholder,

--- a/src/TianWen.Cli/Tui/TuiLiveSessionTab.cs
+++ b/src/TianWen.Cli/Tui/TuiLiveSessionTab.cs
@@ -57,7 +57,10 @@ internal sealed class TuiLiveSessionTab(
     private TextBar? _statusBar;
     private TextBar? _previewToolbar;
 
-    // Preview area — Canvas for Sixel, MarkdownWidget placeholder for non-Sixel
+    // Preview area — Canvas for Sixel, MarkdownWidget placeholder for non-Sixel. The Canvas and its
+    // renderer are pixel-backed, so they are built on first placement and rebuilt on resize (PaintHost);
+    // the viewport is interface-typed because PixelSize is a default interface member.
+    private ITerminalViewport? _previewViewport;
     private Canvas? _previewCanvas;
     private SixelRgbaImageRenderer? _previewRenderer;
     private MarkdownWidget? _previewFallback;
@@ -78,36 +81,110 @@ internal sealed class TuiLiveSessionTab(
     protected override bool IsReady =>
         _topBar is not null && _guideBar is not null && _infoList is not null && _statusBar is not null && _previewToolbar is not null;
 
-    protected override void CreateWidgets(Panel panel)
+    // Fill-leaf keys. The tree names these; PaintHost draws them.
+    private const string TopKey = "top";
+    private const string GuideKey = "guide";
+    private const string InfoKey = "info";
+    private const string ToolbarKey = "toolbar";
+    private const string PreviewKey = "preview";
+    private const string StatusKey = "status";
+
+    private bool UseSixel => terminal.HasSixelSupport;
+
+    protected override void CreateWidgets()
     {
-        var topVp = panel.Dock(DockStyle.Top, 1);
-        var guideVp = panel.Dock(DockStyle.Top, 1);
-        var bottomVp = panel.Dock(DockStyle.Bottom, 1);
-        var leftVp = panel.Dock(DockStyle.Left, LeftPanelCols);
-        var toolbarVp = panel.Dock(DockStyle.Top, 1);
-        var fillVp = panel.Fill();
+        _topBar = new TextBar(Host(TopKey));
+        _guideBar = new TextBar(Host(GuideKey));
+        _statusBar = new TextBar(Host(StatusKey));
+        _infoList = new ScrollableList<InfoRowItem>(Host(InfoKey));
+        _previewToolbar = new TextBar(Host(ToolbarKey));
 
-        _topBar = new TextBar(topVp);
-        _guideBar = new TextBar(guideVp);
-        _statusBar = new TextBar(bottomVp);
-        _infoList = new ScrollableList<InfoRowItem>(leftVp);
-        _previewToolbar = new TextBar(toolbarVp);
-
-        // Preview area: Sixel-capable terminals get a Canvas, others get a text fallback
-        if (terminal.HasSixelSupport)
+        // Preview area: Sixel-capable terminals get a Canvas, others a text fallback. The Canvas needs a
+        // pixel size the arrange has not produced yet, so only its viewport is taken here -- PaintHost
+        // builds the renderer and canvas on first placement and on resize.
+        var previewViewport = Host(PreviewKey);
+        if (UseSixel)
         {
-            var canvasPixelSize = fillVp.PixelSize;
-            _previewRenderer = new SixelRgbaImageRenderer((uint)canvasPixelSize.Width, (uint)canvasPixelSize.Height);
-            _previewCanvas = new Canvas(fillVp, _previewRenderer);
+            _previewViewport = previewViewport;
             _previewFallback = null;
-            panel.Add(_topBar).Add(_guideBar).Add(_statusBar).Add(_infoList).Add(_previewToolbar).Add(_previewCanvas);
         }
         else
         {
-            _previewCanvas = null;
-            _previewRenderer = null;
-            _previewFallback = new MarkdownWidget(fillVp);
-            panel.Add(_topBar).Add(_guideBar).Add(_statusBar).Add(_infoList).Add(_previewToolbar).Add(_previewFallback);
+            _previewViewport = null;
+            _previewFallback = new MarkdownWidget(previewViewport);
+        }
+    }
+
+    /// <summary>
+    /// Two header rows, then the info panel beside the preview (which carries its own toolbar row), then
+    /// the status row -- the same arrangement the docked Panel produced. The Sixel and text preview are
+    /// one leaf, not two branches: only what gets drawn into it differs.
+    /// </summary>
+    protected override Layout.Node BuildLayout() =>
+        Layout.Builder.VStack(
+            Layout.Builder.Fill(key: TopKey).RowH(1),
+            Layout.Builder.Fill(key: GuideKey).RowH(1),
+            Layout.Builder.HStack(
+                Layout.Builder.Fill(key: InfoKey).WFixed(LeftPanelCols),
+                Layout.Builder.VStack(
+                    Layout.Builder.Fill(key: ToolbarKey).RowH(1),
+                    Layout.Builder.Fill(key: PreviewKey).Stretch()).WStar()).Stretch(),
+            Layout.Builder.Fill(key: StatusKey).RowH(1));
+
+    /// <summary>
+    /// Draws one hosted widget. The Sixel preview is why <paramref name="geometryChanged"/> matters: its
+    /// renderer is a fixed-size pixel buffer, so it is allocated on first placement and reallocated on
+    /// resize. The Panel-based version sized it once at construction and never again, so a terminal
+    /// resize left the preview rendering at the old pixel size.
+    /// </summary>
+    protected override void PaintHost(string key, Rect<int> rect, bool geometryChanged)
+    {
+        switch (key)
+        {
+            case TopKey:
+                _topBar?.Render();
+                break;
+
+            case GuideKey:
+                _guideBar?.Render();
+                break;
+
+            case InfoKey:
+                _infoList?.Render();
+                break;
+
+            case ToolbarKey:
+                _previewToolbar?.Render();
+                break;
+
+            case StatusKey:
+                _statusBar?.Render();
+                break;
+
+            case PreviewKey when _previewViewport is { } viewport:
+                if (geometryChanged)
+                {
+                    var (pixelWidth, pixelHeight) = viewport.PixelSize;
+                    _previewRenderer?.Dispose();
+                    _previewRenderer = new SixelRgbaImageRenderer((uint)pixelWidth, (uint)pixelHeight);
+                    _previewCanvas = new Canvas(viewport, _previewRenderer);
+                }
+
+                if (_previewCanvas is { } canvas && _previewRenderer is { } previewRenderer)
+                {
+                    if (_lastDoc is { } doc)
+                    {
+                        // Render directly into the canvas's surface -- ConsoleImageRenderer wraps an RgbaImageRenderer
+                        var renderer = new ConsoleImageRenderer(previewRenderer);
+                        renderer.RenderImage(doc, _viewerState, _viewerState.CurvesBoost);
+                    }
+                    canvas.Render();
+                }
+                break;
+
+            case PreviewKey:
+                _previewFallback?.Render();
+                break;
         }
     }
 
@@ -675,14 +752,9 @@ internal sealed class TuiLiveSessionTab(
             }
         }
 
-        // Render preview to Canvas (Sixel) or text fallback
-        if (_previewCanvas is not null && _previewRenderer is not null && _lastDoc is not null)
-        {
-            // Render directly into the canvas's surface — ConsoleImageRenderer wraps an RgbaImageRenderer
-            var renderer = new ConsoleImageRenderer(_previewRenderer);
-            renderer.RenderImage(_lastDoc, _viewerState, _viewerState.CurvesBoost);
-        }
-        else if (_previewFallback is not null)
+        // The Sixel raster is drawn from PaintHost, not here -- it needs the arranged pixel size.
+        // The text fallback is a cell widget, so its content can be filled now like any other.
+        if (_previewFallback is not null)
         {
             // Non-Sixel: show frame metadata
             var metrics = LiveState.LastFrameMetrics;

--- a/src/TianWen.Cli/Tui/TuiNotificationsTab.cs
+++ b/src/TianWen.Cli/Tui/TuiNotificationsTab.cs
@@ -17,15 +17,34 @@ internal sealed class TuiNotificationsTab(GuiAppState appState) : TuiTabBase
     [MemberNotNullWhen(true, nameof(_list), nameof(_statusBar))]
     protected override bool IsReady => _list is not null && _statusBar is not null;
 
-    protected override void CreateWidgets(Panel panel)
+    // Fill-leaf keys. The tree names these; PaintHost draws them.
+    private const string ListKey = "list";
+    private const string StatusKey = "status";
+
+    protected override void CreateWidgets()
     {
-        var bottomVp = panel.Dock(DockStyle.Bottom, 1);
-        var fillVp = panel.Fill();
+        _list = new ScrollableList<NotificationListItem>(Host(ListKey));
+        _statusBar = new TextBar(Host(StatusKey));
+    }
 
-        _statusBar = new TextBar(bottomVp);
-        _list = new ScrollableList<NotificationListItem>(fillVp);
+    /// <summary>The list takes everything the one-row status bar does not.</summary>
+    protected override Layout.Node BuildLayout() =>
+        Layout.Builder.VStack(
+            Layout.Builder.Fill(key: ListKey).Stretch(),
+            Layout.Builder.Fill(key: StatusKey).RowH(1));
 
-        panel.Add(_statusBar).Add(_list);
+    protected override void PaintHost(string key, Rect<int> rect, bool geometryChanged)
+    {
+        switch (key)
+        {
+            case ListKey:
+                _list?.Render();
+                break;
+
+            case StatusKey:
+                _statusBar?.Render();
+                break;
+        }
     }
 
     protected override void RenderContent()

--- a/src/TianWen.Cli/Tui/TuiPlannerTab.cs
+++ b/src/TianWen.Cli/Tui/TuiPlannerTab.cs
@@ -21,34 +21,119 @@ internal sealed class TuiPlannerTab(
     private TextBar? _statusBar;
     private ScrollableList<TargetListItem>? _targetList;
     private MarkdownWidget? _detailWidget;
+
+    // The altitude chart is pixel-backed, so its renderer can only be sized once the tree has been
+    // arranged. Built on first placement and rebuilt on resize (PaintHost). Interface-typed because
+    // PixelSize is a default interface member, only reachable through ITerminalViewport.
+    private ITerminalViewport? _canvasViewport;
     private Canvas? _canvas;
     private SixelRgbaImageRenderer? _canvasRenderer;
     private int _lastEnsuredIndex = -1;
 
+    /// <summary>
+    /// Readiness covers only what <see cref="CreateWidgets"/> builds. The chart canvas is deliberately
+    /// absent: it cannot exist before the first arrange, so requiring it here would stop the tab ever
+    /// rendering the frame that would size it.
+    /// </summary>
     [MemberNotNullWhen(true, nameof(_topBar), nameof(_statusBar), nameof(_targetList),
-        nameof(_detailWidget), nameof(_canvas), nameof(_canvasRenderer))]
+        nameof(_detailWidget))]
     protected override bool IsReady =>
         _topBar is not null && _statusBar is not null && _targetList is not null
-        && _detailWidget is not null && _canvas is not null && _canvasRenderer is not null;
+        && _detailWidget is not null;
 
-    protected override void CreateWidgets(Panel panel)
+    // Fill-leaf keys. The tree names these; PaintHost draws them.
+    private const string TopKey = "top";
+    private const string ListKey = "list";
+    private const string CanvasKey = "canvas";
+    private const string DetailKey = "detail";
+    private const string StatusKey = "status";
+
+    protected override void CreateWidgets()
     {
-        var topVp = panel.Dock(DockStyle.Top, 1);
-        var bottomVp = panel.Dock(DockStyle.Bottom, 1);
-        var detailVp = panel.Dock(DockStyle.Bottom, 8);
-        var leftVp = panel.Dock(DockStyle.Left, 32);
-        var fillVp = panel.Fill();
+        _topBar = new TextBar(Host(TopKey));
+        _statusBar = new TextBar(Host(StatusKey));
+        _targetList = new ScrollableList<TargetListItem>(Host(ListKey));
+        _detailWidget = new MarkdownWidget(Host(DetailKey));
 
-        _topBar = new TextBar(topVp);
-        _statusBar = new TextBar(bottomVp);
-        _targetList = new ScrollableList<TargetListItem>(leftVp);
-        _detailWidget = new MarkdownWidget(detailVp);
+        // Only the viewport -- the renderer and canvas need a pixel size the arrange has not produced yet.
+        _canvasViewport = Host(CanvasKey);
+    }
 
-        var canvasPixelSize = fillVp.PixelSize;
-        _canvasRenderer = new SixelRgbaImageRenderer((uint)canvasPixelSize.Width, (uint)canvasPixelSize.Height);
-        _canvas = new Canvas(fillVp, _canvasRenderer);
+    /// <summary>
+    /// Top bar, then the target list beside the altitude chart, then the detail panel, then the status
+    /// row -- the same arrangement the docked Panel produced (its Bottom 1 / Bottom 8 order is what put
+    /// the detail panel above the status bar).
+    /// </summary>
+    protected override Layout.Node BuildLayout() =>
+        Layout.Builder.VStack(
+            Layout.Builder.Fill(key: TopKey).RowH(1),
+            Layout.Builder.HStack(
+                Layout.Builder.Fill(key: ListKey).WFixed(32),
+                Layout.Builder.Fill(key: CanvasKey).WStar()).Stretch(),
+            Layout.Builder.Fill(key: DetailKey).RowH(8),
+            Layout.Builder.Fill(key: StatusKey).RowH(1));
 
-        panel.Add(_topBar).Add(_statusBar).Add(_targetList).Add(_detailWidget).Add(_canvas);
+    /// <summary>
+    /// Draws one hosted widget. The chart is why <paramref name="geometryChanged"/> matters: its Sixel
+    /// renderer is a fixed-size pixel buffer, so it is allocated on first placement and reallocated on
+    /// resize. The Panel-based version sized it once at construction and never again, so a terminal
+    /// resize left the chart rendering at the old pixel size.
+    /// </summary>
+    protected override void PaintHost(string key, Rect<int> rect, bool geometryChanged)
+    {
+        switch (key)
+        {
+            case TopKey:
+                _topBar?.Render();
+                break;
+
+            case ListKey:
+                _targetList?.Render();
+                break;
+
+            case DetailKey:
+                _detailWidget?.Render();
+                break;
+
+            case StatusKey:
+                _statusBar?.Render();
+                break;
+
+            case CanvasKey when _canvasViewport is { } viewport:
+                if (geometryChanged)
+                {
+                    var (pixelWidth, pixelHeight) = viewport.PixelSize;
+                    _canvasRenderer?.Dispose();
+                    _canvasRenderer = new SixelRgbaImageRenderer((uint)pixelWidth, (uint)pixelHeight);
+                    _canvas = new Canvas(viewport, _canvasRenderer);
+                }
+
+                if (_canvas is { } canvas && _canvasRenderer is { } canvasRenderer)
+                {
+                    RenderAltitudeChart(canvas, canvasRenderer);
+                    canvas.Render();
+                }
+                break;
+        }
+    }
+
+    /// <summary>
+    /// Draws the altitude chart. Lives here rather than in <see cref="RenderContent"/> because it needs
+    /// the canvas's pixel size, which only exists once the tree has been arranged.
+    /// </summary>
+    private void RenderAltitudeChart(Canvas canvas, SixelRgbaImageRenderer canvasRenderer)
+    {
+        var canvasPixelSize = canvas.PixelSize;
+        canvasRenderer.FillRectangle(
+            new RectInt(new PointInt((int)canvasPixelSize.Width, (int)canvasPixelSize.Height), new PointInt(0, 0)),
+            new RGBAColor32(0x1a, 0x1a, 0x2e, 0xff));
+        var chartCurrentTime = plannerState.PlanningDate.HasValue
+            ? null as DateTimeOffset?
+            : timeProvider.GetUtcNow().ToOffset(plannerState.SiteTimeZone);
+        AltitudeChartRenderer.Render(canvasRenderer, plannerState, fontPath,
+            0, 0, (int)canvasRenderer.Width, (int)canvasRenderer.Height,
+            highlightTargetIndex: plannerState.SelectedTargetIndex,
+            currentTime: chartCurrentTime);
     }
 
     protected override void RenderContent()
@@ -99,16 +184,7 @@ internal sealed class TuiPlannerTab(
             _detailWidget.Markdown(md);
         }
 
-        // Altitude chart
-        var canvasPixelSize = _canvas.PixelSize;
-        _canvasRenderer.FillRectangle(
-            new RectInt(new PointInt((int)canvasPixelSize.Width, (int)canvasPixelSize.Height), new PointInt(0, 0)),
-            new RGBAColor32(0x1a, 0x1a, 0x2e, 0xff));
-        var chartCurrentTime = plannerState.PlanningDate.HasValue ? null as DateTimeOffset? : timeProvider.GetUtcNow().ToOffset(plannerState.SiteTimeZone);
-        AltitudeChartRenderer.Render(_canvasRenderer, plannerState, fontPath,
-            0, 0, (int)_canvasRenderer.Width, (int)_canvasRenderer.Height,
-            highlightTargetIndex: plannerState.SelectedTargetIndex,
-            currentTime: chartCurrentTime);
+        // The altitude chart is drawn from PaintHost, not here -- it needs the arranged pixel size.
 
         // Status bar
         var statusText = plannerState.StatusMessage is { } msg

--- a/src/TianWen.Cli/Tui/TuiSessionTab.cs
+++ b/src/TianWen.Cli/Tui/TuiSessionTab.cs
@@ -25,17 +25,50 @@ internal sealed class TuiSessionTab(
     [MemberNotNullWhen(true, nameof(_configList), nameof(_rightPanel), nameof(_statusBar))]
     protected override bool IsReady => _configList is not null && _rightPanel is not null && _statusBar is not null;
 
-    protected override void CreateWidgets(Panel panel)
+    // Fill-leaf keys. The tree names these; PaintHost draws them.
+    private const string ConfigKey = "config";
+    private const string RightKey = "right";
+    private const string StatusKey = "status";
+
+    protected override void CreateWidgets()
     {
-        var bottomVp = panel.Dock(DockStyle.Bottom, 1);
-        var rightVp = panel.Dock(DockStyle.Right, 44);
-        var fillVp = panel.Fill();
+        _statusBar = new TextBar(Host(StatusKey));
+        _rightPanel = new MarkdownWidget(Host(RightKey));
+        _configList = new ScrollableList<SessionFieldItem>(Host(ConfigKey));
+    }
 
-        _statusBar = new TextBar(bottomVp);
-        _rightPanel = new MarkdownWidget(rightVp);
-        _configList = new ScrollableList<SessionFieldItem>(fillVp);
+    /// <summary>
+    /// Config form left, per-OTA panel right at a fixed 44 columns, one status row underneath --
+    /// the same arrangement the docked Panel produced, so this is a straight translation.
+    /// <para>
+    /// Now that it is a tree rebuilt per frame, a narrow terminal could branch here (stack the two
+    /// vertically, or <c>CollapseBelow</c> the right panel) without touching widget construction.
+    /// Deliberately not doing that in the migration -- behaviour first, responsiveness after.
+    /// </para>
+    /// </summary>
+    protected override Layout.Node BuildLayout() =>
+        Layout.Builder.VStack(
+            Layout.Builder.HStack(
+                Layout.Builder.Fill(key: ConfigKey).WStar(),
+                Layout.Builder.Fill(key: RightKey).WFixed(44)).Stretch(),
+            Layout.Builder.Fill(key: StatusKey).RowH(1));
 
-        panel.Add(_statusBar).Add(_rightPanel).Add(_configList);
+    protected override void PaintHost(string key, Rect<int> rect, bool geometryChanged)
+    {
+        switch (key)
+        {
+            case ConfigKey:
+                _configList?.Render();
+                break;
+
+            case RightKey:
+                _rightPanel?.Render();
+                break;
+
+            case StatusKey:
+                _statusBar?.Render();
+                break;
+        }
     }
 
     protected override void RenderContent()

--- a/src/TianWen.Cli/Tui/TuiTabBase.cs
+++ b/src/TianWen.Cli/Tui/TuiTabBase.cs
@@ -1,70 +1,183 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
 using Console.Lib;
 using DIR.Lib;
 
 namespace TianWen.Cli.Tui;
 
 /// <summary>
-/// Base class for TUI tabs. Manages the <see cref="Panel"/> lifecycle,
-/// <see cref="NeedsRedraw"/> flag, and <see cref="ClickableRegionTracker"/>.
-/// Subclasses override <see cref="CreateWidgets"/> and <see cref="RenderContent"/>.
+/// Base class for TUI tabs. A tab declares its arrangement as a <see cref="Layout.Node"/> tree, the same
+/// surface-agnostic tree the GUI paints, and this class arranges it in cells and paints it via
+/// <see cref="CellLayout"/>.
+/// <para>
+/// <b>The tree owns placement; widgets own behaviour.</b> A <see cref="ScrollableList{T}"/> (scroll state
+/// and thumb), a <see cref="Canvas"/> (Sixel dirty regions) and a <see cref="MarkdownWidget"/> (its own
+/// wrapping) do things a layout node cannot model, so they stay widgets -- but they no longer place
+/// themselves. Each is registered against a key with <see cref="Host"/>, appears in the tree as a
+/// <c>Layout.Builder.Fill(key: ...)</c> leaf, and has its viewport re-pointed at that leaf's arranged rect
+/// before <see cref="PaintHost"/> draws it. Everything else (bars, labels, backgrounds) is just nodes.
+/// </para>
+/// <para>
+/// The tree is rebuilt every frame, so a tab can branch on terminal size, capability or state in plain C#
+/// -- which is how the Sixel and text-fallback arrangements become two expressions rather than two
+/// widget-construction paths.
+/// </para>
 /// </summary>
 internal abstract class TuiTabBase : ITuiTab
 {
     protected readonly ClickableRegionTracker Tracker = new();
 
-    protected Panel? Panel { get; private set; }
+    /// <summary>Stateless (text width is the character count), so one instance serves every tab.</summary>
+    private static readonly CellMeasureContext MeasureContext = new CellMeasureContext();
+
+    private readonly Dictionary<string, HostedRegion> _hosts = [];
+    private IVirtualTerminal? _terminal;
+    private int _topRows;
+    private int _bottomRows;
 
     public bool NeedsRedraw { get; set; } = true;
 
-    public void BuildPanel(IVirtualTerminal terminal, int topRows = 1, int bottomRows = 0)
+    /// <summary>
+    /// The tree as last arranged, for hit-testing via <see cref="CellLayout.HitTest"/> and for tests that
+    /// assert placement without a terminal.
+    /// </summary>
+    protected ImmutableArray<Layout.ArrangedNode<int>> Arranged { get; private set; }
+
+    public void Attach(IVirtualTerminal terminal, int topRows = 1, int bottomRows = 1)
     {
-        Panel = new Panel(terminal);
-        Panel.Dock(DockStyle.Top, topRows);
-        Panel.Dock(DockStyle.Bottom, bottomRows);
-        CreateWidgets(Panel);
+        _terminal = terminal;
+        _topRows = topRows;
+        _bottomRows = bottomRows;
+        _hosts.Clear();
+        CreateWidgets();
         NeedsRedraw = true;
     }
 
     public void Render()
     {
-        if (Panel is null || !IsReady)
+        if (_terminal is not { } terminal || !IsReady)
         {
             return;
         }
 
         NeedsRedraw = false;
         Tracker.BeginFrame();
+
+        // Data first: RenderContent decides what the tab is showing, and BuildLayout is allowed to
+        // branch on that (a placeholder state can arrange differently from a live one).
         RenderContent();
-        Panel.RenderAll();
+
+        var (columns, rows) = terminal.Size;
+        var content = new Rect<int>(0, _topRows, columns, Math.Max(0, rows - _topRows - _bottomRows));
+        if (content.Width <= 0 || content.Height <= 0)
+        {
+            return;
+        }
+
+        Arranged = Layout.Engine.Arrange(BuildLayout(), content, MeasureContext);
+        CellLayout.Paint(terminal, Arranged, PlaceAndPaint);
         RegisterClickableRegions();
+    }
+
+    /// <summary>
+    /// Re-points a hosted widget's viewport at the rect its <c>Fill</c> leaf was arranged into, then lets
+    /// the tab draw. An unregistered key is ignored rather than throwing: a tree that names a host it did
+    /// not create should leave a hole, not take the whole TUI down mid-frame.
+    /// </summary>
+    private void PlaceAndPaint(Layout.Content.Fill fill, Rect<int> rect)
+    {
+        if (fill.Key is not { } key || !_hosts.TryGetValue(key, out var host))
+        {
+            return;
+        }
+
+        var geometryChanged = host.Place(rect);
+        PaintHost(key, rect, geometryChanged);
+    }
+
+    /// <summary>
+    /// Creates and registers a viewport for the widget hosted at <paramref name="key"/>. Call once from
+    /// <see cref="CreateWidgets"/> and pass the result to the widget's constructor; its geometry is
+    /// meaningless until the first arrange places it.
+    /// </summary>
+    protected TerminalViewport Host(string key)
+    {
+        var terminal = _terminal ?? throw new InvalidOperationException(
+            $"Host('{key}') is only valid from CreateWidgets, after Attach has supplied the terminal.");
+
+        var viewport = new TerminalViewport(terminal, 0, 0, 0, 0);
+        _hosts[key] = new HostedRegion(viewport);
+        return viewport;
     }
 
     public abstract bool HandleInput(InputEvent evt);
 
     /// <summary>
-    /// Raw mouse dispatch for ScrollableList drag handling. Default is a no-op —
+    /// Raw mouse dispatch for ScrollableList drag handling. Default is a no-op --
     /// override to route to the tab's list widgets (e.g., <c>_xxxList.HandleMouse(mouse)</c>).
     /// </summary>
     public virtual bool HandleRawMouse(MouseEvent mouse) => false;
 
     /// <summary>
-    /// Creates tab-specific widgets from the panel. Called from <see cref="BuildPanel"/>.
-    /// The panel already has top/bottom rows reserved.
+    /// Creates the tab's widgets, taking each one's viewport from <see cref="Host"/>. Called from
+    /// <see cref="Attach"/>, so it re-runs on terminal resize.
     /// </summary>
-    protected abstract void CreateWidgets(Panel panel);
+    protected abstract void CreateWidgets();
+
+    /// <summary>The arrangement for this frame. Rebuilt every frame, so it may branch on live state.</summary>
+    protected abstract Layout.Node BuildLayout();
 
     /// <summary>Whether all required widgets have been created.</summary>
     protected abstract bool IsReady { get; }
 
     /// <summary>
-    /// Fills widget data for the current frame. Called from <see cref="Render"/>
-    /// after <see cref="NeedsRedraw"/> is cleared and before <see cref="Panel.RenderAll"/>.
+    /// Fills widget data for the current frame. Runs before the tree is built and painted, so the values
+    /// it computes are available to <see cref="BuildLayout"/>.
     /// </summary>
     protected abstract void RenderContent();
 
     /// <summary>
-    /// Registers clickable regions after <see cref="Panel.RenderAll"/> using widget viewport geometry.
-    /// Override to register regions; default is no-op.
+    /// Draws the widget hosted at <paramref name="key"/>; its viewport is already positioned at
+    /// <paramref name="rect"/>.
+    /// <para>
+    /// <paramref name="geometryChanged"/> is true on the first paint and whenever the rect's size changed
+    /// since the last one. A cell-based widget can ignore it, but a <b>pixel-backed</b> host must not: a
+    /// Sixel <see cref="Canvas"/> owns a renderer allocated at a fixed pixel size, and that size is only
+    /// knowable after the arrange. This flag is when to (re)allocate it.
+    /// </para>
+    /// </summary>
+    protected abstract void PaintHost(string key, Rect<int> rect, bool geometryChanged);
+
+    /// <summary>
+    /// Registers clickable regions after the frame is painted. Prefer binding hits on the nodes
+    /// themselves (<c>.Clickable(...)</c>) and dispatching through <see cref="CellLayout.HitTest"/> over
+    /// <see cref="Arranged"/>, which keeps draw and hit on the same rect by construction.
     /// </summary>
     protected virtual void RegisterClickableRegions() { }
+
+    /// <summary>
+    /// One hosted widget's viewport, plus the last size it was placed at so a resize can be reported
+    /// exactly once per change rather than every frame.
+    /// </summary>
+    private sealed class HostedRegion(TerminalViewport viewport)
+    {
+        private int _width = -1;
+        private int _height = -1;
+
+        /// <summary>Moves the viewport to <paramref name="rect"/>; returns true if its size changed.</summary>
+        public bool Place(Rect<int> rect)
+        {
+            viewport.UpdateGeometry(rect.X, rect.Y, rect.Width, rect.Height);
+
+            if (rect.Width == _width && rect.Height == _height)
+            {
+                return false;
+            }
+
+            _width = rect.Width;
+            _height = rect.Height;
+            return true;
+        }
+    }
 }

--- a/src/TianWen.Cli/TuiSubCommand.cs
+++ b/src/TianWen.Cli/TuiSubCommand.cs
@@ -1,4 +1,4 @@
-using Console.Lib;
+﻿using Console.Lib;
 using DIR.Lib;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -140,7 +140,7 @@ internal class TuiSubCommand(
         var tabBar = new TuiTabBar(tabBarVp);
 
         var activeTab = tabs[appState.ActiveTab];
-        activeTab.BuildPanel(terminal);
+        activeTab.Attach(terminal);
 
         var lastClockSecond = -1;
 
@@ -200,7 +200,7 @@ internal class TuiSubCommand(
             if (tabs.TryGetValue(appState.ActiveTab, out var newActiveTab) && newActiveTab != activeTab)
             {
                 activeTab = newActiveTab;
-                activeTab.BuildPanel(terminal);
+                activeTab.Attach(terminal);
                 activeTab.NeedsRedraw = true;
             }
 
@@ -247,7 +247,7 @@ internal class TuiSubCommand(
                 chromePanel = new Panel(terminal);
                 tabBarVp = chromePanel.Dock(DockStyle.Top, 1);
                 tabBar = new TuiTabBar(tabBarVp);
-                activeTab.BuildPanel(terminal);
+                activeTab.Attach(terminal);
                 appState.NeedsRedraw = true;
             }
 
@@ -329,7 +329,7 @@ internal class TuiSubCommand(
         appState.ActiveTab = tab;
         activeTab = tabs[tab];
         terminal.Clear(); // Erase sixel pixel artifacts from previous tab
-        activeTab.BuildPanel(terminal);
+        activeTab.Attach(terminal);
         activeTab.NeedsRedraw = true;
         appState.NeedsRedraw = true;
         return true;


### PR DESCRIPTION
All six TUI tabs now build their arrangement as a Layout.Node tree and let CellLayout arrange and paint it -- the same surface-agnostic tree the GUI paints. The docked-Panel base is gone entirely: there is no second supported way to write a tab, and no nullable BuildLayout to fall through.

## The model

**The tree owns placement; widgets own behaviour.** A ScrollableList (scroll state and thumb), a Canvas (sixel dirty regions) and a MarkdownWidget (its own wrapping) do things a layout node cannot model, so they stay widgets -- but they no longer place themselves. Each registers against a key via Host, appears in the tree as a Fill leaf, and has its viewport re-pointed at that leaf's arranged rect before PaintHost draws it. Everything else is just nodes.

That re-point is what needs Console.Lib 3.13's public TerminalViewport.UpdateGeometry. Re-pointing beats reallocating the widget on every resize, which is what the Panel version effectively did.

## It fixes a real resize bug in three tabs

A sixel Canvas owns a renderer allocated at a **fixed pixel size**. The Panel version read that size once at construction and never again, so after a terminal resize the **guider**, the **planner altitude chart** and the **live preview** all kept encoding at the old pixel size.

PaintHost's geometryChanged flag is true on the first paint and on every subsequent size change, which is exactly when to reallocate. This is also why the chart and preview rasters moved out of RenderContent into PaintHost: they need a pixel size that only exists *after* the arrange, and RenderContent runs before it.

The corollary is that IsReady on those tabs no longer requires the canvas. It cannot exist before the first arrange, so requiring it would stop the tab ever rendering the frame that would size it.

## Falling out of it

Because the tree is rebuilt every frame, a tab can branch on capability, size or state in plain C#. The guider's sixel and text-fallback arrangements are now two expressions of one tree rather than two widget-construction paths. Nothing here takes advantage of that for responsiveness yet -- behaviour first -- but eg. the session tab could collapse its fixed 44-column side panel on a narrow terminal without touching widget construction.

BuildPanel is renamed **Attach**. It has not built a Panel since this change, and a method named after a type that no longer exists is how the next reader gets misled.

## Left deliberately

The two big tabs still register clickable rows from viewport arithmetic in RegisterClickableRegions, rather than binding .Clickable() on the nodes and dispatching through CellLayout.HitTest. It works -- the viewport is re-pointed each frame, so the geometry is current -- and it is the obvious follow-up, but it changes hit dispatch and does not belong in a placement migration.

## Dependencies

Re-pins DIR.Lib 6.19 to 6.20 and Console.Lib 3.12 to 3.13, both merged and published:

- **DIR.Lib 6.20** adds Renderer.FillRoundedRectangle and fixes per-vector alpha compositing in RgbaImage.FillRect. RGB output is bit-identical, so no TianWen golden moved.
- **Console.Lib 3.13** adds the shared TextTable + BorderStyle and the public UpdateGeometry this migration needs.

## Verification

TianWen.Lib.Tests 3554/3554 pass. TianWen.Cli builds clean with 0 warnings both against local siblings and against the published packages (-p:UseLocalSiblings=false, the path CI takes).

Note this branch is cut from main and is independent of the parked #120 -- the two touch no file in common.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JAvraK5yzDZudBV1LaERgc
