### PR TITLE
Sky-map pan ownership, catalog case folding, and the object deep link

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -394,7 +394,7 @@
          backend). It has moved with the family each time rather than being found two minors behind, which
          is the point of it living here. DIR.Lib 7.7's tree-stated hyperlinks matter most on this backend,
          since a web host is the one that can render a real anchor. -->
-    <PackageVersion Include="WebGl.Renderer" Version="1.16.*" />
+    <PackageVersion Include="WebGl.Renderer" Version="1.17.*" />
     <PackageVersion Include="SDL3-CS" Version="3.5.0-preview.20260213-150035" />
     <PackageVersion Include="SDL3-CS.Native" Version="3.5.0-preview.20260205-174353" />
     <!-- Canon DSLR. Both packages ship from the FC.SDK repo at one release line, so they move

--- a/src/TianWen.Lib.Tests/CatalogUtilTests.cs
+++ b/src/TianWen.Lib.Tests/CatalogUtilTests.cs
@@ -130,6 +130,37 @@ public class CatalogUtilTests
     }
 
     [Theory]
+    // The leading catalog letter is case-folded, so the spellings people actually type into a URL or
+    // a search box resolve. Before this, "M42" worked and "m42" did not: case tolerance was hand-rolled
+    // per arm and landed almost entirely on the SECOND character.
+    [InlineData("m42", "M042", Catalog.Messier)]
+    [InlineData("m 42", "M042", Catalog.Messier)]
+    [InlineData("ngc1976", "N1976", Catalog.NGC)]
+    [InlineData("ngc 1976", "N1976", Catalog.NGC)]
+    [InlineData("n11", "N0011", Catalog.NGC)]
+    [InlineData("ic434", "I0434", Catalog.IC)]
+    [InlineData("messier 120", "M120", Catalog.Messier)]
+    [InlineData("vdB 1", "vdB0001", Catalog.vdB)]  // the one arm that already paired 'v' with 'V'
+    [InlineData("VdB 1", "vdB0001", Catalog.vdB)]
+    public void TheLeadingCatalogLetterIsCaseInsensitive(string input, string expectedAbbreviation, Catalog expectedCatalog)
+    {
+        CatalogUtils.TryGetCleanedUpCatalogName(input, out var index).ShouldBeTrue();
+        index.ToAbbreviation().ShouldBe(expectedAbbreviation);
+        index.ToCatalog().ShouldBe(expectedCatalog);
+    }
+
+    [Theory]
+    // Every neighbouring arm pairs an upper-case second letter with its lower-case twin; this one read
+    // 'Y' or 'Y', so the lower-case spelling of the most-typed star catalog silently did not parse.
+    [InlineData("TYC 4038-2410-1")]
+    [InlineData("Tyc 4038-2410-1")]
+    public void TychoParsesWhicheverWayTheSecondLetterIsCased(string input)
+    {
+        CatalogUtils.TryGetCleanedUpCatalogName(input, out var index).ShouldBeTrue();
+        index.ToCatalog().ShouldBe(Catalog.Tycho2);
+    }
+
+    [Theory]
     [InlineData("Not an index")]
     [InlineData("   ")]
     [InlineData("")]

--- a/src/TianWen.Lib.Tests/SkyMapDeepLinkTests.cs
+++ b/src/TianWen.Lib.Tests/SkyMapDeepLinkTests.cs
@@ -1,0 +1,101 @@
+using System;
+using System.Threading.Tasks;
+using Shouldly;
+using TianWen.Lib.Astrometry.Catalogs;
+using TianWen.Lib.Astrometry.SOFA;
+using TianWen.UI.Abstractions;
+using Xunit;
+
+namespace TianWen.Lib.Tests;
+
+/// <summary>
+/// The "?object=" deep link, end to end through the real catalog.
+///
+/// <para>This exists because the reported failure was silent in the worst way: the address bar showed
+/// <c>?view=sky&amp;object=M42</c>, the Sky Atlas opened, and the view simply sat at its default
+/// pointing with no selection and no error. A resolve that answers false has nothing to report and
+/// nobody to report it to, so only a test that asserts the object was actually SELECTED can tell the
+/// difference between "resolved" and "quietly did nothing".</para>
+///
+/// <para>The web host's own ordering bug (it retried the resolve before <c>InitDBAsync</c> had run, so
+/// the catalog was still empty) is fixed in <c>Planner.razor</c>. These pin the other half: that the
+/// spellings a human actually types into a URL do resolve once the catalog IS up.</para>
+/// </summary>
+public class SkyMapDeepLinkTests
+{
+    private static readonly DateTimeOffset ViewingUtc = new(2026, 8, 6, 14, 0, 0, TimeSpan.Zero);
+    private const double SiteLat = -37.8769, SiteLon = 145.1774;
+
+    private static async Task<ICelestialObjectDB> LoadedDbAsync()
+    {
+        var db = new CelestialObjectDB();
+        await db.InitDBAsync();
+        return db;
+    }
+
+    private static bool Select(ICelestialObjectDB db, SkyMapState state, string token)
+        => SkyMapSearchActions.TrySelectByToken(
+            state.Search, state, db, token,
+            SiteLat, SiteLon, ViewingUtc,
+            SiteContext.Create(SiteLat, SiteLon, ViewingUtc));
+
+    [Theory]
+    [InlineData("M42")]     // exactly what a person types, and what the report used
+    [InlineData("M 42")]    // the catalog's own spacing
+    [InlineData("m42")]     // address bars are not case-preserving in practice
+    [InlineData("NGC1976")] // the same object under its other catalogue
+    [InlineData("NGC 1976")]
+    public async Task AMessierDeepLinkSelectsTheObjectAndOpensTheInfoPanel(string token)
+    {
+        var db = await LoadedDbAsync();
+        var state = new SkyMapState { Mode = SkyMapMode.Equatorial };
+
+        Select(db, state, token).ShouldBeTrue($"'{token}' is a spelling a deep link will really carry");
+
+        var panel = state.Search.InfoPanel.ShouldNotBeNull("the deep link must OPEN the detail view, not just resolve");
+        panel.Index.ShouldNotBeNull();
+
+        // M42 is at roughly RA 5h35m, Dec -5.4 deg. Assert the view actually went there -- resolving
+        // without centring is the same failure from the user's side.
+        state.CenterRA.ShouldBe(5.588, 0.05);
+        state.CenterDec.ShouldBe(-5.39, 0.1);
+    }
+
+    [Fact]
+    public async Task AnUnknownTokenIsRejectedAndChangesNothing()
+    {
+        // A typo must leave the view alone rather than centring on some near-miss.
+        var db = await LoadedDbAsync();
+        var state = new SkyMapState { Mode = SkyMapMode.Equatorial, CenterRA = 12.0, CenterDec = 30.0 };
+
+        Select(db, state, "M42x").ShouldBeFalse();
+
+        state.Search.InfoPanel.ShouldBeNull();
+        state.CenterRA.ShouldBe(12.0);
+        state.CenterDec.ShouldBe(30.0);
+    }
+
+    [Fact]
+    public async Task ACometDeepLinkResolvesFromEitherSpelling()
+    {
+        // The URL now carries the comet's display name ("10P/Tempel") rather than the bare designation,
+        // because "10P" alone says nothing about which comet it is. Both must still resolve, or a
+        // shared link from an older build breaks.
+        var db = await LoadedDbAsync();
+        var tenP = StubCometRepository.Comet("10P", "Tempel");
+        var comets = new StubCometRepository(tenP);
+        comets.Positions[tenP.CatalogIndex.ShouldNotBeNull()] = (21.514, -27.47, 12.75);
+
+        foreach (var token in new[] { "10P/Tempel", "10P" })
+        {
+            var state = new SkyMapState { Mode = SkyMapMode.Equatorial };
+            SkyMapSearchActions.TrySelectByToken(
+                state.Search, state, db, token,
+                SiteLat, SiteLon, ViewingUtc,
+                SiteContext.Create(SiteLat, SiteLon, ViewingUtc), comets).ShouldBeTrue($"'{token}' must resolve");
+
+            var panel = state.Search.InfoPanel.ShouldNotBeNull();
+            panel.Name.ShouldBe("10P/Tempel", "the panel always shows the full form, whichever spelling arrived");
+        }
+    }
+}

--- a/src/TianWen.Lib.Tests/SkyMapPanTests.cs
+++ b/src/TianWen.Lib.Tests/SkyMapPanTests.cs
@@ -1,0 +1,202 @@
+using System;
+using System.Numerics;
+using Shouldly;
+using TianWen.UI.Abstractions;
+using Xunit;
+
+namespace TianWen.Lib.Tests;
+
+/// <summary>
+/// What a pan does to the view, measured in the only unit that matters: where the star you grabbed
+/// ends up on screen.
+///
+/// <para>The reported bug was "after panning there is a jerky movement, and even after mouse release
+/// it would rotate", worse near the pole. Both halves were one cause. A drag rotates the whole frame
+/// rigidly, which near the pole legitimately earns a large roll -- at Dec -89 a 100 px pan earns 82
+/// degrees -- because a change of RA at the pole IS a rotation. The per-frame realign then servoed the
+/// roll back to the mode's absolute reference (a constant 0 in Equatorial), undoing it. The drag was
+/// never wrong; the thing that ran after it was.</para>
+///
+/// <para>The severity scaled with the roll earned, which is why it vanished toward the equator: 82
+/// degrees at the pole, 4.4 at Dec -30, exactly 0 at Dec 0.</para>
+/// </summary>
+public class SkyMapPanTests
+{
+    private const float ContentW = 1000f, ContentH = 800f;
+    private const double Fov = 60.0;
+    private const double FrameSeconds = 1.0 / 60.0;
+
+    private static Matrix4x4 ViewMatrix(SkyMapState s)
+    {
+        var (f, r0, u0) = SkyMapState.ReferenceFrame(s.CenterRA, s.CenterDec);
+        var (sinRoll, cosRoll) = Math.SinCos(s.CenterRoll);
+        var right = (float)cosRoll * r0 + (float)sinRoll * u0;
+        var up = (float)cosRoll * u0 - (float)sinRoll * r0;
+        return new Matrix4x4(
+            right.X, right.Y, right.Z, 0f,
+            up.X, up.Y, up.Z, 0f,
+            -f.X, -f.Y, -f.Z, 0f,
+            0f, 0f, 0f, 1f);
+    }
+
+    /// <summary>
+    /// SkyMapTab.HandleDrag's geometry, replayed against a state. Duplicated rather than driven
+    /// through the tab because the tab needs a render surface; the arithmetic below is copied from it
+    /// verbatim, so a change there that this misses shows up as this test agreeing with nothing.
+    /// </summary>
+    private static void Drag(SkyMapState s, float fromX, float fromY, float toX, float toY)
+    {
+        var ppr = SkyMapProjection.PixelsPerRadian(ContentH, s.FieldOfViewDeg);
+        float cx = ContentW * 0.5f, cy = ContentH * 0.5f;
+        var startMatrix = ViewMatrix(s);
+
+        s.IsDragging = true;
+        s.DragStart = (fromX, fromY);
+        s.DragStartCenter = (s.CenterRA, s.CenterDec);
+        s.DragStartViewMatrix = startMatrix;
+
+        var (ra1, dec1) = SkyMapProjection.UnprojectWithMatrix(fromX, fromY, startMatrix, ppr, cx, cy);
+        var (ra2, dec2) = SkyMapProjection.UnprojectWithMatrix(toX, toY, startMatrix, ppr, cx, cy);
+        var v1 = SkyMapState.RaDecToUnitVec(ra1, dec1);
+        var v2 = SkyMapState.RaDecToUnitVec(ra2, dec2);
+        var from = new Vector3(v2.X, v2.Y, v2.Z);
+        var to = new Vector3(v1.X, v1.Y, v1.Z);
+        var q = Quaternion.Normalize(new Quaternion(Vector3.Cross(from, to), 1f + Vector3.Dot(from, to)));
+
+        var startForward = new Vector3(-startMatrix.M31, -startMatrix.M32, -startMatrix.M33);
+        var startRight = new Vector3(startMatrix.M11, startMatrix.M12, startMatrix.M13);
+        var (newRA, newDec, newRoll) = SkyMapState.FrameToCenter(
+            Vector3.Transform(startForward, q), Vector3.Transform(startRight, q));
+
+        s.CenterRA = newRA;
+        s.CenterDec = newDec;
+        s.CenterRoll = newRoll;
+        s.NormalizeCenter();
+    }
+
+    private static void SettleAfterRelease(SkyMapState s)
+    {
+        s.IsDragging = false;
+        for (var frame = 0; frame < 600; frame++)
+        {
+            s.UpdateRollForReference(deltaSeconds: FrameSeconds);
+        }
+    }
+
+    [Theory]
+    [InlineData(-89.0)] // the DEFAULT southern view, and where this was unusable
+    [InlineData(-85.0)]
+    [InlineData(-60.0)]
+    [InlineData(-30.0)]
+    [InlineData(0.0)]
+    [InlineData(89.0)]  // and the northern default, since nothing here may be hemisphere-specific
+    public void TheGrabbedStarStaysUnderThePointer_AndDoesNotMoveAfterRelease(double startDec)
+    {
+        var s = new SkyMapState { Mode = SkyMapMode.Equatorial, FieldOfViewDeg = Fov, CenterRA = 16.12, CenterDec = startDec };
+        var ppr = SkyMapProjection.PixelsPerRadian(ContentH, Fov);
+        float cx = ContentW * 0.5f, cy = ContentH * 0.5f;
+
+        var (grabRA, grabDec) = SkyMapProjection.UnprojectWithMatrix(500f, 400f, ViewMatrix(s), ppr, cx, cy);
+        Drag(s, 500f, 400f, 600f, 400f);
+
+        SkyMapProjection.ProjectWithMatrix(grabRA, grabDec, ViewMatrix(s), ppr, cx, cy, out var releaseX, out var releaseY)
+            .ShouldBeTrue();
+        releaseX.ShouldBe(600f, 0.5f, "the grabbed star must sit under the pointer at mouse-up");
+        releaseY.ShouldBe(400f, 0.5f);
+
+        SettleAfterRelease(s);
+
+        SkyMapProjection.ProjectWithMatrix(grabRA, grabDec, ViewMatrix(s), ppr, cx, cy, out var settledX, out var settledY)
+            .ShouldBeTrue();
+        var slid = Math.Sqrt(Math.Pow(settledX - releaseX, 2) + Math.Pow(settledY - releaseY, 2));
+
+        // This measured 131.9 px at Dec -89 before the fix -- MORE than the 100 px the user dragged,
+        // so letting go threw the sky further than the gesture had moved it.
+        slid.ShouldBeLessThan(0.5, $"the sky must not keep moving after the gesture ends (Dec {startDec})");
+    }
+
+    [Theory]
+    // Alt/Az has the same requirement and the same singularity, with the ZENITH standing in for the
+    // pole: a pan must move the sky in the direction of the drag, so the point you grabbed ends up
+    // where you dropped it. Near the zenith the reference is ill-conditioned, which is exactly where
+    // servoing to it used to throw the field.
+    [InlineData(40.0, "at the zenith")]        // the site's zenith Dec, i.e. straight overhead
+    [InlineData(38.0, "just off the zenith")]  // and just outside the old lock cone, the worst case
+    [InlineData(10.0, "well down the sky")]
+    public void InAltAz_ThePanFollowsTheDragDirection(double startDec, string where)
+    {
+        // A fixed zenith: over one gesture the sky turns by microdegrees, and the claim here is about
+        // the gesture, not the sky's rotation (which InHorizonMode_TheRollFOLLOWS... covers).
+        var zenith = SkyMapState.RaDecToUnitVec(8.0, 40.0);
+        var s = new SkyMapState { Mode = SkyMapMode.Horizon, FieldOfViewDeg = Fov, CenterRA = 8.0, CenterDec = startDec };
+        var ppr = SkyMapProjection.PixelsPerRadian(ContentH, Fov);
+        float cx = ContentW * 0.5f, cy = ContentH * 0.5f;
+
+        // Grab off-centre and drag diagonally, so a sign error on either axis shows up.
+        const float fromX = 430f, fromY = 330f, toX = 610f, toY = 455f;
+        var (grabRA, grabDec) = SkyMapProjection.UnprojectWithMatrix(fromX, fromY, ViewMatrix(s), ppr, cx, cy);
+
+        Drag(s, fromX, fromY, toX, toY);
+        s.IsDragging = false;
+
+        SkyMapProjection.ProjectWithMatrix(grabRA, grabDec, ViewMatrix(s), ppr, cx, cy, out var x, out var y).ShouldBeTrue();
+        x.ShouldBe(toX, 0.5f, $"the grabbed point must land where the drag ended ({where})");
+        y.ShouldBe(toY, 0.5f, $"and on both axes ({where})");
+
+        // Still there after the frames that follow the release.
+        for (var frame = 0; frame < 600; frame++)
+        {
+            s.UpdateRollForReference(zenith.X, zenith.Y, zenith.Z, FrameSeconds);
+        }
+        SkyMapProjection.ProjectWithMatrix(grabRA, grabDec, ViewMatrix(s), ppr, cx, cy, out var settledX, out var settledY).ShouldBeTrue();
+        Math.Sqrt(Math.Pow(settledX - x, 2) + Math.Pow(settledY - y, 2))
+            .ShouldBeLessThan(0.5, $"and it must not drift once the gesture is over ({where})");
+    }
+
+    [Fact]
+    public void APanNearThePoleEarnsRoll_AndKeepsIt()
+    {
+        // The roll is not an artefact to be cleaned up: near the pole it is what holds the sky still
+        // under the pointer, because a change of RA at the pole is itself a rotation. Deleting it is
+        // exactly what made the field spin.
+        var s = new SkyMapState { Mode = SkyMapMode.Equatorial, FieldOfViewDeg = Fov, CenterRA = 16.12, CenterDec = -89.0 };
+        Drag(s, 500f, 400f, 600f, 400f);
+
+        var earned = double.RadiansToDegrees(s.CenterRoll);
+        Math.Abs(earned).ShouldBeGreaterThan(45.0, "a 100 px pan at Dec -89 rolls the frame a long way");
+
+        SettleAfterRelease(s);
+        double.RadiansToDegrees(s.CenterRoll).ShouldBe(earned, 1e-6, "and nothing may take it back unasked");
+    }
+
+    [Fact]
+    public void TheUserCanAlwaysGetBackToNorthUp()
+    {
+        // The counterpart of the rule above: since nothing re-levels on its own, there has to be a
+        // deliberate way back, or a pole pan leaves the atlas permanently tilted. (The L key.)
+        var s = new SkyMapState { Mode = SkyMapMode.Equatorial, FieldOfViewDeg = Fov, CenterRA = 16.12, CenterDec = -89.0 };
+        Drag(s, 500f, 400f, 600f, 400f);
+        s.IsDragging = false;
+
+        s.RequestLevelToReference();
+        for (var frame = 0; frame < 600 && s.IsLevelling; frame++)
+        {
+            s.UpdateRollForReference(deltaSeconds: FrameSeconds);
+        }
+
+        s.CenterRoll.ShouldBe(0.0, 1e-9, "north-up is roll 0 in Equatorial mode, at every declination");
+    }
+
+    [Fact]
+    public void RollIsNeverTakenBackMidGesture()
+    {
+        // The realign must not fight a drag that is still in progress either -- that was the earlier
+        // failure mode, a 63 degree jump the instant the drag left the old lock cone.
+        var s = new SkyMapState { Mode = SkyMapMode.Equatorial, FieldOfViewDeg = Fov, CenterRA = 16.12, CenterDec = -89.0 };
+        Drag(s, 500f, 400f, 600f, 400f); // leaves IsDragging true, as a mid-gesture move does
+        var midGesture = s.CenterRoll;
+
+        s.UpdateRollForReference(deltaSeconds: FrameSeconds).ShouldBeFalse("a pan owns the roll while it is happening");
+        s.CenterRoll.ShouldBe(midGesture, 1e-12);
+    }
+}

--- a/src/TianWen.Lib.Tests/SkyMapViewOrientationTests.cs
+++ b/src/TianWen.Lib.Tests/SkyMapViewOrientationTests.cs
@@ -100,6 +100,7 @@ public class SkyMapViewOrientationTests
         // a real defect: a pan held its rigid roll inside the cone and then snapped it away on the
         // way out, flipping the field by 63 degrees in one frame at Dec 85.
         var state = new SkyMapState { Mode = SkyMapMode.Equatorial, CenterRA = 6.0, CenterDec = dec };
+        state.RequestLevelToReference();
         state.UpdateRollForReference(deltaSeconds: FrameSeconds).ShouldBeTrue("Equatorial mode always knows where north is");
         state.CenterRoll.ShouldBe(0.0, 1e-9);
     }
@@ -123,10 +124,13 @@ public class SkyMapViewOrientationTests
     }
 
     [Fact]
-    public void AfterTheDrag_TheRollTravelsBackToLevel_WithoutSnapping()
+    public void AskedToLevel_TheRollTravelsBackToLevel_WithoutSnapping()
     {
         // A rolled view re-levels over several frames, taking the SHORT way round, and lands exactly.
         // One frame of it must be a small fraction of the journey, or it is the flip again.
+        //
+        // Note what triggers it: the USER asking (the L key). This travel used to run unbidden on
+        // every frame, which is what undid a pan the instant the button came up.
         var state = new SkyMapState
         {
             Mode = SkyMapMode.Equatorial,
@@ -135,6 +139,7 @@ public class SkyMapViewOrientationTests
             CenterRoll = double.DegreesToRadians(63.0), // the angle measured off the report
         };
 
+        state.RequestLevelToReference();
         state.UpdateRollForReference(deltaSeconds: FrameSeconds).ShouldBeTrue();
         var afterOneFrame = double.RadiansToDegrees(state.CenterRoll);
         afterOneFrame.ShouldBeLessThan(63.0, "it must move toward level");
@@ -165,12 +170,14 @@ public class SkyMapViewOrientationTests
         const double halfSecond = 0.5;
 
         var fast = new SkyMapState { Mode = SkyMapMode.Equatorial, CenterRA = 6.0, CenterDec = 85.0, CenterRoll = double.DegreesToRadians(startRoll) };
+        fast.RequestLevelToReference();
         for (var i = 0; i < 30; i++)
         {
             fast.UpdateRollForReference(deltaSeconds: halfSecond / 30);
         }
 
         var slow = new SkyMapState { Mode = SkyMapMode.Equatorial, CenterRA = 6.0, CenterDec = 85.0, CenterRoll = double.DegreesToRadians(startRoll) };
+        slow.RequestLevelToReference();
         for (var i = 0; i < 5; i++)
         {
             slow.UpdateRollForReference(deltaSeconds: halfSecond / 5);
@@ -182,12 +189,14 @@ public class SkyMapViewOrientationTests
 
         // And partway through, where the difference would actually show, they still track each other.
         var fastPartial = new SkyMapState { Mode = SkyMapMode.Equatorial, CenterRA = 6.0, CenterDec = 85.0, CenterRoll = double.DegreesToRadians(startRoll) };
+        fastPartial.RequestLevelToReference();
         for (var i = 0; i < 6; i++)
         {
             fastPartial.UpdateRollForReference(deltaSeconds: 1.0 / 60);
         }
 
         var slowPartial = new SkyMapState { Mode = SkyMapMode.Equatorial, CenterRA = 6.0, CenterDec = 85.0, CenterRoll = double.DegreesToRadians(startRoll) };
+        slowPartial.RequestLevelToReference();
         slowPartial.UpdateRollForReference(deltaSeconds: 6.0 / 60);
 
         double.RadiansToDegrees(fastPartial.CenterRoll)
@@ -208,15 +217,22 @@ public class SkyMapViewOrientationTests
             CenterDec = 85.0,
             CenterRoll = double.DegreesToRadians(63.0),
         };
+        state.RequestLevelToReference();
 
-        // First call has no previous instant, so it takes the nominal frame (1/60 s) and moves ~25%.
+        // First call has no previous instant, so it takes the NOMINAL frame (1/60 s). That is exact and
+        // owes nothing to the clock: 63 * exp(-(1/60) / 0.058) = 47.27 degrees remaining.
         state.UpdateRollForReference().ShouldBeTrue();
         var afterFirst = double.RadiansToDegrees(state.CenterRoll);
-        afterFirst.ShouldBeInRange(40.0, 55.0);
+        afterFirst.ShouldBe(63.0 * Math.Exp(-(1.0 / 60.0) / 0.058), 0.01);
 
-        // Immediately again: real elapsed time is microseconds, so this is nearly a no-op.
+        // Immediately again: now it MEASURES, so how far it travels depends on how long the machine
+        // took to get here -- which under a loaded full-suite run is milliseconds, not microseconds.
+        // Pinning a tight delta here made this flaky by design, so assert only what is true at any
+        // scheduling: it keeps approaching and never overshoots past the target.
         state.UpdateRollForReference().ShouldBeTrue();
-        double.RadiansToDegrees(state.CenterRoll).ShouldBe(afterFirst, tolerance: 1.0);
+        var afterSecond = double.RadiansToDegrees(state.CenterRoll);
+        afterSecond.ShouldBeLessThan(afterFirst, "a measured interval is still an interval, so it moves");
+        afterSecond.ShouldBeGreaterThanOrEqualTo(0.0, "and however long the gap, it may not sail past level");
     }
 
     [Theory]
@@ -234,6 +250,7 @@ public class SkyMapViewOrientationTests
             Mode = SkyMapMode.Equatorial,
             CenterRoll = double.DegreesToRadians(startRollDeg),
         };
+        state.RequestLevelToReference();
 
         var before = Math.Abs(startRollDeg);
         state.UpdateRollForReference(deltaSeconds: FrameSeconds);
@@ -247,15 +264,55 @@ public class SkyMapViewOrientationTests
     [Fact]
     public void AlreadyLevel_IsUntouched_AndAsksForNoExtraFrame()
     {
-        // The common case by far, since the Equatorial target is a constant 0: the approach must cost
-        // it nothing, including not requesting redraws forever.
+        // The common case by far: nobody asked for a re-level and celestial north has not moved, so
+        // the frame must cost nothing at all -- no roll change and no request for another frame.
         var state = new SkyMapState { Mode = SkyMapMode.Equatorial, CenterRA = 3.0, CenterDec = 20.0 };
         state.NeedsRedraw = false;
 
-        state.UpdateRollForReference(deltaSeconds: FrameSeconds).ShouldBeTrue();
+        state.UpdateRollForReference(deltaSeconds: FrameSeconds).ShouldBeFalse("nothing is travelling");
 
         state.CenterRoll.ShouldBe(0.0);
         state.NeedsRedraw.ShouldBeFalse("a level view is not travelling anywhere");
+    }
+
+    [Fact]
+    public void InHorizonMode_TheRollFOLLOWSTheZenithAsTheSkyTurns_ButOnlyByHowFarItMoved()
+    {
+        // Horizon mode's reference really does move (the sky turns ~15 deg/hr), and keeping the
+        // horizon level over a session is the one thing the per-frame realign is entitled to do.
+        // It must do it by tracking the reference's MOTION, never by servoing to its absolute value:
+        // servoing is what dragged a panned view back and made the sky slide after mouse-up.
+        var state = new SkyMapState { Mode = SkyMapMode.Horizon, CenterRA = 8.0, CenterDec = 10.0 };
+        var zenith = SkyMapState.RaDecToUnitVec(4.0, 40.0);
+        state.RequestLevelToReference();
+        for (var frame = 0; frame < 200; frame++)
+        {
+            state.UpdateRollForReference(zenith.X, zenith.Y, zenith.Z, FrameSeconds);
+        }
+        var levelRoll = state.CenterRoll;
+
+        // A gesture rolls the frame off level. Nothing may take that back on its own.
+        state.CenterRoll = levelRoll + double.DegreesToRadians(30.0);
+        state.UpdateRollForReference(zenith.X, zenith.Y, zenith.Z, FrameSeconds);
+        double.RadiansToDegrees(state.CenterRoll - levelRoll)
+            .ShouldBe(30.0, 1e-6, "a static zenith must leave the gesture's roll exactly alone");
+
+        // Now the sky turns. The roll follows it, carrying the gesture's 30 degrees along.
+        var rolled = state.CenterRoll;
+        var moved = SkyMapState.RaDecToUnitVec(4.25, 40.0); // a quarter hour of RA later
+        state.UpdateRollForReference(moved.X, moved.Y, moved.Z, FrameSeconds);
+        var followed = state.CenterRoll - rolled;
+        Math.Abs(followed).ShouldBeGreaterThan(1e-6, "the horizon must stay level as the sky turns");
+
+        // And it followed by exactly the reference's own motion, so the 30 degree offset survives.
+        var reference = new SkyMapState { Mode = SkyMapMode.Horizon, CenterRA = 8.0, CenterDec = 10.0 };
+        reference.RequestLevelToReference();
+        for (var frame = 0; frame < 200; frame++)
+        {
+            reference.UpdateRollForReference(moved.X, moved.Y, moved.Z, FrameSeconds);
+        }
+        double.RadiansToDegrees(state.CenterRoll - reference.CenterRoll)
+            .ShouldBe(30.0, 1e-3, "the gesture's offset rides along, it is not eaten by the tracking");
     }
 
     [Theory]
@@ -296,12 +353,13 @@ public class SkyMapViewOrientationTests
     {
         var zenith = SkyMapState.RaDecToUnitVec(4.0, 40.0);
         var state = new SkyMapState { Mode = SkyMapMode.Horizon, CenterRA = 8.0, CenterDec = 10.0 };
+        state.RequestLevelToReference(); // entering the mode establishes its frame (the P key does this)
 
         // The roll APPROACHES its target a fraction per frame, so settle it before measuring; one
         // call is deliberately only part of the way.
         for (var frame = 0; frame < 200; frame++)
         {
-            state.UpdateRollForReference(zenith.X, zenith.Y, zenith.Z, FrameSeconds).ShouldBeTrue();
+            state.UpdateRollForReference(zenith.X, zenith.Y, zenith.Z, FrameSeconds);
         }
 
         var m = state.ComputeViewMatrix();

--- a/src/TianWen.Lib/Astrometry/Catalogs/CatalogUtils.cs
+++ b/src/TianWen.Lib/Astrometry/Catalogs/CatalogUtils.cs
@@ -53,7 +53,9 @@ public static partial class CatalogUtils
     private static partial Regex WDSPatternGen();
     private static readonly Regex WDSPattern = WDSPatternGen();
 
-    [GeneratedRegex(@"(?:TYC) ([0-9]{1,4})-([0-9]{1,5})-([1-3])", CommonOpts)]
+    // IgnoreCase so "Tyc"/"tyc" parse as well as "TYC". Safe to fold on this pattern specifically:
+    // the only letters in it are the catalog tag, so nothing else can match more widely.
+    [GeneratedRegex(@"(?:TYC) ([0-9]{1,4})-([0-9]{1,5})-([1-3])", CommonOpts | RegexOptions.IgnoreCase)]
     private static partial Regex Tyc2PatternGen();
     private static readonly Regex Tyc2Pattern = Tyc2PatternGen();
 
@@ -427,7 +429,18 @@ public static partial class CatalogUtils
         var secondChar = noSpaces[1];
         var secondIsDigit = char.IsDigit(secondChar);
 
-        (template, catalog) = noSpaces[0] switch
+        // The LEADING catalog letter is matched case-insensitively; the rest of the input is passed
+        // through untouched. Case tolerance below is hand-rolled per arm and lands almost entirely on
+        // the SECOND character ("NGC"/"ngc", "Sh2"/"sh2"), so "M42" resolved while "m42" did not --
+        // which a deep link ("?object=m42") or a lower-cased shared URL hits immediately, and the
+        // search box does not, because it binary-searches OrdinalIgnoreCase.
+        //
+        // Only the first character is folded, deliberately. trimmedInput is handed on to the RA/Dec
+        // regexes (2MASS, PSR, WDS, BD) and to the template arms that match specific lowercase letters
+        // ("Mel", "Sh2", "Messier"), so upper-casing the whole string would change what those match.
+        // Folding one character is strictly additive instead: correctly-cased input takes the identical
+        // path, and input that used to fail either resolves now or fails exactly as it did.
+        (template, catalog) = char.ToUpperInvariant(noSpaces[0]) switch
         {
             // Numbered comets ("13P", "73P-C", "24P/Schaumasse") must be probed before the 2MASS arms:
             // "24P/S..." would otherwise satisfy the '2' + [4]=='S' check.
@@ -468,7 +481,7 @@ public static partial class CatalogUtils
             'M' => secondChar switch
             {
                 'e' when noSpaces.Length > 2 && noSpaces[2] == 'l' => ("Mel000", Catalog.Melotte),
-                'e' when noSpaces.Length > 6 && noSpaces[0..7] == "Messier" => ("M00*", Catalog.Messier),
+                'e' or 'E' when noSpaces.Length > 6 && noSpaces.AsSpan(0, 7).Equals("Messier", StringComparison.OrdinalIgnoreCase) => ("M00*", Catalog.Messier),
                 'W' => ("MWSC0000", Catalog.MWSC),
                 _ when secondIsDigit => ("M00*", Catalog.Messier),
                 _ => ("", 0)
@@ -482,9 +495,10 @@ public static partial class CatalogUtils
             'R' when secondChar == 'C' => ("RCW000*", Catalog.RCW),
             'S' when secondChar is 'H' or 'h' && noSpaces.Length > 2 && noSpaces[2] is '2' or 'a' => ("Sh2-000*", Catalog.Sharpless),
             'T' when secondIsDigit || secondChar == 'r' => ("TrES00", Catalog.TrES),
-            'T' when secondChar is 'Y' or 'Y' => ("TYC 0000-00000-0", Catalog.Tycho2),
+            'T' when secondChar is 'Y' or 'y' => ("TYC 0000-00000-0", Catalog.Tycho2),
             'U' when secondIsDigit || secondChar == 'G' => ("U00000", Catalog.UGC),
-            'v' or 'V' when secondChar is 'd' or 'D' => ("vdB000*", Catalog.vdB),
+            // (first char is already folded above, so 'V' alone covers "vdB" and "VdB")
+            'V' when secondChar is 'd' or 'D' => ("vdB000*", Catalog.vdB),
             'W' when secondChar == 'D' && noSpaces.Length > 2 && noSpaces[2] == 'S' => ("", Catalog.WDS),
             'W' when secondIsDigit || secondChar == 'A' => ("WASP000", Catalog.WASP),
             'X' when secondIsDigit || secondChar == 'O' => ("XO000*", Catalog.XO),

--- a/src/TianWen.UI.Abstractions/SkyMapState.cs
+++ b/src/TianWen.UI.Abstractions/SkyMapState.cs
@@ -854,6 +854,16 @@ namespace TianWen.UI.Abstractions
         /// swings), and at exact parallelism the old code substituted a hardcoded right vector.
         /// Storing the roll removes the derivation, so no view direction is special.
         /// </para>
+        /// <para>
+        /// <b>Owned by the user's gestures.</b> A pan rotates the whole frame rigidly and keeps
+        /// whatever roll that earns; the mode's reference may only add the amount the reference itself
+        /// MOVED (nothing in Equatorial, the sky's rotation in Horizon). It must never servo to the
+        /// reference's absolute value, which is what it used to do: near the pole a change of RA is
+        /// itself a rotation, so a 100 px pan at Dec -89 legitimately earns 82 degrees of roll, and
+        /// erasing that on mouse-up threw the sky 132 px -- further than the gesture had moved it.
+        /// <see cref="RequestLevelToReference"/> (the L key) is the only way back to the reference, and
+        /// it is deliberate.
+        /// </para>
         /// </summary>
         public double CenterRoll { get; set; }
 
@@ -903,6 +913,47 @@ namespace TianWen.UI.Abstractions
         /// elapsed read for animation pacing, never a wall-clock read, so it does not belong to
         /// <c>ITimeProvider</c> (same rule the sky map's zoom-flood detector follows).</summary>
         private long _rollRealignTicks;
+
+        /// <summary>
+        /// The reference roll seen on the previous frame, and whether one has been seen at all.
+        /// <para>
+        /// The roll follows the reference's <b>motion</b>, never its absolute value. That distinction
+        /// is the whole fix for the pan bug: servoing to the absolute reference means every frame after
+        /// a gesture drags the view back toward it, so a pan that legitimately rolled the frame is
+        /// undone the instant the button comes up. Tracking the delta instead leaves a gesture alone
+        /// and still turns the field as the sky turns, which is the only thing the reference is
+        /// actually entitled to do.
+        /// </para>
+        /// <para>
+        /// Cleared whenever the reference is unusable (a drag in progress, an ill-conditioned zenith)
+        /// so the motion missed during the gap is never replayed as one jump on the way out.
+        /// </para>
+        /// </summary>
+        private double _lastReferenceRoll;
+        private bool _hasReferenceRoll;
+
+        /// <summary>Set by <see cref="RequestLevelToReference"/>; the one case that is allowed to servo
+        /// to the reference's absolute value, because the user asked for exactly that.</summary>
+        private bool _levelRequested;
+
+        /// <summary>
+        /// Level the view to the mode's reference (north-up in Equatorial, zenith-up in Horizon),
+        /// easing there over the next few frames rather than snapping.
+        /// <para>
+        /// This exists because the roll is now owned by the user's gestures and nothing takes it back
+        /// automatically. A drag near the pole legitimately rolls the frame by tens of degrees -- at
+        /// Dec -89 a 100 px pan earns 82 -- and without a deliberate way back the atlas would simply
+        /// stay tilted.
+        /// </para>
+        /// </summary>
+        public void RequestLevelToReference()
+        {
+            _levelRequested = true;
+            NeedsRedraw = true;
+        }
+
+        /// <summary>True while a requested re-level is still travelling, for tests and status text.</summary>
+        internal bool IsLevelling => _levelRequested;
 
         /// <summary>
         /// The view frame at <see cref="CenterRA"/> / <see cref="CenterDec"/> with
@@ -988,6 +1039,7 @@ namespace TianWen.UI.Abstractions
             // view flipping rather than as a pan.
             if (IsDragging)
             {
+                _hasReferenceRoll = false;
                 return false;
             }
 
@@ -998,6 +1050,7 @@ namespace TianWen.UI.Abstractions
                 var refLen = reference.Length();
                 if (refLen < 1e-6f)
                 {
+                    _hasReferenceRoll = false;
                     return false;
                 }
                 reference /= refLen;
@@ -1009,6 +1062,7 @@ namespace TianWen.UI.Abstractions
                 var perpendicular = reference - forward * Vector3.Dot(reference, forward);
                 if (perpendicular.Length() < ReferenceRollLockSin)
                 {
+                    _hasReferenceRoll = false;
                     return false;
                 }
 
@@ -1022,17 +1076,48 @@ namespace TianWen.UI.Abstractions
                 target = 0.0;
             }
 
-            var delta = NormalizeSignedAngle(target - CenterRoll);
-            if (Math.Abs(delta) <= RollRealignSnapRad)
+            // The deliberate re-level: the only path allowed to servo to the reference's ABSOLUTE
+            // value, because that is precisely what the user asked for.
+            if (_levelRequested)
             {
-                CenterRoll = target;
+                var toGo = NormalizeSignedAngle(target - CenterRoll);
+                if (Math.Abs(toGo) <= RollRealignSnapRad)
+                {
+                    CenterRoll = target;
+                    _levelRequested = false;
+                }
+                else
+                {
+                    // Travel the shortest way round at a fixed rate PER SECOND, and keep asking for
+                    // frames until it arrives. Snapping straight there is what the flip was.
+                    CenterRoll = NormalizeSignedAngle(CenterRoll + toGo * (1.0 - Math.Exp(-elapsed / RollRealignTimeConstantSec)));
+                    NeedsRedraw = true;
+                }
+                _lastReferenceRoll = target;
+                _hasReferenceRoll = true;
                 return true;
             }
 
-            // Travel the shortest way round at a fixed rate PER SECOND, and keep asking for frames
-            // until it arrives. Snapping straight to the target is what the flip was.
-            var step = 1.0 - Math.Exp(-elapsed / RollRealignTimeConstantSec);
-            CenterRoll = NormalizeSignedAngle(CenterRoll + delta * step);
+            // Otherwise follow only how far the reference MOVED since the previous frame. In
+            // Equatorial that is identically zero -- celestial north does not go anywhere -- so a pan
+            // keeps every degree of roll it earned. In Horizon it is the sky's own rotation, about
+            // 0.004 degrees per frame, which needs no easing and keeps the horizon level over a
+            // session without ever contradicting a gesture.
+            if (!_hasReferenceRoll)
+            {
+                _lastReferenceRoll = target;
+                _hasReferenceRoll = true;
+                return false;
+            }
+
+            var moved = NormalizeSignedAngle(target - _lastReferenceRoll);
+            _lastReferenceRoll = target;
+            if (moved == 0.0)
+            {
+                return false;
+            }
+
+            CenterRoll = NormalizeSignedAngle(CenterRoll + moved);
             NeedsRedraw = true;
             return true;
         }
@@ -1050,7 +1135,7 @@ namespace TianWen.UI.Abstractions
 
         /// <summary>Wraps an angle in radians to (-pi, pi], so a roll correction always takes the
         /// short way round rather than most of a turn the other way.</summary>
-        private static double NormalizeSignedAngle(double radians)
+        internal static double NormalizeSignedAngle(double radians)
         {
             var wrapped = (radians + Math.PI) % Math.Tau;
             if (wrapped < 0)

--- a/src/TianWen.UI.Abstractions/SkyMapTab.cs
+++ b/src/TianWen.UI.Abstractions/SkyMapTab.cs
@@ -809,10 +809,15 @@ namespace TianWen.UI.Abstractions
                 : $"FOV: {State.FieldOfViewDeg:F1}\u00B0";
             var modeLabel = State.Mode == SkyMapMode.Equatorial ? "EQ" : "AZ";
             var skyHint = State.MilkyWayAvailable ? " [S]ky" : "";
+            // Surfaced only while the view is actually off its reference, so the way back appears at
+            // exactly the moment it is wanted instead of sitting in the strip as one more letter.
+            // A pan near the pole rolls the frame by design and this is the only route back.
+            var rollDeg = double.RadiansToDegrees(SkyMapState.NormalizeSignedAngle(State.CenterRoll));
+            var levelHint = Math.Abs(rollDeg) >= 1.0 ? $"  [L]evel ({rollDeg:+0;-0}°)" : "";
             // Limiting magnitude actually rendered (FOV-aware; grows as you zoom in). Gives the
             // +/- magnitude-floor keys visible feedback, which they previously lacked.
             var magText = $"Lim mag {State.EffectiveMagnitudeLimit:F1}";
-            var info = $"RA: {State.CenterRA:F2}h  Dec: {State.CenterDec:F1}\u00B0    {fovText}    {magText}    [{modeLabel}]  [H]orizon [G]rid [A]lt/Az [B]oundaries [C]onst [P]roj [O]bjects [D]ark [M]ount com[e]t{skyHint}";
+            var info = $"RA: {State.CenterRA:F2}h  Dec: {State.CenterDec:F1}\u00B0    {fovText}    {magText}    [{modeLabel}]  [H]orizon [G]rid [A]lt/Az [B]oundaries [C]onst [P]roj [O]bjects [D]ark [M]ount com[e]t{skyHint}{levelHint}";
 
             DrawText(info.AsSpan(), fontPath,
                 rect.X + 8, stripY, rect.Width - 16, stripH,
@@ -1223,10 +1228,21 @@ namespace TianWen.UI.Abstractions
                     State.ShowComets = !State.ShowComets;
                     State.NeedsRedraw = true;
                     return true;
+                // Level the view back to the mode's reference. Needed because a pan owns the roll and
+                // nothing takes it back on its own any more: a drag near the pole legitimately rolls
+                // the frame by tens of degrees, and this is the way back to north-up (zenith-up in
+                // Horizon mode).
+                case InputKey.L:
+                    State.RequestLevelToReference();
+                    return true;
                 case InputKey.P:
                     State.Mode = State.Mode == SkyMapMode.Equatorial
                         ? SkyMapMode.Horizon
                         : SkyMapMode.Equatorial;
+                    // Establish the new mode's frame. Nothing else does it any more: the roll now
+                    // belongs to the user's gestures, so entering Horizon mode with a pan's roll
+                    // still on the view would leave the horizon tilted and never straighten it.
+                    State.RequestLevelToReference();
                     State.NeedsRedraw = true;
                     return true;
                 // Ctrl +/- : keyboard zoom (centre-anchored, spin-free). Plain +/- adjusts the

--- a/src/TianWen.UI.Web/Pages/Planner.razor
+++ b/src/TianWen.UI.Web/Pages/Planner.razor
@@ -335,6 +335,9 @@
         await Db.InitDBAsync();
         Console.WriteLine($"[tianwen-web] catalog init: {sw.ElapsedMilliseconds} ms");
 
+        // The catalog is only NOW loaded, so a "?object=<dso>" deep link can finally resolve.
+        ApplyPendingObjectSelection();
+
         // The catalog sweep (or the lighter same-site rescore) + altitude profiles are one long
         // synchronous block; on the single browser thread nothing repaints while it runs.
         // SetStatusAsync yields first so the status above actually paints before the block starts.
@@ -778,6 +781,9 @@
             // AppSignalHandler rebuilds the cache on comet load).
             _autoComplete = PlannerActions.BuildAutoCompleteList(Db, Comets);
             Console.WriteLine($"[tianwen-web] comets loaded: {sw.ElapsedMilliseconds} ms");
+
+            // A "?object=<comet>" deep link could not resolve until the repository was populated.
+            ApplyPendingObjectSelection();
         }
         catch (Exception ex)
         {
@@ -1040,9 +1046,7 @@
     // per click; the address bar still holds a shareable link to whatever is selected right now.
     void SyncObjectToUrl()
     {
-        var token = _skyTab?.State.Search.InfoPanel is { } panel
-            ? (string.IsNullOrWhiteSpace(panel.Canonical) ? panel.Name : panel.Canonical)
-            : null;
+        var token = _skyTab?.State.Search.InfoPanel is { } panel ? UrlTokenFor(panel) : null;
         if (string.Equals(token, _urlObject, StringComparison.Ordinal))
         {
             return;
@@ -1051,10 +1055,27 @@
         _urlObject = token;
         var viewToken = _view == View.SkyMap ? "sky" : "planner";
         var url = token is { Length: > 0 }
-            ? $"{Nav.BaseUri}?view={viewToken}&object={Uri.EscapeDataString(token)}"
+            ? $"{Nav.BaseUri}?view={viewToken}&object={EscapeObjectToken(token)}"
             : $"{Nav.BaseUri}?view={viewToken}";
         Nav.NavigateTo(url, forceLoad: false, replace: true);
     }
+
+    // What to write into "?object=". A COMET takes its display name ("10P/Tempel"), not its canonical
+    // designation ("10P"): the designation alone is a bare catalogue number that says nothing about
+    // which comet it is, and the full form is what the object calls itself everywhere else in the app.
+    // Both resolve on the way back in -- CometSearchKeys.TryResolve accepts either -- so preferring the
+    // informative one costs nothing. Everything else keeps the canonical index, which is the stable
+    // identifier for a catalogued object (a common name like "Orion Nebula" is not).
+    static string UrlTokenFor(SkyMapInfoPanelData panel)
+        => panel.ObjType == ObjectType.Comet && !string.IsNullOrWhiteSpace(panel.Name)
+            ? panel.Name
+            : (string.IsNullOrWhiteSpace(panel.Canonical) ? panel.Name : panel.Canonical);
+
+    // Uri.EscapeDataString escapes "/" to %2F, which is correct for a path segment and needless in a
+    // query value -- RFC 3986 lists "/" among the characters a query may contain literally. Restoring
+    // it keeps "10P/Tempel" readable in the address bar instead of "10P%2FTempel", and it round-trips
+    // because UnescapeDataString leaves a bare "/" alone.
+    static string EscapeObjectToken(string token) => Uri.EscapeDataString(token).Replace("%2F", "/", StringComparison.Ordinal);
 
     // Apply "?object=" from the address bar (deep link, refresh, back/forward). Resolves through the
     // SEARCH resolver rather than a catalog lookup, so a comet designation restores too -- comets are
@@ -1089,7 +1110,15 @@
     }
 
     // A deep link is parsed before the catalog (and the comet set) has loaded, so the resolve above
-    // can legitimately fail on the first attempt. Retried once the tab and the catalog are up.
+    // can legitimately fail on the first attempt. Retried from every point where one of those inputs
+    // has just become available: after the sky tab is constructed, after InitDBAsync, and after the
+    // comet fetch settles.
+    //
+    // All three matter, and the first version only called it at the first, which is why "?object=M42"
+    // put M42 in the address bar and left the view at the default pole: at that point the tab existed
+    // but Db.InitDBAsync had not run yet (it is awaited inside ComputeAsync, further down
+    // OnInitializedAsync), so the catalog was empty and the resolve simply answered false with nothing
+    // to retry it. Idempotent and cheap -- it returns immediately once something is selected.
     void ApplyPendingObjectSelection()
     {
         if (_urlObject is not { Length: > 0 } token
@@ -1153,7 +1182,7 @@
         // keep the path at the app root, so a refresh/share stays 404-safe on GitHub Pages (see
         // ApplyViewFromLocation, which also treats a bare root as the Planner default).
         // OnLocationChanged syncs the URL back to the active view + chips.
-        var objectSuffix = _urlObject is { Length: > 0 } token ? $"&object={Uri.EscapeDataString(token)}" : "";
+        var objectSuffix = _urlObject is { Length: > 0 } token ? $"&object={EscapeObjectToken(token)}" : "";
         Nav.NavigateTo($"{Nav.BaseUri}?view={(view == View.SkyMap ? "sky" : "planner")}{objectSuffix}");
     }
 


### PR DESCRIPTION
Four reported defects, plus two found while pinning them. Every claim below is measured, not inferred.

## The pan kept moving after mouse release, worse near the pole

The drag was never wrong. It rotates the whole view frame rigidly, and near the pole that legitimately earns a large roll, because a change of RA at the pole *is* a rotation. Over a 100 px horizontal pan:

| start Dec | roll earned | slid after release (before) | after |
|---|---|---|---|
| -89 (the default southern view) | 82.5 deg | **131.9 px** | 0.0 px |
| -85 | 56.7 deg | 95.0 px | 0.0 px |
| -30 | 4.4 deg | 7.7 px | 0.0 px |
| 0 | 0.0 deg | 0.0 px | 0.0 px |

That roll is what holds the sky still under the pointer: with it, the grabbed star lands exactly under the cursor at release at every declination. `UpdateRollForReference` then servoed the roll back to the mode's absolute reference every frame, and in Equatorial that reference is the constant 0 - so it had no legitimate work at all and existed only to undo the user's own pan. It threw the grabbed star further than the gesture had moved it. Severity tracked the roll earned, which is why it faded toward the equator.

The roll now follows how far the reference **moved** since the previous frame instead of servoing to its value: identically nothing in Equatorial, the sky's own rotation in Horizon, so the horizon still self-levels over a session and carries a gesture's offset along untouched.

An earlier attempt made this travel frame-rate independent. Right in itself, wrong as a fix: it changed how fast the unwind ran, not that it ran.

**Behaviour change:** nothing re-levels unprompted now, so after a pole pan the view stays tilted until **L**. The status strip shows `[L]evel (+82 deg)` only while the view is off its reference.

## A deep link put the object in the URL and did nothing

`?view=sky&object=M42` opened the atlas, left the view at its default pointing, and reported nothing. Two independent causes:

- The retry that exists for this ran too early - right after the sky tab was constructed, while `Db.InitDBAsync` is awaited further down `OnInitializedAsync` inside `ComputeAsync`. The catalog was empty, the resolve answered false, and nothing asked again. It now also runs after catalog init and after the comet fetch settles.
- `m42` would not have resolved even then (below).

A resolve that answers false has nobody to report to, which is why this was invisible. The new tests assert the object is **selected and the view centred**, since resolving without centring is the same failure from the user's side.

## The catalog parser only folded case in places

There is no case folding anywhere in `CatalogUtils`. The cleanup trims and strips spaces; case tolerance is hand-rolled per arm and lands almost entirely on the *second* character (`NGC`/`ngc`, `Sh2`/`sh2`), with vdB the only first-char pair in the switch. So `M42` resolved and `m42` did not - while the search box, which binary-searches `OrdinalIgnoreCase`, found both.

Only the leading character is folded, deliberately: `trimmedInput` is passed on to the RA/Dec regexes (2MASS, PSR, WDS, BD) and to template arms matching specific lowercase letters, so folding the whole string would change what those match. One character is strictly additive.

Two more found while pinning it, both silent:

- `'T' when secondChar is 'Y' or 'Y'` - the same letter twice, where every neighbour pairs upper with lower. Tycho2 also needed `IgnoreCase` on `Tyc2Pattern`, since `CommonOpts` carries none; safe on that pattern specifically because its only letters are the tag.
- `noSpaces[0..7] == "Messier"` compared ordinally, so `messier 120` failed where `m120` works.

## The comet URL said only which number, not which comet

`object=10P` for 10P/Tempel. Now writes the display name. Both spellings still resolve, so older shared links keep working, and the slash stays literal (`object=10P/Tempel`) since RFC 3986 allows it in a query and `UnescapeDataString` leaves it alone.

## WebGl.Renderer 1.17

The canvas bound `@onmouse*` while `webgl-canvas.js` called `setPointerCapture` on pointerdown - capture governing one event stream while the app listened to another. Now `@onpointerdown/move/up`, plus a `pointercancel` path that did not exist at all (a gesture the browser took over left a drag latched down). Touch is filtered out of the new handlers because the JS bridge already synthesises pan and pinch and pointer events fire for fingers too.

This is correctness, **not** a proven cure for the web jank - the reporter confirmed they never left the canvas during a pan, which is the only case capture governs.

Pin verified the way CI sees it: a local build compiles against sibling source via `UseLocalSiblings` and never exercises the pin, so `-p:UseLocalSiblings=false` was used to prove `1.17.*` resolves to the published `1.17.261`.

## Still open

The web jank has no confirmed cause. Two candidates survive, both about not respecting the browser frame loop, and neither is touched here: `Planner` is a plain `ComponentBase`, so every pointer move runs a full Blazor diff of the page; and `RenderFrame` is called per event rather than coalesced to one `requestAnimationFrame` ("Web has no per-frame loop; every event ends in a RenderFrame"), so a 120 Hz touchpad drives twice the draws the display can present. The second is fixable inside this repo alone. Measuring before changing either.

## Verification

`4014 unit + 338 functional passed, 0 failed`; solution, web, and sibling all build with 0 warnings. One orientation test pinned a wall-clock-measured step to within a degree and was flaky by construction under a loaded suite; it now pins the nominal first step exactly and only monotonicity thereafter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R8fbd6xrLU7H4sjEHWnsEH