### PR TITLE
Re-pin the sibling family onto DIR.Lib 7.4

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -3,12 +3,12 @@
     "sdl-ui-inspector": {
       "type": "stdio",
       "command": "dotnet",
-      "args": ["dnx", "SdlVulkan.Renderer.Inspector@7.3.1882", "--yes"]
+      "args": ["dnx", "SdlVulkan.Renderer.Inspector@7.4.1891", "--yes"]
     },
     "console-inspector": {
       "type": "stdio",
       "command": "dotnet",
-      "args": ["dnx", "Console.Lib.Inspector@4.10.1411", "--yes"]
+      "args": ["dnx", "Console.Lib.Inspector@4.11.1431", "--yes"]
     }
   }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,19 +108,35 @@ every sibling uses `src/<Lib>/<Lib>.csproj`.
 | `ZWOptical.SDK` | `../zwo-sdk-nuget` | `ZWOptical.SDK.csproj` (repo root) | ❌ |
 | `QHYCCD.SDK` | `../QHYCCD.SDK` | `QHYCCD.SDK.csproj` (repo root) | ✅ |
 | `SharpAstro.Fonts` | `../Fonts.Lib` | `src/SharpAstro.Fonts/SharpAstro.Fonts.csproj` | transitive |
+| `SER.Lib` | `../SER.Lib` | `src/SER.Lib/SER.Lib.csproj` | ✅ |
+| `Lzip.Lib` | `../Lzip.Lib` | `src/Lzip.Lib/Lzip.Lib.csproj` | ✅ |
+| `LAN.Lib` | `../LAN.Lib` | `src/LAN.Lib/LAN.Lib.csproj` | ✅ |
+| `WebGl.Renderer` | `../WebGl.Renderer` | `src/WebGl.Renderer/WebGl.Renderer.csproj` | ⚠️ see below |
 | `TianWen.DAL` | `../TianWen.DAL` | — | ❌ |
 
 **Auto-detection** (`Directory.Build.props`): a **single** property `UseLocalSiblings` gates them all.
 The build switches to ProjectReference when **every** sibling working copy exists — `DIR.Lib`,
 `Console.Lib`, `SdlVulkan.Renderer`, the `Codecs`-repo codec family (`SharpAstro.Tiff`,
 `SharpAstro.Exif`, `SharpAstro.Png`, `SharpAstro.Color.Icc`, `SharpAstro.Jxr`,
-`SharpAstro.Jpeg.IccInjector`, `SharpAstro.Exr`), `QHYCCD.SDK`, and `FITS.Lib` — otherwise it falls
+`SharpAstro.Jpeg.IccInjector`, `SharpAstro.Exr`, `SharpAstro.Codecs`), `QHYCCD.SDK`, `FITS.Lib`,
+`SER.Lib`, `Lzip.Lib`, and `LAN.Lib`; otherwise it falls
 through to PackageReference. Override: `dotnet build -p:UseLocalSiblings=false`. CI always uses
 PackageReference. `Fonts.Lib` is transitive via DIR.Lib's own `UseLocalFontsLib` switch. `QHYCCD.SDK`
 (`../QHYCCD.SDK/QHYCCD.SDK.csproj`) and `FITS.Lib` (`../FITS.Lib/CSharpFITS/CSharpFITS.csproj`) used to
 be outliers (the latter via a separate `UseLocalFitsLib` switch) but were folded into the one switch —
 there is **no** per-library switch anymore. Trade-off: a missing checkout of *any* listed sibling flips
 the whole set back to packages (all-or-nothing), which is fine on a dev box that has them all.
+
+**`WebGl.Renderer` is the one exception, and it bites in two ways.** It is consumed only by
+`TianWen.UI.Web`, which **opts out of CPM**, so its version is pinned **inline in
+`TianWen.UI.Web.csproj`** rather than in `Directory.Packages.props`. Consequences: (1) a sibling-family
+version bump that sweeps `Directory.Packages.props` silently misses it, which is how the pin sat two
+minors behind (`1.12.*` while `1.13` was published) and how the web renderer ended up the last sibling
+still built against DIR.Lib 7.0 after everything else moved to 7.4; grep the whole `src/` tree for a
+pin, not just the props file. (2) It is **gated on `UseLocalSiblings` but absent from that property's
+own `Exists(...)` list**, so a box with every other sibling checked out but no `WebGl.Renderer` gets
+`UseLocalSiblings=true` and a `ProjectReference` to a path that is not there. Clone it, or build that
+one project with `-p:UseLocalSiblings=false`.
 
 For libraries without auto-detection (`FC.SDK`, `ZWOptical.SDK`, `TianWen.DAL`),
 prefer to extend the `UseLocalSiblings` switch in
@@ -1692,6 +1708,14 @@ every widget `Render`/helper signature lives as a **`virtual` property on `Pixel
   in device px). Widget methods that draw open with `var dpiScale = DpiScale;` / `var fontPath = FontPath;`
   (an alias, so the px + `DrawText` calls below are unchanged); input handlers read the property directly
   (input events carry no DPI/font -- this is why the old `_lastDpiScale` render-time cache is gone).
+- **DIR.Lib 7.4 adds a context-taking overload of each** (`ArrangeLayout`/`PaintLayout`/`RenderLayout`
+  taking a `PixelMeasureContext<TSurface>`), for the two cases a single scalar cannot express: a per-axis
+  scale, and a **cell-authored tree arranged on a pixel surface** (`PixelMeasureContext.CellAuthored`, the
+  mirror of Console.Lib's `CellMeasureContext.PixelAuthored` that `TuiHomeTab` uses in the other
+  direction). Build the context ONCE and pass the same instance to Arrange and Paint: the painter reads
+  `FontPath`/`FontScale`/corner radius off it, so measuring with one context and painting with another
+  gives text drawn at a size it was never measured at. The scalar overloads delegate to these with an
+  isotropic context, so they stay the right default and nothing about the rule above changes.
 
 **Do NOT reintroduce these as `Render`/helper parameters.** Rule of thumb: a per-window *constant* ->
 property; a per-call *derived* value stays a parameter. `fontSize` is the canonical parameter -- it varies

--- a/README.md
+++ b/README.md
@@ -52,6 +52,24 @@ You can install the TianWen library via NuGet:
 dotnet add package TianWen.Lib
 ```
 
+### Runtime prerequisites
+
+The release archives are self-contained native AOT builds — no .NET install needed, and the SDL3
+native is bundled. What they cannot bundle is the Vulkan loader, which has to come from the OS. This
+applies to the two GPU-rendered apps (`tianwen-gui`, `tianwen-fits`); `tianwen-cli` and
+`tianwen-server` render in the terminal or not at all, and need none of it.
+
+| Platform | Also needs |
+|----------|------------|
+| Windows (`win-x64`, `win-arm64`) | nothing — `vulkan-1.dll` ships with any modern GPU driver |
+| Linux (`linux-x64`, `linux-arm64`) | `libvulkan.so.1` + an ICD (`mesa-vulkan-drivers`; that package also carries the lavapipe software rasteriser for headless boxes) |
+| macOS (`osx-arm64`, `osx-x64`) | [MoltenVK](https://github.com/KhronosGroup/MoltenVK) (Vulkan-on-Metal) |
+
+`tianwen-gui` bundles its own fonts (`DejaVuSans.ttf`, `Noto-COLRv1.ttf`). `tianwen-fits` resolves a
+system font instead, via `FontResolver.ResolveSystemFont`, so on a minimal Linux image it also needs a
+font package — `fonts-dejavu-core` on Debian/Ubuntu, `font-dejavu` on Alpine. Without one it starts and
+renders the image but draws no text.
+
 ### Server (Headless / Remote)
 
 Pre-built native AOT binaries of `tianwen-server` are available from [GitHub Releases](https://github.com/SharpAstro/tianwen/releases):
@@ -235,12 +253,14 @@ Pre-built native AOT binaries of `TianWen.UI.FitsViewer` are available from [Git
 
 | Platform | Architecture | Artifact |
 |----------|-------------|----------|
-| Windows  | x64         | `tianwen-fits-viewer-win-x64.tar.gz` |
-| Windows  | ARM64       | `tianwen-fits-viewer-win-arm64.tar.gz` |
-| Linux    | x64         | `tianwen-fits-viewer-linux-x64.tar.gz` |
-| Linux    | ARM64       | `tianwen-fits-viewer-linux-arm64.tar.gz` |
-| macOS    | x64         | `tianwen-fits-viewer-osx-x64.tar.gz` |
-| macOS    | ARM64       | `tianwen-fits-viewer-osx-arm64.tar.gz` |
+| Windows  | x64         | `tianwen-fits-win-x64.tar.gz` |
+| Windows  | ARM64       | `tianwen-fits-win-arm64.tar.gz` |
+| Linux    | x64         | `tianwen-fits-linux-x64.tar.gz` |
+| Linux    | ARM64       | `tianwen-fits-linux-arm64.tar.gz` |
+| macOS    | x64         | `tianwen-fits-osx-x64.tar.gz` |
+| macOS    | ARM64       | `tianwen-fits-osx-arm64.tar.gz` |
+
+Needs a Vulkan loader — see [Runtime prerequisites](#runtime-prerequisites).
 
 #### Keyboard Shortcuts
 
@@ -285,6 +305,19 @@ The live session tab includes a real-time Sixel image preview with viewer contro
 The integrated GUI provides a N.I.N.A.-style interface with GPU-accelerated Vulkan rendering,
 including all the same tabs as the TUI plus a full FITS image viewer with real-time stretch,
 star overlay, WCS grid, and histogram.
+
+Pre-built native AOT binaries are available from [GitHub Releases](https://github.com/SharpAstro/tianwen/releases):
+
+| Platform | Architecture | Artifact |
+|----------|-------------|----------|
+| Windows  | x64         | `tianwen-gui-win-x64.tar.gz` |
+| Windows  | ARM64       | `tianwen-gui-win-arm64.tar.gz` |
+| Linux    | x64         | `tianwen-gui-linux-x64.tar.gz` |
+| Linux    | ARM64       | `tianwen-gui-linux-arm64.tar.gz` |
+| macOS    | x64         | `tianwen-gui-osx-x64.tar.gz` |
+| macOS    | ARM64       | `tianwen-gui-osx-arm64.tar.gz` |
+
+Needs a Vulkan loader — see [Runtime prerequisites](#runtime-prerequisites).
 
 ## Architecture
 

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -139,10 +139,22 @@
          sidecar can filter on it. Console.Lib 4.6 is DebugInspectorCore's first non-GPU backend; the
          GPU one moved onto the same core. Serialization is deliberately NON-reflective throughout,
          because an AOT consumer disables reflective JSON and the generic overload throws at runtime.
-         7.3 is the current pin: the inspector core learned the EXECUTION model (batch with per-step
+         7.3 raised the inspector core to the EXECUTION model (batch with per-step
          waits, exclusive vs background pump ownership), published from the sibling family alongside
-         SdlVulkan.Renderer 7.3; TianWen consumes it transitively through Console.Lib 4.8. -->
-    <PackageVersion Include="DIR.Lib" Version="7.3.*" />
+         SdlVulkan.Renderer 7.3; TianWen consumes it transitively through Console.Lib 4.8.
+         7.4 is the current pin: a CELL-authored layout tree can now be arranged on a PIXEL surface.
+         Console.Lib has carried the opposite crossing since 4.10 (CellMeasureContext.PixelAuthored, which
+         is how the Home board paints ONE tree on both the GPU tab and the TUI tab), so this closes the
+         gap rather than adding a feature: PixelMeasureContext gains per-axis scales plus a matching
+         CellAuthored factory on the same nominal 8x16 cell. It also adds PixelWidgetBase
+         Arrange/Paint/RenderLayout overloads that take the measure CONTEXT instead of a bare dpiScale, so
+         the painter reads FontPath, FontScale and corner radius from the same object the measure pass
+         used. That half is what makes per-axis safe: the scalar used to be threaded separately into the
+         measure context and the paint loop, two copies kept in step by hand, and per-axis scales would
+         have turned that into text painted at a size it was never measured at. Additive, since the scalar
+         overloads delegate to the context ones with an isotropic context, so every existing TianWen call
+         site paints byte-identically. -->
+    <PackageVersion Include="DIR.Lib" Version="7.4.*" />
     <!-- DIR.Lib 3.0 extracted its codec layer to these sibling packages, which
          ship as a lockstep family from the Codecs repo. 3.0 brought a
          binary-breaking SharpAstro.Tiff change (TiffPageOptions.IccProfile is
@@ -249,8 +261,10 @@
          ForEachVisibleRow are gone with it, leaving HitTestRow for "which ITEM is under this point".
          The three-overload cascade collapses into fields on RowContext, so the next capability adds a
          field rather than a rung an implementation can silently ignore. See Console.Lib's MIGRATION.md
-         and CLAUDE.md's Layout DSL section. -->
-    <PackageVersion Include="Console.Lib" Version="4.10.*" />
+         and CLAUDE.md's Layout DSL section.
+         4.11 is the current pin: a no-code lockstep rebuild against DIR.Lib 7.4, so the family restores
+         one DIR.Lib instead of two. Nothing in the TUI changes. -->
+    <PackageVersion Include="Console.Lib" Version="4.11.*" />
     <!-- SdlVulkan.Renderer 5.0 adds a multi-page SDF glyph atlas (no more grow
          stall / Adreno submit-wedge) on top of 4.1's SetSystemCursor + anisotropic
          glyph xScale. 5.1 implements DIR.Lib 4.4's PushClip/PopClip via Vulkan
@@ -299,11 +313,12 @@
          DrawPolyline/DrawPolylineDashed overrides (whole polyline into one Flat-pipeline draw); see
          docs/plans/render-batching.md.
          7.1 moved the GPU inspector onto DIR.Lib 7.1's DebugInspectorCore and lost its reflective JSON
-         with it. 7.3 is the current pin: the inspector consolidation completed upstream (one
+         with it. 7.3 completed the inspector consolidation upstream (one
          dir-inspect protocol shared with the terminal inspector, loopback-only bind, the SDL-side
-         transport deleted; batch and wait became core verbs). No render-path change, so these are
+         transport deleted; batch and wait became core verbs). 7.4 is the current pin: a no-code lockstep
+         rebuild against DIR.Lib 7.4. No render-path change, so these are
          rebuilds from TianWen's side, pinned forward to keep the family on one DIR.Lib. -->
-    <PackageVersion Include="SdlVulkan.Renderer" Version="7.3.*" />
+    <PackageVersion Include="SdlVulkan.Renderer" Version="7.4.*" />
     <PackageVersion Include="SDL3-CS" Version="3.5.0-preview.20260213-150035" />
     <PackageVersion Include="SDL3-CS.Native" Version="3.5.0-preview.20260205-174353" />
     <!-- Canon DSLR -->

--- a/src/TianWen.Lib.Tests/TuiRowLayoutTests.cs
+++ b/src/TianWen.Lib.Tests/TuiRowLayoutTests.cs
@@ -181,6 +181,12 @@ namespace TianWen.Lib.Tests
         /// The row names its own background, selected or not. See the class remarks: an unstated colour is
         /// alpha-zero, and a row that inherits one records colourless cells that the diffing buffer paints
         /// as a gap.
+        /// <para>
+        /// There is deliberately nothing asserted about the root's WIDTH here. <c>Layout.Engine.Arrange</c>
+        /// places the root at the rect it was handed and never reads the root's own sizing (only children
+        /// are sized by their parent), so "the root spans the row" is the engine's invariant, not the row's,
+        /// and asserting it here would pass for every conceivable row.
+        /// </para>
         /// </summary>
         [Theory]
         [MemberData(nameof(Rows))]
@@ -195,7 +201,6 @@ namespace TianWen.Lib.Tests
                     $"{name} (selected: {selected}) set no background at all");
                 background.Alpha.ShouldNotBe((byte)0,
                     $"{name} (selected: {selected}) named a background with no alpha, which resolves to the terminal default");
-                root.Bounds.Width.ShouldBe(Width, $"{name} (selected: {selected}) did not fill the row");
             }
         }
 

--- a/src/TianWen.UI.Web/TianWen.UI.Web.csproj
+++ b/src/TianWen.UI.Web/TianWen.UI.Web.csproj
@@ -52,7 +52,7 @@
     <ProjectReference Include="..\..\..\WebGl.Renderer\src\WebGl.Renderer\WebGl.Renderer.csproj" />
   </ItemGroup>
   <ItemGroup Condition="'$(UseLocalSiblings)' != 'true'">
-    <PackageReference Include="WebGl.Renderer" Version="1.12.*" />
+    <PackageReference Include="WebGl.Renderer" Version="1.14.*" />
   </ItemGroup>
 
 


### PR DESCRIPTION
Propagates DIR.Lib 7.4 through every sibling and re-pins TianWen, plus two loose ends that were sitting uncommitted in the working tree.

## The round

DIR.Lib 7.4 lets a **cell-authored layout tree be arranged on a pixel surface**. Console.Lib has carried the opposite crossing since 4.10 (CellMeasureContext.PixelAuthored, which is how the Home board paints one tree on both the GPU tab and the TUI tab), so 7.4 closes a gap rather than adding a feature. It also adds PixelWidgetBase Arrange/Paint/RenderLayout overloads taking the measure *context* instead of a bare dpiScale. Everything is additive, and the scalar overloads delegate through an isotropic context, so every TianWen call site paints byte-identically.

Lockstep rebuilds published for this round:

| Package | Version | Note |
|---|---|---|
| DIR.Lib | 7.4.1721 | the feature (already published) |
| Console.Lib | 4.11.1431 | no-code rebuild |
| SdlVulkan.Renderer | 7.4.1891 | no-code rebuild |
| WebGl.Renderer | 1.14.181 | no-code rebuild, **was on DIR.Lib 7.0** |

`.mcp.json` moves both inspector sidecars with their libraries, since a sidecar ships separately from the app it drives.

## WebGl.Renderer was the straggler, and why

Its pin was `1.12.*` while `1.13` was published, and it was the last sibling still built against DIR.Lib **7.0**, so the package graph unified DIR.Lib by taking the highest version rather than by intent. It drifted because `TianWen.UI.Web` **opts out of CPM** and pins inline, where a sweep of `Directory.Packages.props` never reaches it. CLAUDE.md now records that, plus a second edge on the same project: WebGl.Renderer is gated on `UseLocalSiblings` yet absent from that property's own `Exists(...)` list, so a box with every other sibling cloned resolves the switch to true and then points a ProjectReference at a path that is not there.

The sibling table was also missing four members the switch actually gates (SER.Lib, Lzip.Lib, LAN.Lib, SharpAstro.Codecs).

## Two unrelated loose ends

- **README**: the release archives are self-contained AOT, which reads as "needs nothing", but they cannot bundle the Vulkan loader. Adds a prerequisites table, notes that `tianwen-fits` resolves a *system* font so a minimal image needs a font package too, fixes the stale `tianwen-fits-viewer-<rid>` artifact names, and adds the missing GUI release table.
- **Test**: `ARowStatesItsOwnBackground` asserted the arranged root spans the full row width. That could never fail, because `Layout.Engine.Arrange` places the root at the rect it was handed and never reads the root's own sizing. Deleted, with a note on why there is deliberately nothing about width there.

## Verification

- 3715 unit + 338 functional green against the sibling checkouts
- full solution build with `-p:UseLocalSiblings=false` against all four published packages, 0 warnings
- per-lib against the published DIR.Lib 7.4: Console.Lib 418 Release / 442 Debug, SdlVulkan 43 pass 1 skip, WebGl 34

One gotcha worth recording: a **Debug** build against the published DIR.Lib package is not a valid configuration at all, because `DebugInspectorCore` is `#if DEBUG` inside DIR.Lib and so is absent from the Release nupkg. That also accounts for SdlVulkan reporting 20 tests in Release versus 44 in Debug; nine inspector tests compile out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)