### PR TITLE
Wire the Canon EVF magnified crop as the planetary ROI, on FC.SDK 3.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1147,21 +1147,32 @@ A CPU-first planetary stacker, **completely separate** from the deep-sky `Imagin
   decodes straight from the SDK `byte[]` via `Image.TryDecodeRaster` (the in-memory core of
   `TryReadViaCodecs`, no temp-file round-trip) into a **3-channel [0,1] RGB `Image`** (EVF is camera-processed,
   not raw CFA), single-stream gated + mutually exclusive with the single-shot CR2 path, ISO live-tunable via
-  `ApplyVideoControlsAsync`. `CanVideoCapture => Connected`; **`CanJogRoi => false`** — Canon EVF has no
-  host-side ROI pan through the FC.SDK version we pin, so the recenter loop falls back to mount jog. The
-  5x/10x EVF-zoom planetary regime + zoom-crop ROI-jog is **unblocked in FC.SDK source but not yet
-  consumable**: FC.SDK 3.0 has `SetEvfZoomAsync` / `SetEvfZoomPositionAsync` / `GetEvfZoomRectAsync`,
-  hardware-verified on a 6D, while the newest published version is 2.0.671 and we pin `1.7.*`. See
-  [`docs/plans/planetary-native-video.md`](docs/plans/planetary-native-video.md) Phase E for the four measured
-  behaviours the wiring must respect (threshold-not-value zoom factors, `LiveFace` AF silently blocking
-  magnification, `Factor` 4.96 for a nominal 5x, and a ~1 s apply during which the rect still reads stale).
-  **That note was wrong twice, in two different ways, and both are the lesson.** It was first dated on a
-  version ("pending FC.SDK 1.5") and 1.5, 1.6 and 1.7 all shipped without it. It was then restated as pending
-  "a point/rect property accessor", which could never arrive: over PTP there is **no** `Evf_ZoomPosition` or
-  `Evf_ZoomRect` property at all. Those are EDSDK's model of the feature; the camera takes zoom and pan as
-  *operations* (0x9158 / 0x9159) and reports the crop in a live-view frame record. **So do not date a blocker
-  on a release, and state it in terms of the protocol rather than of a wrapper's shape**, or the note describes
-  something that cannot happen. `DALCameraDriver` (ZWO/QHY native raw video) is Phase D, not yet
+  `ApplyVideoControlsAsync`. **The 5x/10x EVF-zoom planetary regime and its pannable crop are SHIPPED** on
+  FC.SDK `3.0.751`: `NumX` snaps to a zoom level (`ZoomForWindow`), `VideoRoi` reports the body's own crop, and
+  `CanJogRoi` / `JogRoiAsync` pan it via `SetEvfZoomPositionAsync`. `CanJogRoi` is true **exactly while the crop
+  is magnified and the body advertises the pan operation**, so at 1x the recenter loop falls back to mount jog,
+  which is correct rather than a limitation: at 1x the crop is the whole frame and the accepted pan range
+  collapses to a point. Five things this path must keep right, every one of which fails silently:
+  (1) the zoom factor is a **threshold, not a value** (1-4 give 1x, 5-8 give 5x, 10+ give 10x), so the level
+  thresholds sit *between* the nominal factors, or feeding back the body's own 1104 px crop of a 5472 px sensor
+  answers `Fit` and the stream drops out of magnification on its first resize check; (2) `Evf_AFMode = LiveFace`
+  silently blocks magnification while ACKing the zoom, so `Live` is written first, but **only when actually
+  magnifying**, since it is a setting the user sees in the body's own menus; (3) `Factor` is **4.96** for a
+  nominal 5x, so pixel scale comes from the rect, never the level asked for; (4) a zoom takes ~1 s during which
+  the body streams PRE-zoom frames, so level changes use `verify: true` while the per-frame **pan** uses
+  `verify: false` (a second of polling on the capture loop is the thing to avoid) and updates the cached window
+  from the clamped request; (5) a pan coordinate past `[0, sensor - crop]` is **discarded**, not clamped, by the
+  body, so the far corner is computed host-side. **`VideoRoi` is sensor px and deliberately NOT the yielded
+  frame size** (the EVF renders a 1104x736 crop as ~1024x680, so one frame px is ~1.08 sensor px at 5x): the
+  recenter loop under-corrects by that ratio, which a damped loop absorbs as lower gain, whereas frame px would
+  break the `sensorWidth - roi.Width` pan-range arithmetic it cannot get wrong. Pinned by `CanonEvfZoomTests`.
+  **The old blocker note was wrong twice, in two different ways, and both are the lesson.** It was first dated
+  on a version ("pending FC.SDK 1.5") and 1.5, 1.6 and 1.7 all shipped without it. It was then restated as
+  pending "a point/rect property accessor", which could never arrive: over PTP there is **no**
+  `Evf_ZoomPosition` or `Evf_ZoomRect` property at all. Those are EDSDK's model of the feature; the camera takes
+  zoom and pan as *operations* (0x9158 / 0x9159) and reports the crop in a live-view frame record. **So do not
+  date a blocker on a release, and state it in terms of the protocol rather than of a wrapper's shape**, or the
+  note describes something that cannot happen. `DALCameraDriver` (ZWO/QHY native raw video) is Phase D, not yet
   implemented.
 - **COM recenter loop** (Phase C — hold the planet centred): `PlanetaryRecenterController.Decide` (pure, in
   `TianWen.Lib/Imaging/Planetary/`) takes the disk centre of mass + the readout-window geometry and returns a

--- a/docs/plans/planetary-native-video.md
+++ b/docs/plans/planetary-native-video.md
@@ -254,11 +254,14 @@ publish latency.
 
 # Phase E -- Canon Live View (JPEG)
 
-> **Status (2026-08-03): E core SHIPPED; EVF-zoom-pan UNBLOCKED in FC.SDK source, waiting on its release.**
+> **Status (2026-08-03): E core SHIPPED. E.3 EVF zoom + pannable ROI SHIPPED on FC.SDK 3.0.751.**
 > `CanonCameraDriver` implements `IVideoCameraDriver`: full-frame Live View streaming (EVF JPEG -> 3-channel
 > [0,1] `Image` via the in-memory `Image.TryDecodeRaster`, no temp-file round-trip), single-stream gate + mutual
-> exclusion with the single-shot CR2 path, and ISO live-tuning. `CanJogRoi` is still **false** (recenter falls
-> back to mount jog, which `PlanetaryRecenterController` already handles).
+> exclusion with the single-shot CR2 path, ISO live-tuning, and now the magnified regime: `NumX` snaps to a zoom
+> level, `VideoRoi` reports the body's own crop, and `CanJogRoi` / `JogRoiAsync` pan it. `CanJogRoi` is **true
+> exactly while the feed is a magnified, pannable crop**, so at 1x the recenter loop still falls back to mount
+> jog, which is the correct answer rather than a limitation: at 1x the crop is the whole frame and the accepted
+> pan range collapses to a point.
 >
 > **The reason this was deferred was wrong, twice, and it is worth reading before writing another such note.**
 > First it was dated on a release ("pending FC.SDK 1.5"), and 1.5, 1.6 and 1.7 all shipped without it. Then it
@@ -266,13 +269,8 @@ publish latency.
 > **there is no `Evf_Zoom` or `Evf_ZoomPosition` property at all**. Those are EDSDK's *model* of the feature.
 > The camera exposes zoom and pan as PTP **operations** (`0x9158` / `0x9159`), and it reports the resulting crop
 > as a **record inside the live-view frame** (record type 18), not as a readable property. So the plan was
-> waiting on a shape the protocol does not have, which is exactly why no release ever satisfied it.
->
-> FC.SDK 3.0 implements the real shape, hardware-verified on a 6D: `SupportsEvfZoom` / `SupportsEvfZoomPosition`,
-> `SetEvfZoomAsync(CanonEvfZoom.X5)`, `SetEvfZoomPositionAsync(x, y)` (clamped, and it reports where it landed),
-> and `GetEvfZoomRectAsync()` -> `CanonEvfZoomRect(X, Y, Width, Height, SensorWidth, SensorHeight)`. **Not yet
-> consumable:** the newest published FC.SDK is 2.0.671, which predates the zoom work, and TianWen pins `1.7.*`.
-> Sequence is FC.SDK merge -> CI publishes `3.0.<run>` -> re-pin TianWen -> the E.3 work below.
+> waiting on a shape the protocol does not have, which is exactly why no release ever satisfied it. **Do not
+> date a blocker on a release, and state it in terms of the protocol rather than of a wrapper's shape.**
 
 Canon EOS bodies stream a live host feed only one way through FC.SDK: **Live View (EVF) JPEG**. That feed has
 two regimes -- full-frame (downscaled, framing quality) and **5x/10x zoom** (a near-1:1-pixel crop of a small
@@ -349,9 +347,9 @@ accessor of any width could have unblocked this. The camera takes zoom and pan a
 `0x9158`, `CanonZoomPosition` `0x9159`) and describes the resulting crop in a **live-view frame record**
 (type 18), which is also the only trustworthy account of whether either took effect.
 
-FC.SDK 3.0 exposes exactly that, so the remaining TianWen work is: set the zoom in `CaptureVideoAsync`, wire
-`JogRoiAsync` -> `SetEvfZoomPositionAsync`, report `GetEvfZoomRectAsync` from `VideoRoi`, and flip `CanJogRoi`
-to true while zoomed. Four things measured on a 6D that the implementation has to respect:
+FC.SDK 3.0 exposes exactly that, and it is **wired** (FC.SDK `3.0.751`): `CaptureVideoAsync` sets the zoom,
+`JogRoiAsync` -> `SetEvfZoomPositionAsync`, `VideoRoi` reports the body's rect, `CanJogRoi` is true while that
+rect is a pannable crop. Four things measured on a 6D that the implementation has to respect:
 
 - **The zoom factor is a threshold, not a value.** 1-4 give 1x, 5-8 give 5x, 10 and above give 10x. Ask for
   what you want and read the rect back for what you got.
@@ -363,22 +361,47 @@ to true while zoomed. Four things measured on a 6D that the implementation has t
   rect read after the call reliably returns the OLD rect. FC.SDK's own `verify` polls for this; do not
   re-implement a one-shot check on top of it.
 
-Also newly available and directly useful here: `GetEvfHistogramAsync` returns the camera's own four-channel
-exposure histogram for the live frame, which is the only live metering an EOS offers over PTP and the obvious
-input for auto-exposing a DSLR planetary or EAA run whose dial is in Manual.
+Because the zoom crop is pannable, it **is** the Canon ROI jog. The Phase C recenter loop drives it unchanged,
+which is the point: it gets the same mount-free actuator ZWO gets from `ASISetStartPos`. As shipped:
 
-Because the zoom crop is pannable, it **is** the Canon ROI jog:
-- **`CanJogRoi` -> true** (when zoomed). `JogRoiAsync(dx, dy)` writes a new `Evf_ZoomPosition` -- the same
-  mount-free recenter actuator ZWO gets from `ASISetStartPos`. The Phase C recenter loop drives it unchanged.
-- **`VideoRoi`** reports the zoom rect (origin + crop size), so the recenter math knows the remaining pan
-  range before an edge.
-- When **not** zoomed (full-frame framing), `CanJogRoi` is false and recenter falls back to mount jog -- the
-  Phase C fallback already covers this, so the two regimes degrade cleanly into each other.
+- **`CanJogRoi`** is true exactly while the crop is magnified *and* the body advertises `0x9159`. At 1x the
+  crop is the whole frame and the accepted range collapses to a point, so recenter falls back to mount jog, and
+  the two regimes degrade cleanly into each other with no branch in the loop.
+- **`VideoRoi`** reports the body's rect, so the loop knows the pan range left before an edge.
+- **The window SIZE stays `NumX`/`NumY`**, per the `IVideoCameraDriver` contract. An EOS offers three discrete
+  crops rather than a free rectangle, so `ZoomForWindow` snaps a requested width to the nearest level, with the
+  thresholds *between* the nominal factors. That is load-bearing for the round trip: the body's 5x reports a
+  1104 px crop of a 5472 px sensor, so a threshold placed *on* 5 would answer `Fit` when fed the body's own
+  width and the stream would drop out of magnification on its first resize check.
+- **`VideoRoi` is sensor px, and is deliberately NOT the size of the yielded frame.** The EVF renders that
+  1104x736 crop as a ~1024x680 JPEG, so one frame px is ~1.08 sensor px at 5x. `PlanetaryRecenterController`
+  measures its offset in frame px and applies it as sensor px, so it under-corrects by that ratio, which a
+  damped loop absorbs as a slightly lower gain. Reporting frame px instead would break the pan-range
+  arithmetic (`sensorWidth - roi.Width`), which is the part the loop cannot be allowed to get wrong.
+- **The pan is clamped host-side** into `[0, sensor - crop]` before it is sent, because a coordinate beyond
+  that is *discarded* by the body and the axis silently keeps its old value. Asking for "the far corner" with
+  a large number therefore moves nothing at all.
+- **`SetEvfZoomPositionAsync(verify: false)` on the jog path.** The verify polls frames for up to a second to
+  watch the move land, and the jog runs on the capture loop between frames. Since the coordinate was clamped
+  into the accepted range, the position adopted is the one asked for, so the cached window is updated from the
+  request. Level *changes* keep `verify: true` (behaviour 4 above); only the pan skips it.
+- **The AF-method write is gated on actually magnifying.** `Live` is required for zoom to take effect, but it
+  is a setting the user can see in the body's own menus, so plain full-frame streaming does not touch it.
+- **1x is still applied explicitly at stream start**, because zoom and pan persist on the body: a stream that
+  inherited a magnified crop from an earlier session would otherwise open on a corner of the sensor.
 
-The original "defer it, `CanJogRoi=false`" stance was wrong: EVF zoom is not a nicety, it is the only way to
-get planetary-useful resolution **and** a host-side ROI jog out of a Canon, and it is fully reachable through
-the already-published FC.SDK. The remaining risk is per-body quirks in the zoom-position units (verify on
-hardware; the Phase C per-axis cap bounds a wrong guess to a small mis-pan, never a runaway).
+Pinned by `CanonEvfZoomTests` (19 cases over the three pure decisions, using the measured 6D geometry). The
+remaining risk is per-body quirks in the zoom-position units, which libgphoto2 measured as "approx 64 pixel
+steps on the EOS 1000D": verify on hardware, and note the Phase C per-axis cap bounds a wrong guess to a small
+mis-pan rather than a runaway.
+
+**Deferred, and only an optimisation:** the crop arrives *inside* a live-view frame, and the capture loop
+already fetches one per pass, but `GetEvfZoomRectAsync` fetches its own envelope. One FC.SDK call returning
+frame plus decoded metadata together would make the rect free instead of a second round-trip. It is not on the
+hot path today (the rect is read only at a level change), so it buys nothing until something wants per-frame
+geometry. `GetEvfHistogramAsync` has the same shape and the same fix: it is the camera's own four-channel
+metering of the live frame, the only live metering an EOS offers over PTP, and the obvious input for
+auto-exposing a DSLR planetary or EAA run whose dial is in Manual.
 
 ## E.4 Canon movie recording: out of scope for the *live* path (and the offline path that uses it)
 

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -351,15 +351,16 @@
     <PackageVersion Include="SDL3-CS" Version="3.5.0-preview.20260213-150035" />
     <PackageVersion Include="SDL3-CS.Native" Version="3.5.0-preview.20260205-174353" />
     <!-- Canon DSLR. Both packages ship from the FC.SDK repo at one release line, so they move
-         together. 1.4 -> 1.7 catches up three lines: 1.5 added the device report (the one artefact to
-         ask a bug reporter for) and stopped two settings leaking their storage details to the caller,
-         1.6 drove the WPD driver over raw ioctl as a sibling of the COM path, and 1.7 opened the
-         current line. The EVF zoom accessor the planetary ROI-jog work is waiting on is still NOT here:
-         Evf_ZoomPosition / Evf_ZoomRect remain bare property ids with no point/rect accessor. So that
-         deferral stands, and it is no longer "pending 1.5". -->
-    <PackageVersion Include="FC.SDK" Version="1.7.*" />
+         together. 1.7 -> 3.0 crosses two majors: 2.0 reshaped the property surface, and 3.0 adds
+         live-view magnification, which is what the planetary EVF-zoom ROI jog needed and now uses.
+         That work was deferred for three releases on a stated blocker that could not be satisfied:
+         it asked for a point/rect accessor for Evf_ZoomPosition / Evf_ZoomRect, and over PTP no such
+         property exists. Zoom and pan are OPERATIONS (0x9158 / 0x9159) and the resulting crop is a
+         record inside the live-view frame, so 3.0 ships SetEvfZoomAsync / SetEvfZoomPositionAsync /
+         GetEvfZoomRectAsync instead. Do not re-word that as pending a version again. -->
+    <PackageVersion Include="FC.SDK" Version="3.0.*" />
     <!-- Floating: Canon raw decoder (.cr2/.cr3 -> mosaic). Same repo + release line as FC.SDK. -->
-    <PackageVersion Include="FC.SDK.Raw" Version="1.7.*" />
+    <PackageVersion Include="FC.SDK.Raw" Version="3.0.*" />
     <!-- Image encoding -->
     <PackageVersion Include="StbImageWriteSharp" Version="1.16.7" />
     <!-- Blazor WebAssembly host for TianWen.UI.Web. That project is outside TianWen.slnx and is not

--- a/src/TianWen.Lib.Tests/Planetary/CanonEvfZoomTests.cs
+++ b/src/TianWen.Lib.Tests/Planetary/CanonEvfZoomTests.cs
@@ -1,0 +1,198 @@
+using FC.SDK.Canon;
+using Shouldly;
+using TianWen.Lib.Devices;
+using TianWen.Lib.Devices.Canon;
+using Xunit;
+
+namespace TianWen.Lib.Tests;
+
+/// <summary>
+/// Phase E of the live planetary plan: the three pure decisions behind the Canon EVF magnified ROI, which is
+/// the DSLR planetary regime. A requested window size picks one of the body's discrete zoom levels
+/// (<see cref="CanonCameraDriver.ZoomForWindow"/>); the crop the body reports back becomes the live ROI
+/// (<see cref="CanonCameraDriver.WindowFor"/>); and a pan is clamped into the range the body will act on
+/// (<see cref="CanonCameraDriver.ClampPan"/>). No camera, no USB.
+///
+/// <para>The numbers here are the ones measured on an EOS 6D: a 5472x3648 sensor whose nominal 5x is a
+/// (2184,1456) 1104x736 crop, a 4.96x magnification. Everything that could silently do nothing on real
+/// hardware is pinned, because every failure mode on this path is silent: the zoom operation ACKs whether or
+/// not it magnified, and a pan coordinate past the accepted range is discarded rather than refused.</para>
+/// </summary>
+public class CanonEvfZoomTests
+{
+    private const int SensorW = 5472;
+    private const int SensorH = 3648;
+
+    /// <summary>The 6D's measured 5x crop: centred, 1104x736, which is 4.96x rather than an exact fifth.</summary>
+    private static readonly CanonEvfZoomRect Magnified5x = new(2184, 1456, 1104, 736, SensorW, SensorH);
+
+    /// <summary>1x: the crop is the whole frame, so there is nothing to magnify and nowhere to pan.</summary>
+    private static readonly CanonEvfZoomRect FullFrame = new(0, 0, SensorW, SensorH, SensorW, SensorH);
+
+    // ── ZoomForWindow: a requested size snaps to a level the body actually offers ──────────────────
+
+    [Fact]
+    public void An_unset_window_asks_for_the_full_frame()
+    {
+        // NumX defaults to 0 before anything sets it, and that must mean "no magnification" rather than
+        // dividing by zero into the deepest crop.
+        CanonCameraDriver.ZoomForWindow(0, SensorW).ShouldBe(CanonEvfZoom.Fit);
+    }
+
+    [Theory]
+    [InlineData(SensorW)]      // exactly the sensor
+    [InlineData(SensorW + 64)] // more than the sensor, which a caller may well ask for
+    public void A_window_at_or_past_the_sensor_asks_for_the_full_frame(int requested)
+        => CanonCameraDriver.ZoomForWindow(requested, SensorW).ShouldBe(CanonEvfZoom.Fit);
+
+    [Fact]
+    public void A_fifth_of_the_sensor_asks_for_5x()
+        => CanonCameraDriver.ZoomForWindow(SensorW / 5, SensorW).ShouldBe(CanonEvfZoom.X5);
+
+    [Fact]
+    public void The_crop_5x_actually_produces_asks_for_5x_again()
+    {
+        // The round trip that matters: feed back the width the body reported for its own 5x and the same
+        // level comes out. A threshold placed on the nominal factor rather than between them would answer
+        // Fit here, because 4.96 is not 5, and the stream would drop out of magnification on the first
+        // resize check after it zoomed.
+        CanonCameraDriver.ZoomForWindow((int)Magnified5x.Width, SensorW).ShouldBe(CanonEvfZoom.X5);
+    }
+
+    [Fact]
+    public void A_tenth_of_the_sensor_asks_for_10x()
+        => CanonCameraDriver.ZoomForWindow(SensorW / 10, SensorW).ShouldBe(CanonEvfZoom.X10);
+
+    [Fact]
+    public void A_half_frame_window_is_not_worth_magnifying()
+    {
+        // There is no 2x, so a request between the levels has to land somewhere; below the midpoint it stays
+        // at full frame rather than jumping to a 5x crop a quarter the size that was asked for.
+        CanonCameraDriver.ZoomForWindow(SensorW / 2, SensorW).ShouldBe(CanonEvfZoom.Fit);
+    }
+
+    [Fact]
+    public void A_zero_sensor_width_asks_for_the_full_frame()
+    {
+        // Sensor size is populated from a table or the first decoded image, so it can still be 0 here.
+        CanonCameraDriver.ZoomForWindow(1104, 0).ShouldBe(CanonEvfZoom.Fit);
+    }
+
+    // ── WindowFor: the reported crop becomes the ROI, and only a placeable one is pannable ─────────
+
+    [Fact]
+    public void A_magnified_crop_on_a_pannable_body_is_the_roi_and_can_be_panned()
+    {
+        var window = CanonCameraDriver.WindowFor(Magnified5x, bodySupportsPan: true, SensorW, SensorH);
+
+        window.Roi.ShouldBe(new RoiRect(2184, 1456, 1104, 736));
+        window.SensorWidth.ShouldBe(SensorW);
+        window.SensorHeight.ShouldBe(SensorH);
+        window.CanPan.ShouldBeTrue();
+        // The pan range the recenter loop has to work with, which is what makes this worth reporting at all.
+        (window.SensorWidth - window.Roi.Width).ShouldBe(4368);
+        (window.SensorHeight - window.Roi.Height).ShouldBe(2912);
+    }
+
+    [Fact]
+    public void A_body_that_cannot_pan_reports_a_crop_that_cannot_be_panned()
+    {
+        // The crop is still the right ROI to report; only the actuator is missing.
+        var window = CanonCameraDriver.WindowFor(Magnified5x, bodySupportsPan: false, SensorW, SensorH);
+
+        window.Roi.ShouldBe(new RoiRect(2184, 1456, 1104, 736));
+        window.CanPan.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void At_1x_the_crop_is_the_whole_frame_and_cannot_be_panned()
+    {
+        var window = CanonCameraDriver.WindowFor(FullFrame, bodySupportsPan: true, SensorW, SensorH);
+
+        window.Roi.ShouldBe(new RoiRect(0, 0, SensorW, SensorH));
+        window.CanPan.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void No_reported_rect_falls_back_to_a_full_frame_that_cannot_be_panned()
+    {
+        var window = CanonCameraDriver.WindowFor(null, bodySupportsPan: true, 640, 480);
+
+        window.Roi.ShouldBe(new RoiRect(0, 0, 640, 480));
+        window.SensorWidth.ShouldBe(640);
+        window.SensorHeight.ShouldBe(480);
+        window.CanPan.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void A_crop_with_no_sensor_bounds_cannot_be_panned()
+    {
+        // The body sent the crop record but not the sensor-size one, so the crop cannot be placed: there is
+        // no way to say whether it is magnified or how far it may travel. Trusting it half way would let the
+        // recenter loop jog a window against a range it invented, which is the one outcome to rule out.
+        var window = CanonCameraDriver.WindowFor(
+            new CanonEvfZoomRect(2184, 1456, 1104, 736, 0, 0), bodySupportsPan: true, SensorW, SensorH);
+
+        window.Roi.ShouldBe(new RoiRect(0, 0, SensorW, SensorH));
+        window.CanPan.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void A_zero_sized_crop_cannot_be_panned()
+    {
+        var window = CanonCameraDriver.WindowFor(
+            new CanonEvfZoomRect(0, 0, 0, 0, SensorW, SensorH), bodySupportsPan: true, SensorW, SensorH);
+
+        window.Roi.ShouldBe(new RoiRect(0, 0, SensorW, SensorH));
+        window.CanPan.ShouldBeFalse();
+    }
+
+    // ── ClampPan: a coordinate past the range is discarded by the body, so never send one ──────────
+
+    [Fact]
+    public void A_pan_inside_the_range_lands_exactly_where_it_was_asked_to()
+    {
+        var window = CanonCameraDriver.WindowFor(Magnified5x, bodySupportsPan: true, SensorW, SensorH);
+
+        CanonCameraDriver.ClampPan(window, 100, -200).ShouldBe((2284, 1256));
+    }
+
+    [Fact]
+    public void A_pan_past_the_far_edge_is_clamped_to_the_far_edge_rather_than_discarded()
+    {
+        // Asking for "as far right as possible" with a big number is exactly the case the body silently
+        // ignores, so the far corner is computed here: sensor minus crop, per axis.
+        var window = CanonCameraDriver.WindowFor(Magnified5x, bodySupportsPan: true, SensorW, SensorH);
+
+        CanonCameraDriver.ClampPan(window, 999999, 999999).ShouldBe((4368, 2912));
+    }
+
+    [Fact]
+    public void A_pan_past_the_near_edge_is_clamped_to_the_origin()
+    {
+        var window = CanonCameraDriver.WindowFor(Magnified5x, bodySupportsPan: true, SensorW, SensorH);
+
+        CanonCameraDriver.ClampPan(window, -999999, -999999).ShouldBe((0, 0));
+    }
+
+    [Fact]
+    public void Each_axis_clamps_on_its_own()
+    {
+        // A big offset on one axis must not drag the other one, which is the same per-axis rule the recenter
+        // controller applies to its deadband.
+        var window = CanonCameraDriver.WindowFor(Magnified5x, bodySupportsPan: true, SensorW, SensorH);
+
+        CanonCameraDriver.ClampPan(window, 999999, 8).ShouldBe((4368, 1464));
+    }
+
+    [Fact]
+    public void At_1x_the_range_collapses_to_a_point()
+    {
+        // The crop is the whole sensor, so [0, sensor - crop] is [0, 0] and there is nowhere to go. CanPan is
+        // already false here; this pins that even a stray call cannot move the window off the origin.
+        var window = CanonCameraDriver.WindowFor(FullFrame, bodySupportsPan: true, SensorW, SensorH);
+
+        CanonCameraDriver.ClampPan(window, 500, 500).ShouldBe((0, 0));
+        CanonCameraDriver.ClampPan(window, -500, -500).ShouldBe((0, 0));
+    }
+}

--- a/src/TianWen.Lib/Devices/Canon/CanonCameraDriver.cs
+++ b/src/TianWen.Lib/Devices/Canon/CanonCameraDriver.cs
@@ -726,40 +726,70 @@ internal sealed class CanonCameraDriver : ICameraDriver, IVideoCameraDriver
     // We decode each frame straight from the SDK byte[] into a 3-channel [0,1] Image (Image.TryDecodeRaster,
     // no temp-file round-trip) and yield it; the planetary live-stack pipeline consumes it as a colour master.
     //
-    // Core (this build): full-frame framing / EAA streaming, mutually exclusive with single-shot capture.
-    // Not yet wired: the 5x/10x EVF-zoom planetary regime and its pannable crop as the host-side ROI jog, so
-    // CanJogRoi is false and the recenter loop falls back to mount jog (PlanetaryRecenterController already
-    // degrades cleanly). EVF exposure is also EVF-auto, not a true integration time (ISO/gain tuning still
-    // works via ApplyVideoControlsAsync).
+    // The 5x/10x magnified feed IS the planetary regime: at 5x the body sends a near-1:1-pixel crop of a
+    // small sensor region instead of a downscaled whole frame, and that crop is pannable, which makes it the
+    // host-side ROI jog the COM-recenter loop wants. Both are PTP operations (0x9158 zoom / 0x9159 pan) and
+    // the resulting crop arrives as a record inside the live-view frame. There is no Evf_ZoomPosition or
+    // Evf_ZoomRect property to read, which is why this sat deferred behind a request for an accessor that
+    // could never exist; FC.SDK 3.0 ships the operations, so it is wired here.
     //
-    // This used to be recorded as blocked on "an FC.SDK point/rect property accessor for Evf_ZoomPosition
-    // (0x508) / Evf_ZoomRect (0x541)". That was wrong: over PTP there is NO such property. Those are EDSDK's
-    // model of the feature. The camera takes zoom and pan as operations (0x9158 / 0x9159) and describes the
-    // resulting crop in a live-view frame record, so the accessor being waited on could never have existed.
-    // FC.SDK 3.0 implements the real shape and is hardware-verified; it is simply not published yet (newest on
-    // NuGet is 2.0.671, and we pin 1.7.*). See docs/plans/planetary-native-video.md Phase E for the four
-    // measured behaviours the wiring has to respect.
+    // Four behaviours measured on an EOS 6D that the wiring has to respect, every one of which fails
+    // SILENTLY if ignored (see docs/plans/planetary-native-video.md Phase E):
+    //   1. The zoom factor is a THRESHOLD, not a value: 1-4 give 1x, 5-8 give 5x, 10 and up give 10x. So a
+    //      requested window size selects a level, and the body's own rect is the only truth about scale.
+    //   2. Evf_AFMode = LiveFace disables magnification on a body with a lens attached and ACKs the zoom
+    //      anyway, so the AF method is set to Live before asking.
+    //   3. Factor is 4.96 for a nominal 5x, because the crop is a whole number of pixels. Planetary pixel
+    //      scale must come from the rect, never from the level requested.
+    //   4. A zoom takes about a second to apply while the body keeps streaming PRE-zoom frames, so a rect
+    //      read straight after the call reports the OLD crop. Hence verify: true at every level change,
+    //      which waits for the crop to actually move.
+    //
+    // EVF exposure is still EVF-auto rather than a true integration time (ISO/gain tuning works through
+    // ApplyVideoControlsAsync), and streaming stays mutually exclusive with single-shot capture.
 
     /// <summary>EVF poll cadence floor -- the feed runs at its own fps; we treat the requested exposure as a
     /// poll interval clamped to this range so a large "exposure" can't stall the feed to one frame per minute.</summary>
     private static readonly TimeSpan MinVideoPace = TimeSpan.FromMilliseconds(15);
     private static readonly TimeSpan MaxVideoPace = TimeSpan.FromMilliseconds(500);
 
+    /// <summary>
+    /// The live-view crop the body last confirmed, in the body's OWN sensor coordinate space, plus whether it
+    /// can be panned. Held as a record so the whole snapshot swaps in one reference write: the rect alone is
+    /// 16 bytes, well past a pointer, and <see cref="VideoRoi"/> / <see cref="CanJogRoi"/> are polled from the
+    /// render thread while the capture loop writes them. <see langword="null"/> means no stream is running.
+    /// </summary>
+    /// <param name="Roi">The magnified region in sensor px, as the body reports it.</param>
+    /// <param name="SensorWidth">The body's own full-frame width, which is what bounds the pan range. Taken
+    /// from the frame record rather than <see cref="CameraXSize"/>, because the body clamps a pan in the space
+    /// it reported and the two need not agree (active area against total).</param>
+    /// <param name="SensorHeight">The body's own full-frame height.</param>
+    /// <param name="CanPan">Magnified AND the body advertises the pan operation. False at 1x, where the crop is
+    /// the whole frame and the accepted range collapses to a single point.</param>
+    internal sealed record EvfWindow(RoiRect Roi, int SensorWidth, int SensorHeight, bool CanPan);
+
+    private EvfWindow? _evfWindow;
+
     /// <inheritdoc/>
     public bool CanVideoCapture => Connected;
 
     /// <inheritdoc/>
-    // No host-side ROI pan through the FC.SDK version we pin (see the region banner); the recenter loop falls
-    // back to mount jog. Promote to "true while zoomed" once we are on an FC.SDK that has SetEvfZoomPositionAsync.
-    public bool CanJogRoi => false;
+    // True only while the feed is a magnified, pannable crop. At 1x there is nowhere to pan to, so the
+    // recenter loop falls back to the mount on its own without needing to know why.
+    public bool CanJogRoi => Volatile.Read(ref _evfWindow) is { CanPan: true };
 
     /// <inheritdoc/>
     public int DroppedFrames => 0; // EVF has no drop counter.
 
     /// <inheritdoc/>
-    // Full-frame window: without a zoom-rect read we cannot report a magnified EVF crop's origin/size, and
-    // CanJogRoi is false so the recenter loop never reads this for panning. Sensor-sized default.
-    public RoiRect VideoRoi => new(0, 0, CameraXSize, CameraYSize);
+    // The magnified crop in SENSOR px, which is the space the pan range and JogRoiAsync are measured in.
+    // Deliberately not the size of the yielded frame: the EVF renders a 1104x736 crop as a ~1024x680 JPEG, so
+    // one frame px is ~1.08 sensor px at 5x. The recenter controller measures its offset in frame px and
+    // applies it as sensor px, so it under-corrects by that ratio, which a damped loop absorbs as a slightly
+    // lower gain. Reporting frame px instead would break the pan-range arithmetic (sensorWidth - roi.Width),
+    // which is the part the loop cannot be allowed to get wrong.
+    public RoiRect VideoRoi =>
+        Volatile.Read(ref _evfWindow)?.Roi ?? new RoiRect(0, 0, CameraXSize, CameraYSize);
 
     /// <inheritdoc/>
     public async IAsyncEnumerable<Image> CaptureVideoAsync(
@@ -789,6 +819,13 @@ internal sealed class CanonCameraDriver : ICameraDriver, IVideoCameraDriver
                 throw new CanonDriverException(startErr, "Failed to start Canon Live View");
             }
 
+            // The readout-window SIZE comes from NumX/NumY, per IVideoCameraDriver. An EOS offers three
+            // discrete crops rather than a free rectangle, so the request snaps to the nearest zoom level.
+            // Applied even when that is 1x, because zoom and pan PERSIST on the body: a stream that inherited
+            // a magnified crop from an earlier session would otherwise start on a corner of the sensor.
+            var zoom = ZoomForWindow(NumX, CameraXSize);
+            await ApplyEvfZoomAsync(camera, zoom, cancellationToken);
+
             // Requested exposure as a poll-cadence floor (EVF has no true integration time), clamped so a huge
             // value can't stall the feed. Live-tunable exposure is not modelled on EVF; ISO is (ApplyVideoControls).
             var pace = options.Exposure <= TimeSpan.Zero ? MinVideoPace
@@ -802,6 +839,16 @@ internal sealed class CanonCameraDriver : ICameraDriver, IVideoCameraDriver
                 if (!Connected)
                 {
                     yield break;
+                }
+
+                // Live-resizable, like every other streaming driver: re-read the requested window each pass
+                // and re-zoom when it now maps to a different level. ApplyEvfZoomAsync is total, so a
+                // cancellation here falls through to the token check that ends the loop.
+                var wanted = ZoomForWindow(NumX, CameraXSize);
+                if (wanted != zoom)
+                {
+                    zoom = wanted;
+                    await ApplyEvfZoomAsync(camera, zoom, cancellationToken);
                 }
 
                 // Fetch the next EVF JPEG. The await carries no yield, so its OCE is caught here and turned
@@ -861,6 +908,9 @@ internal sealed class CanonCameraDriver : ICameraDriver, IVideoCameraDriver
             {
                 Logger.LogDebug(ex, "Canon Live View stop failed");
             }
+            // No stream, no window: CanJogRoi goes false and VideoRoi reverts to the full-frame default rather
+            // than reporting the last crop as though it were still live.
+            Volatile.Write(ref _evfWindow, null);
             Interlocked.Exchange(ref _videoActive, 0);
         }
     }
@@ -880,10 +930,167 @@ internal sealed class CanonCameraDriver : ICameraDriver, IVideoCameraDriver
     }
 
     /// <inheritdoc/>
-    public ValueTask JogRoiAsync(int dxPixels, int dyPixels, CancellationToken cancellationToken = default)
-        => throw new InvalidOperationException(
-            "Canon Live View ROI jog is not wired: panning the EVF zoom crop needs an FC.SDK release we do not "
-            + "pin yet. CanJogRoi is false and the recenter loop uses mount jog instead.");
+    public async ValueTask JogRoiAsync(int dxPixels, int dyPixels, CancellationToken cancellationToken = default)
+    {
+        if (_camera is not { } camera || Volatile.Read(ref _evfWindow) is not { CanPan: true } window)
+        {
+            throw new InvalidOperationException(
+                "Canon Live View ROI jog needs a magnified, pannable EVF crop. CanJogRoi reports when that "
+                + "holds; at 1x the crop is the whole frame and the recenter loop uses mount jog instead.");
+        }
+
+        var (x, y) = ClampPan(window, dxPixels, dyPixels);
+        if (x == window.Roi.X && y == window.Roi.Y)
+        {
+            return; // Already against that edge; nothing to send.
+        }
+
+        // verify: false deliberately. The verify path polls live-view frames for up to a second to watch the
+        // move land, and this runs on the capture loop between frames, where a second of stall is the whole
+        // point of not doing it. Since the coordinate was clamped into the range the body accepts, the
+        // position it adopts is the one asked for, so the window is updated from the request.
+        var (err, _) = await camera.SetEvfZoomPositionAsync((uint)x, (uint)y, verify: false, cancellationToken);
+        if (err is not EdsError.OK)
+        {
+            Logger.LogDebug("Canon EVF pan to ({X},{Y}) failed: {Error}", x, y, err);
+            return;
+        }
+
+        Volatile.Write(ref _evfWindow, window with { Roi = window.Roi with { X = x, Y = y } });
+    }
+
+    /// <summary>
+    /// Puts the feed at <paramref name="zoom"/> and publishes the crop the body actually adopted.
+    /// </summary>
+    /// <remarks>
+    /// Verifies, because the zoom operation ACKs unconditionally and the body then streams pre-zoom frames for
+    /// about a second, so an unverified call followed by a rect read reports the PREVIOUS crop. Best-effort
+    /// throughout: a body that refuses to magnify keeps streaming whatever it is showing, and the window
+    /// published from its own rect then simply reports no pan range.
+    /// </remarks>
+    private async Task ApplyEvfZoomAsync(CanonCamera camera, CanonEvfZoom zoom, CancellationToken cancellationToken)
+    {
+        try
+        {
+            // The AF method gates magnification: LiveFace refuses to magnify on a body with a lens attached
+            // and ACKs the zoom regardless, so switch to the method that works first. Only when actually
+            // magnifying, because this WRITES a camera setting the user can see in the body's own menus, and
+            // plain full-frame streaming has no business changing it. Best-effort: a body that rejects the
+            // write just stays where it is, and the zoom verify below is what reports the consequence.
+            if (zoom is not CanonEvfZoom.Fit)
+            {
+                var afErr = await camera.SetEvfAfSystemAsync(CanonEvfAfSystem.Live, cancellationToken);
+                if (afErr is not EdsError.OK)
+                {
+                    Logger.LogDebug(
+                        "Canon EVF AF method could not be set to Live ({Error}); magnification may be refused",
+                        afErr);
+                }
+            }
+
+            var err = await camera.SetEvfZoomAsync(zoom, verify: true, cancellationToken);
+            if (err is not EdsError.OK)
+            {
+                Logger.LogWarning(
+                    "Canon EVF zoom {Zoom} was not adopted ({Error}); staying at the current magnification",
+                    zoom, err);
+            }
+
+            // Read the rect whatever the zoom answered: it is the only account of where the crop sits and how
+            // big it is, which is what the recenter loop pans, and it is right even when the zoom was refused.
+            PublishEvfWindow(camera, await camera.GetEvfZoomRectAsync(cancellationToken));
+        }
+        catch (OperationCanceledException)
+        {
+            // The stream is shutting down; the caller's own token check ends the enumeration.
+        }
+        catch (Exception ex)
+        {
+            Logger.LogDebug(ex, "Canon EVF zoom {Zoom} failed", zoom);
+        }
+    }
+
+    /// <summary>
+    /// Records the body's reported crop as the live ROI. A rect the body did not describe publishes a
+    /// full-frame window with no pan range, which is the honest answer: unknown geometry must never read as
+    /// pannable, or the recenter loop would jog against a window it cannot place.
+    /// </summary>
+    private void PublishEvfWindow(CanonCamera camera, CanonEvfZoomRect? rect)
+    {
+        var window = WindowFor(rect, camera.SupportsEvfZoomPosition, CameraXSize, CameraYSize);
+        Volatile.Write(ref _evfWindow, window);
+        Logger.LogDebug("Canon EVF window {Roi} of {W}x{H}, pannable {CanPan}",
+            window.Roi, window.SensorWidth, window.SensorHeight, window.CanPan);
+    }
+
+    /// <summary>
+    /// The window a reported zoom rect describes, or a non-pannable full-frame window when the body did not
+    /// describe one. Pure, so the rule that matters can be pinned: a rect we cannot place must never come back
+    /// pannable.
+    /// </summary>
+    /// <param name="rect">What the body reported, or <see langword="null"/> when it reported nothing.</param>
+    /// <param name="bodySupportsPan">Whether the body advertises the pan operation at all (0x9159).</param>
+    /// <param name="fallbackWidth">Sensor width to fall back on when the rect is absent or unusable.</param>
+    /// <param name="fallbackHeight">Sensor height to fall back on.</param>
+    internal static EvfWindow WindowFor(
+        CanonEvfZoomRect? rect, bool bodySupportsPan, int fallbackWidth, int fallbackHeight)
+    {
+        // A rect with no sensor bounds cannot answer "is this magnified" or "how far can it pan", and a zero
+        // crop is not a window at all, so both fall through to the full-frame default rather than being
+        // half-trusted.
+        if (rect is { SensorWidth: > 0, SensorHeight: > 0, Width: > 0, Height: > 0 } r)
+        {
+            return new EvfWindow(
+                new RoiRect((int)r.X, (int)r.Y, (int)r.Width, (int)r.Height),
+                (int)r.SensorWidth,
+                (int)r.SensorHeight,
+                r.IsMagnified && bodySupportsPan);
+        }
+
+        return new EvfWindow(
+            new RoiRect(0, 0, fallbackWidth, fallbackHeight), fallbackWidth, fallbackHeight, false);
+    }
+
+    /// <summary>
+    /// Where a pan of (<paramref name="dxPixels"/>, <paramref name="dyPixels"/>) from
+    /// <paramref name="window"/> may actually land.
+    /// </summary>
+    /// <remarks>
+    /// Clamped here rather than left to the body. A coordinate up to (sensor - crop) is accepted and then
+    /// clamped inwards by the body itself, but anything BEYOND that is discarded outright and the axis silently
+    /// keeps its previous value, which is indistinguishable from a pan that did not work. So asking for "the
+    /// far corner" with a large number moves nothing at all, and the far corner is computed instead.
+    /// </remarks>
+    internal static (int X, int Y) ClampPan(EvfWindow window, int dxPixels, int dyPixels)
+    {
+        var maxX = Math.Max(0, window.SensorWidth - window.Roi.Width);
+        var maxY = Math.Max(0, window.SensorHeight - window.Roi.Height);
+        return (
+            Math.Clamp(window.Roi.X + dxPixels, 0, maxX),
+            Math.Clamp(window.Roi.Y + dyPixels, 0, maxY));
+    }
+
+    /// <summary>
+    /// The zoom level whose crop is closest to a requested window width.
+    /// </summary>
+    /// <remarks>
+    /// An EOS offers three discrete magnifications rather than a free rectangle, so a requested size snaps to
+    /// one and the body's own rect is then the truth about what that means in pixels (a nominal 5x measures
+    /// 4.96x). Thresholds sit between the nominal factors, so a full-frame request gives 1x and a request for
+    /// a tenth gives 10x. A width of 0, the default before anything sets NumX, is a full-frame request.
+    /// </remarks>
+    internal static CanonEvfZoom ZoomForWindow(int requestedWidth, int sensorWidth)
+    {
+        if (requestedWidth <= 0 || sensorWidth <= 0 || requestedWidth >= sensorWidth)
+        {
+            return CanonEvfZoom.Fit;
+        }
+
+        var factor = (double)sensorWidth / requestedWidth;
+        return factor < 3.0 ? CanonEvfZoom.Fit
+            : factor < 7.5 ? CanonEvfZoom.X5
+            : CanonEvfZoom.X10;
+    }
 
     /// <inheritdoc/>
     public async ValueTask ApplyVideoControlsAsync(VideoCaptureOptions controls, CancellationToken cancellationToken = default)


### PR DESCRIPTION
## Why

FC.SDK `3.0.751` publishes live-view magnification, which is the DSLR planetary regime: at 5x the body sends a
near-1:1-pixel crop of a small sensor region instead of a downscaled whole frame, and that crop is pannable, so
it is also the mount-free recenter actuator the Phase C loop wanted and ZWO already had from `ASISetStartPos`.

This had been deferred for three releases behind a stated blocker that could never be satisfied: it asked for an
FC.SDK point/rect accessor for `Evf_ZoomPosition` / `Evf_ZoomRect`, and over PTP no such property exists. Those
are EDSDK's model of the feature. The camera takes zoom and pan as **operations** (0x9158 / 0x9159) and reports
the resulting crop as a **record inside the live-view frame**. 3.0 ships the operations.

## What landed

Re-pinned both FC.SDK packages from `1.7.*` to `3.0.*` (one release line, they move together), then wired it:
`NumX` picks a zoom level, `VideoRoi` reports the body's own rect, `CanJogRoi` / `JogRoiAsync` pan it.

`CanJogRoi` is true **exactly while the crop is magnified and the body advertises the pan operation**, so at 1x
the recenter loop still falls back to mount jog. That is the correct answer rather than a limitation: at 1x the
crop is the whole frame, so the accepted pan range collapses to a point.

## Every failure mode here is silent, which shaped the implementation

The zoom operation ACKs whether or not it magnified, and a pan coordinate past `[0, sensor - crop]` is
**discarded** rather than refused, leaving the axis on its previous value. So:

- **Level thresholds sit BETWEEN the nominal factors.** The body's 5x is a 1104 px crop of a 5472 px sensor, so a
  threshold placed *on* 5 would answer `Fit` when fed the body's own width, and the stream would drop out of
  magnification on its first resize check. There is a test for exactly that round trip.
- **The far corner is computed host-side** rather than requested with a large number, which would move nothing.
- **Level changes verify, the per-frame pan does not.** A zoom takes about a second while the body keeps
  streaming pre-zoom frames, so an immediate rect read returns the old crop; but a second of frame polling on
  the capture loop is the thing worth avoiding, and a coordinate already clamped into the accepted range lands
  where it was asked to, so the cached window updates from the request.
- **`Evf_AFMode = LiveFace` silently blocks magnification**, so `Live` is written first, but only when actually
  magnifying: it is a setting the user sees in the body's own menus and plain full-frame streaming has no
  business changing it.
- **1x is still applied explicitly at stream start**, because zoom and pan persist on the body, so a stream that
  inherited a magnified crop from an earlier session would otherwise open on a corner of the sensor.

## One deliberate deviation from the interface doc

`VideoRoi` is sensor px and **not** the size of the yielded frame. The EVF renders that 1104x736 crop as a
~1024x680 JPEG, so one frame px is ~1.08 sensor px at 5x, and `PlanetaryRecenterController` measures in frame px
while applying in sensor px. It therefore under-corrects by that ratio, which a damped loop absorbs as a
slightly lower gain. Reporting frame px instead would break the `sensorWidth - roi.Width` pan-range arithmetic,
which is the part the loop cannot be allowed to get wrong. Stated at the property and in the plan.

## Verification

Build clean at 0 warnings across the solution. 3795 unit tests pass, 0 fail, 19 skipped (the pre-existing
`IncrementalSolverTests` ones); +19 new.

The three decisions were made pure and `internal` so they could be pinned without a camera, using the measured
6D geometry: which level a requested width asks for, which window a reported rect describes, and where a pan may
land. The safety rule has its own test: a rect the body did not fully describe (crop record but no sensor
record) publishes a full-frame window that **cannot** be panned, because half-trusting it would let the loop jog
against a range it invented.

**Not hardware-verified from TianWen.** The FC.SDK side is verified on an EOS 6D, and the four measured
behaviours above come from that work, but this wiring has only been exercised through the pure tests. The
per-body risk is the zoom-position units (libgphoto2 measured "approx 64 pixel steps on the EOS 1000D"); the
Phase C per-axis cap bounds a wrong guess to a small mis-pan rather than a runaway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R8fbd6xrLU7H4sjEHWnsEH
