### PR TITLE
Retire the CPM opt-outs, and resync the generated solution

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -3,9 +3,12 @@ name: pages
 # Deploy the TianWen.UI.Web in-browser planner to GitHub Pages.
 #
 # TianWen.UI.Web is a standalone Blazor WebAssembly app hosting PlannerTab<WebGlContext>
-# (WebGl.Renderer) - a fully static site, no server. It lives OUTSIDE TianWen.slnx + CPM,
-# so the PR `dotnet.yml` loop never builds it; this workflow is its sole CI and publishes
+# (WebGl.Renderer) - a fully static site, no server. It lives OUTSIDE TianWen.slnx, so the PR
+# `dotnet.yml` loop never builds it; this workflow is its sole CI and publishes
 # to https://sharpastro.github.io/tianwen/. Design + findings: docs/plans/web-showcase.md.
+# It IS under the repo's Central Package Management, despite the above: CPM resolves by walking
+# directories, so solution membership never had any bearing on it. While the project opted out,
+# its inline WebGl.Renderer pin was invisible to a sibling-family sweep and fell two minors behind.
 #
 # Two deploy-only concerns handled here (neither applies to local dev on :5099):
 #  - Mono WASM AOT (RunAOTCompilation=true): measured 24-42x on the catalog init + planner

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,8 +141,24 @@ Both are now closed: the project is under CPM like everything else (all three of
 `Directory.Packages.props`), and `WebGl.Renderer` is in the `Exists(...)` list, so the switch and that
 `ProjectReference` agree by construction. **Being outside a solution never had any bearing on CPM**,
 which resolves by walking directories, so the opt-out bought nothing it could not have had anyway.
-`src/TianWen.UI.Web.E2E` is the last CPM opt-out, and it has already drifted the same way
-(`Microsoft.NET.Test.Sdk` 18.6.0 inline against 18.3.0 centrally).
+`TianWen.UI.Web.E2E` opted out for the same non-reason and had drifted the same way
+(`Microsoft.NET.Test.Sdk` 18.6.0 inline against 18.3.0 centrally, since reconciled upward to 18.6.0 for
+every test project); it is now under CPM too. **There are no CPM opt-outs left in `src/`, and a new one
+needs a real technical justification, not "this project is not in the solution".**
+
+**Both web projects stay out of `TianWen.slnx`, which is a separate and legitimate decision.**
+`TianWen.UI.Web` is a Blazor WASM app whose sole CI is `pages.yml` (a mono AOT publish, far too heavy for
+the per-push `dotnet.yml` loop), and `TianWen.UI.Web.E2E` needs a browser plus a running dev server, so a
+solution-wide `dotnet test` must not sweep it up. Run them explicitly:
+`dotnet build TianWen.UI.Web`, `dotnet test TianWen.UI.Web.E2E`.
+
+**`open-vs.ps1` generates `TianWen.local.slnx`** at the repo root (gitignored) by re-rooting
+`src/TianWen.slnx` and appending a `/Siblings/` folder, so Go To Definition lands in sibling *source*.
+Its project list **must** match the `UseLocalSiblings` `Exists(...)` conjunction, and nothing enforces
+that: it had drifted to `../StbImageSharp` for all seven codec projects (that repo is `../Codecs` now),
+and was missing `LAN.Lib`, `SharpAstro.Codecs` and `WebGl.Renderer`. A generated solution with
+unresolvable entries loads with them silently unloaded rather than failing, so touch one file and re-read
+the other.
 
 For libraries without auto-detection (`FC.SDK`, `ZWOptical.SDK`, `TianWen.DAL`),
 prefer to extend the `UseLocalSiblings` switch in

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,12 +111,12 @@ every sibling uses `src/<Lib>/<Lib>.csproj`.
 | `SER.Lib` | `../SER.Lib` | `src/SER.Lib/SER.Lib.csproj` | ✅ |
 | `Lzip.Lib` | `../Lzip.Lib` | `src/Lzip.Lib/Lzip.Lib.csproj` | ✅ |
 | `LAN.Lib` | `../LAN.Lib` | `src/LAN.Lib/LAN.Lib.csproj` | ✅ |
-| `WebGl.Renderer` | `../WebGl.Renderer` | `src/WebGl.Renderer/WebGl.Renderer.csproj` | ⚠️ see below |
+| `WebGl.Renderer` | `../WebGl.Renderer` | `src/WebGl.Renderer/WebGl.Renderer.csproj` | ✅ |
 | `TianWen.DAL` | `../TianWen.DAL` | — | ❌ |
 
 **Auto-detection** (`Directory.Build.props`): a **single** property `UseLocalSiblings` gates them all.
 The build switches to ProjectReference when **every** sibling working copy exists — `DIR.Lib`,
-`Console.Lib`, `SdlVulkan.Renderer`, the `Codecs`-repo codec family (`SharpAstro.Tiff`,
+`Console.Lib`, `SdlVulkan.Renderer`, `WebGl.Renderer`, the `Codecs`-repo codec family (`SharpAstro.Tiff`,
 `SharpAstro.Exif`, `SharpAstro.Png`, `SharpAstro.Color.Icc`, `SharpAstro.Jxr`,
 `SharpAstro.Jpeg.IccInjector`, `SharpAstro.Exr`, `SharpAstro.Codecs`), `QHYCCD.SDK`, `FITS.Lib`,
 `SER.Lib`, `Lzip.Lib`, and `LAN.Lib`; otherwise it falls
@@ -127,16 +127,22 @@ be outliers (the latter via a separate `UseLocalFitsLib` switch) but were folded
 there is **no** per-library switch anymore. Trade-off: a missing checkout of *any* listed sibling flips
 the whole set back to packages (all-or-nothing), which is fine on a dev box that has them all.
 
-**`WebGl.Renderer` is the one exception, and it bites in two ways.** It is consumed only by
-`TianWen.UI.Web`, which **opts out of CPM**, so its version is pinned **inline in
-`TianWen.UI.Web.csproj`** rather than in `Directory.Packages.props`. Consequences: (1) a sibling-family
-version bump that sweeps `Directory.Packages.props` silently misses it, which is how the pin sat two
-minors behind (`1.12.*` while `1.13` was published) and how the web renderer ended up the last sibling
-still built against DIR.Lib 7.0 after everything else moved to 7.4; grep the whole `src/` tree for a
-pin, not just the props file. (2) It is **gated on `UseLocalSiblings` but absent from that property's
-own `Exists(...)` list**, so a box with every other sibling checked out but no `WebGl.Renderer` gets
-`UseLocalSiblings=true` and a `ProjectReference` to a path that is not there. Clone it, or build that
-one project with `-p:UseLocalSiblings=false`.
+**`WebGl.Renderer` used to be an exception on both counts, and the two ways it bit are the argument for
+never making one again.** It is consumed only by `TianWen.UI.Web`, which sits outside `TianWen.slnx`, and
+that project used to **opt out of CPM** so its Blazor deps could carry inline versions. The convenience
+cost two real defects: (1) a sibling-family bump sweeping `Directory.Packages.props` could not see an
+inline pin, so it sat two minors behind (`1.12.*` while `1.13` was published) and became the last member
+still built against DIR.Lib 7.0 after the rest moved to 7.4, leaving the package graph to unify DIR.Lib
+by taking the highest version rather than by intent; (2) it was gated on `UseLocalSiblings` yet absent
+from that property's own `Exists(...)` list, so a box with every other sibling cloned resolved the switch
+to `true` and then pointed a `ProjectReference` at a path that was not there.
+
+Both are now closed: the project is under CPM like everything else (all three of its versions live in
+`Directory.Packages.props`), and `WebGl.Renderer` is in the `Exists(...)` list, so the switch and that
+`ProjectReference` agree by construction. **Being outside a solution never had any bearing on CPM**,
+which resolves by walking directories, so the opt-out bought nothing it could not have had anyway.
+`src/TianWen.UI.Web.E2E` is the last CPM opt-out, and it has already drifted the same way
+(`Microsoft.NET.Test.Sdk` 18.6.0 inline against 18.3.0 centrally).
 
 For libraries without auto-detection (`FC.SDK`, `ZWOptical.SDK`, `TianWen.DAL`),
 prefer to extend the `UseLocalSiblings` switch in

--- a/open-vs.ps1
+++ b/open-vs.ps1
@@ -1,13 +1,23 @@
 #!/usr/bin/env pwsh
 # Generates TianWen.local.slnx at the repo root with sibling project references,
 # then opens it in Visual Studio. This gives Go To Definition into every sibling
-# that Directory.Build.props' UseLocalSiblings switch project-references (DIR.Lib,
-# Console.Lib, SdlVulkan.Renderer, the SharpAstro codec projects in the StbImageSharp
-# repo, QHYCCD.SDK, FITS.Lib, SER.Lib, Lzip.Lib). Keep this list in sync with
-# Directory.Build.props. NB: the stb_image port itself (StbImageSharp.csproj) is not
-# listed — TianWen consumes only the SharpAstro.* codecs, not the port.
+# that Directory.Build.props' UseLocalSiblings switch project-references.
 #
-# The base TianWen.slnx in src/ stays untouched (used by CI and dotnet build).
+# THIS LIST MUST MATCH THAT SWITCH'S Exists(...) CONJUNCTION. It had drifted badly,
+# in a way nothing could catch: the codec projects pointed at ../StbImageSharp, a repo
+# that no longer exists (it is ../Codecs now), so seven of the entries below resolved
+# to nothing and VS silently loaded an unloadable-project solution. LAN.Lib,
+# SharpAstro.Codecs and WebGl.Renderer were simply missing. A generated file is not
+# self-checking, so re-read Directory.Build.props when you touch either one.
+#
+# NB: the stb_image port itself (StbImageSharp.csproj) is deliberately not listed.
+# TianWen consumes only the SharpAstro.* codecs, not the port.
+#
+# The base TianWen.slnx in src/ stays untouched (used by CI and dotnet build). It
+# omits TianWen.UI.Web and TianWen.UI.Web.E2E on purpose, so this generated solution
+# omits them too: the WASM app has its own workflow (pages.yml) as its sole CI, and
+# the E2E suite needs a browser plus a running dev server, so neither belongs in a
+# solution-wide build or `dotnet test`.
 
 $repoRoot = $PSScriptRoot
 $baseSlnx = Join-Path $repoRoot 'src' 'TianWen.slnx'
@@ -34,20 +44,26 @@ $siblings = @"
     <Project Path="../Fonts.Lib/src/SharpAstro.Fonts/SharpAstro.Fonts.csproj" />
     <Project Path="../Console.Lib/src/Console.Lib/Console.Lib.csproj" />
     <Project Path="../SdlVulkan.Renderer/src/SdlVulkan.Renderer/SdlVulkan.Renderer.csproj" />
-    <!-- SharpAstro.* codec projects from the StbImageSharp repo. The stb_image
-         port (StbImageSharp.csproj) is intentionally omitted: nothing in the
+    <!-- The WebGL2 backend for the same DIR.Lib Renderer. Its only consumer,
+         TianWen.UI.Web, is not in this solution, but the project is here so a
+         sibling-wide refactor can see and rebuild it. -->
+    <Project Path="../WebGl.Renderer/src/WebGl.Renderer/WebGl.Renderer.csproj" />
+    <!-- SharpAstro.* codec projects from the Codecs repo. The stb_image port
+         (StbImageSharp.csproj) is intentionally omitted: nothing in the
          solution references it (Fonts decodes CBDT PNGs via SharpAstro.Png). -->
-    <Project Path="../StbImageSharp/src/SharpAstro.Tiff/SharpAstro.Tiff.csproj" />
-    <Project Path="../StbImageSharp/src/SharpAstro.Exif/SharpAstro.Exif.csproj" />
-    <Project Path="../StbImageSharp/src/SharpAstro.Png/SharpAstro.Png.csproj" />
-    <Project Path="../StbImageSharp/src/SharpAstro.Color.Icc/SharpAstro.Color.Icc.csproj" />
-    <Project Path="../StbImageSharp/src/SharpAstro.Jxr/SharpAstro.Jxr.csproj" />
-    <Project Path="../StbImageSharp/src/SharpAstro.Jpeg.IccInjector/SharpAstro.Jpeg.IccInjector.csproj" />
-    <Project Path="../StbImageSharp/src/SharpAstro.Exr/SharpAstro.Exr.csproj" />
+    <Project Path="../Codecs/src/SharpAstro.Tiff/SharpAstro.Tiff.csproj" />
+    <Project Path="../Codecs/src/SharpAstro.Exif/SharpAstro.Exif.csproj" />
+    <Project Path="../Codecs/src/SharpAstro.Png/SharpAstro.Png.csproj" />
+    <Project Path="../Codecs/src/SharpAstro.Color.Icc/SharpAstro.Color.Icc.csproj" />
+    <Project Path="../Codecs/src/SharpAstro.Jxr/SharpAstro.Jxr.csproj" />
+    <Project Path="../Codecs/src/SharpAstro.Jpeg.IccInjector/SharpAstro.Jpeg.IccInjector.csproj" />
+    <Project Path="../Codecs/src/SharpAstro.Exr/SharpAstro.Exr.csproj" />
+    <Project Path="../Codecs/src/SharpAstro.Codecs/SharpAstro.Codecs.csproj" />
     <Project Path="../QHYCCD.SDK/QHYCCD.SDK.csproj" />
     <Project Path="../FITS.Lib/CSharpFITS/CSharpFITS.csproj" />
     <Project Path="../SER.Lib/src/SER.Lib/SER.Lib.csproj" />
     <Project Path="../Lzip.Lib/src/Lzip.Lib/Lzip.Lib.csproj" />
+    <Project Path="../LAN.Lib/src/LAN.Lib/LAN.Lib.csproj" />
   </Folder>
 "@
 

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -7,12 +7,21 @@
     through to PackageReference automatically (version from Directory.Packages.props).
 
     Override: dotnet build -p:UseLocalSiblings=false
+
+    All-or-nothing on purpose: a missing checkout of ANY listed sibling flips the whole
+    set back to packages. WebGl.Renderer is listed even though its only consumer
+    (TianWen.UI.Web) sits outside TianWen.slnx, because the alternative is worse. While it
+    was absent from this list, a box holding every other sibling resolved this property to
+    true and then pointed a ProjectReference at a path that was not there, so the web
+    project simply failed to build. Listed, the switch and that ProjectReference agree by
+    construction: no WebGl.Renderer checkout means packages everywhere, which restores.
   -->
   <PropertyGroup>
     <UseLocalSiblings Condition="'$(UseLocalSiblings)' == ''
       AND Exists('$(MSBuildThisFileDirectory)..\..\DIR.Lib\src\DIR.Lib\DIR.Lib.csproj')
       AND Exists('$(MSBuildThisFileDirectory)..\..\Console.Lib\src\Console.Lib\Console.Lib.csproj')
       AND Exists('$(MSBuildThisFileDirectory)..\..\SdlVulkan.Renderer\src\SdlVulkan.Renderer\SdlVulkan.Renderer.csproj')
+      AND Exists('$(MSBuildThisFileDirectory)..\..\WebGl.Renderer\src\WebGl.Renderer\WebGl.Renderer.csproj')
       AND Exists('$(MSBuildThisFileDirectory)..\..\Codecs\src\SharpAstro.Tiff\SharpAstro.Tiff.csproj')
       AND Exists('$(MSBuildThisFileDirectory)..\..\Codecs\src\SharpAstro.Exif\SharpAstro.Exif.csproj')
       AND Exists('$(MSBuildThisFileDirectory)..\..\Codecs\src\SharpAstro.Png\SharpAstro.Png.csproj')

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -54,7 +54,7 @@
          stdio server so an AI assistant can call read-only debugging tools
          against TianWen.Lib. AOT-compatible when registered via WithTools<T>(). -->
     <PackageVersion Include="ModelContextProtocol" Version="1.1.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.201" />
     <PackageVersion Include="System.IO.Ports" Version="10.0.5" />
     <PackageVersion Include="System.Numerics.Tensors" Version="10.0.5" />
@@ -73,6 +73,12 @@
     <PackageVersion Include="coverlet.collector" Version="8.0.1" />
     <PackageVersion Include="Meziantou.Extensions.Logging.Xunit.v3" Version="1.1.26" />
     <PackageVersion Include="Nerdbank.Streams" Version="2.13.16" />
+    <!-- Browser driver for TianWen.UI.Web.E2E. That project stays OUTSIDE TianWen.slnx, because it
+         needs a browser and a running dev server and must not be swept up by a solution-wide
+         dotnet test, but it is under CPM like everything else: solution membership and CPM are
+         unrelated, and keeping it out of CPM only meant its versions could drift unseen (they did,
+         with Microsoft.NET.Test.Sdk 18.6.0 inline against 18.3.0 here). -->
+    <PackageVersion Include="Microsoft.Playwright" Version="1.61.0" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="NSubstitute.Analyzers.CSharp" Version="1.0.17" />
     <PackageVersion Include="Shouldly" Version="4.3.0" />

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -319,6 +319,14 @@
          rebuild against DIR.Lib 7.4. No render-path change, so these are
          rebuilds from TianWen's side, pinned forward to keep the family on one DIR.Lib. -->
     <PackageVersion Include="SdlVulkan.Renderer" Version="7.4.*" />
+    <!-- The WebGL2 backend for the same DIR.Lib Renderer, consumed ONLY by TianWen.UI.Web (which sits
+         outside TianWen.slnx). It lives here, next to its desktop counterpart, because it used to be
+         pinned inline in that csproj instead: a sibling-family bump that swept this file could not see
+         it, so it silently sat two minors behind at 1.12 while 1.13 was published, and stayed the last
+         member built against DIR.Lib 7.0 after the rest moved to 7.4. The package graph then unified
+         DIR.Lib by taking the highest version rather than by intent. Bump it with the family.
+         1.14 is the current pin: the no-code lockstep rebuild against DIR.Lib 7.4. -->
+    <PackageVersion Include="WebGl.Renderer" Version="1.14.*" />
     <PackageVersion Include="SDL3-CS" Version="3.5.0-preview.20260213-150035" />
     <PackageVersion Include="SDL3-CS.Native" Version="3.5.0-preview.20260205-174353" />
     <!-- Canon DSLR -->
@@ -327,6 +335,11 @@
     <PackageVersion Include="FC.SDK.Raw" Version="1.4.*" />
     <!-- Image encoding -->
     <PackageVersion Include="StbImageWriteSharp" Version="1.16.7" />
+    <!-- Blazor WebAssembly host for TianWen.UI.Web. That project is outside TianWen.slnx and is not
+         part of the desktop test/release chain, but it is still governed by this file: being outside a
+         solution has no bearing on CPM, which is resolved by walking directories. -->
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.9" />
     <!-- Other packages -->
     <PackageVersion Include="QHYCCD.SDK" Version="1.0.*" />
     <PackageVersion Include="TianWen.DAL" Version="2.0.*" />

--- a/src/TianWen.UI.Web.E2E/TianWen.UI.Web.E2E.csproj
+++ b/src/TianWen.UI.Web.E2E/TianWen.UI.Web.E2E.csproj
@@ -6,20 +6,22 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <IsPackable>false</IsPackable>
     <IsPublishable>false</IsPublishable>
-    <!-- Browser E2E for TianWen.UI.Web. Like the web app itself, this lives OUTSIDE TianWen.slnx
-         and opts out of the repo's Central Package Management: it needs a browser + a running
-         dev server, so it must NOT be swept up by the solution-wide `dotnet test` CI runs on
-         every push. Run it explicitly: `dotnet test TianWen.UI.Web.E2E`.
-         Mirrors chess's Chess.Web.E2E harness (Playwright for .NET + xUnit v3). -->
-    <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
+    <!-- Browser E2E for TianWen.UI.Web. Like the web app itself, this lives OUTSIDE TianWen.slnx:
+         it needs a browser + a running dev server, so it must NOT be swept up by the solution-wide
+         `dotnet test` CI runs on every push. Run it explicitly: `dotnet test TianWen.UI.Web.E2E`.
+         Mirrors chess's Chess.Web.E2E harness (Playwright for .NET + xUnit v3).
+         It used to opt out of Central Package Management as well, as though that followed from the
+         above. It does not: CPM is resolved by walking directories and has no bearing on which
+         projects a solution sweeps. All the opt-out achieved was letting these versions drift
+         unseen, which they did (Microsoft.NET.Test.Sdk 18.6.0 here against 18.3.0 centrally). -->
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Playwright" Version="1.61.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
-    <PackageReference Include="xunit.v3" Version="3.2.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+    <PackageReference Include="Microsoft.Playwright" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit.v3" />
+    <PackageReference Include="xunit.runner.visualstudio">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/TianWen.UI.Web/TianWen.UI.Web.csproj
+++ b/src/TianWen.UI.Web/TianWen.UI.Web.csproj
@@ -6,10 +6,14 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <OverrideHtmlAssetPlaceholders>true</OverrideHtmlAssetPlaceholders>
     <!-- The in-browser app is a consumer of TianWen.Lib / TianWen.UI.Abstractions, not a shipped
-         package and not part of the desktop test/release chain. It lives OUTSIDE TianWen.slnx and
-         opts out of Central Package Management so the Blazor deps carry their own versions without
-         touching Directory.Packages.props. Mirrors ../../sebgod/chess/Chess.Web. -->
-    <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
+         package and not part of the desktop test/release chain, and it lives OUTSIDE TianWen.slnx.
+         It is nonetheless under Central Package Management like every other project here: it used to
+         opt out, so that the Blazor deps could carry their own versions without touching
+         Directory.Packages.props, and the cost of that convenience was WebGl.Renderer. Pinned inline,
+         it was invisible to a sweep of the props file, so it drifted two minors behind and became the
+         last sibling built against DIR.Lib 7.0 while the rest moved to 7.4. Being outside a solution
+         has no bearing on CPM, which resolves by walking directories, so there was never a technical
+         reason for the opt-out. All three versions now live in Directory.Packages.props. -->
     <IsPackable>false</IsPackable>
     <!-- No culture data needed; dropping ICU trims the payload. Site timezone resolves via the
          bundled wasm tzdata (TimeZoneInfo), which is independent of ICU; the planner falls back to
@@ -26,8 +30,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.9" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.9" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>
@@ -46,13 +50,15 @@
     <_AOT_InternalForceInterpretAssemblies Include="LibUsbDotNet.LibUsbDotNet.dll" />
   </ItemGroup>
 
-  <!-- WebGL backend: sibling working copy for local iteration, NuGet in CI (same UseLocalSiblings
-       switch the desktop projects use; the web project opts out of CPM so the version rides inline). -->
+  <!-- WebGL backend: sibling working copy for local iteration, NuGet otherwise, on the same
+       UseLocalSiblings switch and the same CPM pin as every desktop sibling. WebGl.Renderer is in that
+       switch's own Exists list, so the two branches below can never disagree about whether the sibling
+       is on disk. -->
   <ItemGroup Condition="'$(UseLocalSiblings)' == 'true'">
     <ProjectReference Include="..\..\..\WebGl.Renderer\src\WebGl.Renderer\WebGl.Renderer.csproj" />
   </ItemGroup>
   <ItemGroup Condition="'$(UseLocalSiblings)' != 'true'">
-    <PackageReference Include="WebGl.Renderer" Version="1.14.*" />
+    <PackageReference Include="WebGl.Renderer" />
   </ItemGroup>
 
 


### PR DESCRIPTION
Follow-up to #128. Two projects were exempt from the mechanisms that keep this repo's versions coherent, and were caught by neither. That is how `WebGl.Renderer` ended up two minors stale (`1.12.*` pinned while `1.13` was published) and the last member still built against DIR.Lib **7.0** after everything else moved to 7.4, leaving the package graph to unify DIR.Lib by taking the highest version rather than by intent.

## The same non-reason, twice

Both `TianWen.UI.Web` and `TianWen.UI.Web.E2E` justified leaving **CPM** with a fact about the **solution**: the web app "is not part of the desktop test/release chain", the E2E suite "needs a browser + a running dev server, so it must NOT be swept up by the solution-wide `dotnet test`". Both are sound reasons to stay out of `TianWen.slnx`, and both still do. Neither is a reason to leave CPM, which resolves by **walking directories** and has nothing to say about what a solution sweeps.

What the opt-outs actually bought was invisible drift:

| Project | Drifted |
|---|---|
| `TianWen.UI.Web` | `WebGl.Renderer` `1.12.*` while `1.13` shipped; stayed on DIR.Lib 7.0 |
| `TianWen.UI.Web.E2E` | `Microsoft.NET.Test.Sdk` 18.6.0 inline vs 18.3.0 centrally |

Both are now under CPM. The Test.Sdk conflict is reconciled **upward**, so the central pin is 18.6.0 for every test project rather than E2E being dragged back two patches. `Microsoft.Playwright` joins the central list. **Zero CPM opt-outs and zero inline-versioned `PackageReference`s remain under `src/`.**

## The `Exists(...)` list

`WebGl.Renderer` was gated on `UseLocalSiblings` but missing from that property's own conjunction, so a box holding every other sibling resolved the switch to `true` and then pointed a `ProjectReference` at a path that was not there. Adding it makes the two agree by construction: no checkout means the property is false, means the `PackageReference` branch, which restores.

**Tradeoff:** a box without a `WebGl.Renderer` checkout now builds *everything* from packages. That is this switch's documented all-or-nothing behaviour and the bargain every other sibling already makes; the alternative is a per-library switch, which this repo deliberately does not have.

## The generated solution was quietly broken

`open-vs.ps1` generates `TianWen.local.slnx` with a `/Siblings/` folder so Go To Definition lands in sibling *source*. It carries a "keep this list in sync with Directory.Build.props" instruction that nothing enforces, and it had drifted:

- all **seven** codec projects pointed at `../StbImageSharp`, **a repo that no longer exists** (it is `../Codecs`)
- `LAN.Lib`, `SharpAstro.Codecs` and `WebGl.Renderer` were absent entirely

A generated solution with unresolvable entries does not fail. It loads with them silently unloaded, which is why this survived. All 18 sibling paths now resolve and the generated solution restores all 37 projects clean.

## Why the web projects stay out of the slnx

Asked and worth recording, so it is now in CLAUDE.md: `TianWen.UI.Web`'s sole CI is `pages.yml`, a mono AOT publish far too heavy for the per-push loop, and E2E needs a browser plus a running dev server. Run them explicitly: `dotnet build TianWen.UI.Web`, `dotnet test TianWen.UI.Web.E2E`.

## Verification

- **resolution unchanged everywhere**, read back out of `project.assets.json`: `WebGl.Renderer/1.14.181`, both Blazor packages `10.0.9`, E2E on `Test.Sdk/18.6.0` + `Playwright/1.61.0` + `xunit.v3/3.2.2` + `runner/3.1.5`
- 3715 unit + 338 functional green on Test.Sdk 18.6.0, counts unchanged
- solution builds both ways, 0 warnings; web project builds both ways; E2E builds
- generated `TianWen.local.slnx`: valid XML, 37 projects, 0 unresolvable, restores clean
- `UseLocalSiblings` still resolves `true` on a full box, so the new conjunct does not accidentally disable the switch

Two notes for the record. A first test attempt ran the two suites concurrently and died inside `GenerateRuntimeConfigurationFiles`; that was the two builds colliding over shared projects, **not** the version bump, and both pass run sequentially. And on the missing-checkout case I verified both endpoints (switch true takes the ProjectReference and builds; switch false takes the PackageReference and builds) rather than renaming a real checkout to force the middle, since a parallel build could have been running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)