### PR TITLE
feat(gui): the window title names the tab you are looking at

### DIFF
--- a/docs/todo/ui.md
+++ b/docs/todo/ui.md
@@ -48,6 +48,35 @@ Part of the TianWen TODO set. See [TODO.md](../../TODO.md) for the index and the
   via the console inspector: row 3 `Mount` returns as unselected). Remember the cursor index per tab
   instance across `Attach`, clamped to the rebuilt item count.
 
+## TUI terminal integration (Windows Terminal / ConEmu), explored 2026-08-08
+
+The TUI already writes the terminal title (OSC 0, change-gated in the `TuiSubCommand` render block)
+and Console.Lib already speaks OSC 8 (hyperlinks), OSC 52 (clipboard) and Sixel, so surfacing session
+state through the terminal is a small addition that follows an existing pattern:
+
+- [ ] **Taskbar progress via OSC 9;4** (`ESC ] 9 ; 4 ; <state> ; <pct> BEL` -- ConEmu's sequence,
+  rendered by Windows Terminal 1.6+ as progress on the taskbar button; every other mainstream
+  terminal consumes an unknown OSC silently, so it can be emitted unconditionally, same rule as the
+  existing OSC 0 title). Add an `Osc9Progress` helper beside `Osc8` in Console.Lib (the library owns
+  escape shapes, the app owns the mapping) and emit it change-gated next to the title write:
+  - imaging: state 1 (normal) + percent -- reuse the `F:n/~est` math `TuiLiveSessionTab.RenderTopBar`
+    already does (extract it to `LiveSessionActions` so the top bar and the taskbar cannot disagree);
+  - running with no meaningful denominator (cooling / slew / focus / guider calibration): state 3
+    (indeterminate);
+  - pending session prompt: state 4 (paused/yellow) -- the rig is blocked on a human, which is exactly
+    what a taskbar-visible state exists to surface;
+  - `SessionPhase.Failed`: state 2 (error/red);
+  - idle: state 0 (remove), and also clear it on the quit path so a stale bar cannot outlive the run.
+- [ ] **BEL on prompt raise** (once per prompt, alongside state 4): Windows Terminal's `bellStyle`
+  can flash the taskbar/window on BEL (user-configurable; the default is audible only), which turns
+  "a prompt is waiting" into an OS-level attention signal with no new machinery.
+- [ ] **Meridian-flip warning in the title**: within N minutes of the flip, prepend a countdown to
+  the already change-gated title (the four taskbar states are too coarse for a countdown). Ties into
+  the "Meridian flip countdown indicator" item in the Live Session section above.
+- [ ] Consider unifying the TUI title shape with the GUI's window title
+  (`{tab icon} {tab} - {profile} · {phase} - {target}`, `TianWen.UI.Gui/Program.cs`); the TUI
+  currently writes `\U0001F52D {profile} — {tab}` with the phase folded into the tab name.
+
 ## FITS Viewer
 
 - [ ] Rename HDR button/label to "Compress Highlights"

--- a/src/TianWen.UI.Gui/Program.cs
+++ b/src/TianWen.UI.Gui/Program.cs
@@ -559,8 +559,10 @@ loop.OnPostFrame = () =>
     }
     plannerState.NeedsRedraw = false;
 
-    // Update window title with session state (only when changed). The title names what you are
-    // LOOKING at, so it follows the active context -- including WHICH rig, when that is not this computer.
+    // Update window title (only when changed). The title names what you are LOOKING at: the active
+    // tab's icon + name exactly as the sidebar draws them (TabTitleChrome, so the Live Session glyph
+    // follows the mode), the profile it runs -- prefixed with WHICH rig, when that is not this
+    // computer -- and, while a session runs, its phase + target after a separating middle dot.
     var ls = guiRenderer.ViewContexts.Active.LiveSession;
     var viewed = guiRenderer.ViewContexts.Active;
 
@@ -576,14 +578,20 @@ loop.OnPostFrame = () =>
         }
     }
 
-    var viewedName = viewed.IsLocal ? "TianWen" : viewed.DisplayName;
-    var newTitle = ls.IsRunning
-        ? ls.ActiveObservation is { Target: var target }
-            ? $"\U0001F52D {LiveSessionActions.PhaseLabel(ls.Phase)} - {target.Name}"
-            : $"\U0001F52D {LiveSessionActions.PhaseLabel(ls.Phase)}"
-        : viewedProfile is { Length: > 0 } profile
-            ? $"\U0001F52D {viewedName} - {profile}"
-            : $"\U0001F52D {viewedName}";
+    var (tabIcon, tabLabel) = guiRenderer.TabTitleChrome(appState.ActiveTab);
+    // The local rig is implied by the window itself, so only a remote rig names itself.
+    var context = viewed.IsLocal
+        ? viewedProfile
+        : viewedProfile is { Length: > 0 } p ? $"{viewed.DisplayName} - {p}" : viewed.DisplayName;
+    var newTitle = context is { Length: > 0 }
+        ? $"{tabIcon} {tabLabel} - {context}"
+        : $"{tabIcon} {tabLabel}";
+    if (ls.IsRunning)
+    {
+        newTitle = ls.ActiveObservation is { Target: var target }
+            ? $"{newTitle} · {LiveSessionActions.PhaseLabel(ls.Phase)} - {target.Name}"
+            : $"{newTitle} · {LiveSessionActions.PhaseLabel(ls.Phase)}";
+    }
     if (newTitle != lastWindowTitle)
     {
         lastWindowTitle = newTitle;

--- a/src/TianWen.UI.Gui/VkGuiRenderer.cs
+++ b/src/TianWen.UI.Gui/VkGuiRenderer.cs
@@ -191,23 +191,55 @@ namespace TianWen.UI.Gui
         private const string LiveSessionPlanetaryIcon = "\U0001FA90"; // ringed planet (Planetary mode)
         private const string LiveSessionFlatsIcon     = "\U0001F4A1"; // light bulb (Flats mode)
 
-        // Per-tab sidebar chrome (icon + hover tooltip with the Ctrl+letter shortcut). The sidebar
-        // ORDER comes from GuiAppState.TabOrder (shared with Ctrl+Tab cycling) so the visual order
-        // and the cycle order can't drift apart.
-        private static readonly Dictionary<GuiTab, (string Icon, string Tooltip)> TabChrome = new()
+        // Per-tab sidebar chrome (icon + display name + Ctrl+letter shortcut; the hover tooltip is
+        // "Label (Shortcut)"). The sidebar ORDER comes from GuiAppState.TabOrder (shared with
+        // Ctrl+Tab cycling) so the visual order and the cycle order can't drift apart. The label is
+        // a separate field because the window title reuses it (via TabTitleChrome) without the
+        // shortcut suffix.
+        private static readonly Dictionary<GuiTab, (string Icon, string Label, string Shortcut)> TabChrome = new()
         {
             // House, not satellite/antenna/globe: the icon has to stay neutral between local and remote,
             // or a single-scope user's one-card board looks like a remote-monitoring feature they do not
             // use -- and it names the SCREEN, which is due to hold multi-night progress beside the cards.
-            [GuiTab.Home]          = ("\U0001F3E0",        "Home (Ctrl+H)"),
-            [GuiTab.Equipment]     = ("\U0001F52D",        "Equipment (Ctrl+E)"),
-            [GuiTab.Planner]       = ("\U0001F4C5",        "Planner (Ctrl+P)"),
-            [GuiTab.SkyMap]        = ("\U0001F30C",        "Sky Map (Ctrl+M)"),
-            [GuiTab.Session]       = ("\U0001F3AC",        "Session Setup (Ctrl+S)"),
-            [GuiTab.LiveSession]   = (LiveSessionIdleIcon, "Live Session (Ctrl+L)"),
-            [GuiTab.Guider]        = ("\U0001F3AF",        "Guider (Ctrl+G)"),
-            [GuiTab.Notifications] = ("\U0001F514",        "Notifications (Ctrl+N)"),
+            [GuiTab.Home]          = ("\U0001F3E0",        "Home",          "Ctrl+H"),
+            [GuiTab.Equipment]     = ("\U0001F52D",        "Equipment",     "Ctrl+E"),
+            [GuiTab.Planner]       = ("\U0001F4C5",        "Planner",       "Ctrl+P"),
+            [GuiTab.SkyMap]        = ("\U0001F30C",        "Sky Map",       "Ctrl+M"),
+            [GuiTab.Session]       = ("\U0001F3AC",        "Session Setup", "Ctrl+S"),
+            [GuiTab.LiveSession]   = (LiveSessionIdleIcon, "Live Session",  "Ctrl+L"),
+            [GuiTab.Guider]        = ("\U0001F3AF",        "Guider",        "Ctrl+G"),
+            [GuiTab.Notifications] = ("\U0001F514",        "Notifications", "Ctrl+N"),
         };
+
+        // The Live Session glyph follows the VIEWED context's state: a running session flips to
+        // "camera with flash"; otherwise the mode picks the glyph -- compass for Polar Align, ringed
+        // planet for Planetary, light bulb for Flats, camera for Preview. (Mirrors the mode pill so
+        // the sidebar reads at a glance.) A flat run deliberately leaves IsRunning false, so the
+        // running-session glyph never masks the Flats one for the duration of the run.
+        private string LiveSessionIcon => ViewedLiveSession.IsRunning
+            ? LiveSessionRunningIcon
+            : ViewedLiveSession.Mode switch
+            {
+                LiveSessionMode.PolarAlign => LiveSessionPolarIcon,
+                LiveSessionMode.Planetary => LiveSessionPlanetaryIcon,
+                LiveSessionMode.Flats => LiveSessionFlatsIcon,
+                _ => LiveSessionIdleIcon,
+            };
+
+        /// <summary>
+        /// Icon + display name for <paramref name="tab"/> exactly as the sidebar draws it this frame
+        /// (the Live Session glyph follows the viewed context's mode/run state). The window title is
+        /// built from this, so the title and the sidebar can never disagree about the active tab.
+        /// </summary>
+        public (string Icon, string Label) TabTitleChrome(GuiTab tab)
+        {
+            var (icon, label, _) = TabChrome[tab];
+            if (tab is GuiTab.LiveSession)
+            {
+                icon = LiveSessionIcon;
+            }
+            return (icon, label);
+        }
 
         // Window chrome, entirely from the shared palette. PROPERTIES, not static readonly fields: a
         // field initialiser snapshots at type-init, which is how the one palette-derived colour that was
@@ -372,24 +404,10 @@ namespace TianWen.UI.Gui
             for (var i = 0; i < tabs.Length; i++)
             {
                 var tab = tabs[i];
-                var (icon, tooltip) = TabChrome[tab];
-                // Live Session icon reflects the active mode: a running session flips to "camera with
-                // flash"; otherwise the mode picks the glyph -- compass for Polar Align, ringed planet for
-                // Planetary, light bulb for Flats, camera for Preview. (Mirrors the mode pill so the
-                // sidebar reads at a glance.) A flat run deliberately leaves IsRunning false, so the
-                // running-session glyph never masks the Flats one for the duration of the run.
-                if (tab is GuiTab.LiveSession)
-                {
-                    icon = ViewedLiveSession.IsRunning
-                        ? LiveSessionRunningIcon
-                        : ViewedLiveSession.Mode switch
-                        {
-                            LiveSessionMode.PolarAlign => LiveSessionPolarIcon,
-                            LiveSessionMode.Planetary => LiveSessionPlanetaryIcon,
-                            LiveSessionMode.Flats => LiveSessionFlatsIcon,
-                            _ => LiveSessionIdleIcon,
-                        };
-                }
+                // One path with the window title: the mode-following Live Session glyph is resolved
+                // inside TabTitleChrome (see LiveSessionIcon), never re-derived here.
+                var (icon, label) = TabTitleChrome(tab);
+                var shortcut = TabChrome[tab].Shortcut;
                 var btnY = startY + i * buttonSize;
                 var isActive = appState.ActiveTab == tab;
                 var isLocked = (noProfile && tab is not GuiTab.Equipment)
@@ -425,7 +443,7 @@ namespace TianWen.UI.Gui
 
                 if (isHover)
                 {
-                    hoverTooltip = tooltip;
+                    hoverTooltip = $"{label} ({shortcut})";
                     hoverY = btnY + buttonSize * 0.5f;
                 }
             }


### PR DESCRIPTION
## What

The GUI window title now names the tab you are looking at.

It read the profile, and while a session ran it replaced that with the phase, so a running rig's window stopped saying which profile it was running. The new shape is:

    <tab icon> <tab name> - <profile>

with the phase and target appended after a separating middle dot for as long as a session runs. A remote rig prefixes its own name into the context segment; the local one stays unnamed, because the window already implies it.

## Why it is not just a string change

The icon and label come from a new **TabTitleChrome**, which is the same chrome the sidebar tab strip draws. The title and the sidebar therefore cannot disagree about the active tab, or about the Live Session glyph that follows the mode (camera / camera-with-flash / compass / ringed planet / light bulb).

Getting there meant two small refactors, both of which remove a second copy of something:

- The mode-following Live Session glyph moved out of the sidebar render loop into one **LiveSessionIcon** property, so it is resolved in a single place instead of being re-derived wherever a glyph is needed.
- **TabChrome** stored a pre-baked tooltip string ("Equipment (Ctrl+E)"). It now stores the label and the shortcut separately, composed at the hover site, so the title can reuse the label without inheriting the shortcut suffix. The sidebar tooltip is unchanged in what it displays.

The sidebar **order** is untouched: it still comes from `GuiAppState.TabOrder`, which is what `GuiTabNavigationTests.TabOrder_IsTheSidebarLayoutOrder` pins.

## Also in this PR

`docs/todo/ui.md` gains a TUI terminal-integration section explored alongside this (backlog notes only, no code):

- OSC 9;4 taskbar progress, mapping imaging to a percentage, the indeterminate phases to state 3, a **pending session prompt to the paused state** (a rig blocked on a human is exactly what a taskbar-visible state exists to surface), and `Failed` to the error state.
- BEL on prompt raise, so Windows Terminal's `bellStyle` can turn a waiting prompt into an OS-level attention signal.
- A meridian-flip countdown in the terminal title, since the four taskbar states are too coarse for one.
- A note to consider unifying the TUI title shape with the GUI's, which is what this PR just changed.

## Verification

- `dotnet build TianWen.UI.Gui` succeeds, 0 warnings.
- No test references `TabChrome`, `TabTitleChrome`, or the tooltip strings, so the record-shape change is not pinned anywhere.

Not done, and worth a reviewer's eye: the GUI was not launched to look at the rendered title, and the full test suite was not run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NtmhDs1m29HJR3J2o24yHo
