### PR TITLE
chore(deps): pin the sibling family forward, including two that had drifted

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -3,12 +3,12 @@
     "sdl-ui-inspector": {
       "type": "stdio",
       "command": "dotnet",
-      "args": ["dnx", "SdlVulkan.Renderer.Inspector@7.4.1891", "--yes"]
+      "args": ["dnx", "SdlVulkan.Renderer.Inspector@7.5.1921", "--yes"]
     },
     "console-inspector": {
       "type": "stdio",
       "command": "dotnet",
-      "args": ["dnx", "Console.Lib.Inspector@4.11.1431", "--yes"]
+      "args": ["dnx", "Console.Lib.Inspector@4.12.1451", "--yes"]
     }
   }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1088,11 +1088,14 @@ A CPU-first planetary stacker, **completely separate** from the deep-sky `Imagin
   `TryReadViaCodecs`, no temp-file round-trip) into a **3-channel [0,1] RGB `Image`** (EVF is camera-processed,
   not raw CFA), single-stream gated + mutually exclusive with the single-shot CR2 path, ISO live-tunable via
   `ApplyVideoControlsAsync`. `CanVideoCapture => Connected`; **`CanJogRoi => false`** — Canon EVF has no
-  host-side ROI pan through the published FC.SDK 1.4 (`Evf_ZoomPosition`/`Evf_ZoomRect` are POINT/RECT
+  host-side ROI pan through FC.SDK as published (`Evf_ZoomPosition`/`Evf_ZoomRect` are POINT/RECT
   properties but FC.SDK exposes only a `uint32` accessor), so the recenter loop falls back to mount jog. The
-  5x/10x EVF-zoom planetary regime + zoom-crop ROI-jog is **deferred** pending an FC.SDK 1.5 point/rect
-  property accessor (see [`docs/plans/planetary-native-video.md`](docs/plans/planetary-native-video.md)
-  Phase E). `DALCameraDriver` (ZWO/QHY native raw video) is Phase D — not yet implemented.
+  5x/10x EVF-zoom planetary regime + zoom-crop ROI-jog is **deferred** pending a point/rect property
+  accessor in FC.SDK (see [`docs/plans/planetary-native-video.md`](docs/plans/planetary-native-video.md)
+  Phase E). **Do not date that on a version:** it was written as "pending FC.SDK 1.5", and 1.5, 1.6 and 1.7
+  have all shipped without it, so the note read as satisfied when nothing had changed. The blocker is the
+  accessor existing, not a release going by. `DALCameraDriver` (ZWO/QHY native raw video) is Phase D — not
+  yet implemented.
 - **COM recenter loop** (Phase C — hold the planet centred): `PlanetaryRecenterController.Decide` (pure, in
   `TianWen.Lib/Imaging/Planetary/`) takes the disk centre of mass + the readout-window geometry and returns a
   `RecenterDecision` — a **per-axis-deadband** (not distance — a big offset on one axis must not drag the other

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -168,6 +168,52 @@ cadence forces a version bump), commit + push + wait for NuGet publish — **do 
 local nupkg feeds or run `dotnet pack` to short-circuit the release dance, since CI builds
 will still pull from nuget.org and a local-only nupkg will mask version-skew bugs.
 
+### How every sibling repo is versioned (one property, read back in CI)
+
+**To cut a release in ANY SharpAstro repo, edit `<VersionMajorMinor>` in its `Directory.Build.props`
+and nothing else.** Every repo now uses the same shape, under the same property name, so the answer to
+"where does this repo's version live" never varies:
+
+- **`Directory.Build.props`** (repo root, or `src/` where the repo keeps one there) holds
+  `<VersionMajorMinor>X.Y</VersionMajorMinor>`. Everything else in the repo derives from it:
+  `<VersionPrefix Condition="'$(VersionPrefix)' == ''">$(VersionMajorMinor).0</VersionPrefix>` for local
+  builds, and `AssemblyVersion` as `$(VersionMajorMinor).0.0` where a repo pins one.
+- **The workflow READS IT BACK** rather than restating it. A `dotnet msbuild <props> -getProperty:VersionMajorMinor`
+  step writes `VERSION_PREFIX=<X.Y>.<run>` into `$GITHUB_ENV` before restore. `-getProperty` only
+  *evaluates* the file, so it needs no restore and runs first.
+
+**Why it is read back rather than duplicated:** CI stamps one `-p:Version` across the whole repo, so a
+per-csproj version only ever surfaces in a *local* build, which is exactly where nobody looks, while a
+workflow copy silently decides what ships. Nothing compared them, and they drifted — DIR.Lib.Shaping
+sat at 6.8.0 while DIR.Lib was 7.5.0, so a local `dotnet pack` shipped the satellite a full major
+behind the library it ships with; SdlVulkan's Inspector/WebView trio sat at 6.0.0 against 7.4.0; and
+Codecs' own comment recorded the 3.5 work shipping as 3.4.49 because only one of its two copies moved.
+The SDK repos had the inverse: no csproj version at all, so a local pack produced the SDK default
+1.0.0 against a package whose real line was 4.2 or 2.0.
+
+Two rules that make the step safe, both load-bearing:
+- **`DOTNET_NOLOGO: 1` in the workflow `env:`.** The value is captured from stdout, so the SDK's
+  first-run banner must not be able to land in it.
+- **A shape check that fails the run.** An unresolvable or renamed property must not quietly stamp
+  every package as `.<run>`.
+
+**Release notes stay in the workflow `env:`, not next to the number.** Several entries contain a double
+hyphen, which XML forbids inside a comment. Add the entry there when you bump the property here.
+
+**`LALR.CC` is deliberately exempt** and should stay that way. It is tag-driven, not run-number driven:
+the package version *is* `<Version>` in `LALR.CC.csproj`, and its workflow already has a guard step that
+fails when a pushed `vX.Y.Z` tag disagrees with it. That is the same invariant — one place, CI verifies
+instead of duplicating — expressed for a different release model, and converting it would break the
+tag-to-version contract the guard enforces.
+
+**A live failure mode worth knowing** (it cost WebGl.Renderer a stray published package on every run
+for fifteen releases): if a **test step rebuilds a `GeneratePackageOnBuild` project without
+`-p:Version`**, it packs a *second* time at the csproj default `X.Y.0`, into the same `bin/Release` the
+publish job globs with `**/*.nupkg`. Both get pushed, and `--skip-duplicate` hides it by making the
+re-push a no-op rather than an error. Either pass `--no-build` to `dotnet test` (what most repos here
+do) or `-p:GeneratePackageOnBuild=false`. To audit: list a package's versions and look for a bare
+`X.Y.0` sitting beside the run-numbered ones.
+
 ## Key Technologies
 
 | Area | Technology |

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -9,8 +9,12 @@
          the SharpAstro.Codecs facade) ships in lockstep from the Codecs repo, so they
          must all resolve to the SAME minor (mixing minors across a lockstep break is a
          runtime hazard). Bump this ONE prefix on a family minor/major; the X.Y.* float
-         still auto-picks CI patch builds within the minor. -->
-    <SharpAstroCodecsVersion>3.6.*</SharpAstroCodecsVersion>
+         still auto-picks CI patch builds within the minor.
+         3.7 added SharpAstro.Jbig2 (clean-room ITU-T T.88, for PDF's /JBIG2Decode) to the family and
+         3.8 gave it resource limits, after the shipped 3.7 decoder was found to accept decompression
+         bombs. TianWen references neither package, so 3.6 -> 3.8 carries no API change here; the bump
+         is to keep the matched set matched, which is the whole reason this one property exists. -->
+    <SharpAstroCodecsVersion>3.8.*</SharpAstroCodecsVersion>
   </PropertyGroup>
   <ItemGroup>
     <!-- Source generator packages -->
@@ -159,8 +163,15 @@
          measure context and the paint loop, two copies kept in step by hand, and per-axis scales would
          have turned that into text painted at a size it was never measured at. Additive, since the scalar
          overloads delegate to the context ones with an isotropic context, so every existing TianWen call
-         site paints byte-identically. -->
-    <PackageVersion Include="DIR.Lib" Version="7.4.*" />
+         site paints byte-identically.
+         7.5 is the current pin: a font now resolves by its DECLARED family rather than by file identity,
+         so every face in a family is reachable, and a run a face cannot cover falls back per RUN instead
+         of per request. The fallback split is allocation-free and gated on an allocation-free
+         PrimaryCoversAll, so text needing no fallback costs nothing; the all-ASCII shortcut was fixed to
+         check that the primary actually covers ASCII. 7.5 also collapsed every package in that repo onto
+         one version property, which is how DIR.Lib.Shaping stopped shipping a full major behind the
+         library it ships with. -->
+    <PackageVersion Include="DIR.Lib" Version="7.5.*" />
     <!-- DIR.Lib 3.0 extracted its codec layer to these sibling packages, which
          ship as a lockstep family from the Codecs repo. 3.0 brought a
          binary-breaking SharpAstro.Tiff change (TiffPageOptions.IccProfile is
@@ -268,9 +279,10 @@
          The three-overload cascade collapses into fields on RowContext, so the next capability adds a
          field rather than a rung an implementation can silently ignore. See Console.Lib's MIGRATION.md
          and CLAUDE.md's Layout DSL section.
-         4.11 is the current pin: a no-code lockstep rebuild against DIR.Lib 7.4, so the family restores
-         one DIR.Lib instead of two. Nothing in the TUI changes. -->
-    <PackageVersion Include="Console.Lib" Version="4.11.*" />
+         4.11 was a no-code lockstep rebuild against DIR.Lib 7.4, so the family restores one DIR.Lib
+         instead of two. 4.12 is the current pin and is the same thing against DIR.Lib 7.5. Nothing in
+         the TUI changes in either. -->
+    <PackageVersion Include="Console.Lib" Version="4.12.*" />
     <!-- SdlVulkan.Renderer 5.0 adds a multi-page SDF glyph atlas (no more grow
          stall / Adreno submit-wedge) on top of 4.1's SetSystemCursor + anisotropic
          glyph xScale. 5.1 implements DIR.Lib 4.4's PushClip/PopClip via Vulkan
@@ -322,23 +334,32 @@
          with it. 7.3 completed the inspector consolidation upstream (one
          dir-inspect protocol shared with the terminal inspector, loopback-only bind, the SDL-side
          transport deleted; batch and wait became core verbs). 7.4 is the current pin: a no-code lockstep
-         rebuild against DIR.Lib 7.4. No render-path change, so these are
-         rebuilds from TianWen's side, pinned forward to keep the family on one DIR.Lib. -->
-    <PackageVersion Include="SdlVulkan.Renderer" Version="7.4.*" />
+         rebuild against DIR.Lib 7.4, and 7.5 is the current pin, the same against DIR.Lib 7.5. No
+         render-path change in either, so these are rebuilds from TianWen's side, pinned forward to keep
+         the family on one DIR.Lib. -->
+    <PackageVersion Include="SdlVulkan.Renderer" Version="7.5.*" />
     <!-- The WebGL2 backend for the same DIR.Lib Renderer, consumed ONLY by TianWen.UI.Web (which sits
          outside TianWen.slnx). It lives here, next to its desktop counterpart, because it used to be
          pinned inline in that csproj instead: a sibling-family bump that swept this file could not see
          it, so it silently sat two minors behind at 1.12 while 1.13 was published, and stayed the last
          member built against DIR.Lib 7.0 after the rest moved to 7.4. The package graph then unified
          DIR.Lib by taking the highest version rather than by intent. Bump it with the family.
-         1.14 is the current pin: the no-code lockstep rebuild against DIR.Lib 7.4. -->
-    <PackageVersion Include="WebGl.Renderer" Version="1.14.*" />
+         1.14 was the no-code lockstep rebuild against DIR.Lib 7.4; 1.15 is the current pin, the same
+         against DIR.Lib 7.5. It moved with the family this time rather than being found two minors
+         behind, which is the point of it living here. -->
+    <PackageVersion Include="WebGl.Renderer" Version="1.15.*" />
     <PackageVersion Include="SDL3-CS" Version="3.5.0-preview.20260213-150035" />
     <PackageVersion Include="SDL3-CS.Native" Version="3.5.0-preview.20260205-174353" />
-    <!-- Canon DSLR -->
-    <PackageVersion Include="FC.SDK" Version="1.4.*" />
-    <!-- Floating: Canon raw decoder (.cr2/.cr3 -> mosaic). Tracks FC.SDK repo CI (1.3.x). -->
-    <PackageVersion Include="FC.SDK.Raw" Version="1.4.*" />
+    <!-- Canon DSLR. Both packages ship from the FC.SDK repo at one release line, so they move
+         together. 1.4 -> 1.7 catches up three lines: 1.5 added the device report (the one artefact to
+         ask a bug reporter for) and stopped two settings leaking their storage details to the caller,
+         1.6 drove the WPD driver over raw ioctl as a sibling of the COM path, and 1.7 opened the
+         current line. The EVF zoom accessor the planetary ROI-jog work is waiting on is still NOT here:
+         Evf_ZoomPosition / Evf_ZoomRect remain bare property ids with no point/rect accessor. So that
+         deferral stands, and it is no longer "pending 1.5". -->
+    <PackageVersion Include="FC.SDK" Version="1.7.*" />
+    <!-- Floating: Canon raw decoder (.cr2/.cr3 -> mosaic). Same repo + release line as FC.SDK. -->
+    <PackageVersion Include="FC.SDK.Raw" Version="1.7.*" />
     <!-- Image encoding -->
     <PackageVersion Include="StbImageWriteSharp" Version="1.16.7" />
     <!-- Blazor WebAssembly host for TianWen.UI.Web. That project is outside TianWen.slnx and is not

--- a/src/TianWen.Lib/Devices/Canon/CanonCameraDriver.cs
+++ b/src/TianWen.Lib/Devices/Canon/CanonCameraDriver.cs
@@ -645,11 +645,18 @@ internal sealed class CanonCameraDriver : ICameraDriver, IVideoCameraDriver
     }
 
     /// <summary>
-    /// Reads the C.Fn block, flips Long Exposure NR to Off using whichever of the
-    /// known per-generation function IDs (6D-class or Rebel-class) is present on this
-    /// body, and writes it back. Silent no-op if the ID isn't found or the camera
-    /// doesn't expose a C.Fn block.
+    /// Reads the C.Fn block, flips Long Exposure NR to Off, and writes it back. Silent
+    /// no-op when this body keeps the setting somewhere other than a C.Fn, when its C.Fn
+    /// ID has not been verified against real hardware, or when it exposes no C.Fn block.
     /// </summary>
+    /// <remarks>
+    /// The ID comes from <see cref="CanonCustomFunctionId.LongExposureNrIdFor"/>, which owns the
+    /// per-model table. This used to try two IDs of its own, a "6D" one and a "Rebel" one, and both
+    /// were guesses: on the 6D long-exposure NR is a plain shooting-menu property with no C.Fn ID at
+    /// all. So the call could only ever no-op, or write into whatever function a body happened to
+    /// keep at that address. FC.SDK deleted both constants and grew this resolver instead, which is
+    /// the right home for it: a C.Fn ID is camera-specific, so guessing one is never safe.
+    /// </remarks>
     private async ValueTask DisableLongExposureNRAsync(CancellationToken ct)
     {
         if (_camera is null)
@@ -659,6 +666,12 @@ internal sealed class CanonCameraDriver : ICameraDriver, IVideoCameraDriver
 
         try
         {
+            if (CanonCustomFunctionId.LongExposureNrIdFor(_camera.Model) is not { } cfnId)
+            {
+                Logger.LogDebug("Canon LongExposureNR: no verified C.Fn ID for {Model}", _camera.Model);
+                return;
+            }
+
             var (err, block) = await _camera.GetCustomFunctionBlockAsync(ct);
             if (err is not EdsError.OK || block is null)
             {
@@ -666,10 +679,7 @@ internal sealed class CanonCameraDriver : ICameraDriver, IVideoCameraDriver
                 return;
             }
 
-            var offValue = (uint)EdsLongExposureNR.Off;
-            var patched = block.SetValue(CanonCustomFunctionId.LongExposureNR_6D, offValue)
-                       || block.SetValue(CanonCustomFunctionId.LongExposureNR_Rebel, offValue);
-            if (!patched)
+            if (!block.SetValue(cfnId, (uint)EdsLongExposureNR.Off))
             {
                 Logger.LogDebug("Canon LongExposureNR: C.Fn ID not present on this body");
                 return;


### PR DESCRIPTION
## What

Moves every SharpAstro pin to what is actually published.

**The lockstep four** (DIR.Lib 7.5 and its rebuilds): DIR.Lib 7.4 to 7.5, Console.Lib 4.11 to 4.12, SdlVulkan.Renderer 7.4 to 7.5, WebGl.Renderer 1.14 to 1.15. DIR.Lib 7.5 resolves a font by its declared family rather than by file identity, so every face in a family is reachable and a run a face cannot cover falls back per run instead of per request. The other three are no-code rebuilds that keep the graph restoring one DIR.Lib. The two inspector sidecars in .mcp.json move with them.

**Two that a family sweep would never have caught:**

- **Codecs 3.6 to 3.8.** 3.7 added SharpAstro.Jbig2, 3.8 gave it resource limits after the shipped 3.7 decoder turned out to accept decompression bombs. TianWen references neither, so no API moves here. It bumps so the matched set stays matched, which is what the single float property is for.
- **FC.SDK 1.4 to 1.7**, three release lines, and this one is not inert.

## The FC.SDK break was a latent bug, not just a version gap

1.5 deleted `CanonCustomFunctionId.LongExposureNR_6D` and `_Rebel` as guessed wire ids. That was right: on the 6D long-exposure NR is a plain shooting-menu property with no C.Fn id at all. `DisableLongExposureNRAsync` tried both, so it could only ever no-op, or write into whatever function some other body happens to keep at 0x0201. A C.Fn id is camera-specific, so guessing one is never safe.

It now asks `CanonCustomFunctionId.LongExposureNrIdFor(model)`, which I added to FC.SDK for this (released as 1.7.651) alongside the `MirrorLockupIdFor` / `HighIsoNrIdFor` it completes. The model table belongs there, not in a consumer.

Also corrects a note that dated the deferred EVF zoom-pan work at "pending FC.SDK 1.5". 1.5, 1.6 and 1.7 have all shipped without the point/rect accessor, so the note read as satisfied when nothing had changed. The blocker is the accessor existing, not a release going by.

## Verification

Built and tested against the **packages**, not the sibling checkouts (`-p:UseLocalSiblings=false`, the CI configuration), since a local build would have resolved sibling source and told me nothing about the pins:

- 0 warnings, 0 errors
- 3715 unit tests, 19 skipped
- 338 functional tests

Both counts unchanged from main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R8fbd6xrLU7H4sjEHWnsEH