### PR TITLE
Correct the pan bug's recorded cause, and de-flake the viewer load-pending test

### DIFF
--- a/docs/todo/ui.md
+++ b/docs/todo/ui.md
@@ -196,8 +196,11 @@ Five user-reported items, all fixed the same day. Two of the causes recorded whe
 written turned out to be wrong; both corrections are kept below, because each was the plausible
 reading and the next person will reach for it again.
 
-- [x] **Panning jerks, and the view keeps rotating after the mouse is released.** Two real causes,
-  not three.
+- [x] **Panning jerks, and the view keeps rotating after the mouse is released.** Three causes. The
+  two below were both real and both fixed, but **neither was the reported symptom** -- that was (3),
+  found only after the reporter said it was still happening and that it eased away from the pole.
+  Recorded in this order because the order is the lesson: (1) and (2) were the visible, plausible
+  suspects, and fixing them changed how fast the wrong thing happened rather than stopping it.
   1. `SkyMapState.UpdateRollForReference` eased `CenterRoll` toward the mode's reference by a flat
      fraction of the remaining angle **per FRAME**, so the travel took a fixed number of frames and
      therefore a duration that scaled with frame time: the same ten frames are 0.17 s at 60 fps and a
@@ -213,6 +216,29 @@ reading and the next person will reach for it again.
      pan reads as the sky twitching. The cache now interpolates between syncs (`_cachedLiveTime +
      elapsed`), so the viewing time is continuous while `GetUtcNow` still runs only once a second.
      **The reporter diagnosed this one unaided.**
+
+  3. **The real one.** `UpdateRollForReference` servoed `CenterRoll` to the mode's ABSOLUTE
+     reference every frame, and in Equatorial that reference is the constant 0 -- so it had no
+     legitimate work at all (celestial north does not move) and existed only to undo the user's own
+     pan. A drag rotates the whole frame rigidly and near the pole legitimately earns a large roll,
+     because a change of RA at the pole IS a rotation; that roll is precisely what holds the sky
+     still under the pointer. Measured over a 100 px pan: 82.5 deg of roll earned at Dec -89, 56.7 at
+     -85, 13.0 at -60, 4.4 at -30, exactly 0 at the equator -- which is the "less severe away from the
+     pole" the reporter noticed, and why (1) and (2) could never have explained it. The grabbed star
+     landed under the cursor at release at every declination and was then thrown **131.9 px** by the
+     unwind, further than the 100 px the gesture had moved it.
+
+     The roll now follows how far the reference MOVED since the previous frame instead of servoing to
+     its value: identically nothing in Equatorial, the sky's own rotation in Horizon (so the horizon
+     still self-levels over a session, carrying a gesture's offset along untouched). Nothing re-levels
+     unprompted any more, so **L** levels the view and the status strip shows a `[L]evel` hint only
+     while the view is off its reference; **P** re-establishes the new mode's frame on a switch.
+     Pinned by `SkyMapPanTests`, which measures what the user actually sees -- where the grabbed star
+     is, in pixels -- in both modes, at the zenith, and just outside the old lock cone.
+
+     **Behaviour change:** the atlas now stays where you drag it, so a pole pan leaves the view
+     genuinely tilted until L. That is the cost of keeping the sky under the pointer, and it is the
+     right trade only because the alternative is the view moving on its own after you let go.
   - **WRONG when first recorded:** that the easing also fought the drag. It does not; there has been
     an explicit `if (IsDragging) return false` guard since the pole fix. Do not "fix" it again.
 

--- a/src/TianWen.Lib.Tests/ViewerControllerTests.cs
+++ b/src/TianWen.Lib.Tests/ViewerControllerTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -166,13 +166,21 @@ public class ViewerControllerTests
     public async Task ReleaseCompletedTasks_ClearsFinishedTaskReferences()
     {
         var (controller, state, cache, _, _) = CreateSut();
+
+        // The load must be GENUINELY in flight when the first assertion runs, so the cache is gated on
+        // a TaskCompletionSource the test completes rather than an already-finished Task.FromResult.
+        // With a completed task the load can finish between HandleFileRequest and the assertion, and
+        // IsLoadPending is then legitimately false -- which is exactly how this failed on the arm64 CI
+        // leg while passing everywhere else. Same shape as ShutdownAsync_AwaitsRunningTasks below.
+        var load = new TaskCompletionSource<AstroImageDocument?>();
         cache.GetOrLoadAsync(Arg.Any<string>(), Arg.Any<DebayerAlgorithm>(), Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult<AstroImageDocument?>(null));
+            .Returns(load.Task);
 
         state.RequestedFilePath = "/test/image.fits";
         controller.HandleFileRequest(CancellationToken.None);
-        controller.IsLoadPending.ShouldBeTrue();
+        controller.IsLoadPending.ShouldBeTrue("the load cannot have completed: nothing has resolved it yet");
 
+        load.SetResult(null);
         await WaitForLoadAsync(controller);
 
         controller.ReleaseCompletedTasks();


### PR DESCRIPTION
Two small things: a docs correction and the fix for the red CI on `main`.

## The viewer test that went red on main

`ViewerControllerTests.ReleaseCompletedTasks_ClearsFinishedTaskReferences` failed on `main` at `55631594`, on the **arm64 leg only**. Unrelated to that commit - the assertion has always been racy and that runner lost the race.

```csharp
cache.GetOrLoadAsync(...).Returns(Task.FromResult<AstroImageDocument?>(null));  // already complete
controller.HandleFileRequest(CancellationToken.None);
controller.IsLoadPending.ShouldBeTrue();   // only true if completion has not been observed yet
```

It asserts a load is in flight immediately after starting one whose task was already finished, so it passes only while the machine is slow enough. Now gated on a `TaskCompletionSource` the test resolves explicitly, which is the shape `ShutdownAsync_AwaitsRunningTasks` in the same file already uses - it is the only other in-flight assertion here and it was already correct. The remaining `Task.FromResult` callers go straight to `WaitForLoadAsync` and never assert mid-flight.

Confirmed with 20 consecutive runs of the single test.

## The pan bug's recorded cause was wrong

The `docs/todo/ui.md` entry was marked done while crediting the frame-rate re-level and the 1 Hz clock cache. Both were real fixes; neither was the reported symptom, which kept happening and was then observed to ease away from the pole - something neither could account for.

The cause was `UpdateRollForReference` servoing the roll to the mode's absolute reference every frame. In Equatorial that reference is the constant 0, so it had no legitimate work at all and existed only to undo the user's own pan.

| start Dec | roll a 100 px pan earns | grabbed star thrown on release |
|---|---|---|
| -89 | 82.5 deg | 131.9 px |
| -60 | 13.0 deg | - |
| 0 | 0.0 deg | 0.0 px |

That gradient is the observation that identified it. The entry keeps all three in discovery order, because the order is the lesson: the two plausible suspects went first, and fixing them changed how fast the wrong thing happened rather than stopping it. It also records the deliberate behaviour change, which is not obvious from the code: the atlas stays where you drag it, so a pole pan leaves the view tilted until **L**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R8fbd6xrLU7H4sjEHWnsEH