### PR TITLE
chore(build): the version is one property, read back by CI

### DIFF
--- a/.claude/skills/bump-version/SKILL.md
+++ b/.claude/skills/bump-version/SKILL.md
@@ -1,28 +1,59 @@
 ---
 name: bump-version
-description: Bump TianWen's version number across all version locations that must stay in sync (the AssemblyVersion in TianWen.Lib.csproj, the VersionPrefix default in each published-app csproj, Cli, Server, UI.FitsViewer, UI.Gui, AI.MCP, and VERSION_PREFIX in .github/workflows/dotnet.yml). Use when the user asks to bump, update, or increment TianWen's version.
+description: Bump TianWen's version by editing the single VersionMajorMinor property in src/Directory.Build.props (everything else - the published apps' VersionPrefix, TianWen.Lib's AssemblyVersion, and CI's VERSION_PREFIX - derives from it). Use when the user asks to bump, update, or increment TianWen's version.
 ---
 
-Usage: `/bump-version <major.minor>` (e.g. `/bump-version 0.9`) or pass the version as an argument.
+Usage: `/bump-version <major.minor>` (e.g. `/bump-version 6.2`) or pass the version as an argument.
 
-The version locations (6 csproj defaults + the CI workflow). The workflow `VERSION_PREFIX` is the
-authoritative release version, it overrides the csproj defaults via `-p:Version=` in CI, but bump the
-csproj defaults too so local builds + the NuGet `AssemblyVersion` stay in sync:
-1. `src/TianWen.Lib/TianWen.Lib.csproj` - `<AssemblyVersion>X.Y.0.0</AssemblyVersion>`
-2. `src/TianWen.Cli/TianWen.Cli.csproj` - `<VersionPrefix>X.Y.0</VersionPrefix>`
-3. `src/TianWen.Server/TianWen.Server.csproj` - `<VersionPrefix>X.Y.0</VersionPrefix>`
-4. `src/TianWen.UI.FitsViewer/TianWen.UI.FitsViewer.csproj` - `<VersionPrefix>X.Y.0</VersionPrefix>`
-5. `src/TianWen.UI.Gui/TianWen.UI.Gui.csproj` - `<VersionPrefix>X.Y.0</VersionPrefix>`
-6. `src/TianWen.AI.MCP/TianWen.AI.MCP.csproj` - `<VersionPrefix>X.Y.0</VersionPrefix>`
-7. `.github/workflows/dotnet.yml` - `VERSION_PREFIX: X.Y.${{ github.run_number }}`
+## There is exactly ONE place
 
-The csproj VersionPrefix lines are guarded `<VersionPrefix Condition=" '$(VersionPrefix)' == '' ">X.Y.0</VersionPrefix>`;
-match the literal `>X.Y.0</VersionPrefix>` (the sibling `<Version ...>$(VersionPrefix)</Version>` lines need
-no change). A CRLF-preserving byte replace (python, asserting exactly one hit per file) is the safe way.
+```xml
+<!-- src/Directory.Build.props -->
+<VersionMajorMinor>6.1</VersionMajorMinor>
+```
 
-Steps:
-1. Read the current version from all locations
-2. Show the user what will change (old -> new)
-3. Update all locations
-4. Verify all now have the new version (and no stray old version remains)
-5. Do NOT commit - let the user review and commit when ready
+Everything derives from it and **must not be hand-edited**:
+
+| derived | where | how |
+|---|---|---|
+| `VersionPrefix` (all projects) | `src/Directory.Build.props` | `$(VersionMajorMinor).0`, guarded on empty so CI's `-p:Version` wins |
+| `AssemblyVersion` | `src/TianWen.Lib/TianWen.Lib.csproj` | `$(VersionMajorMinor).0.0` |
+| `VERSION_PREFIX` | `.github/workflows/dotnet.yml` | the `version` job reads the property back with `dotnet msbuild -getProperty:VersionMajorMinor` and exposes it as a job output |
+
+**This replaced a seven-location hand-edit** (converted 2026-08-09), which is what this skill used to
+automate. If you find a literal version anywhere in a csproj or the workflow, that is a regression:
+delete it and let it derive.
+
+Semantics, per the org convention: `X.Y` -> `X.(Y+1)` additive, `X.*` -> `(X+1).0` breaking. **The
+patch segment is CI's** (`github.run_number`) and is never written by hand.
+
+## Steps
+
+1. Read the current `VersionMajorMinor` from `src/Directory.Build.props`.
+2. Show the user old -> new.
+3. Edit that one line.
+4. Verify, using the same command CI uses, that it resolves and keeps its shape:
+   ```bash
+   dotnet msbuild src/Directory.Build.props -getProperty:VersionMajorMinor -nologo
+   ```
+   Then confirm it propagated (expect `X.Y.0` for each, and `X.Y.0.0` for Lib's AssemblyVersion):
+   ```bash
+   cd src && for p in TianWen.Lib TianWen.Cli TianWen.Server TianWen.UI.Gui TianWen.UI.FitsViewer TianWen.AI.MCP; do
+     echo "$p $(dotnet msbuild $p/$p.csproj -getProperty:VersionPrefix -nologo)"
+   done
+   ```
+5. Confirm no stale literal survived anywhere:
+   ```bash
+   grep -rn "<VersionPrefix>[0-9]\|<AssemblyVersion>[0-9]" src/*/*.csproj
+   grep -n "VERSION_PREFIX:" .github/workflows/dotnet.yml   # expect only the job-env indirections
+   ```
+6. Add the release-notes entry to the workflow `env:` if the user wants one. **Release notes live
+   there, not beside the number** — several entries contain a double hyphen, which XML forbids inside
+   a comment (MSBuild reports it as MSB4025 "the project file could not be loaded", which reads like
+   corruption rather than punctuation).
+7. Do NOT commit. Let the user review and commit when ready.
+
+## If you are editing the props file for any other reason
+
+**No double hyphen inside an XML comment**, ever — same MSB4025 trap as above. It bit this conversion
+while it was being written.

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -11,14 +11,26 @@ on:
   workflow_dispatch:
 
 env:
-  VERSION_PREFIX: 6.1.${{ github.run_number }}
   VERSION_REV: ${{ github.run_attempt }}
   VERSION_HASH: +${{ github.sha }}
   BUILD_CONF: Release
+  # The version is CAPTURED from `dotnet msbuild -getProperty` stdout in build's "Resolve version
+  # prefix" step, so the SDK's first-run banner must not be able to land in it.
+  DOTNET_NOLOGO: 1
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    # Published for the downstream jobs. $GITHUB_ENV is PER-JOB, so the `echo >> $GITHUB_ENV` step
+    # that single-job repos use (Lzip.Lib, the reference implementation) would set VERSION_PREFIX
+    # for this job only and leave test-unit / test-functional / publish-apps / release with an empty
+    # value -- silently malforming `-p:Version=` and tagging a release `v.`. A job output crosses
+    # the boundary; each consumer maps it back to the same env name, so no `run:` line changes.
+    # Resolved here rather than in a dedicated `version` job so it costs no extra runner: this job
+    # already checks out and sets up the SDK, and a separate job would serialise its own startup
+    # onto every push and PR.
+    outputs:
+      version-prefix: ${{ steps.resolve-version.outputs.prefix }}
     steps:
     # The PreprocessCatalogs MSBuild target produces the *.gs.gz embedded
     # resources from *.json.lz / *.csv.lz sources, decoding the .lz inputs with
@@ -54,6 +66,27 @@ jobs:
         dotnet-version: 10.0.x
         cache: true
         cache-dependency-path: src/Directory.Packages.props
+    # Read the major.minor back from the ONE place it is written (src/Directory.Build.props ->
+    # VersionMajorMinor) instead of restating it in this file. It used to be a literal in the
+    # workflow `env:`, so the number lived in two places and nothing compared them.
+    #
+    # -getProperty only EVALUATES the file: nothing is built and no restore is needed, so this runs
+    # before restore. The value is CAPTURED from stdout, so nothing else may print to it:
+    # DOTNET_NOLOGO (workflow env) keeps the SDK first-run banner out, and the shape check makes
+    # anything unexpected, or a renamed property, FAIL the run rather than quietly stamping every
+    # package and the release tag as ".<run>". Written to BOTH $GITHUB_ENV (for this job's own steps)
+    # and $GITHUB_OUTPUT (for the downstream jobs, since $GITHUB_ENV does not cross a job boundary).
+    - name: Resolve version prefix
+      id: resolve-version
+      run: |
+        MM="$(dotnet msbuild src/Directory.Build.props -getProperty:VersionMajorMinor -nologo | tr -d '[:space:]')"
+        case "$MM" in
+          [0-9]*.[0-9]*) ;;
+          *) echo "::error::VersionMajorMinor did not resolve from src/Directory.Build.props (got '$MM')"; exit 1 ;;
+        esac
+        echo "VERSION_PREFIX=${MM}.${{ github.run_number }}" >> "$GITHUB_ENV"
+        echo "prefix=${MM}.${{ github.run_number }}" >> "$GITHUB_OUTPUT"
+        echo "Resolved VERSION_PREFIX=${MM}.${{ github.run_number }}"
     - name: Restore dependencies
       run: dotnet restore
       working-directory: src
@@ -79,6 +112,8 @@ jobs:
 
   test-unit:
     needs: build
+    env:
+      VERSION_PREFIX: ${{ needs.build.outputs.version-prefix }}
     # Matrix on x86_64 + ARM64 so we cover both architectures. `fail-fast: false` so a
     # regression on one architecture doesn't cancel the other.
     strategy:
@@ -236,6 +271,8 @@ jobs:
   test-functional:
     needs: build
     runs-on: ubuntu-latest
+    env:
+      VERSION_PREFIX: ${{ needs.build.outputs.version-prefix }}
     steps:
     # astrometry-data-2mass-08-19 alone is ~1 GB. Caching saves ~30-60s and a
     # fair chunk of network on every run.
@@ -292,6 +329,8 @@ jobs:
   publish-apps:
     needs: build
     if: github.event_name == 'workflow_dispatch'
+    env:
+      VERSION_PREFIX: ${{ needs.build.outputs.version-prefix }}
     strategy:
       fail-fast: false
       matrix:
@@ -390,11 +429,13 @@ jobs:
   # target-platform publishes succeeded. Workflow_dispatch only -- piggybacks
   # off publish-apps, which is also dispatch-gated.
   release:
-    needs: [test-unit, test-functional, publish-apps]
+    needs: [build, test-unit, test-functional, publish-apps]
     if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    env:
+      VERSION_PREFIX: ${{ needs.build.outputs.version-prefix }}
     steps:
     - uses: actions/download-artifact@v8
       with:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,9 +33,12 @@ Available in `.claude/skills/<name>/SKILL.md`: auto-invocable when the request m
 | `release-tianwen` | Cut a TianWen binary release (workflow_dispatch + GitHub Release with .tar.gz assets) |
 | `sibling-status` | Git status + version across all SharpAstro repos |
 | `check-ci` | GitHub Actions CI status across all repos |
-| `bump-version` | Bump TianWen version in all 4 required locations |
-| `run-gui` / `run-tui` | Build and launch the GUI / CLI TUI with stderr redirect |
+| `bump-version` | Bump TianWen's version: the one `<VersionMajorMinor>` in `src/Directory.Build.props` |
+| `run-gui` / `run-tui` / `run-fits` | Build and launch the GUI / CLI TUI / FITS viewer with stderr redirect |
 | `test-filter` | Run tests matching a name pattern |
+| `test-image-diff` | Diff test-output PNGs across run folders to flag visual regressions |
+| `test-output-prune` | Delete old `yyyyMMdd` test-output folders, keeping the N most recent |
+| `stack` | Run `tianwen stack` against a folder of FITS lights + calibration |
 | `tick-todo` | Mark a TODO item done and update CLAUDE.md, PLAN files, and memory |
 
 ## Project Overview
@@ -44,9 +47,9 @@ TianWen is a .NET 10 library for astronomical device management, image processin
 Supports cameras, mounts, focusers, filter wheels, cover/calibrators, and guiders via ASCOM, Alpaca (HTTP),
 ZWO, QHYCCD, Meade LX200, Skywatcher, OnStep (serial + WiFi/mDNS), iOptron SkyGuider Pro, Gemini FlatPanel
 Lite (native serial cover/calibrator), Gemini Focuser Pro (native serial focuser, a rebadged myFocuserPro2),
-PHD2, and a built-in guider. Published as `TianWen.Lib` on NuGet,
-plus four AOT-published binaries (`tianwen` CLI,
-`tianwen-server` headless, `tianwen-gui`, `tianwen-fits`).
+PHD2, and a built-in guider. Published as `TianWen.Lib` on NuGet, plus AOT-published binaries — of
+which **four are release assets** (`tianwen` CLI, `tianwen-server` headless, `tianwen-gui`,
+`tianwen-fits`) and two are built but not shipped as `.tar.gz` (`tianwen-mcp`, `tianwen-ascomhost`).
 
 Repository: https://github.com/SharpAstro/tianwen
 
@@ -80,8 +83,10 @@ src/
 └── TianWen.AI.MCP/                # MCP (Model Context Protocol) stdio server (AOT-published → `tianwen-mcp`)
 ```
 
-CLI, Server, FitsViewer, Gui, MCP set `<AssemblyName>` to a short lower-case name so the published
-binaries are `tianwen`, `tianwen-server`, `tianwen-fits`, `tianwen-gui`, `tianwen-mcp`.
+Six projects set `PublishAot` + an `<AssemblyName>` short lower-case name: `tianwen`,
+`tianwen-server`, `tianwen-fits`, `tianwen-gui`, `tianwen-mcp`, `tianwen-ascomhost`. **Only the
+first four are packaged as release assets** by `.github/workflows/dotnet.yml` — adding a binary to
+the release means adding it to the upload/glob steps there as well as setting the properties here.
 
 ## Build & Test Commands
 
@@ -127,24 +132,17 @@ be outliers (the latter via a separate `UseLocalFitsLib` switch) but were folded
 there is **no** per-library switch anymore. Trade-off: a missing checkout of *any* listed sibling flips
 the whole set back to packages (all-or-nothing), which is fine on a dev box that has them all.
 
-**`WebGl.Renderer` used to be an exception on both counts, and the two ways it bit are the argument for
-never making one again.** It is consumed only by `TianWen.UI.Web`, which sits outside `TianWen.slnx`, and
-that project used to **opt out of CPM** so its Blazor deps could carry inline versions. The convenience
-cost two real defects: (1) a sibling-family bump sweeping `Directory.Packages.props` could not see an
-inline pin, so it sat two minors behind (`1.12.*` while `1.13` was published) and became the last member
-still built against DIR.Lib 7.0 after the rest moved to 7.4, leaving the package graph to unify DIR.Lib
-by taking the highest version rather than by intent; (2) it was gated on `UseLocalSiblings` yet absent
-from that property's own `Exists(...)` list, so a box with every other sibling cloned resolved the switch
-to `true` and then pointed a `ProjectReference` at a path that was not there.
+**There are no CPM opt-outs left in `src/`, and a new one needs a real technical justification, not
+"this project is not in the solution".** `TianWen.UI.Web` + `.E2E` were the two opt-outs and each drifted
+exactly as you would expect: a sibling-family bump sweeping `Directory.Packages.props` cannot see an
+inline pin, so WebGl.Renderer sat two minors behind and became the last consumer on DIR.Lib 7.0 after the
+rest moved to 7.4 (the graph then unified DIR.Lib by highest-version rather than by intent), and
+`Microsoft.NET.Test.Sdk` sat at 18.6.0 inline against 18.3.0 centrally. **Being outside a solution never
+had any bearing on CPM**, which resolves by walking directories, so the opt-out bought nothing.
 
-Both are now closed: the project is under CPM like everything else (all three of its versions live in
-`Directory.Packages.props`), and `WebGl.Renderer` is in the `Exists(...)` list, so the switch and that
-`ProjectReference` agree by construction. **Being outside a solution never had any bearing on CPM**,
-which resolves by walking directories, so the opt-out bought nothing it could not have had anyway.
-`TianWen.UI.Web.E2E` opted out for the same non-reason and had drifted the same way
-(`Microsoft.NET.Test.Sdk` 18.6.0 inline against 18.3.0 centrally, since reconciled upward to 18.6.0 for
-every test project); it is now under CPM too. **There are no CPM opt-outs left in `src/`, and a new one
-needs a real technical justification, not "this project is not in the solution".**
+**A sibling in the `UseLocalSiblings` gate must also be in that property's own `Exists(...)` list.**
+WebGl.Renderer was gated on the switch but absent from the list, so a box with every *other* sibling
+cloned resolved it to `true` and aimed a `ProjectReference` at a path that was not there.
 
 **Both web projects stay out of `TianWen.slnx`, which is a separate and legitimate decision.**
 `TianWen.UI.Web` is a Blazor WASM app whose sole CI is `pages.yml` (a mono AOT publish, far too heavy for
@@ -154,11 +152,10 @@ solution-wide `dotnet test` must not sweep it up. Run them explicitly:
 
 **`open-vs.ps1` generates `TianWen.local.slnx`** at the repo root (gitignored) by re-rooting
 `src/TianWen.slnx` and appending a `/Siblings/` folder, so Go To Definition lands in sibling *source*.
-Its project list **must** match the `UseLocalSiblings` `Exists(...)` conjunction, and nothing enforces
-that: it had drifted to `../StbImageSharp` for all seven codec projects (that repo is `../Codecs` now),
-and was missing `LAN.Lib`, `SharpAstro.Codecs` and `WebGl.Renderer`. A generated solution with
-unresolvable entries loads with them silently unloaded rather than failing, so touch one file and re-read
-the other.
+Its project list **must** match the `UseLocalSiblings` `Exists(...)` conjunction and **nothing enforces
+that** — it had drifted to `../StbImageSharp` for all seven codec projects (that repo is `../Codecs`
+now) and was missing three others. A generated solution with unresolvable entries loads with them
+silently unloaded rather than failing, so touch one file and re-read the other.
 
 For libraries without auto-detection (`FC.SDK`, `ZWOptical.SDK`, `TianWen.DAL`),
 prefer to extend the `UseLocalSiblings` switch in
@@ -168,51 +165,53 @@ cadence forces a version bump), commit + push + wait for NuGet publish; **do not
 local nupkg feeds or run `dotnet pack` to short-circuit the release dance, since CI builds
 will still pull from nuget.org and a local-only nupkg will mask version-skew bugs.
 
-### How every sibling repo is versioned (one property, read back in CI)
+### Releasing a sibling (three traps the org doc does not cover)
 
-**To cut a release in ANY SharpAstro repo, edit `<VersionMajorMinor>` in its `Directory.Build.props`
-and nothing else.** Every repo now uses the same shape, under the same property name, so the answer to
-"where does this repo's version live" never varies:
+**The mechanism is org-wide and documented once, in the imported `.github/CLAUDE.md` ("Versioning")
+plus `.github/docs/dotnet-ci-pattern.md` — a release in ANY SharpAstro repo is editing
+`<VersionMajorMinor>` in that repo's `Directory.Build.props` and nothing else.** Do not restate it
+here. What follows is only what that doc omits:
 
-- **`Directory.Build.props`** (repo root, or `src/` where the repo keeps one there) holds
-  `<VersionMajorMinor>X.Y</VersionMajorMinor>`. Everything else in the repo derives from it:
-  `<VersionPrefix Condition="'$(VersionPrefix)' == ''">$(VersionMajorMinor).0</VersionPrefix>` for local
-  builds, and `AssemblyVersion` as `$(VersionMajorMinor).0.0` where a repo pins one.
-- **The workflow READS IT BACK** rather than restating it. A `dotnet msbuild <props> -getProperty:VersionMajorMinor`
-  step writes `VERSION_PREFIX=<X.Y>.<run>` into `$GITHUB_ENV` before restore. `-getProperty` only
-  *evaluates* the file, so it needs no restore and runs first.
+- **`DOTNET_NOLOGO: 1` must be in the workflow `env:`.** The version is captured from `dotnet msbuild
+  -getProperty` stdout, so the SDK's first-run banner must not be able to land in it. Pair it with a
+  shape check that *fails the run*, so a renamed or unresolvable property cannot quietly stamp every
+  package as `.<run>`.
+- **Release notes go in the workflow `env:`, never beside the number.** Several entries contain a
+  double hyphen, which XML forbids inside a comment (see the NU1015 note in memory).
+- **A test step that rebuilds a `GeneratePackageOnBuild` project without `-p:Version` publishes a
+  second, stray package.** It packs again at the csproj default `X.Y.0` into the same `bin/Release`
+  the publish job globs with `**/*.nupkg`; both get pushed and `--skip-duplicate` hides it by making
+  the re-push a no-op rather than an error. This cost WebGl.Renderer a stray package on every run for
+  fifteen releases. Pass `--no-build` to `dotnet test` (what most repos do) or
+  `-p:GeneratePackageOnBuild=false`. To audit: list a package's versions and look for a bare `X.Y.0`
+  beside the run-numbered ones.
 
-**Why it is read back rather than duplicated:** CI stamps one `-p:Version` across the whole repo, so a
-per-csproj version only ever surfaces in a *local* build, which is exactly where nobody looks, while a
-workflow copy silently decides what ships. Nothing compared them, and they drifted. DIR.Lib.Shaping
-sat at 6.8.0 while DIR.Lib was 7.5.0, so a local `dotnet pack` shipped the satellite a full major
-behind the library it ships with; SdlVulkan's Inspector/WebView trio sat at 6.0.0 against 7.4.0; and
-Codecs' own comment recorded the 3.5 work shipping as 3.4.49 because only one of its two copies moved.
-The SDK repos had the inverse: no csproj version at all, so a local pack produced the SDK default
-1.0.0 against a package whose real line was 4.2 or 2.0.
+`LALR.CC` is deliberately exempt from the shared shape (tag-driven, version guarded against the pushed
+`vX.Y.Z`); leave it alone.
 
-Two rules that make the step safe, both load-bearing:
-- **`DOTNET_NOLOGO: 1` in the workflow `env:`.** The value is captured from stdout, so the SDK's
-  first-run banner must not be able to land in it.
-- **A shape check that fails the run.** An unresolvable or renamed property must not quietly stamp
-  every package as `.<run>`.
+**TianWen now uses that shape too** (converted 2026-08-09; it was seven hand-edited places until
+then). `<VersionMajorMinor>` lives in `src/Directory.Build.props` and everything derives: `VersionPrefix`
+for every project (guarded on empty so CI's `-p:Version` wins), `AssemblyVersion` in
+`TianWen.Lib.csproj` as `$(VersionMajorMinor).0.0`, and CI's `VERSION_PREFIX`. `/bump-version` edits
+the one line. **A version literal in a csproj or the workflow is now a regression** — delete it and
+let it derive.
 
-**Release notes stay in the workflow `env:`, not next to the number.** Several entries contain a double
-hyphen, which XML forbids inside a comment. Add the entry there when you bump the property here.
+Two things specific to this repo's conversion:
 
-**`LALR.CC` is deliberately exempt** and should stay that way. It is tag-driven, not run-number driven:
-the package version *is* `<Version>` in `LALR.CC.csproj`, and its workflow already has a guard step that
-fails when a pushed `vX.Y.Z` tag disagrees with it. That is the same invariant, one place, CI verifies
-instead of duplicating, expressed for a different release model, and converting it would break the
-tag-to-version contract the guard enforces.
-
-**A live failure mode worth knowing** (it cost WebGl.Renderer a stray published package on every run
-for fifteen releases): if a **test step rebuilds a `GeneratePackageOnBuild` project without
-`-p:Version`**, it packs a *second* time at the csproj default `X.Y.0`, into the same `bin/Release` the
-publish job globs with `**/*.nupkg`. Both get pushed, and `--skip-duplicate` hides it by making the
-re-push a no-op rather than an error. Either pass `--no-build` to `dotnet test` (what most repos here
-do) or `-p:GeneratePackageOnBuild=false`. To audit: list a package's versions and look for a bare
-`X.Y.0` sitting beside the run-numbered ones.
+- **The read-back writes BOTH `$GITHUB_ENV` and a `build` job output**, because `$GITHUB_ENV` is
+  **per-job** and five jobs here consume `VERSION_PREFIX` (`build`, `test-unit`, `test-functional`,
+  `publish-apps`, `release`). The bare-step form that single-job repos use (Lzip.Lib, the reference
+  implementation) would have set it for `build` only and left the rest empty — silently malforming
+  `-p:Version=` and tagging a release `v.`. So `build`'s "Resolve version prefix" step exports
+  `version-prefix`, and every consumer declares `needs: build` plus a job-level
+  `env: VERSION_PREFIX: ${{ needs.build.outputs.version-prefix }}`, which leaves all the `run:` lines
+  untouched. **A new job that builds or publishes needs both halves.** It lives in `build` rather than
+  a dedicated `version` job on purpose: `build` already checks out and sets up the SDK, so a separate
+  job would only serialise its own runner startup onto every push and PR.
+- **It closed a latent bug.** `TianWen.Lib` sets `GeneratePackageOnBuild` but had no `VersionPrefix`
+  of its own, so a local `dotnet build` packed it at the SDK default **1.0.0** while its
+  `AssemblyVersion` read 6.1 — there was a 43 MB `TianWen.Lib.1.0.0.nupkg` sitting in `bin/Release`
+  to prove it. The shared `VersionPrefix` now covers every project.
 
 ## Key Technologies
 
@@ -266,8 +265,17 @@ See [docs/plans/device-simulator-ci.md](docs/plans/device-simulator-ci.md).
 
 Tests grouped into `[Collection("X")]` by functional area. All `Session*Tests` share `[Collection("Session")]`
 and run sequentially to avoid thread pool starvation from concurrent `Task.Run` + `FakeTimeProvider` timer
-callbacks. `maxParallelThreads: 4` in `xunit.runner.json`. **No wall-clock `CancellationTokenSource` timeouts**
-in session tests; use `[Fact(Timeout = ...)]`; inner timeouts cause flakes.
+callbacks. **No wall-clock `CancellationTokenSource` timeouts** in session tests; use
+`[Fact(Timeout = ...)]`; inner timeouts cause flakes.
+
+**Less parallelism is faster here, and the config only counts if it is copied to the output.** All three
+test projects carry an `xunit.runner.json` (`maxParallelThreads: 4`; Simulators pins 1 +
+`parallelizeTestCollections: false`) **and** a matching
+`<Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />`. `TianWen.Lib.Tests`
+had neither for a long time while this file claimed otherwise, so xUnit silently defaulted to the core
+count (12) and thrashed the box; adding the file plus the `Content Include` cut the suite from 8m45–12m
+to 7m46 **and made it green** — contention was dominating. Never diagnose a slow suite by re-running it
+repeatedly: one run with a TRX logger, then rank durations.
 
 `SessionTestHelper` defaults to `FakeMountDriver`; pass `mountPort: "LX200"` or `"SkyWatcher"` only for
 protocol-specific tests.
@@ -504,9 +512,9 @@ that into `Channel`'s `[y, x]` row-major layout (see `AlpacaImageBytesTests`). `
 downloads + decodes **once** when the server first reports `imageready`, populating `ImageData` /
 `ChannelBuffer` for the default `ICameraDriver.GetImageAsync`; `StartExposureAsync` clears them so the
 next frame re-downloads. Before this, `ImageData => null` meant the camera connected but never
-returned a frame, which is why `AddAlpaca()` was previously left unregistered. **Not yet validated
-against a live Omni/Alpaca Simulator**: the decoder is byte-exact + unit-pinned but the HTTP
-round-trip is unverified.
+returned a frame, which is why `AddAlpaca()` was previously left unregistered. **The HTTP round-trip
+is validated against a live OmniSim** by `AlpacaSimulatorTests.Camera_ExposesAndDownloadsViaImageBytes`
+(see the simulator suite below) — the decoder stays separately byte-pinned by `AlpacaImageBytesTests`.
 
 ### Device Secrets (Credential Store)
 
@@ -1494,6 +1502,31 @@ touches six places: the `GuiTab` enum, `GuiAppState.TabOrder`, `TabChrome`, the 
 Ctrl+letter map, the two `VkGuiRenderer` switches, and
 `GuiTabNavigationTests.TabOrder_IsTheSidebarLayoutOrder` (which pins the order and will go red by
 design).
+
+### Colour Theme (`GuiTheme`, four states incl. Night)
+
+`GuiTheme` (`TianWen.UI.Abstractions/GuiTheme.cs`) owns the one palette every surface paints with;
+`UiThemeState` is **System / Light / Dark / Night**, and `GuiTheme.Apply(state, desktopIsDark)`
+resolves + swaps it in as a single reference write. `Palette` is one reference read, never torn. The
+source XML comments carry the full rationale (including the scotopic-sensitivity numbers) — read them
+before changing a colour.
+
+- **Anything that CACHES a projection of the palette owes `GuiTheme.PaletteGeneration` in its cache
+  key.** `Apply` bumps the generation only when the resolved palette actually moves. This is the
+  frozen-snapshot bug in another costume: the planner chart renders to a GPU texture keyed on the data
+  it draws, a theme switch changes none of that data, so the chart kept painting the old palette after
+  F12 while every other surface moved. `Apply`'s `bool` return ("did it change") cannot fix a cache —
+  the consumer may not have been asked — but a generation is comparable later by anyone.
+- **Night is not a darker Dark, and is deliberately unreachable from `System`.** F12 toggles it
+  (SharpCap's night-vision gesture). Blue is **zero** throughout and green is spent only to buy hue
+  separation, because red is the only cheap channel for dark adaptation; red-on-black caps at 5.25:1,
+  so the whole text ladder fits under that ceiling — anything that must be READ uses `BodyText`, and
+  `DimText` is reserved for chrome nobody needs to read. Two derived colours had leaked blue into
+  Night and had to be fixed; derive new ones from the palette, never from a literal.
+- **Judge Night at night.** A sky-map screenshot taken at 5pm shows its daylight tint, not the theme's;
+  anchor the clock with `TIANWEN_NOW` before concluding a Night colour is wrong.
+
+98 raw colour literals remain of an original 317, all categorical or two-trace series by design.
 
 ### Image Pipeline & Buffer Lifecycle
 

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,5 +1,35 @@
 <Project>
 
+  <PropertyGroup>
+    <!--
+      THE version for this repo, and the only place it is written. It used to be stated SEVEN times:
+      AssemblyVersion in TianWen.Lib.csproj, a VersionPrefix default in each of the five published
+      apps, and VERSION_PREFIX in .github/workflows/dotnet.yml. CI stamps one -p:Version over the
+      whole build, so the csproj copies only ever surfaced in a LOCAL build (exactly where nobody
+      looks) while the workflow copy silently decided what shipped. Nothing compared them.
+
+      NOTE: no double hyphen anywhere in this comment. XML forbids it inside a comment, and MSBuild
+      reports it as MSB4025 "the project file could not be loaded", which reads like corruption
+      rather than punctuation.
+
+      The workflow now READS this back (dotnet msbuild -getProperty:VersionMajorMinor) in a `version`
+      job and passes it to the others as a job output, so a release bump is this one line and CI
+      cannot publish a version the packages disagree with. Matches every other SharpAstro repo; see
+      the org's .github/CLAUDE.md "Versioning" and .github/docs/dotnet-ci-pattern.md.
+
+      A release bump is 1.0 -> 1.1 additive, 1.x -> 2.x breaking. The patch segment is CI's
+      (github.run_number) and is never written by hand.
+    -->
+    <VersionMajorMinor>6.1</VersionMajorMinor>
+    <!--
+      Local builds get Major.Minor.0; CI passes -p:Version=Major.Minor.<run><attempt>+<sha> and the
+      condition lets it win. This applies to EVERY project, which also closes a latent bug:
+      TianWen.Lib sets GeneratePackageOnBuild but had no VersionPrefix of its own, so a local
+      `dotnet build` packed TianWen.Lib at the SDK default 1.0.0 while its AssemblyVersion read 6.1.
+    -->
+    <VersionPrefix Condition="'$(VersionPrefix)' == ''">$(VersionMajorMinor).0</VersionPrefix>
+  </PropertyGroup>
+
   <!--
     Auto-detect sibling SharpAstro working copies.
     When a sibling repo exists locally, its project is used via ProjectReference

--- a/src/TianWen.AI.MCP/TianWen.AI.MCP.csproj
+++ b/src/TianWen.AI.MCP/TianWen.AI.MCP.csproj
@@ -16,7 +16,6 @@
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Version)' == '' ">
-    <VersionPrefix Condition=" '$(VersionPrefix)' == '' ">6.1.0</VersionPrefix>
     <Version Condition=" '$(VersionSuffix)' != '' And $(VersionSuffix[0]) != '+'">$(VersionPrefix)-$(VersionSuffix)</Version>
     <Version Condition=" '$(VersionSuffix)' != '' And $(VersionSuffix[0]) == '+'">$(VersionPrefix)$(VersionSuffix)</Version>
     <Version Condition=" '$(Version)' == '' ">$(VersionPrefix)</Version>

--- a/src/TianWen.Cli/TianWen.Cli.csproj
+++ b/src/TianWen.Cli/TianWen.Cli.csproj
@@ -12,7 +12,6 @@
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Version)' == '' ">
-    <VersionPrefix Condition=" '$(VersionPrefix)' == '' ">6.1.0</VersionPrefix>
     <Version Condition=" '$(VersionSuffix)' != '' And $(VersionSuffix[0]) != '+'">$(VersionPrefix)-$(VersionSuffix)</Version>
     <Version Condition=" '$(VersionSuffix)' != '' And $(VersionSuffix[0]) == '+'">$(VersionPrefix)$(VersionSuffix)</Version>
     <Version Condition=" '$(Version)' == '' ">$(VersionPrefix)</Version>

--- a/src/TianWen.Lib/TianWen.Lib.csproj
+++ b/src/TianWen.Lib/TianWen.Lib.csproj
@@ -4,7 +4,8 @@
     <OutputType>Library</OutputType>
     <TargetFramework>net10.0</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <AssemblyVersion>6.1.0.0</AssemblyVersion>
+    <!-- Derived; the version itself lives in src/Directory.Build.props (VersionMajorMinor). -->
+    <AssemblyVersion>$(VersionMajorMinor).0.0</AssemblyVersion>
     <PackageID>TianWen.Lib</PackageID>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>

--- a/src/TianWen.Server/TianWen.Server.csproj
+++ b/src/TianWen.Server/TianWen.Server.csproj
@@ -12,7 +12,6 @@
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Version)' == '' ">
-    <VersionPrefix Condition=" '$(VersionPrefix)' == '' ">6.1.0</VersionPrefix>
     <Version Condition=" '$(VersionSuffix)' != '' And $(VersionSuffix[0]) != '+'">$(VersionPrefix)-$(VersionSuffix)</Version>
     <Version Condition=" '$(VersionSuffix)' != '' And $(VersionSuffix[0]) == '+'">$(VersionPrefix)$(VersionSuffix)</Version>
     <Version Condition=" '$(Version)' == '' ">$(VersionPrefix)</Version>

--- a/src/TianWen.UI.FitsViewer/TianWen.UI.FitsViewer.csproj
+++ b/src/TianWen.UI.FitsViewer/TianWen.UI.FitsViewer.csproj
@@ -14,7 +14,6 @@
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Version)' == '' ">
-    <VersionPrefix Condition=" '$(VersionPrefix)' == '' ">6.1.0</VersionPrefix>
     <Version Condition=" '$(VersionSuffix)' != '' And $(VersionSuffix[0]) != '+'">$(VersionPrefix)-$(VersionSuffix)</Version>
     <Version Condition=" '$(VersionSuffix)' != '' And $(VersionSuffix[0]) == '+'">$(VersionPrefix)$(VersionSuffix)</Version>
     <Version Condition=" '$(Version)' == '' ">$(VersionPrefix)</Version>

--- a/src/TianWen.UI.Gui/TianWen.UI.Gui.csproj
+++ b/src/TianWen.UI.Gui/TianWen.UI.Gui.csproj
@@ -14,7 +14,6 @@
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Version)' == '' ">
-    <VersionPrefix Condition=" '$(VersionPrefix)' == '' ">6.1.0</VersionPrefix>
     <Version Condition=" '$(VersionSuffix)' != '' And $(VersionSuffix[0]) != '+'">$(VersionPrefix)-$(VersionSuffix)</Version>
     <Version Condition=" '$(VersionSuffix)' != '' And $(VersionSuffix[0]) == '+'">$(VersionPrefix)$(VersionSuffix)</Version>
     <Version Condition=" '$(Version)' == '' ">$(VersionPrefix)</Version>


### PR DESCRIPTION
## The version is one property now

Every other SharpAstro repo cuts a release by editing VersionMajorMinor in Directory.Build.props. TianWen wrote it out longhand in **seven** places: AssemblyVersion in TianWen.Lib, a VersionPrefix default in each of the five published apps, and VERSION_PREFIX in the workflow. CI stamps one -p:Version over the whole build, so the csproj copies only ever surfaced in a *local* build, which is exactly where nobody looks, while the workflow copy silently decided what shipped. Nothing compared them.

Now VersionMajorMinor is the only place it is written and everything derives. A shape check fails the run rather than quietly stamping every package and the release tag as ".&lt;run&gt;", and DOTNET_NOLOGO keeps the SDK banner out of a value captured from stdout.

## Two things specific to this repo

**The read-back writes BOTH $GITHUB_ENV and a build job output.** $GITHUB_ENV is per-job and five jobs here consume VERSION_PREFIX, so the single-job step form the reference repo (Lzip.Lib) uses would have set it for build alone and left the other four empty, malforming -p:Version= and tagging a release "v.". That is a failure the shape check cannot catch, because it passes in the one job that runs it. Each consumer now declares needs: build plus a job-level env mapping, so every run: line is unchanged.

It lives in build rather than a dedicated version job because build already checks out and sets up the SDK; a separate job would only serialise its own runner startup onto every push and PR.

**It closes a latent bug.** TianWen.Lib sets GeneratePackageOnBuild but had no VersionPrefix of its own, so a local build packed it at the SDK default **1.0.0** while its AssemblyVersion read 6.1 - there was a 43 MB TianWen.Lib.1.0.0.nupkg in bin/Release to prove it. The shared property covers every project, and the same build now produces TianWen.Lib.6.1.0.nupkg.

## Verified locally

- read-back resolves 6.1 and passes the shape check
- all six projects derive 6.1.0; TianWen.Lib AssemblyVersion 6.1.0.0
- a -p:VersionPrefix override still wins (CI's path)
- workflow parses; every VERSION_PREFIX consumer has both needs: build and the env mapping
- Release build clean, 0 warnings 0 errors; tests pass
- no version literal left in any csproj or the workflow

**This PR is the first real exercise of the CI plumbing** - build's version-prefix output reaching the four downstream jobs is the thing to watch.

## Also

CLAUDE.md accuracy pass in the second commit: the published-binary count (said four, is six), an Alpaca claim its own simulator section refutes, the duplicated org-wide versioning section, a missing GuiTheme section including the PaletteGeneration cache-key invariant, the load-bearing half of the test-parallelism note, and a stale skills table. /bump-version was rewritten - it would otherwise edit lines that no longer exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018PaKJcLr5e8jzZymJe77RA
