### PR TITLE
Derive the planned frame count from the slot, not from the filter plan's counts

### DIFF
--- a/src/TianWen.Hosting.Contracts/Dto/SessionStateDto.cs
+++ b/src/TianWen.Hosting.Contracts/Dto/SessionStateDto.cs
@@ -380,14 +380,21 @@ public sealed class ObservationDto
     public required bool AcrossMeridian { get; init; }
 
     /// <summary>
-    /// Frames the filter plan asks for, per OTA -- the denominator for "frame 23/100". Null when the
-    /// observation carries no filter plan, which is what a bare target queued through <c>/targets</c> looks
-    /// like, and also what a node too old to send this produces.
+    /// Frames this slot is expected to yield, per OTA -- the denominator for "frame 23/100". Null when
+    /// the observation carries no filter plan, which is what a bare target queued through <c>/targets</c>
+    /// looks like, and also what a node too old to send this produces.
     /// <para>
-    /// Summed from the plan rather than derived from <see cref="DurationMinutes"/>: duration is the
-    /// scheduler's slot, which a run can leave early or overrun, while the plan is what the imaging loop
-    /// actually works through. It is <b>per OTA</b>, because each OTA works the same plan in parallel -- a
-    /// client comparing it against a session-wide frame count has to multiply by the camera count.
+    /// An <b>estimate</b>, derived from <see cref="DurationMinutes"/> and the plan's sub-exposures;
+    /// clients should present it as approximate, because a run can leave a slot early or overrun it. It
+    /// is <b>per OTA</b>, because each OTA works the same plan in parallel -- a client comparing it
+    /// against a session-wide frame count has to multiply by the camera count.
+    /// </para>
+    /// <para>
+    /// This used to be summed from the filter plan's frame counts, on the stated grounds that "the plan
+    /// is what the imaging loop actually works through". That is not true of a single-filter plan: the
+    /// loop only advances on <c>Count</c> when the plan has more than one entry, so it shoots until the
+    /// slot's time runs out and the duration is what it works through. The sum reported 1 for every rig
+    /// without a filter wheel.
     /// </para>
     /// </summary>
     public int? PlannedFrameCount { get; init; }
@@ -402,7 +409,7 @@ public sealed class ObservationDto
         DurationMinutes = obs.Duration.TotalMinutes,
         AcrossMeridian = obs.AcrossMeridian,
         // Null rather than 0 for "no plan", so a client can tell "not stated" from "stated as none" -- the
-        // sum itself comes from the observation, which is where it is defined.
+        // estimate itself comes from the observation, which is where it is defined.
         PlannedFrameCount = obs.PlannedFrameCount is var planned and > 0 ? planned : null,
     };
 }

--- a/src/TianWen.Lib.Tests/FrameCountEstimateTests.cs
+++ b/src/TianWen.Lib.Tests/FrameCountEstimateTests.cs
@@ -1,0 +1,107 @@
+using System;
+using Shouldly;
+using TianWen.Lib.Sequencing;
+using Xunit;
+
+namespace TianWen.Lib.Tests;
+
+/// <summary>
+/// How many frames a slot is expected to yield.
+///
+/// <para>The bug that produced these: the Home board reported <c>frame 5/1</c> during a real run. The
+/// denominator was the sum of <see cref="FilterExposure.Count"/> over the filter plan, and
+/// <c>FilterPlanBuilder.BuildSingleFilterPlan</c> omits <c>Count</c>, so it defaulted to 1. Raising the
+/// default would not have fixed it: <c>Count</c> is a cycling quantum ("frames before advancing to the
+/// next filter"), and the imaging loop only consults it when the plan has more than one entry -- so a
+/// single-filter plan shoots until the slot's time runs out and no count could be right.</para>
+///
+/// <para>Meanwhile the Session Setup tab carried its own duration-derived formula and said <c>~245</c>
+/// for the same observation. Two answers, 245x apart, on two screens at once. These tests pin the one
+/// that replaced both.</para>
+/// </summary>
+public class FrameCountEstimateTests
+{
+    [Fact]
+    public void ARigWithNoFilterWheelGetsTheSlotsWorthOfFrames_NotOne()
+    {
+        // The exact shape BuildSingleFilterPlan produces: one passthrough entry, Count left at its
+        // default of 1. Summing counts answered 1 here, for the commonest configuration there is.
+        var plan = FilterPlanBuilder.BuildSingleFilterPlan(TimeSpan.FromSeconds(50));
+
+        plan.Length.ShouldBe(1);
+        plan[0].Count.ShouldBe(1, "the cycling quantum is genuinely 1; it is just not a frame total");
+
+        // 50 s subs + 10 s overhead is a frame a minute, so a 100-minute slot holds 100.
+        FrameCountEstimate.ForPlan(TimeSpan.FromMinutes(100), plan).ShouldBe(100);
+    }
+
+    [Fact]
+    public void ALadderIsWeightedByEachEntrysFrameCount()
+    {
+        // One cycle: 3 x (50 + 10) + 1 x (110 + 10) = 300 s for 4 frames = 75 s a frame.
+        // A 1 h slot therefore holds 48. An UNWEIGHTED mean of the two entries would be 90 s a frame
+        // and answer 40, so this distinguishes the two.
+        var ladder = System.Collections.Immutable.ImmutableArray.Create(
+            new FilterExposure(0, TimeSpan.FromSeconds(50), 3),
+            new FilterExposure(1, TimeSpan.FromSeconds(110), 1));
+
+        FrameCountEstimate.ForPlan(TimeSpan.FromHours(1), ladder).ShouldBe(48);
+    }
+
+    [Fact]
+    public void ASingleEntryLadderAgreesWithThePlainWindowFormula()
+    {
+        // The two entry points must not be allowed to diverge: one is what the Session Setup tab asks,
+        // the other is what an observation asks, and they are the same question.
+        var window = TimeSpan.FromMinutes(137);
+        var sub = TimeSpan.FromSeconds(90);
+
+        FrameCountEstimate.ForPlan(window, FilterPlanBuilder.BuildSingleFilterPlan(sub))
+            .ShouldBe(FrameCountEstimate.ForWindow(window, sub));
+    }
+
+    [Theory]
+    [InlineData(0)]      // no slot
+    [InlineData(-30)]    // a slot that has already closed
+    public void ANonPositiveWindowYieldsNothingRatherThanANegativeCount(int minutes)
+    {
+        var plan = FilterPlanBuilder.BuildSingleFilterPlan(TimeSpan.FromSeconds(60));
+
+        FrameCountEstimate.ForPlan(TimeSpan.FromMinutes(minutes), plan).ShouldBe(0);
+        FrameCountEstimate.ForWindow(TimeSpan.FromMinutes(minutes), TimeSpan.FromSeconds(60)).ShouldBe(0);
+    }
+
+    [Fact]
+    public void AnEmptyPlanHasNoDenominatorRatherThanAFabricatedOne()
+    {
+        // A bare target queued through /targets carries no plan. Inventing a denominator would misreport
+        // how far along the run is; 0 is what the display treats as "unknown" and drops.
+        FrameCountEstimate.ForPlan(TimeSpan.FromHours(1), []).ShouldBe(0);
+        FrameCountEstimate.ForPlan(TimeSpan.FromHours(1), default).ShouldBe(0);
+    }
+
+    [Theory]
+    [InlineData(60, 100)]
+    [InlineData(137, 48)]
+    [InlineData(500, 3)]
+    public void TheInverseReproducesTheEstimateExactly(int windowMinutes, int frames)
+    {
+        // This is what RemoteSessionMirror leans on: the state DTO carries the estimate but not the plan,
+        // so the mirror rebuilds a plan from the number and must land back on the same number. Integer
+        // truncation makes that non-obvious, hence pinning it.
+        var window = TimeSpan.FromMinutes(windowMinutes);
+
+        var sub = FrameCountEstimate.SubExposureForFrames(window, frames);
+
+        FrameCountEstimate.ForWindow(window, sub).ShouldBe(frames);
+    }
+
+    [Fact]
+    public void AnUnreachableFrameCountInvertsToNothingRatherThanANegativeExposure()
+    {
+        // More frames than the slot could hold even at zero exposure: 10 frames of pure overhead is
+        // 100 s, which does not fit in a minute.
+        FrameCountEstimate.SubExposureForFrames(TimeSpan.FromMinutes(1), 10).ShouldBe(TimeSpan.Zero);
+        FrameCountEstimate.SubExposureForFrames(TimeSpan.FromHours(1), 0).ShouldBe(TimeSpan.Zero);
+    }
+}

--- a/src/TianWen.Lib.Tests/HomeBoardTests.cs
+++ b/src/TianWen.Lib.Tests/HomeBoardTests.cs
@@ -135,12 +135,21 @@ namespace TianWen.Lib.Tests
             cards[0].FramesWritten.ShouldBe(412);
         }
 
+        // The progress denominator comes from the SLOT, not from a number written into the filter plan:
+        // 50 s subs plus the 10 s per-frame overhead is one frame a minute, and a 1 h 40 m slot holds 100
+        // of them. These used to be a `planned` argument stuffed into FilterExposure.Count, which decides
+        // nothing -- that count is a cycling quantum, and reading it as a total is the defect these tests
+        // now guard (it reported 1 for every rig without a filter wheel).
+        private static readonly TimeSpan SlotSubExposure = TimeSpan.FromSeconds(50);
+        private static readonly TimeSpan SlotDuration = TimeSpan.FromMinutes(100);
+        private const int SlotPlannedFrames = 100;
+
         /// <summary>
-        /// Puts a run on the local context: <paramref name="written"/> frames of the active target already in
-        /// the log, out of a plan asking for <paramref name="planned"/> per OTA.
+        /// Puts a run on the local context: <paramref name="written"/> frames of the active target already
+        /// in the log, against a slot expected to yield <see cref="SlotPlannedFrames"/> per OTA.
         /// </summary>
         private static LiveSessionState RunningSession(
-            ViewContexts contexts, int written, int planned, int scheduled = 1, int activeIndex = 0)
+            ViewContexts contexts, int written, int scheduled = 1, int activeIndex = 0)
         {
             var session = contexts.Local.LiveSession;
             session.IsRunning = true;
@@ -152,8 +161,8 @@ namespace TianWen.Lib.Tests
             for (var i = 0; i < scheduled; i++)
             {
                 observations.Add(new ScheduledObservation(
-                    new Target(1.0, 2.0, $"T{i}", null), Now, TimeSpan.FromHours(1), false,
-                    FilterPlan: [new FilterExposure(-1, TimeSpan.FromSeconds(300), planned)],
+                    new Target(1.0, 2.0, $"T{i}", null), Now, SlotDuration, false,
+                    FilterPlan: [new FilterExposure(-1, SlotSubExposure)],
                     Gain: null, Offset: null));
             }
 
@@ -177,7 +186,7 @@ namespace TianWen.Lib.Tests
         public void ProgressCountsTheCurrentTargetsFramesNotTheWholeNights()
         {
             var (contexts, rigs, appState) = Board();
-            var session = RunningSession(contexts, written: 23, planned: 100, scheduled: 3, activeIndex: 1);
+            var session = RunningSession(contexts, written: 23, scheduled: 3, activeIndex: 1);
 
             // Frames from an EARLIER target sit ahead of the current one's in the log. A session total would
             // fold them in and report 31/100 for a target that has taken 23.
@@ -190,7 +199,7 @@ namespace TianWen.Lib.Tests
             progress.TargetIndex.ShouldBe(2);
             progress.TargetCount.ShouldBe(3);
             progress.FramesDone.ShouldBe(23);
-            progress.FramesPlanned.ShouldBe(100);
+            progress.FramesPlanned.ShouldBe(SlotPlannedFrames);
             progress.Describe().ShouldBe("target 2/3 · frame 23/100");
         }
 
@@ -210,14 +219,14 @@ namespace TianWen.Lib.Tests
         public void TheDenominatorScalesWithTheOtasThatAreShooting()
         {
             var (contexts, rigs, appState) = Board();
-            var session = RunningSession(contexts, written: 10, planned: 50);
+            var session = RunningSession(contexts, written: 10);
             // A dual-OTA rig works the same plan on both cameras, and the log counts both OTAs' frames, so
             // the planned side has to scale too or a two-scope rig reads as twice as far along as it is.
             session.CameraStates = [default, default];
 
             var progress = HomeBoard.BuildCards(contexts, rigs, appState, Now)[0].Progress.ShouldNotBeNull();
 
-            progress.FramesPlanned.ShouldBe(100);
+            progress.FramesPlanned.ShouldBe(SlotPlannedFrames * 2);
         }
 
         [Fact]

--- a/src/TianWen.Lib.Tests/RemoteSessionMirrorTests.cs
+++ b/src/TianWen.Lib.Tests/RemoteSessionMirrorTests.cs
@@ -793,7 +793,7 @@ public class RemoteSessionMirrorTests
     }
 
     [Fact]
-    public async Task ThePlanFrameTotalCrossesSoProgressHasOnePathLocallyAndRemotely()
+    public async Task TheFrameEstimateCrossesSoProgressHasOnePathLocallyAndRemotely()
     {
         var session = Substitute.For<ISessionTelemetry>();
         session.Phase.Returns(SessionPhase.Observing);
@@ -805,21 +805,23 @@ public class RemoteSessionMirrorTests
         session.LastFrameMetrics.Returns([]);
         session.PhaseTimeline.Returns([]);
         session.GuideSamples.Returns([]);
-        // Three filter entries: the per-filter breakdown does NOT cross, but the total must.
+        // A ladder with UNEQUAL sub-exposures, so the estimate depends on weighting each entry by its
+        // frame count and not on a plain average: one cycle is 3 x (50 + 10) + 1 x (110 + 10) = 300 s for
+        // 4 frames, i.e. 75 s a frame, so a 1 h slot holds 48. An unweighted mean of the two entries
+        // would give 90 s a frame and 40 -- a different number, which is what makes this worth asserting.
         session.Observations.Returns(new ScheduledObservationTree(
             [new ScheduledObservation(new Target(5.588, -5.39, "M42", null),
                 new DateTimeOffset(2026, 7, 26, 19, 45, 0, TimeSpan.Zero), TimeSpan.FromHours(1),
                 AcrossMeridian: false,
                 FilterPlan:
                 [
-                    new FilterExposure(0, TimeSpan.FromSeconds(300), 40),
-                    new FilterExposure(1, TimeSpan.FromSeconds(300), 35),
-                    new FilterExposure(2, TimeSpan.FromSeconds(300), 25),
+                    new FilterExposure(0, TimeSpan.FromSeconds(50), 3),
+                    new FilterExposure(1, TimeSpan.FromSeconds(110), 1),
                 ],
                 Gain: null, Offset: null)]));
 
         var projected = SessionStateDto.FromSession(session);
-        projected.Observations[0].PlannedFrameCount.ShouldBe(100);
+        projected.Observations[0].PlannedFrameCount.ShouldBe(48);
 
         var (mirror, _) = BuildMirror(_ => Json(ResponseEnvelope<SessionStateDto>.Ok(projected)));
         await using var _mirror = mirror;
@@ -827,8 +829,10 @@ public class RemoteSessionMirrorTests
         await mirror.PollOnceAsync(TestContext.Current.CancellationToken);
 
         // PlannedFrameCount answers the same on the mirror as on the session, which is what lets the home
-        // card's progress row read one property instead of branching on local-vs-remote.
-        mirror.ActiveObservation.ShouldNotBeNull().PlannedFrameCount.ShouldBe(100);
+        // card's progress row read one property instead of branching on local-vs-remote. The per-filter
+        // breakdown does not cross, so the mirror rebuilds a single entry by INVERTING the estimate --
+        // collapsing the ladder to its first entry's 50 s subs instead would answer 60, not 48.
+        mirror.ActiveObservation.ShouldNotBeNull().PlannedFrameCount.ShouldBe(48);
     }
 
     // -------------------------------------------------------------------------------------------

--- a/src/TianWen.Lib/Sequencing/FrameCountEstimate.cs
+++ b/src/TianWen.Lib/Sequencing/FrameCountEstimate.cs
@@ -1,0 +1,119 @@
+using System;
+using System.Collections.Immutable;
+
+namespace TianWen.Lib.Sequencing;
+
+/// <summary>
+/// How many light frames an observation slot is expected to yield, <b>per OTA</b>. The one place this
+/// is worked out.
+///
+/// <para>It is derived from the slot's DURATION, not from the filter plan's frame counts, because the
+/// imaging loop is time-bounded rather than count-bounded.
+/// <see cref="FilterExposure.Count"/> is a <i>cycling quantum</i> -- "frames at this filter before
+/// advancing to the next entry" -- and <c>Session.Imaging</c> only consults it when the plan has more
+/// than one entry:
+/// <code>if (filterFrameCounters[i] >= currentEntry.Count &amp;&amp; plan.Length > 1)</code>
+/// So a single-entry plan never advances and never stops on <c>Count</c>; it exposes until the slot's
+/// time runs out. No value of <c>Count</c> can answer "how many frames" there, and summing the counts
+/// answers a different question entirely -- <em>one pass of the filter ladder</em>, which is 1 for a
+/// single filter and, for a real ladder, one cycle of a loop that then repeats.</para>
+///
+/// <para>That summing is what this replaces. It made the Home board report
+/// <c>frame 5/1</c> for any rig without a filter wheel -- the common OSC case -- while the Session
+/// Setup tab, using its own duration-derived formula, said <c>~245</c> for the very same observation.
+/// Two formulas for one quantity, disagreeing by 245x on two screens at once.</para>
+///
+/// <para><b>This is an estimate and callers should present it as one.</b> Real per-frame overhead
+/// varies with download size, dither settle and the occasional refocus, and a run can leave a slot
+/// early or overrun it.</para>
+/// </summary>
+public static class FrameCountEstimate
+{
+    /// <summary>
+    /// Wall-clock cost per frame beyond the exposure itself: download, dither and settle. A rough
+    /// constant on purpose -- the alternative is a per-rig model whose inputs nobody measures.
+    /// </summary>
+    public const double PerFrameOverheadSeconds = 10.0;
+
+    /// <summary>
+    /// Frames a window yields at a single sub-exposure. Zero for a non-positive window or exposure,
+    /// which is what "no plan yet" looks like on a freshly-built schedule.
+    /// </summary>
+    public static int ForWindow(TimeSpan window, TimeSpan subExposure)
+    {
+        if (subExposure <= TimeSpan.Zero || window <= TimeSpan.Zero)
+        {
+            return 0;
+        }
+
+        var perFrameSeconds = subExposure.TotalSeconds + PerFrameOverheadSeconds;
+        return Math.Max(0, (int)(window.TotalSeconds / perFrameSeconds));
+    }
+
+    /// <summary>
+    /// Frames a window yields while cycling <paramref name="plan"/>.
+    /// <para>
+    /// The ladder repeats for the whole slot, so what matters is the mean cost of a frame across one
+    /// cycle, weighted by each entry's <see cref="FilterExposure.Count"/> -- an Ha entry shooting three
+    /// 600 s subs costs far more of the slot than an L entry shooting one 60 s sub, and a plain average
+    /// over the entries would hide that. With a single entry the weights cancel and this reduces exactly
+    /// to <see cref="ForWindow"/>, which is why both cases can share one path.
+    /// </para>
+    /// </summary>
+    public static int ForPlan(TimeSpan window, ImmutableArray<FilterExposure> plan)
+    {
+        if (plan.IsDefaultOrEmpty || window <= TimeSpan.Zero)
+        {
+            return 0;
+        }
+
+        var cycleSeconds = 0.0;
+        var cycleFrames = 0;
+        foreach (var entry in plan)
+        {
+            // A non-positive Count would silently drop an entry from the weighting rather than the
+            // plan, so it is floored at one frame -- the cycling quantum's own minimum.
+            var count = Math.Max(1, entry.Count);
+            cycleFrames += count;
+            cycleSeconds += count * (entry.SubExposure.TotalSeconds + PerFrameOverheadSeconds);
+        }
+
+        if (cycleFrames == 0 || cycleSeconds <= 0.0)
+        {
+            return 0;
+        }
+
+        var meanFrameSeconds = cycleSeconds / cycleFrames;
+        return Math.Max(0, (int)(window.TotalSeconds / meanFrameSeconds));
+    }
+
+    /// <summary>
+    /// The inverse of <see cref="ForWindow"/>: the sub-exposure at which <paramref name="window"/>
+    /// yields exactly <paramref name="frames"/>, or <see cref="TimeSpan.Zero"/> when there is no such
+    /// exposure (a non-positive window or frame count, or a slot too short to hold that many frames
+    /// even at zero exposure).
+    ///
+    /// <para>This exists for <c>RemoteSessionMirror</c>. The state DTO flattens the filter plan away and
+    /// carries only the frame estimate, so the mirror rebuilds a single-entry plan that reproduces it --
+    /// and the only way to reproduce a derived number is to invert the derivation. Keeping the inverse
+    /// in this file is the point: a copy of the arithmetic in the client is exactly how the two answers
+    /// drifted apart the first time.</para>
+    ///
+    /// <para>Reconstructing from the ESTIMATE rather than from a sub-exposure carried on the wire is
+    /// deliberate. A real multi-filter ladder weights its entries, so collapsing it to its first entry's
+    /// sub-exposure would give the mirror a different answer than the node computed (48 frames against
+    /// 60, for one Ha-plus-luminance plan). Inverting reproduces the node's number whatever the plan
+    /// behind it was.</para>
+    /// </summary>
+    public static TimeSpan SubExposureForFrames(TimeSpan window, int frames)
+    {
+        if (frames <= 0 || window <= TimeSpan.Zero)
+        {
+            return TimeSpan.Zero;
+        }
+
+        var perFrameSeconds = window.TotalSeconds / frames;
+        var subExposureSeconds = perFrameSeconds - PerFrameOverheadSeconds;
+        return subExposureSeconds > 0.0 ? TimeSpan.FromSeconds(subExposureSeconds) : TimeSpan.Zero;
+    }
+}

--- a/src/TianWen.Lib/Sequencing/ScheduledObservation.cs
+++ b/src/TianWen.Lib/Sequencing/ScheduledObservation.cs
@@ -21,29 +21,18 @@ public record ScheduledObservation(
     public TimeSpan SubExposure => FilterPlan is { IsDefaultOrEmpty: false } ? FilterPlan[0].SubExposure : TimeSpan.Zero;
 
     /// <summary>
-    /// Frames the whole plan asks for, <b>per OTA</b> (each OTA works the same plan in parallel), or 0 when
-    /// there is no plan -- which is what a bare target queued without one looks like.
+    /// Frames this slot is expected to yield, <b>per OTA</b> (each OTA works the same plan in parallel),
+    /// or 0 when there is no plan -- which is what a bare target queued without one looks like.
     /// <para>
-    /// The one place this sum is computed. Progress displays and the wire projection both need it, and a
-    /// second loop over <see cref="FilterPlan"/> elsewhere is a second answer waiting to disagree.
+    /// An <b>estimate</b>, derived from <see cref="Duration"/> via <see cref="FrameCountEstimate"/>;
+    /// present it as approximate. It used to be the sum of <see cref="FilterExposure.Count"/> over the
+    /// plan, which answers a different question -- see the remarks on <see cref="FrameCountEstimate"/>
+    /// for why the imaging loop makes that sum wrong (it reported 1 for any rig with no filter wheel).
+    /// </para>
+    /// <para>
+    /// Progress displays and the wire projection both need this number, and a second formula elsewhere
+    /// is a second answer waiting to disagree -- which is exactly what had happened.
     /// </para>
     /// </summary>
-    public int PlannedFrameCount
-    {
-        get
-        {
-            if (FilterPlan.IsDefaultOrEmpty)
-            {
-                return 0;
-            }
-
-            var total = 0;
-            foreach (var entry in FilterPlan)
-            {
-                total += entry.Count;
-            }
-
-            return total;
-        }
-    }
+    public int PlannedFrameCount => FrameCountEstimate.ForPlan(Duration, FilterPlan);
 }

--- a/src/TianWen.RemoteClient/RemoteSessionMirror.cs
+++ b/src/TianWen.RemoteClient/RemoteSessionMirror.cs
@@ -1199,13 +1199,16 @@ namespace TianWen.RemoteClient
             TimeSpan.FromMinutes(obs.DurationMinutes),
             obs.AcrossMeridian,
             // The state DTO flattens the filter plan away (it is a scheduling input, not observed
-            // state); the schedule-fidelity DTO of Part 2 item 8 is what carries it back. What DOES cross is
-            // the plan's frame TOTAL, so it is rebuilt as a single passthrough entry (FilterPosition -1)
-            // holding that count. The per-filter breakdown is genuinely not on the wire and is not invented
-            // here -- but this makes ScheduledObservation.PlannedFrameCount answer the same number locally
-            // and remotely, so a progress display has one path instead of a local branch and a wire branch.
+            // state); the schedule-fidelity DTO of Part 2 item 8 is what carries it back. What DOES cross
+            // is the frame ESTIMATE, so the plan is rebuilt as a single passthrough entry
+            // (FilterPosition -1) whose sub-exposure reproduces it -- FrameCountEstimate owns both the
+            // derivation and its inverse, so this cannot drift from what the node computed. The
+            // per-filter breakdown is genuinely not on the wire and is not invented here, but
+            // ScheduledObservation.PlannedFrameCount answers the same number locally and remotely, so a
+            // progress display has one path instead of a local branch and a wire branch.
             FilterPlan: obs.PlannedFrameCount is { } planned and > 0
-                ? [new FilterExposure(-1, TimeSpan.Zero, planned)]
+                ? [new FilterExposure(-1, FrameCountEstimate.SubExposureForFrames(
+                    TimeSpan.FromMinutes(obs.DurationMinutes), planned))]
                 : [],
             Gain: null,
             Offset: null);

--- a/src/TianWen.UI.Abstractions/SessionTabState.cs
+++ b/src/TianWen.UI.Abstractions/SessionTabState.cs
@@ -273,19 +273,15 @@ namespace TianWen.UI.Abstractions
 
         /// <summary>
         /// Estimates the number of frames given window duration and sub-exposure.
-        /// Accounts for ~10s overhead per frame (download, dither, settle).
+        /// <para>
+        /// Delegates to <see cref="FrameCountEstimate"/> in the Lib, which is the single source: this
+        /// used to carry its own copy of the arithmetic, and the copy disagreed with
+        /// <see cref="ScheduledObservation.PlannedFrameCount"/> by 245x on the same observation --
+        /// this tab said "~245" while the Home board said "1". Do not re-inline it.
+        /// </para>
         /// </summary>
         public static int EstimateFrameCount(TimeSpan window, TimeSpan subExposure)
-        {
-            if (subExposure <= TimeSpan.Zero)
-            {
-                return 0;
-            }
-
-            const double overheadSeconds = 10.0;
-            var cycleSeconds = subExposure.TotalSeconds + overheadSeconds;
-            return Math.Max(0, (int)(window.TotalSeconds / cycleSeconds));
-        }
+            => FrameCountEstimate.ForWindow(window, subExposure);
 
         /// <summary>
         /// Finds the <see cref="ConfigFieldDescriptor"/> at the given flat field index


### PR DESCRIPTION
## The symptom

The Home board reported **frame 5/1** during a real run, in both the card and table views.

## Why

The denominator was the sum of FilterExposure.Count over the filter plan, and
FilterPlanBuilder.BuildSingleFilterPlan omits Count, so it defaulted to 1 -- for **every rig
without a filter wheel**, which is the common OSC case.

Raising that default would not have fixed it. Count is a *cycling quantum* -- "frames at this filter
before advancing to the next entry" -- and the imaging loop only consults it when the plan has more
than one entry (Session.Imaging.cs:524):

    if (filterFrameCounters[i] >= currentEntry.Count && plan.Length > 1)

So a single-entry plan never advances and never stops on Count; it exposes until the slot's time
runs out, and the duration is what decides. No value of Count could be right there. Summing counts
answers *one pass of the filter ladder*: 1 for a single filter, and for a real ladder one cycle of a
loop that then repeats -- so not a total in that case either.

ObservationDto.PlannedFrameCount justified the sum on the grounds that "duration is the scheduler's
slot [...] while the plan is what the imaging loop actually works through". That is exactly what is
not true of a single-filter plan.

## There were already two answers

SessionTabState.EstimateFrameCount derived the number from the slot duration -- that is the "~245"
shown on Session Setup -- while PlannedFrameCount summed the plan and said 1. Same observation, two
screens, 245x apart. The duration-derived one also sat in TianWen.UI.Abstractions while the domain
concept lives in TianWen.Lib.

## The change

FrameCountEstimate (new, in the Lib) is the single source. A ladder is weighted by each entry's
Count, because an Ha entry shooting three 600 s subs costs far more of the slot than an L entry
shooting one 60 s sub and a plain average would hide that; with one entry the weights cancel, so
both cases share one path. EstimateFrameCount delegates to it.

The estimate reaches a mirror without the plan behind it, so FrameCountEstimate owns the inverse too
and RemoteSessionMirror rebuilds its single-entry plan by inverting. Collapsing a ladder to its first
entry's sub-exposure instead would answer differently from the node (48 frames against 60, for the
plan the mirror test now uses). **No wire contract change** -- an earlier draft added a
SubExposureSeconds field and it turned out not to be needed.

The number is an estimate and the API docs now say so. Display strings are unchanged; Session Setup
already writes a tilde.

## Tests

FrameCountEstimateTests is new and pins the originating case directly: the exact plan
BuildSingleFilterPlan produces now yields the slot's worth of frames rather than 1. It also pins the
ladder weighting against a plain average (48 vs 40), the two entry points agreeing, empty and
non-positive inputs, and the inverse round-tripping exactly through integer truncation.

HomeBoardTests no longer passes a planned count in; its helper states a slot instead, so the inputs
express what actually decides the denominator. The mirror test now uses unequal sub-exposures, which
is what distinguishes weighted from unweighted.

Full suites green locally: 4024 unit passed, 338 functional passed, 0 failed.

## Found while

Capturing screenshots for the new organisation site at sharpastro.github.io -- the rig card was going
to ship the defect onto a public page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)