### PR TITLE
chore(deps): DIR.Lib 6.21, SdlVulkan.Renderer 6.33, WebGl.Renderer 1.12

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -128,8 +128,12 @@
          6.20 is the current pin: it adds Renderer.FillRoundedRectangle (a base virtual, so every
          backend gains rounded fills at once) and fixes per-vector alpha compositing in
          RgbaImage.FillRect, where a translucent fill over an opaque surface now yields alpha 255 as
-         it always should have. RGB output is bit-identical, so no TianWen golden moved. -->
-    <PackageVersion Include="DIR.Lib" Version="6.20.*" />
+         it always should have. RGB output is bit-identical, so no TianWen golden moved.
+         6.21 is the current pin: Layout.Node.CornerRadius + the .Radius(designUnits) fluent, so a
+         rounded panel is a property of the tree. Chrome only, so arrange is unaffected and a rounded
+         node occupies exactly the rect a square one would; a zero radius keeps the plain FillRectangle
+         path, so untouched trees paint byte-identically. -->
+    <PackageVersion Include="DIR.Lib" Version="6.21.*" />
     <!-- DIR.Lib 3.0 extracted its codec layer to these sibling packages, which
          ship as a lockstep family from the Codecs repo. 3.0 brought a
          binary-breaking SharpAstro.Tiff change (TiffPageOptions.IccProfile is
@@ -245,7 +249,7 @@
          opt-in even in Debug (CompiledDebug and SDLVK_VALIDATION=1). 6.27 is the current pin: batched
          DrawPolyline/DrawPolylineDashed overrides (whole polyline into one Flat-pipeline draw); see
          docs/plans/render-batching.md. -->
-    <PackageVersion Include="SdlVulkan.Renderer" Version="6.32.*" />
+    <PackageVersion Include="SdlVulkan.Renderer" Version="6.33.*" />
     <PackageVersion Include="SDL3-CS" Version="3.5.0-preview.20260213-150035" />
     <PackageVersion Include="SDL3-CS.Native" Version="3.5.0-preview.20260205-174353" />
     <!-- Canon DSLR -->

--- a/src/TianWen.UI.Web/TianWen.UI.Web.csproj
+++ b/src/TianWen.UI.Web/TianWen.UI.Web.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
+﻿<Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
@@ -52,7 +52,7 @@
     <ProjectReference Include="..\..\..\WebGl.Renderer\src\WebGl.Renderer\WebGl.Renderer.csproj" />
   </ItemGroup>
   <ItemGroup Condition="'$(UseLocalSiblings)' != 'true'">
-    <PackageReference Include="WebGl.Renderer" Version="1.11.*" />
+    <PackageReference Include="WebGl.Renderer" Version="1.12.*" />
   </ItemGroup>
 
 


### PR DESCRIPTION
Picks up rounded rectangles end to end. Three merged, published sibling releases.

| Package | From | To |
|---|---|---|
| DIR.Lib | 6.20.* | **6.21.*** |
| SdlVulkan.Renderer | 6.32.* | **6.33.*** |
| WebGl.Renderer | 1.11.* | **1.12.*** |

## What lands

**DIR.Lib 6.21** adds `Layout.Node.CornerRadius` + `.Radius(designUnits)`, so a rounded panel is a property of the tree rather than something a host hand-draws:

```csharp
Layout.Builder.VStack(rows).Pad(8).Bg(panelBg).Radius(6f)
```

Chrome only. Arrange never sees it, so a rounded node occupies exactly the rect a square one would and rounding a panel cannot shift the layout inside or around it. A zero radius keeps the plain `FillRectangle` path, so untouched trees paint byte-identically.

**SdlVulkan.Renderer 6.33** and **WebGl.Renderer 1.12** override `FillRoundedRectangle` with a single rounded-box SDF quad instead of the base class's one-span-per-row scanline fallback, with antialiased corners. Both keep single coverage, so a translucent panel background blends the same amount in the corners as in the middle. On the WebGl side the win is larger than it looks: each fallback span would have been its own command-buffer record crossing into JS.

DIR.Lib 6.20 (already pinned) also fixed per-vector alpha compositing in `RgbaImage.FillRect`. RGB output was bit-identical there, which is why no TianWen golden moved then or now.

WebGl was several minors behind on DIR.Lib (6.14); it is now on the same version as everything else.

## Nothing here uses it yet

This is the pin, not the adoption. No TianWen chrome asks for a radius, so rendering is unchanged. Converting panels is a follow-up, and now a one-word change per panel.

## Verification

Verified against the **published packages** rather than the local siblings (`-p:UseLocalSiblings=false`, the path CI takes): Release solution builds with 0 warnings, `TianWen.Lib.Tests` 3554/3554 pass.

One note for anyone reproducing locally: `Debug` + packages does not build, and never did. SdlVkR's `DebugInspector` is compiled out of the Release package, so that combination is not a valid one; it fails identically on unmodified main. CI builds Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JAvraK5yzDZudBV1LaERgc
