### PR TITLE
refactor(tui): equipment profile rows come from the list too

### DIFF
--- a/src/TianWen.Cli/Tui/TuiEquipmentTab.cs
+++ b/src/TianWen.Cli/Tui/TuiEquipmentTab.cs
@@ -772,52 +772,30 @@ internal sealed class TuiEquipmentTab(
         }
     }
 
+    /// <summary>
+    /// Left panel: clicking a profile row selects and switches to it. The list's own HandleMouse moved
+    /// the cursor on MouseDown; this callback fires on MouseUp and adds the side effect. The MoveTo is
+    /// re-issued so a drag-release (down on row A, up on row B) still ends up on B.
+    /// <para>
+    /// Right panel: <see cref="ScrollableList{T}"/>'s built-in HandleMouse moves its own cursor on
+    /// click, so cursor-only effects need no registration here.
+    /// </para>
+    /// </summary>
     protected override void RegisterClickableRegions()
     {
-        // Left panel: clicking a profile row selects and switches to it. The list's
-        // own HandleMouse moved the cursor on MouseDown; the tracker callback fires
-        // on MouseUp and adds the side-effect (switch active profile). We re-issue
-        // MoveTo so a drag-release (down on row A, up on row B) still ends up on B.
-        if (_profileList is { } pl && _cachedProfiles.Count > 0)
+        if (_profileList is not { } profileList)
         {
-            var (bx, by, rowW, rowH) = GetRowGeometry(pl);
-            var count = _cachedProfiles.Count;
-            for (var i = 0; i < pl.VisibleRows && pl.ScrollOffset + i < count; i++)
-            {
-                var capturedIdx = pl.ScrollOffset + i;
-                var y = by + (1 + i) * rowH; // +1 for header row
-                Tracker.Register(bx, y, rowW, rowH,
-                    new HitResult.ListItemHit("Profile", capturedIdx),
-                    _ =>
-                    {
-                        pl.MoveTo(capturedIdx);
-                        SwitchToSelectedProfile();
-                        NeedsRedraw = true;
-                    });
-            }
+            return;
         }
 
-        // Right panel: ScrollableList's built-in HandleMouse moves its own cursor
-        // on click — no tracker registration needed for cursor-only effects. We
-        // still need a tracker hit for header rows (so HandleRawMouse can snap
-        // past them), but since header rows have FieldIndex < 0, they're excluded
-        // here exactly as before.
-    }
-
-    // Computes (baseX, baseY, rowWidth, rowHeight) for a list, excluding the
-    // scrollbar column from the clickable width so drag/click on the track
-    // reaches ScrollableList.HandleMouse instead of triggering a row-select.
-    private static (float BaseX, float BaseY, float RowW, float RowH) GetRowGeometry<T>(
-        ScrollableList<T> list) where T : IRowFormatter
-    {
-        var vp = list.Viewport;
-        var cell = vp.CellSize;
-        var bx = (float)(vp.Offset.Column * cell.Width);
-        var by = (float)(vp.Offset.Row * cell.Height);
-        var cols = vp.Size.Width - (list.ItemCount > list.VisibleRows ? 1 : 0);
-        var rowW = (float)(cols * cell.Width);
-        var rowH = (float)cell.Height;
-        return (bx, by, rowW, rowH);
+        profileList.RegisterRowHits(Tracker,
+            hitFor: (index, _) => new HitResult.ListItemHit("Profile", index),
+            onClick: (index, _) =>
+            {
+                profileList.MoveTo(index);
+                SwitchToSelectedProfile();
+                NeedsRedraw = true;
+            });
     }
 
     public override bool HandleInput(InputEvent evt)


### PR DESCRIPTION
The fourth call site, missed in #123: `TuiEquipmentTab` still rebuilt row geometry by hand for the profile picker, through its own `GetRowGeometry` helper.

Its version was actually **the most complete of the four** — it did exclude the scrollbar column, and it did honour the scroll offset. That is precisely why it was easy to overlook: nothing was visibly wrong with it.

Being correct is not the same as being the right place for the knowledge. The scroll state lives in the widget, so the geometry should too — otherwise the next change to how a list lays out rows has to find four copies again, and this one would have been the copy that looked fine and got skipped.

`RegisterRowHits` replaces it; `GetRowGeometry` is deleted.

**No `Tracker.Register` call remains anywhere in the TUI.** Every tab now states only which rows are clickable and what a click means.

## Verification

Release builds with 0 warnings, `TianWen.Lib.Tests` 3554/3554 pass, both against the published packages (`-p:UseLocalSiblings=false`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JAvraK5yzDZudBV1LaERgc
