### PR TITLE
refactor(tui): row hit regions come from the list, not from each tab

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -200,8 +200,14 @@
          3.13 is the current pin: it adds the shared TextTable + BorderStyle (markdown tables render
          through it, so mdcat inherits the border vocabulary) and widens TerminalViewport.UpdateGeometry
          to public so a layout tree can host a widget at a Fill leaf and re-point it at the arranged
-         rect each frame. That is the seam the TUI's CellLayout migration is built on. -->
-    <PackageVersion Include="Console.Lib" Version="3.13.*" />
+         rect each frame. That is the seam the TUI's CellLayout migration is built on.
+         3.15 is the current pin. 3.14 taught CellLayout to honour Layout.Node.CornerRadius (one arc
+         glyph per corner; the magnitude is ignored because a grid cannot round by fractions of a cell)
+         and added ScrollableList.RegisterRowHits; 3.15 added RegisterRowSpanHits for rows carrying
+         inline buttons. Between them the list now owns the row hit geometry the TUI tabs used to
+         reconstruct by hand: viewport-offset origin, header row, SCROLLED item index, and yielding the
+         scrollbar column so the thumb stays grabbable. -->
+    <PackageVersion Include="Console.Lib" Version="3.15.*" />
     <!-- SdlVulkan.Renderer 5.0 adds a multi-page SDF glyph atlas (no more grow
          stall / Adreno submit-wedge) on top of 4.1's SetSystemCursor + anisotropic
          glyph xScale. 5.1 implements DIR.Lib 4.4's PushClip/PopClip via Vulkan

--- a/src/TianWen.Cli/Tui/TuiLiveSessionTab.cs
+++ b/src/TianWen.Cli/Tui/TuiLiveSessionTab.cs
@@ -873,48 +873,33 @@ internal sealed class TuiLiveSessionTab(
         return new string(spark);
     }
 
-    protected override void RegisterClickableRegions()
-    {
-        if (_infoList is null || _rows.Count == 0)
+    /// <summary>
+    /// The info panel's rows carry inline buttons (steppers, actions), so each row contributes column
+    /// SPANS rather than one whole-row region. The list owns all the geometry.
+    /// <para>
+    /// This previously hardcoded a zero scroll offset, with a comment that the widget had no public
+    /// <c>ScrollOffset</c>. It does, and now the list applies it -- so the panel becoming scrollable
+    /// stops being a latent mis-click bug waiting for the first list long enough to need it.
+    /// </para>
+    /// </summary>
+    protected override void RegisterClickableRegions() =>
+        _infoList?.RegisterRowSpanHits(Tracker, (index, row) =>
         {
-            return;
-        }
-
-        var cellSize = _infoList.Viewport.CellSize;
-        var offset = _infoList.Viewport.Offset;
-        // Info panel isn't scrolled programmatically; if it ever is, the list widget
-        // would need a public ScrollOffset getter (currently private) for hit-test
-        // accuracy. Without scrolling, line index == visible-row index.
-        const int scrollOffset = 0;
-        var baseX = (float)(offset.Column * cellSize.Width);
-        var baseY = (float)(offset.Row * cellSize.Height);
-        var visibleRows = _infoList.VisibleRows;
-        var rowWidth = _infoList.Viewport.Size.Width;
-
-        for (var lineIdx = 0; lineIdx < _rows.Count; lineIdx++)
-        {
-            var row = _rows[lineIdx];
             var buttons = row.Buttons;
-            if (buttons.Count == 0) continue;
-
-            var visibleLine = lineIdx - scrollOffset;
-            if (visibleLine < 0 || visibleLine >= visibleRows)
+            if (buttons.Count == 0)
             {
-                continue;
+                return [];
             }
 
-            var y = baseY + visibleLine * (float)cellSize.Height;
-            foreach (var btn in buttons)
+            var spans = new RowSpan[buttons.Count];
+            for (var i = 0; i < buttons.Count; i++)
             {
-                var colEnd = Math.Min(btn.ColEnd, rowWidth);
-                if (btn.ColStart >= colEnd) continue;
-                var x = baseX + btn.ColStart * (float)cellSize.Width;
-                var w = (colEnd - btn.ColStart) * (float)cellSize.Width;
-                Tracker.Register(x, y, w, (float)cellSize.Height,
-                    new HitResult.ListItemHit("InfoRow", lineIdx), btn.OnClick);
+                var button = buttons[i];
+                spans[i] = new RowSpan(button.ColStart, button.ColEnd,
+                    new HitResult.ListItemHit("InfoRow", index), button.OnClick);
             }
-        }
-    }
+            return spans;
+        });
 
     public override bool HandleRawMouse(MouseEvent mouse)
     {

--- a/src/TianWen.Cli/Tui/TuiPlannerTab.cs
+++ b/src/TianWen.Cli/Tui/TuiPlannerTab.cs
@@ -194,34 +194,14 @@ internal sealed class TuiPlannerTab(
         _statusBar.RightText(appState.StatusMessage ?? "");
     }
 
-    protected override void RegisterClickableRegions()
-    {
-        if (_targetList is not { } targetList)
-        {
-            return;
-        }
-
-        var cellSize = targetList.Viewport.CellSize;
-        var offset = targetList.Viewport.Offset;
-        var baseX = (float)(offset.Column * cellSize.Width);
-        var baseY = (float)(offset.Row * cellSize.Height);
-        // Exclude the rightmost column when a scrollbar is drawn so clicks there reach
-        // the list's drag handler rather than the row's click handler.
-        var visibleWidth = targetList.Viewport.Size.Width - (targetList.ItemCount > targetList.VisibleRows ? 1 : 0);
-        var rowW = (float)(visibleWidth * cellSize.Width);
-        var rowH = (float)cellSize.Height;
-        var scrollOffset = targetList.ScrollOffset;
-
-        var filteredCount = PlannerActions.GetFilteredTargets(plannerState).Count;
-        for (var i = 0; i < targetList.VisibleRows && scrollOffset + i < filteredCount; i++)
-        {
-            var capturedIdx = scrollOffset + i;
-            var y = baseY + (1 + i) * rowH; // +1 for header
-            Tracker.Register(baseX, y, rowW, rowH,
-                new HitResult.ListItemHit("TargetList", capturedIdx),
-                _ => { plannerState.SelectedTargetIndex = capturedIdx; });
-        }
-    }
+    /// <summary>
+    /// Row clicks select the target. The list owns the geometry -- including yielding the scrollbar
+    /// column, which this used to compute for itself.
+    /// </summary>
+    protected override void RegisterClickableRegions() =>
+        _targetList?.RegisterRowHits(Tracker,
+            hitFor: (index, _) => new HitResult.ListItemHit("TargetList", index),
+            onClick: (index, _) => plannerState.SelectedTargetIndex = index);
 
     public override bool HandleRawMouse(MouseEvent mouse)
     {
@@ -331,6 +311,12 @@ internal sealed class TuiPlannerTab(
     /// <summary>
     /// Hit-tests sliders on the chart canvas using chart time-layout math.
     /// Returns true if a slider was hit and selected.
+    /// <para>
+    /// The one place in this tab that still converts cells to pixels by hand, and legitimately so: the
+    /// chart is a raster surface, and a slider drawn into it is at a pixel position no layout node
+    /// describes. Row-level geometry belongs to <see cref="ScrollableList{T}"/> (see
+    /// <see cref="RegisterClickableRegions"/>); this is the raster bucket, not that one.
+    /// </para>
     /// </summary>
     private bool HitTestSliderOnCanvas(float x, float y)
     {

--- a/src/TianWen.Cli/Tui/TuiSessionTab.cs
+++ b/src/TianWen.Cli/Tui/TuiSessionTab.cs
@@ -179,36 +179,25 @@ internal sealed class TuiSessionTab(
         _statusBar.RightText(appState.StatusMessage ?? "");
     }
 
-    protected override void RegisterClickableRegions()
-    {
-        if (_configList is null || _lastItems.Count == 0)
-        {
-            return;
-        }
-
-        var cellSize = _configList.Viewport.CellSize;
-        var offset = _configList.Viewport.Offset;
-        var baseX = (float)(offset.Column * cellSize.Width);
-        var baseY = (float)(offset.Row * cellSize.Height);
-        var rowW = (float)(_configList.Viewport.Size.Width * cellSize.Width);
-        var rowH = (float)cellSize.Height;
-        var headerRows = 1; // ScrollableList header row
-
-        for (var i = 0; i < _configList.VisibleRows && sessionState.ConfigScrollOffset + i < _lastItems.Count; i++)
-        {
-            var item = _lastItems[sessionState.ConfigScrollOffset + i];
-            if (item.FieldIndex < 0)
+    /// <summary>
+    /// Row clicks select the field. The list owns the geometry (viewport origin, header row, scroll
+    /// offset, scrollbar column), so this only has to say which rows are clickable and what a click
+    /// means -- a group header carries no field index and stays inert.
+    /// </summary>
+    protected override void RegisterClickableRegions() =>
+        _configList?.RegisterRowHits(Tracker,
+            hitFor: (_, item) => item.FieldIndex >= 0
+                ? new HitResult.ListItemHit("ConfigField", item.FieldIndex)
+                : null,
+            // Only rows hitFor accepted get here, so the field index is known good; the bound check is
+            // against _lastItems, which mirrors the list's items rather than being the same array.
+            onClick: (index, _) =>
             {
-                continue; // skip group headers
-            }
-
-            var capturedIdx = item.FieldIndex;
-            var y = baseY + (headerRows + i) * rowH;
-            Tracker.Register(baseX, y, rowW, rowH,
-                new HitResult.ListItemHit("ConfigField", item.FieldIndex),
-                _ => { sessionState.SelectedFieldIndex = capturedIdx; });
-        }
-    }
+                if (index >= 0 && index < _lastItems.Count)
+                {
+                    sessionState.SelectedFieldIndex = _lastItems[index].FieldIndex;
+                }
+            });
 
     public override bool HandleRawMouse(MouseEvent mouse)
     {


### PR DESCRIPTION
The three tabs that make list rows clickable each rebuilt the widget's geometry by hand, and each got a different subset of it right. They now ask `ScrollableList` (Console.Lib 3.15), which owns the scroll state and is the only thing that knows all of it without being told.

## What was being reconstructed

Four things have to be right at once, and **each one fails quietly**:

- the pixel origin is the viewport **`Offset`** times cell size, not the viewport rect
- a header displaces the first data row
- visible row N is item **`ScrollOffset` + N**
- the **scrollbar owns the last column** — a region drawn across it wins the hit test and the thumb can never be grabbed again

## Two real defects fall out

Neither was hunted; both were exposed by having one implementation instead of three.

- **The session config list registered rows across the full viewport width**, scrollbar column included. Config long enough to scroll, and the scrollbar could not be dragged.
- **The live-session info panel hardcoded a zero scroll offset**, with a comment claiming the widget had no public `ScrollOffset`. It does. The panel doesn't scroll today, so this was a latent mis-click waiting for the first info list long enough to need it — not a live bug, but one whose trigger is "someone adds a few more rows".

## Shape

The info panel's rows carry inline buttons rather than being clickable as a whole, so it uses `RegisterRowSpanHits` (column ranges) while the other two use `RegisterRowHits`. Both share one geometry walk inside the widget.

What's left in the tabs is only *intent*: which rows are clickable and what a click means. A group header returns no hit and stays inert.

```csharp
protected override void RegisterClickableRegions() =>
    _targetList?.RegisterRowHits(Tracker,
        hitFor: (index, _) => new HitResult.ListItemHit("TargetList", index),
        onClick: (index, _) => plannerState.SelectedTargetIndex = index);
```

## Deliberately kept

`TuiPlannerTab.HitTestSliderOnCanvas` still converts cells to pixels by hand, and should: the altitude chart is a raster surface, and a slider drawn into it sits at a pixel position no layout node describes. It's now commented as the raster bucket so it isn't mistaken for missed cleanup.

This closes out the TUI migration — no tab reconstructs widget geometry any more.

## Dependency

Re-pins Console.Lib `3.13.*` to `3.15.*` (3.14 = cell-side `Layout.Node.Radius` + `RegisterRowHits`, 3.15 = `RegisterRowSpanHits`).

## Verification

Verified against the published packages (`-p:UseLocalSiblings=false`, the CI path): Release builds with 0 warnings, `TianWen.Lib.Tests` 3554/3554 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JAvraK5yzDZudBV1LaERgc
