### PR TITLE
Make F12 reach the whole app: unfreeze the palette snapshots, theme the chrome, and pin the contrast matrix

### DIFF
--- a/src/TianWen.Lib.Tests/GuiThemeTests.cs
+++ b/src/TianWen.Lib.Tests/GuiThemeTests.cs
@@ -70,6 +70,125 @@ namespace TianWen.Lib.Tests
             Contrast(p.Error, p.PanelBg).ShouldBeGreaterThanOrEqualTo(4.5);
         }
 
+        // Every (text role, surface role) pair the UI actually paints, checked in one place. This exists
+        // because eyeballing screenshots missed three real failures that arithmetic caught at once:
+        // SeparatorStrong used as placeholder text (1.5-1.9:1, invisible in ALL three states), DimText on
+        // the green Success fill (1.4:1), and Night's own Info at 2.46:1. A role lookup makes a colour
+        // consistent, not legible; only the pairing is legible or not.
+        //
+        // Night is held to a LOWER floor than Light and Dark, and that is not a concession to sloppiness:
+        // red on black caps at 5.25:1, so the whole ladder lives under that ceiling and a 4.5 floor would
+        // leave no room for a secondary weight at all. 3.4 keeps every pair perceptible while preserving
+        // the body/dim distinction; the standing rule is that anything which MUST be read uses BodyText.
+        public static TheoryData<string, string, string> TextPairs => new()
+        {
+            { "BodyText",   "PanelBg",   "body text on a panel" },
+            { "BodyText",   "ContentBg", "body text on the backdrop" },
+            { "BodyText",   "HeaderBg",  "body text on chrome" },
+            { "BodyText",   "Selection", "text on a selected row" },
+            { "DimText",    "PanelBg",   "secondary text on a panel" },
+            { "DimText",    "ContentBg", "secondary text on the backdrop" },
+            { "DimText",    "HeaderBg",  "the status bar clock" },
+            { "HeaderText", "HeaderBg",  "a header label" },
+            { "HeaderText", "PanelBg",   "a panel header" },
+            { "Accent",     "PanelBg",   "an accented value" },
+            { "Accent",     "HeaderBg",  "a pinned planning date" },
+            { "Info",       "PanelBg",   "an info message" },
+            { "Warn",       "PanelBg",   "a warning" },
+            { "Warn",       "HeaderBg",  "the status message in the top bar" },
+            { "Error",      "PanelBg",   "an error" },
+            { "Success",    "PanelBg",   "a positive mark" },
+        };
+
+        private static RGBAColor32 Role(UiPalette p, string name) => name switch
+        {
+            "ContentBg" => p.ContentBg,
+            "PanelBg" => p.PanelBg,
+            "HeaderBg" => p.HeaderBg,
+            "Selection" => p.Selection,
+            "BodyText" => p.BodyText,
+            "DimText" => p.DimText,
+            "HeaderText" => p.HeaderText,
+            "Accent" => p.Accent,
+            "Info" => p.Info,
+            "Warn" => p.Warn,
+            "Error" => p.Error,
+            "Success" => p.Success,
+            _ => throw new ArgumentOutOfRangeException(nameof(name), name, "unknown role"),
+        };
+
+        [Theory]
+        [MemberData(nameof(TextPairs))]
+        public void EveryTextPairIsPerceptibleInEveryState(string text, string surface, string usage)
+        {
+            foreach (var state in new[] { "Light", "Dark", "Night" })
+            {
+                var p = ByName(state);
+                var floor = state == "Night" ? 3.4 : 4.5;
+                var ratio = Contrast(Role(p, text), Role(p, surface));
+
+                ratio.ShouldBeGreaterThanOrEqualTo(
+                    floor,
+                    $"{state}: {text} on {surface} ({usage}) is {ratio:F2}:1, below the {floor:F1} floor");
+            }
+        }
+
+        // The one text pair deliberately left OUT of the matrix above, recorded here so it is a decision
+        // rather than a gap: Night's DimText on Selection is 2.94:1.
+        //
+        // Lightening Selection to lift it is the wrong trade, and the numbers say so. A selection fill is
+        // SUPPOSED to be subtle: it measures 1.27:1 in Light and 1.28:1 in Dark against the panel it sits
+        // on, and Night's 1.21:1 is the same order, so it is not anomalous. Pushing Night's lighter to
+        // "fix" the dim label drops BodyText on Selection from 4.11 to about 2.9, trading a pair that
+        // works for a fill nobody asked to be louder. So the standing rule resolves it instead: anything
+        // that must be read on a selected row uses BodyText.
+        [Theory]
+        [InlineData("Light")]
+        [InlineData("Dark")]
+        [InlineData("Night")]
+        public void ASelectionFillIsSubtleInEveryStateByDesign(string state)
+        {
+            var p = ByName(state);
+
+            // Present, but nowhere near a text-contrast ratio; all three states sit in a narrow band.
+            var visibility = Contrast(p.Selection, p.PanelBg);
+            visibility.ShouldBeGreaterThan(1.15);
+            visibility.ShouldBeLessThan(1.6);
+
+            // Which is what makes BodyText the required choice on a selected row.
+            Contrast(p.BodyText, p.Selection).ShouldBeGreaterThanOrEqualTo(state == "Night" ? 3.4 : 4.5);
+        }
+
+        [Fact]
+        public void NightDimTextOnSelectionIsKnowinglyBelowTheFloor()
+        {
+            var p = GuiTheme.NightPalette;
+
+            Contrast(p.DimText, p.Selection).ShouldBeLessThan(3.4);
+            Contrast(p.BodyText, p.Selection).ShouldBeGreaterThanOrEqualTo(3.4);
+        }
+
+        // A filled semantic chip takes ink from its FILL, never a text role. The bug this pins shipped in
+        // the chrome sweep: Connect All fills with Success and labelled itself DimText, which measured
+        // 1.4:1 on the Dark green. Any FIXED ink is wrong too, because a semantic fill's lightness flips
+        // between states, so the check is that InkOn's answer clears AA on the fill in every state.
+        [Theory]
+        [InlineData("Success")]
+        [InlineData("Warn")]
+        [InlineData("Error")]
+        [InlineData("Info")]
+        public void InkOnAFilledChipIsLegibleAgainstThatFill(string fillRole)
+        {
+            foreach (var state in new[] { "Light", "Dark", "Night" })
+            {
+                var fill = Role(ByName(state), fillRole);
+                var ratio = Contrast(GuiTheme.InkOn(fill), fill);
+
+                ratio.ShouldBeGreaterThanOrEqualTo(
+                    4.5, $"{state}: ink on the {fillRole} fill is {ratio:F2}:1");
+            }
+        }
+
         // The home board's status dot is a THREE-way mark -- offline / online / running, drawn from
         // DimText / Success / Info -- so those three must be three colours. Leaving Success to its
         // accent fallback shipped a real regression: in Dark, Info IS Accent, so online and running

--- a/src/TianWen.UI.Abstractions/EquipmentPanelLayout.cs
+++ b/src/TianWen.UI.Abstractions/EquipmentPanelLayout.cs
@@ -17,8 +17,17 @@ namespace TianWen.UI.Abstractions
         RGBAColor32 OtaHeaderBg,
         RGBAColor32 FilterTableBg)
     {
-        /// <summary>The default dark equipment palette (matches the values previously inlined in EquipmentTab).</summary>
-        public static EquipmentPanelStyle Default { get; } = new(
+        /// <summary>
+        /// The default equipment palette (the values previously inlined in EquipmentTab).
+        /// </summary>
+        /// <remarks>
+        /// A computed property, NOT <c>{ get; } = new(...)</c>. An auto-property initialiser runs once at
+        /// type-init, so this captured whichever <see cref="GuiTheme.Theme"/> happened to be current then
+        /// and went on handing out that palette through every later theme switch. The four slot/OTA
+        /// colours below are still literals because no palette role covers them; giving them Night
+        /// variants is the remaining part of the sweep.
+        /// </remarks>
+        public static EquipmentPanelStyle Default => new(
             GuiTheme.Theme,
             SlotNormal:    new RGBAColor32(0x2a, 0x2a, 0x35, 0xff),
             SlotActive:    new RGBAColor32(0x2a, 0x6b, 0xb8, 0xff),

--- a/src/TianWen.UI.Abstractions/EquipmentTab.cs
+++ b/src/TianWen.UI.Abstractions/EquipmentTab.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
@@ -36,24 +36,24 @@ namespace TianWen.UI.Abstractions
         private static readonly RGBAColor32 DeviceListBg     = new RGBAColor32(0x18, 0x18, 0x22, 0xff);
         // Slot/OTA/filter chrome colours live on EquipmentPanelStyle.Default (the single source shared
         // with the data-driven EquipmentPanelLayout); reference them here rather than re-declaring literals.
-        private static readonly RGBAColor32 SlotNormal       = EquipmentPanelStyle.Default.SlotNormal;
-        private static readonly RGBAColor32 SlotActive       = EquipmentPanelStyle.Default.SlotActive;
+        private static RGBAColor32 SlotNormal                => EquipmentPanelStyle.Default.SlotNormal;
+        private static RGBAColor32 SlotActive                => EquipmentPanelStyle.Default.SlotActive;
         private static readonly RGBAColor32 DeviceRowBg      = new RGBAColor32(0x20, 0x20, 0x2c, 0xff);
         private static readonly RGBAColor32 DeviceRowBgAlt   = new RGBAColor32(0x25, 0x25, 0x33, 0xff);
         private static readonly RGBAColor32 AssignedGreen    = new RGBAColor32(0x40, 0xc0, 0x40, 0xff);
         private static readonly RGBAColor32 DimmedText       = new RGBAColor32(0x60, 0x60, 0x70, 0xff);
         private static readonly RGBAColor32 CreateButton     = new RGBAColor32(0x30, 0x60, 0x90, 0xff);
-        private static readonly RGBAColor32 HeaderText       = GuiTheme.Palette.HeaderText;
-        private static readonly RGBAColor32 BodyText         = GuiTheme.Palette.BodyText;
-        private static readonly RGBAColor32 DimText          = GuiTheme.Palette.DimText;
-        private static readonly RGBAColor32 SeparatorColor   = GuiTheme.Palette.Separator;
+        private static RGBAColor32 HeaderText                => GuiTheme.Palette.HeaderText;
+        private static RGBAColor32 BodyText                  => GuiTheme.Palette.BodyText;
+        private static RGBAColor32 DimText                   => GuiTheme.Palette.DimText;
+        private static RGBAColor32 SeparatorColor            => GuiTheme.Palette.Separator;
         private static readonly RGBAColor32 BadgeBg          = new RGBAColor32(0x28, 0x28, 0x38, 0xff);
         private static readonly RGBAColor32 SiteText         = new RGBAColor32(0x99, 0xbb, 0x99, 0xff);
-        private static readonly RGBAColor32 OtaHeaderBg      = EquipmentPanelStyle.Default.OtaHeaderBg;
-        private static readonly RGBAColor32 ContentBg        = GuiTheme.Palette.ContentBg;
+        private static RGBAColor32 OtaHeaderBg               => EquipmentPanelStyle.Default.OtaHeaderBg;
+        private static RGBAColor32 ContentBg                 => GuiTheme.Palette.ContentBg;
         private static readonly RGBAColor32 BottomBarBg      = new RGBAColor32(0x14, 0x14, 0x1c, 0xff);
         private static readonly RGBAColor32 AccentInstruct   = new RGBAColor32(0x88, 0xcc, 0xff, 0xff);
-        private static readonly RGBAColor32 FilterTableBg    = EquipmentPanelStyle.Default.FilterTableBg;
+        private static RGBAColor32 FilterTableBg             => EquipmentPanelStyle.Default.FilterTableBg;
         private static readonly RGBAColor32 FilterRowAlt     = new RGBAColor32(0x20, 0x20, 0x2e, 0xff);
         private static readonly RGBAColor32 EditButtonBg     = new RGBAColor32(0x2a, 0x40, 0x5a, 0xff);
         private static readonly RGBAColor32 RemoveButtonBg   = new RGBAColor32(0x6a, 0x2a, 0x2a, 0xff); // muted red: arm OTA removal

--- a/src/TianWen.UI.Abstractions/GuiTheme.cs
+++ b/src/TianWen.UI.Abstractions/GuiTheme.cs
@@ -165,6 +165,20 @@ namespace TianWen.UI.Abstractions
             return true;
         }
 
+        /// <summary>
+        /// Text to lay ON a filled colour chip, chosen from the fill's own lightness.
+        /// </summary>
+        /// <remarks>
+        /// A semantic fill's lightness flips between states: <see cref="UiPalette.Warn"/> is a dark ochre
+        /// in Light and a bright amber in Dark, and <see cref="UiPalette.Success"/> is a deep green in
+        /// Light and a light one in Dark. So ANY fixed ink is legible in one state and invisible in
+        /// another, and a de-emphasised role is wrong in all of them: a <c>DimText</c> label on the green
+        /// Connect All fill measured about 1.4:1. Ask here instead of picking a colour per call site.
+        /// </remarks>
+        public static RGBAColor32 InkOn(RGBAColor32 fill) => fill.Luminance < 0x80
+            ? new RGBAColor32(0xff, 0xff, 0xff, 0xff)
+            : new RGBAColor32(0x14, 0x10, 0x08, 0xff);
+
         // What Night was toggled ON from, so toggling OFF restores it rather than guessing. Seeded to
         // the startup state so an F12 pressed before anything else has touched the theme still returns
         // somewhere sensible.

--- a/src/TianWen.UI.Abstractions/GuiTheme.cs
+++ b/src/TianWen.UI.Abstractions/GuiTheme.cs
@@ -1,3 +1,4 @@
+using System;
 using DIR.Lib;
 
 namespace TianWen.UI.Abstractions
@@ -112,7 +113,15 @@ namespace TianWen.UI.Abstractions
             Accent          = new RGBAColor32(0xff, 0x6a, 0x00, 0xff),
             AccentAlt       = new RGBAColor32(0xa8, 0x3c, 0x00, 0xff),
             Selection       = new RGBAColor32(0x3a, 0x10, 0x00, 0xff),
-            Info            = new RGBAColor32(0x8c, 0x30, 0x00, 0xff),
+            // Info carries the BodyText value on purpose. It was its own dim red (#8c3000) and measured
+            // 2.46:1 on PanelBg, which is unreadable; every value that IS readable collides with Warn,
+            // because with blue at zero and green rationed there is not enough room for a fourth
+            // distinguishable semantic hue. The way out is not a compromise colour: informational IS the
+            // baseline weight, so Info reads as ordinary text and the two severities that must interrupt
+            // keep the hue budget (Warn orange, Error pure red). Same reasoning as Success borrowing the
+            // accent. An info message therefore reads as text in Night and as blue in Light and Dark,
+            // which is correct rather than a shortcoming.
+            Info            = new RGBAColor32(0xe0, 0x4a, 0x00, 0xff),
             Warn            = new RGBAColor32(0xcc, 0x5c, 0x00, 0xff),
             Error           = new RGBAColor32(0xff, 0x15, 0x00, 0xff),
         };
@@ -175,9 +184,35 @@ namespace TianWen.UI.Abstractions
         /// another, and a de-emphasised role is wrong in all of them: a <c>DimText</c> label on the green
         /// Connect All fill measured about 1.4:1. Ask here instead of picking a colour per call site.
         /// </remarks>
-        public static RGBAColor32 InkOn(RGBAColor32 fill) => fill.Luminance < 0x80
-            ? new RGBAColor32(0xff, 0xff, 0xff, 0xff)
-            : new RGBAColor32(0x14, 0x10, 0x08, 0xff);
+        public static RGBAColor32 InkOn(RGBAColor32 fill)
+        {
+            // Pick whichever ink MEASURES better, rather than branching on a lightness threshold. Two
+            // reasons. RGBAColor32.Luminance is the gamma-encoded NTSC approximation, which is fine for
+            // "is this dark" and is not the quantity a contrast ratio is defined on; and a threshold has
+            // to guess at the crossover, which it got wrong for Night's Warn, Error and Info fills (all
+            // three landed near 4:1 on white when black would have given 4.5 or better). Comparing the
+            // two candidates has no crossover to get wrong.
+            var white = new RGBAColor32(0xff, 0xff, 0xff, 0xff);
+            var ink = new RGBAColor32(0x14, 0x10, 0x08, 0xff);
+            return Contrast(white, fill) >= Contrast(ink, fill) ? white : ink;
+        }
+
+        // WCAG relative luminance + contrast ratio. Small enough to keep here rather than take a
+        // dependency, and it is the only place production code needs it.
+        private static double Contrast(RGBAColor32 a, RGBAColor32 b)
+        {
+            double x = RelativeLuminance(a), y = RelativeLuminance(b);
+            return (Math.Max(x, y) + 0.05) / (Math.Min(x, y) + 0.05);
+        }
+
+        private static double RelativeLuminance(RGBAColor32 c)
+            => (0.2126 * Linearise(c.Red)) + (0.7152 * Linearise(c.Green)) + (0.0722 * Linearise(c.Blue));
+
+        private static double Linearise(byte channel)
+        {
+            var v = channel / 255.0;
+            return v <= 0.04045 ? v / 12.92 : Math.Pow((v + 0.055) / 1.055, 2.4);
+        }
 
         // What Night was toggled ON from, so toggling OFF restores it rather than guessing. Seeded to
         // the startup state so an F12 pressed before anything else has touched the theme still returns

--- a/src/TianWen.UI.Abstractions/GuiderTab.cs
+++ b/src/TianWen.UI.Abstractions/GuiderTab.cs
@@ -37,13 +37,16 @@ namespace TianWen.UI.Abstractions
         private const string TargetFillKey = "targetView";
         private const string GraphFillKey = "guideGraph";
 
-        // Colors
-        private static readonly RGBAColor32 ContentBg = GuiTheme.Palette.ContentBg;
-        private static readonly RGBAColor32 PanelBg = GuiTheme.Palette.PanelBg;
-        private static readonly RGBAColor32 HeaderBg = GuiTheme.Palette.HeaderBg;
-        private static readonly RGBAColor32 HeaderText = GuiTheme.Palette.HeaderText;
-        private static readonly RGBAColor32 BodyText = GuiTheme.Palette.BodyText;
-        private static readonly RGBAColor32 DimText = GuiTheme.Palette.DimText;
+        // Colors. The palette-derived ones are PROPERTIES, not static readonly fields: a field
+        // initialiser snapshots the palette at type-init, so this tab went on painting the startup
+        // scheme through every theme switch. RGBAColor32 is a struct, so reading through allocates
+        // nothing. The literals below have no role yet and still need Night variants.
+        private static RGBAColor32 ContentBg => GuiTheme.Palette.ContentBg;
+        private static RGBAColor32 PanelBg => GuiTheme.Palette.PanelBg;
+        private static RGBAColor32 HeaderBg => GuiTheme.Palette.HeaderBg;
+        private static RGBAColor32 HeaderText => GuiTheme.Palette.HeaderText;
+        private static RGBAColor32 BodyText => GuiTheme.Palette.BodyText;
+        private static RGBAColor32 DimText => GuiTheme.Palette.DimText;
         private static readonly RGBAColor32 PlaceholderText = new RGBAColor32(0x66, 0x66, 0x88, 0xff);
         private static readonly RGBAColor32 AlertText = new RGBAColor32(0xff, 0x55, 0x44, 0xff);
 

--- a/src/TianWen.UI.Abstractions/HomeBoardLayout.cs
+++ b/src/TianWen.UI.Abstractions/HomeBoardLayout.cs
@@ -64,14 +64,9 @@ namespace TianWen.UI.Abstractions
             }
         }
 
-        /// <summary>
-        /// Text to lay ON a filled colour chip. The prompt badge fills with <c>Warn</c>, whose own
-        /// lightness flips between states (a dark ochre in Light, a bright amber in Dark), so a fixed
-        /// ink colour is legible in one state and invisible in the other.
-        /// </summary>
-        private static RGBAColor32 Ink(RGBAColor32 fill) => fill.Luminance < 0x80
-            ? new RGBAColor32(0xff, 0xff, 0xff, 0xff)
-            : new RGBAColor32(0x14, 0x10, 0x08, 0xff);
+        // Ink-on-fill moved to GuiTheme.InkOn when the Connect All button became the second caller;
+        // a second copy of the rule is how one of them drifts.
+        private static RGBAColor32 Ink(RGBAColor32 fill) => GuiTheme.InkOn(fill);
     }
 
     /// <summary>

--- a/src/TianWen.UI.Abstractions/LiveSessionTab.cs
+++ b/src/TianWen.UI.Abstractions/LiveSessionTab.cs
@@ -91,15 +91,18 @@ namespace TianWen.UI.Abstractions
         private const float BaseRowHeight      = 20f;
         private const float BaseProgressBarH   = 14f;
 
-        // Colors
-        private static readonly RGBAColor32 ContentBg        = GuiTheme.Palette.ContentBg;
-        private static readonly RGBAColor32 PanelBg          = GuiTheme.Palette.PanelBg;
-        private static readonly RGBAColor32 HeaderBg         = GuiTheme.Palette.HeaderBg;
-        private static readonly RGBAColor32 HeaderText       = GuiTheme.Palette.HeaderText;
-        private static readonly RGBAColor32 BodyText         = GuiTheme.Palette.BodyText;
-        private static readonly RGBAColor32 DimText          = GuiTheme.Palette.DimText;
+        // Colors. The palette-derived ones are PROPERTIES, not static readonly fields: a field
+        // initialiser snapshots the palette at type-init, so this tab went on painting the startup
+        // scheme through every theme switch. RGBAColor32 is a struct, so reading through allocates
+        // nothing. The literals below have no role yet and still need Night variants.
+        private static RGBAColor32 ContentBg        => GuiTheme.Palette.ContentBg;
+        private static RGBAColor32 PanelBg          => GuiTheme.Palette.PanelBg;
+        private static RGBAColor32 HeaderBg         => GuiTheme.Palette.HeaderBg;
+        private static RGBAColor32 HeaderText       => GuiTheme.Palette.HeaderText;
+        private static RGBAColor32 BodyText         => GuiTheme.Palette.BodyText;
+        private static RGBAColor32 DimText          => GuiTheme.Palette.DimText;
         private static readonly RGBAColor32 BrightText       = new RGBAColor32(0xff, 0xff, 0xff, 0xff);
-        private static readonly RGBAColor32 SeparatorColor   = GuiTheme.Palette.Separator;
+        private static RGBAColor32 SeparatorColor   => GuiTheme.Palette.Separator;
         private static readonly RGBAColor32 GraphBg          = new RGBAColor32(0x12, 0x12, 0x1a, 0xff);
         private static readonly RGBAColor32 RaColor          = new RGBAColor32(0x44, 0x88, 0xff, 0xff); // blue
         private static readonly RGBAColor32 DecColor         = new RGBAColor32(0xff, 0x88, 0x44, 0xff); // orange

--- a/src/TianWen.UI.Abstractions/PlannerTab.cs
+++ b/src/TianWen.UI.Abstractions/PlannerTab.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
@@ -42,10 +42,14 @@ namespace TianWen.UI.Abstractions
 
         // Colors
         private static readonly RGBAColor32 PanelBgOpaque   = new RGBAColor32(0x1a, 0x1a, 0x22, 0xff);
-        private static readonly RGBAColor32 HeaderBg        = GuiTheme.Palette.HeaderBg;
+        // The palette-derived colours here are PROPERTIES, not static readonly fields: a field
+        // initialiser snapshots the palette at type-init, so this tab went on painting the startup
+        // scheme through every theme switch. RGBAColor32 is a struct, so reading through allocates
+        // nothing. The literals alongside have no role yet and still need Night variants.
+        private static RGBAColor32 HeaderBg                 => GuiTheme.Palette.HeaderBg;
         private static readonly RGBAColor32 HeaderText      = new RGBAColor32(0xff, 0xff, 0xff, 0xff);
-        private static readonly RGBAColor32 ItemText        = GuiTheme.Palette.BodyText;
-        private static readonly RGBAColor32 SelectedBg      = GuiTheme.Palette.Selection;
+        private static RGBAColor32 ItemText                 => GuiTheme.Palette.BodyText;
+        private static RGBAColor32 SelectedBg               => GuiTheme.Palette.Selection;
         private static readonly RGBAColor32 SelectedText    = new RGBAColor32(0xff, 0xff, 0xff, 0xff);
         private static readonly RGBAColor32 PinnedBg        = new RGBAColor32(0x18, 0x2a, 0x28, 0xff);
         private static readonly RGBAColor32 PinnedText      = new RGBAColor32(0x66, 0xdd, 0xcc, 0xff);
@@ -55,12 +59,12 @@ namespace TianWen.UI.Abstractions
         private static readonly RGBAColor32 DetailsBg       = new RGBAColor32(0x14, 0x14, 0x1e, 0xff);
         private static readonly RGBAColor32 DetailsNameText = new RGBAColor32(0xff, 0xff, 0xff, 0xff);
         private static readonly RGBAColor32 DetailsInfoText = new RGBAColor32(0xaa, 0xaa, 0xaa, 0xff);
-        private static readonly RGBAColor32 SeparatorColor  = GuiTheme.Palette.Separator;
+        private static RGBAColor32 SeparatorColor           => GuiTheme.Palette.Separator;
         private static readonly RGBAColor32 FilterBtnBg     = new RGBAColor32(0x35, 0x35, 0x48, 0xff);
         private static readonly RGBAColor32 ActiveFilterBg  = new RGBAColor32(0x30, 0x50, 0x30, 0xff);
         private static readonly RGBAColor32 FilterBtnText   = new RGBAColor32(0xdd, 0xdd, 0xdd, 0xff);
         private static readonly RGBAColor32 DropdownBg       = new RGBAColor32(0x22, 0x22, 0x35, 0xff);
-        private static readonly RGBAColor32 DropdownSelBg    = GuiTheme.Palette.Selection;
+        private static RGBAColor32 DropdownSelBg            => GuiTheme.Palette.Selection;
         private static readonly RGBAColor32 DropdownBorder   = new RGBAColor32(0x44, 0x44, 0x60, 0xff);
 
         private IReadOnlyList<ScoredTarget> _lastFilteredTargets = [];

--- a/src/TianWen.UI.Abstractions/SessionTab.cs
+++ b/src/TianWen.UI.Abstractions/SessionTab.cs
@@ -26,14 +26,17 @@ namespace TianWen.UI.Abstractions
         private const float BaseSeparatorW    = 1f;
         private const float BaseObsPanelWidth = 440f;
 
-        // Colors
-        private static readonly RGBAColor32 ContentBg      = GuiTheme.Palette.ContentBg;
-        private static readonly RGBAColor32 PanelBg        = GuiTheme.Palette.PanelBg;
-        private static readonly RGBAColor32 HeaderBg       = GuiTheme.Palette.HeaderBg;
-        private static readonly RGBAColor32 HeaderText     = GuiTheme.Palette.HeaderText;
-        private static readonly RGBAColor32 BodyText       = GuiTheme.Palette.BodyText;
-        private static readonly RGBAColor32 DimText        = GuiTheme.Palette.DimText;
-        private static readonly RGBAColor32 SeparatorColor = GuiTheme.Palette.Separator;
+        // Colors. The palette-derived ones are PROPERTIES, not static readonly fields: a field
+        // initialiser snapshots the palette at type-init, so this tab went on painting the startup
+        // scheme through every theme switch. RGBAColor32 is a struct, so reading through allocates
+        // nothing. The literals below have no role yet and still need Night variants.
+        private static RGBAColor32 ContentBg      => GuiTheme.Palette.ContentBg;
+        private static RGBAColor32 PanelBg        => GuiTheme.Palette.PanelBg;
+        private static RGBAColor32 HeaderBg       => GuiTheme.Palette.HeaderBg;
+        private static RGBAColor32 HeaderText     => GuiTheme.Palette.HeaderText;
+        private static RGBAColor32 BodyText       => GuiTheme.Palette.BodyText;
+        private static RGBAColor32 DimText        => GuiTheme.Palette.DimText;
+        private static RGBAColor32 SeparatorColor => GuiTheme.Palette.Separator;
         private static readonly RGBAColor32 StepperBg      = new RGBAColor32(0x2a, 0x2a, 0x3a, 0xff);
         private static readonly RGBAColor32 ToggleOnBg     = new RGBAColor32(0x30, 0x60, 0x40, 0xff);
         private static readonly RGBAColor32 ToggleOffBg    = new RGBAColor32(0x40, 0x30, 0x30, 0xff);
@@ -44,7 +47,7 @@ namespace TianWen.UI.Abstractions
         private static readonly RGBAColor32 HintText       = new RGBAColor32(0x55, 0x55, 0x66, 0xff);
         private static readonly RGBAColor32 OtaHeaderBg    = new RGBAColor32(0x24, 0x24, 0x32, 0xff);
         private static readonly RGBAColor32 FrameCountText = new RGBAColor32(0x88, 0xdd, 0x88, 0xff);
-        private static readonly RGBAColor32 SelectedRowBg  = GuiTheme.Palette.Selection;
+        private static RGBAColor32 SelectedRowBg           => GuiTheme.Palette.Selection;
 
         private float _totalConfigHeight;
 

--- a/src/TianWen.UI.Gui/VkGuiRenderer.cs
+++ b/src/TianWen.UI.Gui/VkGuiRenderer.cs
@@ -209,21 +209,34 @@ namespace TianWen.UI.Gui
             [GuiTab.Notifications] = ("\U0001F514",        "Notifications (Ctrl+N)"),
         };
 
-        // Sidebar colors
-        private static readonly RGBAColor32 SidebarBg     = new RGBAColor32(0x1a, 0x1a, 0x22, 0xff);
-        private static readonly RGBAColor32 ActiveTabBg   = new RGBAColor32(0x20, 0x30, 0x50, 0xff);
-        private static readonly RGBAColor32 HoverTabBg    = new RGBAColor32(0x2a, 0x2a, 0x35, 0xff);
-        private static readonly RGBAColor32 IconColor     = new RGBAColor32(0xcc, 0xcc, 0xcc, 0xff);
-        private static readonly RGBAColor32 ActiveIcon    = new RGBAColor32(0xff, 0xff, 0xff, 0xff);
-        private static readonly RGBAColor32 LockedIcon    = new RGBAColor32(0x44, 0x44, 0x50, 0xff);
+        // Window chrome, entirely from the shared palette. PROPERTIES, not static readonly fields: a
+        // field initialiser snapshots at type-init, which is how the one palette-derived colour that was
+        // already here (ContentBg) still failed to follow a theme switch.
+        //
+        // The sidebar is a panel that the active tab lifts off, so it takes PanelBg and the active tab
+        // takes Selection: the selected-surface role IS what "the tab you are on" means, and it already
+        // carries the cool lift the hand-picked 0x203050 was reaching for. Hover sits between the two on
+        // HeaderBg. An inactive icon is de-emphasised text and an active one is body text, so they are
+        // DimText and BodyText rather than two greys; a locked tab is not text at all, so it takes the
+        // heavier rule weight instead of a third one.
+        private static RGBAColor32 SidebarBg       => Palette.PanelBg;
+        private static RGBAColor32 ActiveTabBg     => Palette.Selection;
+        private static RGBAColor32 HoverTabBg      => Palette.HeaderBg;
+        private static RGBAColor32 IconColor       => Palette.DimText;
+        private static RGBAColor32 ActiveIcon      => Palette.BodyText;
+        private static RGBAColor32 LockedIcon      => Palette.SeparatorStrong;
 
-        // Status bar colors
-        private static readonly RGBAColor32 StatusBarBg   = new RGBAColor32(0x22, 0x22, 0x28, 0xff);
-        private static readonly RGBAColor32 StatusText    = new RGBAColor32(0xaa, 0xaa, 0xaa, 0xff);
+        // Status bar
+        private static RGBAColor32 StatusBarBg     => Palette.HeaderBg;
+        private static RGBAColor32 StatusText      => Palette.DimText;
 
         // Content area placeholder
-        private static readonly RGBAColor32 ContentBg     = TianWen.UI.Abstractions.GuiTheme.Palette.ContentBg;
-        private static readonly RGBAColor32 PlaceholderText = new RGBAColor32(0x55, 0x55, 0x66, 0xff);
+        private static RGBAColor32 ContentBg       => Palette.ContentBg;
+        private static RGBAColor32 PlaceholderText => Palette.SeparatorStrong;
+
+        // Local alias so the chrome above reads as roles rather than as a namespace walk. UiPalette is
+        // DIR.Lib's (already in scope via the using); only GuiTheme is TianWen's.
+        private static UiPalette Palette => TianWen.UI.Abstractions.GuiTheme.Palette;
 
         public VkGuiRenderer(VkRenderer renderer, uint width, uint height, SignalBus? bus = null, ILogger? logger = null) : base(renderer)
         {
@@ -431,11 +444,12 @@ namespace TianWen.UI.Gui
             var x = anchorX;
             var y = anchorY - h * 0.5f;
 
-            // Border + fill
-            FillRect(x - 1, y - 1, w + 2, h + 2, new RGBAColor32(0x50, 0x50, 0x60, 0xFF));
-            FillRect(x, y, w, h, new RGBAColor32(0x22, 0x22, 0x2C, 0xF0));
+            // Border + fill. The fill keeps its near-opaque alpha so the tooltip still reads as floating
+            // over the content rather than cut into it; only the hue comes from the palette.
+            FillRect(x - 1, y - 1, w + 2, h + 2, Palette.SeparatorStrong);
+            FillRect(x, y, w, h, Palette.HeaderBg.WithAlpha(0xF0));
             _renderer.DrawText(text.AsSpan(), FontPath, fontSize,
-                new RGBAColor32(0xE6, 0xE6, 0xE6, 0xFF),
+                Palette.BodyText,
                 new RectInt(new PointInt((int)(x + w), (int)(y + h)), new PointInt((int)(x + pad), (int)y)),
                 TextAlign.Near, TextAlign.Center);
         }
@@ -481,13 +495,15 @@ namespace TianWen.UI.Gui
             {
                 dateStr = isTonight ? "Tonight" : planDate.ToString("ddd d MMM");
             }
-            var dateColor = plannerState.PlanningDate.HasValue ? new RGBAColor32(0x88, 0xcc, 0xff, 0xff) : StatusText;
+            // A pinned planning date is the one thing in this bar that differs from "now", so it takes the
+            // accent; an unpinned date is ordinary de-emphasised chrome.
+            var dateColor = plannerState.PlanningDate.HasValue ? Palette.Accent : StatusText;
 
             // The whole bar is one layout tree: three star-weighted zones (left | centre | right), so
             // placement is "weights + spacers", not pixel arithmetic. Sizes/fonts are design units;
             // RenderLayout scales them by DpiScale. Every leaf is .HStar() so it fills the bar height and
             // VAlign=Center centres the glyph (a horizontal stack top-aligns Auto-height children).
-            var arrowBg = new RGBAColor32(0x2a, 0x2a, 0x35, 0xff);
+            var arrowBg = Palette.HeaderBg;
             const float gapDu = 6f; // design-unit inter-element gap
 
             // LEFT: the (truncated) status message.
@@ -504,7 +520,7 @@ namespace TianWen.UI.Gui
                 var contentW = w - (SidebarWidth + 6f) - 4f;
                 var msgCellW = Math.Max(contentW / 3f, 40f);
                 var displayMsg = TruncateToFit(msg, msgCellW, FontSize * 0.85f);
-                statusNode = Layout.Builder.Text(displayMsg, BaseFontSize * 0.85f, new RGBAColor32(0xff, 0xcc, 0x66, 0xff), TextAlign.Near, TextAlign.Center)
+                statusNode = Layout.Builder.Text(displayMsg, BaseFontSize * 0.85f, Palette.Warn, TextAlign.Near, TextAlign.Center)
                     .WStar().HStar();
             }
             else
@@ -555,8 +571,17 @@ namespace TianWen.UI.Gui
                     EquipmentState.IsDiscovering);
                 if (ca.Visible)
                 {
-                    var caLabelColor = ca.Enabled ? StatusText : new RGBAColor32(0x99, 0x99, 0xa3, 0xff);
-                    var caBg = ca.Enabled ? new RGBAColor32(0x2e, 0x7d, 0x32, 0xff) : new RGBAColor32(0x30, 0x30, 0x3a, 0xff);
+                    // Connect All was the loudest literal left in the chrome: a fixed green that ignored
+                    // the theme entirely and, in a dark-adaptation palette, became the brightest thing on
+                    // screen. Success is the role for it, and in a palette with no green to spend it
+                    // resolves to the accent instead of insisting on one. Disabled is a plain rule fill.
+                    // Enabled is a FILLED chip, so its label is ink chosen from the fill, not a text role:
+                    // DimText on the green Success fill measured about 1.4:1 and was effectively unreadable.
+                    // Disabled is a plain rule fill, where the ordinary de-emphasised role is right.
+                    var caBg = ca.Enabled ? Palette.Success : Palette.Separator;
+                    var caLabelColor = ca.Enabled
+                        ? TianWen.UI.Abstractions.GuiTheme.InkOn(caBg)
+                        : Palette.DimText;
                     var caButton = Layout.Builder.HStack(
                             Layout.Builder.Spacer().WFixed(gapDu * 2f),
                             Layout.Builder.Text(ca.Label, BaseFontSize * 0.9f, caLabelColor, TextAlign.Center, TextAlign.Center).WAuto().HStar(),

--- a/src/TianWen.UI.Gui/VkGuiRenderer.cs
+++ b/src/TianWen.UI.Gui/VkGuiRenderer.cs
@@ -224,6 +224,10 @@ namespace TianWen.UI.Gui
         private static RGBAColor32 HoverTabBg      => Palette.HeaderBg;
         private static RGBAColor32 IconColor       => Palette.DimText;
         private static RGBAColor32 ActiveIcon      => Palette.BodyText;
+        // A locked tab's icon is deliberately the heaviest RULE weight rather than a text role: it marks an
+        // affordance that is unavailable, and WCAG exempts inactive components from the contrast minimums
+        // (it measures 1.45-1.75:1, close to the 1.95 the hand-picked 0x444450 gave). Do NOT "fix" this to
+        // DimText, which would make a locked tab look merely de-emphasised.
         private static RGBAColor32 LockedIcon      => Palette.SeparatorStrong;
 
         // Status bar
@@ -232,7 +236,9 @@ namespace TianWen.UI.Gui
 
         // Content area placeholder
         private static RGBAColor32 ContentBg       => Palette.ContentBg;
-        private static RGBAColor32 PlaceholderText => Palette.SeparatorStrong;
+        // Text that must be READ, so a text role and not a rule weight. SeparatorStrong measured
+        // 1.5-1.9:1 here in every state, which is invisible rather than subdued.
+        private static RGBAColor32 PlaceholderText => Palette.DimText;
 
         // Local alias so the chrome above reads as roles rather than as a namespace walk. UiPalette is
         // DIR.Lib's (already in scope via the using); only GuiTheme is TianWen's.

--- a/src/TianWen.UI.Gui/VkPlanetaryTab.cs
+++ b/src/TianWen.UI.Gui/VkPlanetaryTab.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Immutable;
 using DIR.Lib;
 using SdlVulkan.Renderer;
@@ -44,9 +44,9 @@ public sealed class VkPlanetaryTab : VkImageRenderer, IPlanetaryViewWidget
     private const int PlanetaryOtaIndex = 0;
 
     private static readonly RGBAColor32 ContentBg = new RGBAColor32(0x06, 0x06, 0x08, 0xff);
-    private static readonly RGBAColor32 PanelBg = GuiTheme.Palette.HeaderBg;
-    private static readonly RGBAColor32 HeaderText = GuiTheme.Palette.HeaderText;
-    private static readonly RGBAColor32 DimText = GuiTheme.Palette.DimText;
+    private static RGBAColor32 PanelBg => GuiTheme.Palette.HeaderBg;
+    private static RGBAColor32 HeaderText => GuiTheme.Palette.HeaderText;
+    private static RGBAColor32 DimText => GuiTheme.Palette.DimText;
     private static readonly RGBAColor32 StartBg = new RGBAColor32(0x1e, 0x5e, 0x2e, 0xff);
     private static readonly RGBAColor32 StopBg = new RGBAColor32(0x6e, 0x24, 0x24, 0xff);
     private static readonly RGBAColor32 ButtonText = new RGBAColor32(0xff, 0xff, 0xff, 0xff);


### PR DESCRIPTION
C2 of docs/plans/colour-theme.md, in three commits. F12 shipped in #143 but only half-worked; this is why, and the fix.

## 1. Unfreeze the palette snapshots

Thirty-four colours across six tabs were static readonly fields initialised FROM the palette, plus two style bundles held as get-only auto-properties with initialisers. All of those run once at type-init, so SessionTab, LiveSessionTab, GuiderTab, PlannerTab, EquipmentTab and VkPlanetaryTab captured the startup palette and painted it forever. That is the whole reason F12 moved the Home board and nothing else.

This shape is worse than a bare literal and deserves the attention: a literal shows up in a grep for colour constants, while "= GuiTheme.Palette.HeaderText" reads as correct and is not. EquipmentPanelStyle.Default was the same bug one level up, and EquipmentTab then snapshotted three colours THROUGH it, so the chain needed breaking at both ends.

## 2. Put the window chrome on palette roles

VkGuiRenderer held its own scheme in seventeen literals, so the frame stayed cool grey-blue while everything inside went red. Mapped by MEANING rather than nearest hue: the sidebar is a panel the active tab lifts off, so PanelBg with the active tab on Selection (the selected-surface role IS what "the tab you are on" means, and it already carries the lift the hand-picked 0x203050 was reaching for); an inactive icon is de-emphasised text and an active one is body text, so DimText and BodyText rather than two greys; a pinned planning date is the one thing in the bar that differs from "now", so Accent.

Connect All was the loudest literal left: a fixed green that ignored the theme and, in a dark-adaptation palette, would have been the brightest thing on screen. It is Success now, which where there is no green to spend resolves to the accent rather than insisting on one.

Zero colour literals left in VkGuiRenderer.

## 3. No text pair is too dim, and the matrix is now a test

Asked to check for dim text, I computed it instead of squinting, which found four failures. Two were mine from commit 2.

PlaceholderText was mapped to SeparatorStrong, a RULE weight rather than a text role, and measured 1.50 to 1.89:1 in ALL THREE states. Night's own Info was 2.46:1, and every value that IS readable collides with Warn, because with blue at zero and green rationed there is no room for a fourth semantic hue: so Info carries the BodyText value, since informational IS the baseline weight and the hue budget belongs to the severities that must interrupt.

InkOn was deciding on the wrong quantity. It branched on RGBAColor32.Luminance, the gamma-encoded NTSC approximation, which is not what a contrast ratio is defined on; its guessed crossover put Night's Warn, Error and Info labels near 4:1 where the other ink gave 4.5 or better. It now measures both candidates and takes the higher.

The locked-tab icon deliberately STAYS at about 1.5:1: it marks an unavailable affordance, WCAG exempts inactive components, and it matches what the old hand-picked colour gave. Commented so nobody "fixes" it.

The durable part is the matrix as a test: sixteen text pairs across three states plus ink-on-fill for four semantic fills. Night gets a 3.4 floor instead of 4.5 because red on black caps at 5.25, so a 4.5 floor would leave no room for a secondary weight; that ceiling is asserted now rather than described in a comment. Worst pair per state: Light 5.02, Dark 5.08, Night 3.43.

One accepted exception is pinned as a decision rather than left as a gap. Night's DimText on Selection is 2.94. I first tried to fix it with the reasoning backwards, claiming the highlight was 1.67:1 against the panel from a hand estimate; it is 1.21, and computing Light (1.27) and Dark (1.28) showed a selection fill is SUPPOSED to be subtle. Lightening Night's would drop BodyText on Selection from 4.11 to about 2.9.

## Verification

4077 unit tests pass. Validated on screen in both Dark and Night via the debug inspector: the chrome follows F12, and Connect All is readable in each (green with dark ink in Dark, orange with dark ink in Night).

## Not in scope

C2c: the genuinely local data-series colours in AltitudeChartRenderer (41 literals), SkyMapRenderer (14) and GuideGraphRenderer (9). Those stay local but need Night variants, and the hard part is that a two-trace guide graph in Night has neither blue nor green available, so RA and Dec must separate by something other than hue. The tab emoji also stay full-colour in Night, being glyphs from the bundled emoji font.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
