### PR TITLE
feat(home): icon controls in the board header, centred and squared

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1489,16 +1489,32 @@ across surface kinds, so a change to the card lands on both surfaces or neither.
   not exist on a cell one. **Auto keeps a visible segment**: it is the default state, so lighting nothing
   would leave the board's commonest configuration unlabelled, and the camera-convention bracketed `A` is
   what makes it sayable at icon size. The theme cycler beside it advances System -> Light -> Dark -> Night
-  (`CycleUiThemeSignal` -> `GuiTheme.CycleTheme`) and is deliberately a WORD, not a pictogram: the fourth
-  mark would have to separate Night from Dark at 13 px, and a crescent is drawn by over-painting the
-  button's own ground, which the shared painter cannot do (it is handed ink and no background). Cycling
-  into Night records where it came from, so a later F12 restores that rather than a stale toggle memory.
+  (`CycleUiThemeSignal` -> `GuiTheme.CycleTheme`) and shows a MARK PLUS THE WORD, selected by
+  `ThemeControlStyle` (a code-level choice, not a user setting). Icon-only is a real option and the wrong
+  default: three marks cover four states because Night IS a dark scheme and takes the same crescent as Dark,
+  and inside Night the whole UI is red, so the colour that would separate them says nothing -- on the one
+  control whose job is telling an observer at the mount which scheme they are in. Cycling into Night records
+  where it came from, so a later F12 restores that rather than a stale toggle memory.
 - **`.RowH(h)` sets `Width = Star` and silently eats a `.WFixed(w)` before it.** It means "a full-width row
   of fixed height", which is right for a card and wrong for a button. The view segments were built that way
   from the start, so `ViewButtonWidth` was inert for their whole life and three buttons sprawled across the
   bar; use `.WFixed(w).HFixed(h)` for anything that is genuinely fixed on both axes. Neither a build nor a
   screenshot review catches this -- only an arranged rect does, which is what
   `HomeTabLayoutTests.TheSegmentsKeepTheirFixedWidthInsteadOfSharingTheHeader` asserts.
+- **A `Stack` places children at the cross-axis START, so centring a row's controls needs
+  `.CrossCenter()`** (`Layout.CrossAlign`, DIR.Lib 7.21). Without it a `HFixed` control in a taller bar hugs
+  the top and its centre sits half the slack high -- which the header did, visibly, and which reads as a
+  styling bug rather than a layout one. Do **not** re-solve it by padding the container or wrapping each
+  child in a spacer sandwich: both worked, and both re-derive at the call site a position the engine already
+  knows, the padding version also insetting the row's label horizontally as a side effect. The Home header
+  is the reference consumer, pinned by `EveryHeaderControlSharesOneTopAndBottom_CentredInTheBar`.
+- **An icon draws at the size it DECLARES and every kind inks that full square** (DIR.Lib 7.20 + 7.21).
+  Before 7.20 `Content.Icon.Size` was a measure-time hint only, so a 13-unit mark in a 20-unit cell painted
+  at 20 and stood a third taller than the label beside it; before 7.21 the kinds inked between 63% and 100%
+  of their declared size, so a row of different marks was ragged whatever the alignment. Both were measured
+  from rendered ink rather than eyeballed, which is the only way to see either. Consequence for a consumer:
+  **size a mark to the text it sits beside** (about 13 units against a 13 px label's ~10 units of cap
+  height), and size it independently where it stands alone in a button.
 - **`Build` takes the viewport, not a resolved column count.** Columns, card detail and cards-vs-table are
   all decided inside it; both hosts previously ran the same `ColumnsFor` -> `ColumnWidth` -> `DetailFor`
   arithmetic, and every new input had to be threaded through both again.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1481,6 +1481,24 @@ across surface kinds, so a change to the card lands on both surfaces or neither.
   be hidden (two rigs can be waiting, so only one could be at the front). Both shapes are `Layout.Node`
   projections over the same `RigCard` data in `HomeBoardLayout`, so the shared tree costs nothing here --
   it is a description language, not a fixed shape, and both surfaces get the table for free.
+- **The header's two controls are icon segments plus a four-state theme cycler**, and both are shared-tree
+  nodes rather than per-surface chrome. The shape selector is three `Layout.Content.Icon` leaves
+  (DIR.Lib 7.18): the pixel painter builds each from rectangles and `CellLayout` picks a block-element
+  glyph, which is why an icon names its MEANING (`Grid` / `List` / `Auto`) and not its drawing -- a `Text`
+  run carrying a symbol character would be .notdef on a pixel surface missing that face, and rectangles do
+  not exist on a cell one. **Auto keeps a visible segment**: it is the default state, so lighting nothing
+  would leave the board's commonest configuration unlabelled, and the camera-convention bracketed `A` is
+  what makes it sayable at icon size. The theme cycler beside it advances System -> Light -> Dark -> Night
+  (`CycleUiThemeSignal` -> `GuiTheme.CycleTheme`) and is deliberately a WORD, not a pictogram: the fourth
+  mark would have to separate Night from Dark at 13 px, and a crescent is drawn by over-painting the
+  button's own ground, which the shared painter cannot do (it is handed ink and no background). Cycling
+  into Night records where it came from, so a later F12 restores that rather than a stale toggle memory.
+- **`.RowH(h)` sets `Width = Star` and silently eats a `.WFixed(w)` before it.** It means "a full-width row
+  of fixed height", which is right for a card and wrong for a button. The view segments were built that way
+  from the start, so `ViewButtonWidth` was inert for their whole life and three buttons sprawled across the
+  bar; use `.WFixed(w).HFixed(h)` for anything that is genuinely fixed on both axes. Neither a build nor a
+  screenshot review catches this -- only an arranged rect does, which is what
+  `HomeTabLayoutTests.TheSegmentsKeepTheirFixedWidthInsteadOfSharingTheHeader` asserts.
 - **`Build` takes the viewport, not a resolved column count.** Columns, card detail and cards-vs-table are
   all decided inside it; both hosts previously ran the same `ColumnsFor` -> `ColumnWidth` -> `DetailFor`
   arithmetic, and every new input had to be threaded through both again.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,7 +47,7 @@ TianWen is a .NET 10 library for astronomical device management, image processin
 Supports cameras, mounts, focusers, filter wheels, cover/calibrators, and guiders via ASCOM, Alpaca (HTTP),
 ZWO, QHYCCD, Meade LX200, Skywatcher, OnStep (serial + WiFi/mDNS), iOptron SkyGuider Pro, Gemini FlatPanel
 Lite (native serial cover/calibrator), Gemini Focuser Pro (native serial focuser, a rebadged myFocuserPro2),
-PHD2, and a built-in guider. Published as `TianWen.Lib` on NuGet, plus AOT-published binaries — of
+PHD2, and a built-in guider. Published as `TianWen.Lib` on NuGet, plus AOT-published binaries, of
 which **four are release assets** (`tianwen` CLI, `tianwen-server` headless, `tianwen-gui`,
 `tianwen-fits`) and two are built but not shipped as `.tar.gz` (`tianwen-mcp`, `tianwen-ascomhost`).
 
@@ -85,7 +85,7 @@ src/
 
 Six projects set `PublishAot` + an `<AssemblyName>` short lower-case name: `tianwen`,
 `tianwen-server`, `tianwen-fits`, `tianwen-gui`, `tianwen-mcp`, `tianwen-ascomhost`. **Only the
-first four are packaged as release assets** by `.github/workflows/dotnet.yml` — adding a binary to
+first four are packaged as release assets** by `.github/workflows/dotnet.yml`; adding a binary to
 the release means adding it to the upload/glob steps there as well as setting the properties here.
 
 ## Build & Test Commands
@@ -153,7 +153,7 @@ solution-wide `dotnet test` must not sweep it up. Run them explicitly:
 **`open-vs.ps1` generates `TianWen.local.slnx`** at the repo root (gitignored) by re-rooting
 `src/TianWen.slnx` and appending a `/Siblings/` folder, so Go To Definition lands in sibling *source*.
 Its project list **must** match the `UseLocalSiblings` `Exists(...)` conjunction and **nothing enforces
-that** — it had drifted to `../StbImageSharp` for all seven codec projects (that repo is `../Codecs`
+that**: it had drifted to `../StbImageSharp` for all seven codec projects (that repo is `../Codecs`
 now) and was missing three others. A generated solution with unresolvable entries loads with them
 silently unloaded rather than failing, so touch one file and re-read the other.
 
@@ -167,8 +167,9 @@ will still pull from nuget.org and a local-only nupkg will mask version-skew bug
 
 ### Releasing a sibling (three traps the org doc does not cover)
 
-**The mechanism is org-wide and documented once, in the imported `.github/CLAUDE.md` ("Versioning")
-plus `.github/docs/dotnet-ci-pattern.md` — a release in ANY SharpAstro repo is editing
+**The mechanism is org-wide and documented once, in the imported `../.github/CLAUDE.md` ("Versioning")
+plus `../.github/docs/dotnet-ci-pattern.md` (the org root's `.github` clone, one level up from this
+repo, NOT this repo's own `.github/`): a release in ANY SharpAstro repo is editing
 `<VersionMajorMinor>` in that repo's `Directory.Build.props` and nothing else.** Do not restate it
 here. What follows is only what that doc omits:
 
@@ -193,7 +194,7 @@ here. What follows is only what that doc omits:
 then). `<VersionMajorMinor>` lives in `src/Directory.Build.props` and everything derives: `VersionPrefix`
 for every project (guarded on empty so CI's `-p:Version` wins), `AssemblyVersion` in
 `TianWen.Lib.csproj` as `$(VersionMajorMinor).0.0`, and CI's `VERSION_PREFIX`. `/bump-version` edits
-the one line. **A version literal in a csproj or the workflow is now a regression** — delete it and
+the one line. **A version literal in a csproj or the workflow is now a regression**; delete it and
 let it derive.
 
 Two things specific to this repo's conversion:
@@ -201,7 +202,7 @@ Two things specific to this repo's conversion:
 - **The read-back writes BOTH `$GITHUB_ENV` and a `build` job output**, because `$GITHUB_ENV` is
   **per-job** and five jobs here consume `VERSION_PREFIX` (`build`, `test-unit`, `test-functional`,
   `publish-apps`, `release`). The bare-step form that single-job repos use (Lzip.Lib, the reference
-  implementation) would have set it for `build` only and left the rest empty — silently malforming
+  implementation) would have set it for `build` only and left the rest empty, silently malforming
   `-p:Version=` and tagging a release `v.`. So `build`'s "Resolve version prefix" step exports
   `version-prefix`, and every consumer declares `needs: build` plus a job-level
   `env: VERSION_PREFIX: ${{ needs.build.outputs.version-prefix }}`, which leaves all the `run:` lines
@@ -210,7 +211,7 @@ Two things specific to this repo's conversion:
   job would only serialise its own runner startup onto every push and PR.
 - **It closed a latent bug.** `TianWen.Lib` sets `GeneratePackageOnBuild` but had no `VersionPrefix`
   of its own, so a local `dotnet build` packed it at the SDK default **1.0.0** while its
-  `AssemblyVersion` read 6.1 — there was a 43 MB `TianWen.Lib.1.0.0.nupkg` sitting in `bin/Release`
+  `AssemblyVersion` read 6.1; there was a 43 MB `TianWen.Lib.1.0.0.nupkg` sitting in `bin/Release`
   to prove it. The shared `VersionPrefix` now covers every project.
 
 ## Key Technologies
@@ -220,7 +221,7 @@ Two things specific to this repo's conversion:
 | DI / Logging | Microsoft.Extensions.* |
 | CLI | System.CommandLine v2 + Pastel |
 | Testing | xUnit v3 + Shouldly + NSubstitute |
-| Imaging | SharpAstro codecs facade + DIR.Lib Tiff/Png, FITS.Lib (Magick.NET removed) |
+| Imaging | SharpAstro codecs facade (`SharpAstro.Tiff`/`.Png`/`.Exr`/...), FITS.Lib (Magick.NET removed) |
 | UI / GPU | SDL3 + Vulkan (SdlVulkan.Renderer) |
 | Hosting | ASP.NET Core Minimal API, SharpAstro.Jpeg (preview encode) |
 | Astronomy | ASCOM, ZWOptical.SDK, QHYCCD.SDK, IAU SOFA (C# port) |
@@ -273,8 +274,8 @@ test projects carry an `xunit.runner.json` (`maxParallelThreads: 4`; Simulators 
 `parallelizeTestCollections: false`) **and** a matching
 `<Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />`. `TianWen.Lib.Tests`
 had neither for a long time while this file claimed otherwise, so xUnit silently defaulted to the core
-count (12) and thrashed the box; adding the file plus the `Content Include` cut the suite from 8m45–12m
-to 7m46 **and made it green** — contention was dominating. Never diagnose a slow suite by re-running it
+count (12) and thrashed the box; adding the file plus the `Content Include` cut the suite from 8m45-12m
+to 7m46 **and made it green**: contention was dominating. Never diagnose a slow suite by re-running it
 repeatedly: one run with a TRX logger, then rank durations.
 
 `SessionTestHelper` defaults to `FakeMountDriver`; pass `mountPort: "LX200"` or `"SkyWatcher"` only for
@@ -360,6 +361,21 @@ screenshot-poll-and-OCR**. Three pieces compose:
      `render_liveness` classifies ALIVE/BLOCKED/DEAD (and on BLOCKED prints the `dotnet-stack report -p <pid>`
      to capture the frozen frame); `watchSeconds>0` polls until it wedges. Use this, not screenshot/describe,
      to decide IF the render thread is stuck (those also block when it is).
+   - **Validation report** (`validation_report`, and read it with the gate in mind): **a zero message count
+     is evidence of correctness only when `active` is true.** `active` is the DEBUG + `SDLVK_VALIDATION=1`
+     gate AND `layerAvailable`, and before SdlVulkan.Renderer 7.11 only the gate was reported, so a host
+     with no Khronos validation layer installed answered `enabled: true` with zero messages and zero sync
+     hazards, indistinguishable from a clean run. That reading is what sent a device-loss investigation
+     upstream down the wrong path. Install the Vulkan SDK's layer before believing a clean report.
+
+   **A GPU fault names itself now** (SdlVulkan.Renderer 7.11, which is where the `Shaders/` + swapchain path
+   got its validation-layer pass). `VK_ERROR_DEVICE_LOST` is terminal and logs event 115 instead of entering
+   swapchain recovery, which could never work once the device is gone and used to surface as a
+   "recovery storm" (event 110) that reads like a workload problem. So a wedge and a dead device are now
+   distinguishable in `GUI_*.log`, and `render_liveness` BLOCKED means the render thread, not the device.
+   Event 501 additionally names the selected GPU (device, type, driver + API version, queue family, how many
+   were enumerated), so a report is attributable to hardware from our own log; selection now prefers a
+   discrete GPU, which is a preference and a no-op on an integrated-only box.
 
    `StartSession` needs ≥1 pinned target (`PlannerState.Proposals.Length > 0`, else it no-ops with "pin
    targets in the Planner first"). Planner pins persist **per-profile** to `AppData/Planner` and reload at
@@ -426,7 +442,7 @@ around the picture instead of blanking it). Ctrl+H also works now -- Console.Lib
 
 ## Coding Style
 
-Enforced via `.editorconfig`:
+Enforced via `src/.editorconfig` (it sits beside the solution, not at the repo root):
 - 4 spaces, CRLF line endings, block-scoped namespaces (`namespace Foo { }`, not file-scoped)
 - Primary constructors preferred for DI
 - No implicit `new(...)`, always `new SomeType()`
@@ -514,7 +530,7 @@ downloads + decodes **once** when the server first reports `imageready`, populat
 next frame re-downloads. Before this, `ImageData => null` meant the camera connected but never
 returned a frame, which is why `AddAlpaca()` was previously left unregistered. **The HTTP round-trip
 is validated against a live OmniSim** by `AlpacaSimulatorTests.Camera_ExposesAndDownloadsViaImageBytes`
-(see the simulator suite below) — the decoder stays separately byte-pinned by `AlpacaImageBytesTests`.
+(see the simulator suite below); the decoder stays separately byte-pinned by `AlpacaImageBytesTests`.
 
 ### Device Secrets (Credential Store)
 
@@ -726,7 +742,7 @@ or "re-order" logic must operate on the OTA set as a single unit.
 
 `RunAsync` workflow: `InitialisationAsync` → wait for twilight → `CoolCamerasToSetpointAsync` →
 `InitialRoughFocusAsync` → `AutoFocusAllTelescopesAsync` → `CalibrateGuiderAsync` → `ObservationLoopAsync`.
-See class XML doc + `PLAN-*.md` for details on each phase.
+See the class XML doc + the relevant `docs/plans/*.md` for details on each phase.
 
 **Session failure surfacing (`ISession.FailureReason`):** when a run ends `SessionPhase.Failed`, the
 session carries a plain-language, user-actionable reason (which device to check, what to do) -- surfaced
@@ -1508,19 +1524,19 @@ design).
 `GuiTheme` (`TianWen.UI.Abstractions/GuiTheme.cs`) owns the one palette every surface paints with;
 `UiThemeState` is **System / Light / Dark / Night**, and `GuiTheme.Apply(state, desktopIsDark)`
 resolves + swaps it in as a single reference write. `Palette` is one reference read, never torn. The
-source XML comments carry the full rationale (including the scotopic-sensitivity numbers) — read them
+source XML comments carry the full rationale (including the scotopic-sensitivity numbers); read them
 before changing a colour.
 
 - **Anything that CACHES a projection of the palette owes `GuiTheme.PaletteGeneration` in its cache
   key.** `Apply` bumps the generation only when the resolved palette actually moves. This is the
   frozen-snapshot bug in another costume: the planner chart renders to a GPU texture keyed on the data
   it draws, a theme switch changes none of that data, so the chart kept painting the old palette after
-  F12 while every other surface moved. `Apply`'s `bool` return ("did it change") cannot fix a cache —
-  the consumer may not have been asked — but a generation is comparable later by anyone.
+  F12 while every other surface moved. `Apply`'s `bool` return ("did it change") cannot fix a cache
+  (the consumer may not have been asked), but a generation is comparable later by anyone.
 - **Night is not a darker Dark, and is deliberately unreachable from `System`.** F12 toggles it
   (SharpCap's night-vision gesture). Blue is **zero** throughout and green is spent only to buy hue
   separation, because red is the only cheap channel for dark adaptation; red-on-black caps at 5.25:1,
-  so the whole text ladder fits under that ceiling — anything that must be READ uses `BodyText`, and
+  so the whole text ladder fits under that ceiling; anything that must be READ uses `BodyText`, and
   `DimText` is reserved for chrome nobody needs to read. Two derived colours had leaked blue into
   Night and had to be fixed; derive new ones from the palette, never from a literal.
 - **Judge Night at night.** A sky-map screenshot taken at 5pm shows its daylight tint, not the theme's;
@@ -1612,13 +1628,20 @@ not reintroduce an `Image`-keyed cache. Two parallel collections passing the sam
 flake; the `Background()` histogram peak drifts off scale once the data has been rescaled
 to `[0, 1]` while `MaxValue` still reads the original.
 
-### Float TIFF Convention (DIR.Lib Tiff I/O; Magick.NET fully removed)
+### Float TIFF Convention (`SharpAstro.Tiff` I/O; Magick.NET fully removed)
 
 **Magick.NET is no longer a dependency anywhere in this repo** (no PackageReference in any
 project incl. tests; remaining "Magick" strings are historical comments). Float32 TIFF I/O goes
-through `DIR.Lib.Tiff.TiffWriter`/`TiffReader` (`Image.Export.cs` / `Image.Import.cs`); imports
+through `SharpAstro.Tiff.TiffWriter`/`TiffReader` (`Image.Export.cs` / `Image.Import.cs`); imports
 route through the SharpAstro codecs facade (extension-based, no Magick fallback; CR2/CR3 →
 FC.SDK.Raw, FITS → FITS.Lib).
+
+**These types are NOT in DIR.Lib, though they used to be.** DIR.Lib 3.0 extracted the codec layer
+into the `Codecs` repo's own packages and 4.0 dropped the dependencies outright, so the namespaces
+TianWen imports are `SharpAstro.Png` / `.Jpeg` / `.Tiff` / `.Color.Icc` / `.Jxr` / `.Exr` / `.Exif` /
+`.Codecs`, pinned as one family through `$(SharpAstroCodecsVersion)` (see the sibling table above,
+which lists the same family). A `DIR.Lib.Tiff.*` or `DIR.Lib.Color.*` reference anywhere is a stale
+name, not a second implementation.
 
 The **on-disk convention** predates the swap and must not regress, because two reader families
 disagree about float TIFFs:
@@ -1637,22 +1660,25 @@ bits as uint) + `SMinSampleValue = 0` / `SMaxSampleValue = 65535` (the `Q16HdriQ
 const, kept so ImageMagick-based tools read back at their expected `[0, 65535]`). `[0, 1]` is
 the canonical in-memory range on read as well.
 
-See `DIR.Lib.Tests/TiffWriterRoundTripTests.cs` for the byte-level reader probe and
-`TianWen.Lib.Tests/TiffRoundTripTests.cs` for the round-trip + SATURATE/unit-scale guard.
+See the `Codecs` repo's `tests/SharpAstro.Codecs.Tests/TiffWriterRoundTripTests.cs` for the
+byte-level reader probe and `TianWen.Lib.Tests/TiffRoundTripTests.cs` for the round-trip +
+SATURATE/unit-scale guard.
 
-**DIR.Lib Phase-1.5 additions** (available as of DIR.Lib 2.14.x):
+**The codec surface these paths rely on** (long-standing baseline, not a changelog; the current pins
+live in `Directory.Packages.props`):
 
-- `DIR.Lib.Color.IccProfiles.SRgbV4`: bundled 588-byte sRGB v4 profile bytes
+- `SharpAstro.Color.Icc.IccProfiles.SRgbV4`: bundled 588-byte sRGB v4 profile bytes
   (LittleCMS-generated). Pass to `TiffPageOptions.IccProfile` or
   `PngWriter.Encode(..., iccProfile)` to embed a colour-management tag without
   having to source profile bytes yourself.
-- `PngWriter.EncodeGray8` / `EncodeGray16` / `EncodeRgba16`; bit-depth and
+- `SharpAstro.Png.PngWriter.EncodeGray8` / `EncodeGray16` / `EncodeRgba16`; bit-depth and
   grayscale variants on top of the original RGBA8 entry point. 16-bit overloads
   accept `ReadOnlySpan<ushort>` in system-endian and byte-swap to PNG's required
-  BE order internally.
+  BE order internally. Each also takes a `PngWriteOptions` overload (that is the one that
+  carries `Cicp`, used by the PQ-HDR PNG path).
 - `PngWriter.Encode(rgba, w, h, iccProfile)`: emits an `iCCP` chunk between
   IHDR and IDAT, keyword "ICC profile", zlib-deflated. Empty span = no chunk.
-- `DIR.Lib.Tiff.TiffReader.Read(stream | span)`: pure-managed decoder; v1
+- `SharpAstro.Tiff.TiffReader.Read(stream | span)`: pure-managed decoder; v1
   scope is strip layout + Uncompressed/Deflate/ZlibPkzip + 8/16/32-bit uint
   or IeeeFloat + contig planar config. Both "II" (LE) and "MM" (BE) byte
   orders are accepted; the reader detects file-order from the header and
@@ -1676,11 +1702,15 @@ WCS annotation), `.Histogram`, `.InfoPanel` (incl. WB + wavelet sliders), `.Stat
 monolith. The whole chrome is arranged from ONE layout pass rooted at `ContentRegion` (see the
 `.Layout.cs` banner) -- never hand-place chrome at `(0,0,Width,...)`.
 
-**One slider widget.** The WB sliders, the 6 wavelet-layer sliders, and the SER transport scrub are the
-same horizontal press/drag/release track. `ImageRendererBase.TrackSlider.cs` is the single source:
-`DrawTrackSlider(trackX, trackW, barCenterY, handleY, handleH, frac, fillColor, hitBand, hit)` (render +
-register the drag hit-band) and `static TrackFrac(RectF32, px)` (the cursor-X -> fraction drag math). A
-new track-style control calls these; never re-triplicate the bar/fill/handle/clamp math.
+**One slider widget, and it lives in DIR.Lib now.** The WB sliders, the 6 wavelet-layer sliders, and the
+SER transport scrub are the same horizontal press/drag/release track. The single source is
+`PixelWidgetBase` (DIR.Lib), upstreamed out of TianWen by the controls plan, so there is no
+`ImageRendererBase.TrackSlider.cs` here to look for:
+`DrawTrackSlider(trackX, trackW, barCenterY, handleY, handleH, frac, fillColor, hitBand, hit, chrome)`
+(render + register the drag hit-band) plus a `(trackX, trackW, handleY, handleH, frac, ...)` overload for
+the common case where the bar runs through the middle of the handle, and
+`static TrackFrac(RectF32, px)` (the cursor-X -> fraction drag math). A new track-style control calls
+these; never re-triplicate the bar/fill/handle/clamp math.
 
 **One viewer (no mini viewer).** There is no separate "mini viewer" -- the Live Session preview, polar-align,
 and guide-cam all host this same full viewer configured chromeless (`ViewerState.HideChrome` drops the
@@ -1724,8 +1754,9 @@ pedestal → rescale → MTF). Don't reimplement it.
 
 The stretch pipeline runs in two parallel implementations that must produce visually equivalent
 output for the same `StretchUniforms`:
-- **GPU**: `VkFitsImagePipeline.glsl` `stretchChannel` (per-channel) + `StretchLumaPixelCpu` analogue
-  in shader (Luma); used by the live FITS viewer.
+- **GPU**: `TianWen.UI.Shared/Shaders/image.frag` (loaded by `VkFitsImagePipeline` from the baked
+  `Shaders/spirv/image.frag.spv`): `stretchChannel` (per-channel) + the Luma branch that mirrors
+  `StretchLumaPixelCpu`; used by the live FITS viewer.
 - **CPU**: `Image.StretchChannelCpu`, `Image.StretchLumaPixelCpu`, `Image.ApplyHdr`,
   `Image.ApplyCurveLut`, `Image.ApplyBoost`, `Image.RenderStretchedRgba`; used by
   `ConsoleImageRenderer` (TUI Sixel) and tests (`StretchTests_NewPipeline`). Never use the GPU.
@@ -1974,11 +2005,20 @@ Centralized in `Directory.Packages.props`: version numbers go there, not in indi
 
 ## Runtime Data (AppData)
 
-`%LOCALAPPDATA%/TianWen/`:
+`%LOCALAPPDATA%/TianWen/`. The whole set, because there is **no** single choke point that creates these:
+`IExternal.CreateSubDirectoryInAppDataFolder(name)` covers four of them, `Planner`/`Session` are built
+from `AppDataFolder` directly, `Profiles`/`Logs` off `SharedStaticData.CommonDataRoot`, and `models` +
+`lan-node-id.txt` are resolved by their own owners. Add a directory here when you add one there.
 ```
 TianWen/
-├── Logs/        # Per-day log files: GUI_*.log, FitsViewer_*.log
-├── Profiles/   # Per-profile data (*.json + NeuralGuider/*.ngm + BacklashHistory/*.json)
-├── Planner/    # Persisted planner state (pinned targets)
-└── Secrets/    # Non-Windows only: 0600 file per device secret (Windows uses Credential Manager)
+├── Logs/<date>/        # <appName>_<timestamp>.log per process: GUI_*, FitsViewer_*, ... (FileLoggerProvider)
+├── Profiles/           # Per-profile data (*.json + NeuralGuider/*.ngm + BacklashHistory/*.json)
+├── Planner/            # Pinned targets: <profileId>/<date>.json, remote rigs under rigs/<bindingId>/
+├── Session/            # Session-setup state, <profileId>.json (SessionPersistence)
+├── Guider/             # Guider frames dumped for plate solving (guider_*.fits + .ini)
+├── Weather/            # OpenMeteo / OpenWeatherMap forecast cache
+├── SmallBodies/        # JPL SBDB comet cache: comets.json + apparitions.json
+├── models/             # AI ONNX models (ModelResolver; also probes SASpro's own models dir)
+├── Secrets/            # Non-Windows only: 0600 file per device secret (Windows uses Credential Manager)
+└── lan-node-id.txt     # tianwen-server's stable LAN NodeId, the key remote-rig bindings persist against
 ```

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -186,7 +186,7 @@
          where it happened not to fit. PaintLayout now fits every Content.Text to its arranged rect
          through the new public TextFit. Relevant to every tab here, since the whole chrome is arranged
          from one layout pass.
-         7.11 is the current pin, and unlike the last few it is one TianWen asked for. UiPalette gained
+         7.11 was the one TianWen asked for, and unlike the last few before it. UiPalette gained
          eight roles (Accent, AccentAlt, Focus, SeparatorStrong, Success, Info, Warn, Error) and became a
          sealed record with required members, which is what GuiTheme's Light/Dark/Night palettes are built
          on; see MIGRATION.md in that repo. BREAKING there, so this pin cannot go backwards. 7.10 (TabBar
@@ -196,8 +196,29 @@
          Console.Lib, SdlVulkan.Renderer and WebGl.Renderer still pin DIR.Lib 7.8.* and are NOT being
          re-released for this: all three reference UiPalette zero times, so there is nothing to port, and
          the graph unifies DIR.Lib upward to 7.11 for us anyway. That unification is the standing smell
-         noted elsewhere in this file, not something this bump introduces. -->
-    <PackageVersion Include="DIR.Lib" Version="7.12.*" />
+         noted elsewhere in this file, not something this bump introduces.
+         7.12 (TextInputColors, additive) was taken without this prose moving; it says so now.
+         Two of the crossed minors are text MEASUREMENT behaviour, which is why an app whose whole chrome
+         is arranged from one layout pass wants them: 7.13 bounds the SDF rasterize retry (a glyph that
+         can never rasterize is given up on instead of retried forever) and carries a whitespace-advance
+         fix that shipped unnoted, and 7.14 makes ShrinkToWidth return a size it actually measured rather
+         than an unverified estimate. 7.17 follows Fonts.Lib to 1.11. 7.15 and
+         7.16 are TabBar (a "+" after the last tab, then hover from a pointer the bar is given) and are
+         not exercised here for the same reason 7.9 and 7.10 were not: TianWen draws its own sidebar
+         chrome.
+         7.18 is the current pin and is what this bump is FOR: Layout.Content.Icon, a leaf named by
+         MEANING (Grid / List / Auto) that each surface then draws the way that surface actually can, the
+         pixel painter from rectangles and a cell painter from a block-element glyph. The Home board's
+         view selector is its first consumer here. A Text run carrying a symbol character is the obvious
+         alternative and is the wrong tool, because the two surfaces fail in opposite directions: on a
+         pixel surface a glyph missing from the bound font arrives as .notdef, an empty box exactly where
+         the icon belongs, while a cell surface cannot draw rectangles at all but is relied on for
+         precisely those glyph ranges.
+         The whole family moved with it (Console.Lib 4.21, SdlVulkan.Renderer 7.13 and WebGl.Renderer
+         1.19 all pin DIR.Lib 7.18.*), so for the first time in several minors no member lags and the
+         graph resolves ONE DIR.Lib by intent rather than by highest version. That retires the standing
+         smell noted above, until some member is next left behind. -->
+    <PackageVersion Include="DIR.Lib" Version="7.18.*" />
     <!-- DIR.Lib 3.0 extracted its codec layer to these sibling packages, which
          ship as a lockstep family from the Codecs repo. 3.0 brought a
          binary-breaking SharpAstro.Tiff change (TiffPageOptions.IccProfile is
@@ -318,8 +339,16 @@
          4.19 is the current pin, and the reason for the bump: TextBar.Caret parks the terminal's own
          cursor at a column of a bar's text. TuiEquipmentTab's site row needs it — three fields in one bar
          means the caret column is an offset into the joined string, which no single-field widget can
-         derive. 4.18 is what put the caret on ITerminalViewport in the first place. -->
-    <PackageVersion Include="Console.Lib" Version="4.19.*" />
+         derive. 4.18 is what put the caret on ITerminalViewport in the first place.
+         4.20 was the no-code lockstep rebuild that follows DIR.Lib 7.14, taken so the TUI and the GPU
+         surface keep resolving ONE DIR.Lib rather than two. Nothing in the TUI changed.
+         4.21 is the current pin and is NOT a rebuild: it is the cell half of DIR.Lib 7.18's
+         Layout.Content.Icon. CellLayout paints the icon a shared tree names, mapping Grid / List / Auto
+         onto the block-element and mathematical-operator ranges a terminal font is relied on to carry
+         (the same well every border and tree marker here already draws from). So a view selector authored
+         once renders on the GPU board and in TuiHomeTab, which is the whole point of naming an icon by
+         meaning rather than by drawing. -->
+    <PackageVersion Include="Console.Lib" Version="4.21.*" />
     <!-- SdlVulkan.Renderer 5.0 adds a multi-page SDF glyph atlas (no more grow
          stall / Adreno submit-wedge) on top of 4.1's SetSystemCursor + anisotropic
          glyph xScale. 5.1 implements DIR.Lib 4.4's PushClip/PopClip via Vulkan
@@ -390,8 +419,47 @@
          GpuStretchPipelineTests all render offscreen, so a rejection on the CI runner could hang the job
          instead of failing it. An offscreen submit now RETRIES a rejection instead of dropping the frame,
          which is right because offscreen the frame IS the output and a dropped one reads back stale or
-         blank pixels indistinguishable from a render. -->
-    <PackageVersion Include="SdlVulkan.Renderer" Version="7.10.*" />
+         blank pixels indistinguishable from a render.
+         7.12 is the current pin and 7.11 is the substance: five renderer fixes found by running under
+         the Khronos validation layer from the Vulkan SDK, which is the same wedge/device-loss hunt 7.9
+         and 7.10 are above. Read as a set, they say a GPU fault must NAME itself.
+         (a) VK_ERROR_DEVICE_LOST is terminal now, not a swapchain-recovery case. It used to enter the
+         mid-frame recovery path, which cannot work once the device and every object it owns are gone, so
+         it re-failed on the next submit (three attempts inside 34ms) and escaped only because the
+         recover-streak detector tripped, logging a "recovery storm" that reads as a WORKLOAD problem and
+         points diagnosis away from a dead device. New event 115 says device loss instead. That matters
+         here because our own render-thread watchdog (the inspector's render_liveness ALIVE/BLOCKED/DEAD)
+         is the other half of the same diagnosis, and it was being handed a load-shedding story.
+         (b) The render-finished semaphore is per swapchain IMAGE now, not per frame in flight: present
+         waits until the presentation engine releases the image, image count is not bounded by
+         MaxFramesInFlight, so a new submit could re-signal a semaphore an earlier present still waited on
+         (VUID-vkQueueSubmit-pSignalSemaphores-00067). Latent while presentation is regular, which is why
+         it surfaced upstream as device losses over Remote Desktop.
+         (c) One shared subpass-dependency pair, declared once in VulkanDevice.FillSubpassDependencies and
+         used by all six creation sites, with srcAccessMask = ColorAttachmentWrite. Render-pass
+         compatibility covers dependencies, so pre-baked pipelines drawn inside the thumbnail-capture pass
+         (two) after being baked against the swapchain pass (one) reported
+         VUID-vkCmdDraw-renderPass-02684; and srcAccessMask = 0 ordered execution without a memory
+         dependency on the previous frame's storeOp write, a WRITE_AFTER_WRITE hazard on alternating
+         frames. This repo drew through both passes: the thumbnail path backs the inspector's screenshot
+         verb, and OffscreenGpuFixture / VkRendererPrimitiveTests / VkHistogramPipelineTests /
+         GpuStretchPipelineTests all render offscreen.
+         (d) validationReport stops lying. "enabled" came straight from the DEBUG + SDLVK_VALIDATION gate,
+         so a host with no Khronos layer installed reported enabled:true with zero messages, read once as
+         a clean run when nothing had been checking anything. It now also reports layerAvailable and
+         active. RULE for us: a zero message count out of the inspector's validation_report tool is
+         evidence of correctness only when active is true.
+         (e) Prefers a DiscreteGpu (a preference, never a requirement, so an integrated-only box is
+         unaffected, including the win-arm64 dev box, where it is a no-op) and logs the selection as
+         event 501: device name, type, driver version, API version, queue family, count enumerated. Until
+         this, a GPU report in our own logs could not be attributed to hardware at all.
+         7.12 itself adds a window icon from an RgbaImage, which nothing here sets yet.
+         7.13 is the current pin and carries no renderer change at all: it follows DIR.Lib to 7.18 so the
+         backend paints Layout.Content.Icon through the same PixelWidgetBase every other leaf goes
+         through, and so this repo resolves one DIR.Lib rather than two. Verified on the CI path
+         (-p:UseLocalDirLib=false) rather than a plain build, which self-enables the sibling switch and
+         resolves the project's own 7.18.0 instead of the published package. -->
+    <PackageVersion Include="SdlVulkan.Renderer" Version="7.13.*" />
     <!-- The WebGL2 backend for the same DIR.Lib Renderer, consumed ONLY by TianWen.UI.Web (which sits
          outside TianWen.slnx). It lives here, next to its desktop counterpart, because it used to be
          pinned inline in that csproj instead: a sibling-family bump that swept this file could not see
@@ -399,11 +467,17 @@
          member built against DIR.Lib 7.0 after the rest moved to 7.4. The package graph then unified
          DIR.Lib by taking the highest version rather than by intent. Bump it with the family.
          1.14 was the no-code lockstep rebuild against DIR.Lib 7.4; 1.15 the same against DIR.Lib 7.5;
-         1.16 is the current pin, the same against DIR.Lib 7.8 (nothing in 7.6 or 7.7 touched this
-         backend). It has moved with the family each time rather than being found two minors behind, which
-         is the point of it living here. DIR.Lib 7.7's tree-stated hyperlinks matter most on this backend,
-         since a web host is the one that can render a real anchor. -->
-    <PackageVersion Include="WebGl.Renderer" Version="1.17.*" />
+         1.16 the same against DIR.Lib 7.8 (nothing in 7.6 or 7.7 touched this backend). It has moved with
+         the family each time rather than being found two minors behind, which is the point of it living
+         here. DIR.Lib 7.7's tree-stated hyperlinks matter most on this backend, since a web host is the
+         one that can render a real anchor.
+         1.18 followed DIR.Lib 7.14 with the rest of the family; 1.17 brought the canvas capture and its
+         events in as one family.
+         1.19 is the current pin and follows DIR.Lib to 7.18, so the web backend inherits
+         Layout.Content.Icon from the shared painter with no code of its own. Taken in the same cut as
+         SdlVulkan.Renderer 7.13, which is the arrangement this comment has been arguing for since 1.12
+         sat two minors behind: the family lands together or it does not land. -->
+    <PackageVersion Include="WebGl.Renderer" Version="1.19.*" />
     <PackageVersion Include="SDL3-CS" Version="3.5.0-preview.20260213-150035" />
     <PackageVersion Include="SDL3-CS.Native" Version="3.5.0-preview.20260205-174353" />
     <!-- Canon DSLR. Both packages ship from the FC.SDK repo at one release line, so they move

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -217,8 +217,25 @@
          The whole family moved with it (Console.Lib 4.21, SdlVulkan.Renderer 7.13 and WebGl.Renderer
          1.19 all pin DIR.Lib 7.18.*), so for the first time in several minors no member lags and the
          graph resolves ONE DIR.Lib by intent rather than by highest version. That retires the standing
-         smell noted above, until some member is next left behind. -->
-    <PackageVersion Include="DIR.Lib" Version="7.18.*" />
+         smell noted above, until some member is next left behind.
+         7.19 adds three theme marks to the same set (ThemeSystem, ThemeLight, ThemeDark), which is what
+         the Home board's theme control now draws. They arrive as a family for the reason the enum's own
+         doc gives: an app with a light/dark setting needs all three or none. Note the CONSTRUCTION, since
+         it is what makes them usable here at all. Each is built from scanline spans, so the crescent is
+         the spans an offset disc does not cover rather than that disc over-painted in the button's
+         background. The over-paint trick has to know the ground, and this board paints its control on a
+         Selection fill in four different palettes.
+         7.20 makes an icon draw at the size it DECLARES, centred and clamped by its rect, instead of
+         stretching to fill it. Size had been a measure-time hint only, which is meaningless once a node
+         carries explicit sizing, and every icon here does. 7.21 then normalises every kind to ink that
+         full square: the same declared size used to produce ink spanning 63% (the half-disc) to 100%
+         (the grid) of it, so a row of marks looked ragged however carefully it was centred.
+         7.21 also adds Layout.CrossAlign to a Stack, which this board now uses. A Stack placed every
+         child at the cross-axis START, so a Fixed-height control in a taller bar hugged the top and sat
+         half the slack high. The workaround was padding the bar and making every child Star-height, which
+         also inset the label horizontally as a side effect; .CrossCenter() states the intent and lets the
+         engine, which knows both extents, do the arithmetic. -->
+    <PackageVersion Include="DIR.Lib" Version="7.21.*" />
     <!-- DIR.Lib 3.0 extracted its codec layer to these sibling packages, which
          ship as a lockstep family from the Codecs repo. 3.0 brought a
          binary-breaking SharpAstro.Tiff change (TiffPageOptions.IccProfile is
@@ -347,8 +364,13 @@
          onto the block-element and mathematical-operator ranges a terminal font is relied on to carry
          (the same well every border and tree marker here already draws from). So a view selector authored
          once renders on the GPU board and in TuiHomeTab, which is the whole point of naming an icon by
-         meaning rather than by drawing. -->
-    <PackageVersion Include="Console.Lib" Version="4.21.*" />
+         meaning rather than by drawing.
+         4.22 is the cell half of those three marks, mapping them to the geometric-shapes circles rather
+         than to the sun and moon of Miscellaneous Symbols, which a monospace face need not carry. So the
+         TUI Home header renders the same theme control with no code of its own.
+         4.23 follows DIR.Lib to 7.21, so the TUI arranges through the same engine and the shared Home
+         tree centres its header controls on both surfaces from one authoring pass. -->
+    <PackageVersion Include="Console.Lib" Version="4.23.*" />
     <!-- SdlVulkan.Renderer 5.0 adds a multi-page SDF glyph atlas (no more grow
          stall / Adreno submit-wedge) on top of 4.1's SetSystemCursor + anisotropic
          glyph xScale. 5.1 implements DIR.Lib 4.4's PushClip/PopClip via Vulkan
@@ -458,8 +480,10 @@
          backend paints Layout.Content.Icon through the same PixelWidgetBase every other leaf goes
          through, and so this repo resolves one DIR.Lib rather than two. Verified on the CI path
          (-p:UseLocalDirLib=false) rather than a plain build, which self-enables the sibling switch and
-         resolves the project's own 7.18.0 instead of the published package. -->
-    <PackageVersion Include="SdlVulkan.Renderer" Version="7.13.*" />
+         resolves the project's own 7.18.0 instead of the published package.
+         7.14 follows DIR.Lib to 7.19 with no renderer change, keeping the family on one DIR.Lib.
+         7.15 follows DIR.Lib to 7.21; the alignment and icon work is all in shared code. -->
+    <PackageVersion Include="SdlVulkan.Renderer" Version="7.15.*" />
     <!-- The WebGL2 backend for the same DIR.Lib Renderer, consumed ONLY by TianWen.UI.Web (which sits
          outside TianWen.slnx). It lives here, next to its desktop counterpart, because it used to be
          pinned inline in that csproj instead: a sibling-family bump that swept this file could not see
@@ -476,8 +500,10 @@
          1.19 is the current pin and follows DIR.Lib to 7.18, so the web backend inherits
          Layout.Content.Icon from the shared painter with no code of its own. Taken in the same cut as
          SdlVulkan.Renderer 7.13, which is the arrangement this comment has been arguing for since 1.12
-         sat two minors behind: the family lands together or it does not land. -->
-    <PackageVersion Include="WebGl.Renderer" Version="1.19.*" />
+         sat two minors behind: the family lands together or it does not land.
+         1.20 follows DIR.Lib to 7.19 in the same cut as SdlVulkan.Renderer 7.14.
+         1.21 follows DIR.Lib to 7.21 in the same cut. -->
+    <PackageVersion Include="WebGl.Renderer" Version="1.21.*" />
     <PackageVersion Include="SDL3-CS" Version="3.5.0-preview.20260213-150035" />
     <PackageVersion Include="SDL3-CS.Native" Version="3.5.0-preview.20260205-174353" />
     <!-- Canon DSLR. Both packages ship from the FC.SDK repo at one release line, so they move

--- a/src/TianWen.Cli/Tui/TuiHomeTab.cs
+++ b/src/TianWen.Cli/Tui/TuiHomeTab.cs
@@ -59,7 +59,8 @@ internal sealed class TuiHomeTab(
             appState.HomeCards, HomeBoardStyle.Default,
             Content.Width * PixelAuthoredCellWidth, timeProvider.GetUtcNow(),
             Content.Height * PixelAuthoredCellHeight,
-            appState.HomeBoardView, SelectAction, SelectViewAction);
+            appState.HomeBoardView, SelectAction, SelectViewAction,
+            GuiTheme.State, CycleThemeAction);
     }
 
     /// <summary>Design units per character cell, matching <see cref="CellMeasureContext.PixelAuthored"/>'s 8x16.</summary>
@@ -79,6 +80,17 @@ internal sealed class TuiHomeTab(
         bus.Post(new SetHomeBoardViewSignal(view));
         NeedsRedraw = true;
     };
+
+    /// <summary>
+    /// Advances the theme, posting the same signal the GUI board's control does. The TUI honours it because
+    /// every colour it paints comes from the same palette, and Night is the state an observer at the mount
+    /// wants whichever surface they happen to be sitting in front of.
+    /// </summary>
+    private void CycleThemeAction(InputModifier _)
+    {
+        bus.Post(new CycleUiThemeSignal());
+        NeedsRedraw = true;
+    }
 
     /// <summary>Looking at a rig, not driving it -- the same two signals the GUI board posts.</summary>
     private Action<InputModifier>? SelectAction(RigCard card) => _ =>

--- a/src/TianWen.Lib.Tests/GuiThemeTests.cs
+++ b/src/TianWen.Lib.Tests/GuiThemeTests.cs
@@ -533,5 +533,47 @@ namespace TianWen.Lib.Tests
                 GuiTheme.Apply(UiThemeState.Dark, desktopIsDark: true);
             }
         }
+
+        // Four clicks return you to where you started, which is the property that makes a cycler
+        // usable at all: every state is reachable and none is a dead end.
+        [Fact]
+        public void TheCycleVisitsAllFourStatesAndComesBack()
+        {
+            var seen = new[]
+            {
+                UiThemeState.System.Next(),
+                UiThemeState.System.Next().Next(),
+                UiThemeState.System.Next().Next().Next(),
+                UiThemeState.System.Next().Next().Next().Next(),
+            };
+
+            seen.ShouldBe([UiThemeState.Light, UiThemeState.Dark, UiThemeState.Night, UiThemeState.System]);
+        }
+
+        // The composition invariant between the two theme controls. Night is entered from the CYCLER
+        // here, so the remembered "state before Night" has to come from the cycler too -- otherwise F12
+        // restores whatever the last toggle recorded, which is stale exactly when both are used, and the
+        // observer who cycled into Night at the mount is dropped somewhere they never chose.
+        [Fact]
+        public void CyclingIntoNightIsWhatF12ThenRestoresFrom()
+        {
+            try
+            {
+                GuiTheme.Apply(UiThemeState.Light, desktopIsDark: false);
+
+                GuiTheme.CycleTheme();
+                GuiTheme.State.ShouldBe(UiThemeState.Dark);
+
+                GuiTheme.CycleTheme();
+                GuiTheme.State.ShouldBe(UiThemeState.Night);
+
+                GuiTheme.ToggleNight();
+                GuiTheme.State.ShouldBe(UiThemeState.Dark, "F12 returns to where the CYCLE entered Night");
+            }
+            finally
+            {
+                GuiTheme.Apply(UiThemeState.Dark, desktopIsDark: true);
+            }
+        }
     }
 }

--- a/src/TianWen.Lib.Tests/HomeTabLayoutTests.cs
+++ b/src/TianWen.Lib.Tests/HomeTabLayoutTests.cs
@@ -588,6 +588,119 @@ namespace TianWen.Lib.Tests
                 .ShouldBe(1);
         }
 
+        /// <summary>
+        /// The three presentations, by the thing that separates them: whether the state's WORD is on screen,
+        /// and whether the control carries an icon leaf. The default has both, which is what makes Dark and
+        /// Night distinguishable while the marks still read as one family with the segments.
+        /// </summary>
+        [Theory]
+        [InlineData(ThemeControlStyle.IconAndLabel, true, true)]
+        [InlineData(ThemeControlStyle.IconOnly, false, true)]
+        [InlineData(ThemeControlStyle.LabelOnly, true, false)]
+        public void TheThemeControlPresentsItselfHowTheHostAsked(
+            ThemeControlStyle presentation, bool expectWord, bool expectIcon)
+        {
+            var tree = HomeBoardLayout.Build(
+                ImmutableArray.Create(Card("A")), HomeBoardStyle.Default, 200 * 8f, Now,
+                theme: UiThemeState.Night, onCycleTheme: _ => { }, themeControl: presentation);
+
+            var arranged = Layout.Engine.Arrange(
+                tree, new Rect<int>(0, 0, 200, 56), CellMeasureContext.PixelAuthored);
+
+            Texts(arranged).Contains("Night").ShouldBe(expectWord);
+
+            arranged.Any(a => a.Node is Layout.Node.Leaf { Content: Layout.Content.Icon icon }
+                    && icon.Kind is Layout.IconKind.ThemeDark)
+                .ShouldBe(expectIcon);
+        }
+
+        /// <summary>
+        /// Three marks cover four states: Night IS a dark scheme, so it shares the crescent. Pinned because
+        /// it is the reason the default keeps the label, and a future fourth mark would have to argue with
+        /// this test rather than quietly change the meaning of the control.
+        /// </summary>
+        [Theory]
+        [InlineData(UiThemeState.System, Layout.IconKind.ThemeSystem)]
+        [InlineData(UiThemeState.Light, Layout.IconKind.ThemeLight)]
+        [InlineData(UiThemeState.Dark, Layout.IconKind.ThemeDark)]
+        [InlineData(UiThemeState.Night, Layout.IconKind.ThemeDark)]
+        public void EachThemeStateShowsItsMark(UiThemeState state, Layout.IconKind expected)
+        {
+            var tree = HomeBoardLayout.Build(
+                ImmutableArray.Create(Card("A")), HomeBoardStyle.Default, 200 * 8f, Now,
+                theme: state, onCycleTheme: _ => { });
+
+            var arranged = Layout.Engine.Arrange(
+                tree, new Rect<int>(0, 0, 200, 56), CellMeasureContext.PixelAuthored);
+
+            var marks = arranged
+                .Select(a => a.Node is Layout.Node.Leaf { Content: Layout.Content.Icon icon }
+                    ? icon.Kind
+                    : (Layout.IconKind?)null)
+                .Where(k => k is Layout.IconKind.ThemeSystem or Layout.IconKind.ThemeLight
+                    or Layout.IconKind.ThemeDark)
+                .ToArray();
+
+            marks.ShouldHaveSingleItem().ShouldBe(expected);
+        }
+
+        /// <summary>
+        /// Every header control is the same square-or-taller box, sharing one top and one bottom, centred on
+        /// the bar's own centre line.
+        /// <para>
+        /// None of that is automatic. A <c>Layout.Node.Stack</c> places children at the cross-axis START, so
+        /// a Fixed-height button in a taller bar hugs the top and sits half the difference ABOVE centre --
+        /// which is what it did, visibly, until the bar was padded and the children made Star-height. A test
+        /// is the only thing that notices when someone reintroduces a Fixed height here.
+        /// </para>
+        /// </summary>
+        [Fact]
+        public void EveryHeaderControlSharesOneTopAndBottom_CentredInTheBar()
+        {
+            // Rendered through the real tab at DPI 1, so an arranged pixel IS a design unit and the bar's
+            // 28 and its 4 of padding read as themselves.
+            using var renderer = new RgbaImageRenderer(2000, 800);
+            var tab = RenderTab(renderer, [Card("A")]);
+
+            var controls = tab.GetRegisteredRegions()
+                .Where(r => r.Result is HitResult.ButtonHit { Action: var action }
+                    && (action.StartsWith("HomeView:") || action.StartsWith("HomeTheme:")))
+                .ToArray();
+
+            controls.Length.ShouldBe(4, "three shape segments plus the theme control");
+
+            foreach (var c in controls)
+            {
+                c.Y.ShouldBe(controls[0].Y, 0.5f, "every control starts at the same top");
+                c.Height.ShouldBe(controls[0].Height, 0.5f, "every control is the same height");
+
+                // Centred: the gap above equals the gap below, within the bar.
+                var above = c.Y;
+                var below = HomeBoardLayout.HeaderHeight - (c.Y + c.Height);
+                below.ShouldBe(above, 0.5f, "the control is centred in the bar, not hugging its top");
+                above.ShouldBeGreaterThan(0f, "it stops short of the bar's edge, which is the separation");
+            }
+        }
+
+        /// <summary>The three shape segments are square, which is the shape a lone pictogram button takes.</summary>
+        [Fact]
+        public void TheShapeSegmentsAreSquare()
+        {
+            using var renderer = new RgbaImageRenderer(2000, 800);
+            var tab = RenderTab(renderer, [Card("A")]);
+
+            var segments = tab.GetRegisteredRegions()
+                .Where(r => r.Result is HitResult.ButtonHit { Action: var action }
+                    && action.StartsWith("HomeView:"))
+                .ToArray();
+
+            segments.Length.ShouldBe(3);
+            foreach (var seg in segments)
+            {
+                seg.Width.ShouldBe(seg.Height, 0.5f);
+            }
+        }
+
         [Fact]
         public void ABoardWithNoThemeCallbackDrawsNoThemeControl()
         {

--- a/src/TianWen.Lib.Tests/HomeTabLayoutTests.cs
+++ b/src/TianWen.Lib.Tests/HomeTabLayoutTests.cs
@@ -481,6 +481,68 @@ namespace TianWen.Lib.Tests
             options.ShouldBe(["Auto", "Cards", "Table"]);
         }
 
+        /// <summary>
+        /// The segments are <see cref="Layout.Content.Icon"/> leaves, not text runs, which is what lets the
+        /// same tree paint rectangles on the GPU board and a block-element glyph in the terminal. Asserting
+        /// the CONTENT rather than a pixel keeps this a statement about the tree both surfaces read.
+        /// </summary>
+        [Fact]
+        public void EachSegmentCarriesItsShapesIcon()
+        {
+            var tree = HomeBoardLayout.Build(
+                ImmutableArray.Create(Card("A")), HomeBoardStyle.Default, 200 * 8f, Now,
+                view: HomeBoardView.Table, onSelectView: _ => _ => { });
+
+            var arranged = Layout.Engine.Arrange(
+                tree, new Rect<int>(0, 0, 200, 56), CellMeasureContext.PixelAuthored);
+
+            var icons = arranged
+                .Where(a => a.Node.Hit is HitResult.ButtonHit { Action: var action }
+                    && action.StartsWith("HomeView:"))
+                .Select(a => a.Node is Layout.Node.Leaf { Content: Layout.Content.Icon icon }
+                    ? icon.Kind
+                    : (Layout.IconKind?)null)
+                .ToArray();
+
+            icons.ShouldBe([Layout.IconKind.Auto, Layout.IconKind.Grid, Layout.IconKind.List]);
+        }
+
+        /// <summary>
+        /// The segments are the fixed width they ask for, not a third of the header each.
+        /// <para>
+        /// This is the <c>RowH</c> trap in its second costume, and it is why this file exists: <c>RowH</c>
+        /// means "a full-width row of fixed height", so it sets <c>Width = Star</c> and silently discards a
+        /// <c>WFixed</c> before it. The selector had been built that way from the start, which compiled,
+        /// rendered, and spread three buttons across the whole bar -- only an arranged rect says so.
+        /// </para>
+        /// </summary>
+        [Fact]
+        public void TheSegmentsKeepTheirFixedWidthInsteadOfSharingTheHeader()
+        {
+            var tree = HomeBoardLayout.Build(
+                ImmutableArray.Create(Card("A")), HomeBoardStyle.Default, 200 * 8f, Now,
+                view: HomeBoardView.Auto, onSelectView: _ => _ => { },
+                theme: UiThemeState.Dark, onCycleTheme: _ => { });
+
+            var arranged = Layout.Engine.Arrange(
+                tree, new Rect<int>(0, 0, 200, 56), CellMeasureContext.PixelAuthored);
+
+            var widths = arranged
+                .Where(a => a.Node.Hit is HitResult.ButtonHit { Action: var action }
+                    && action.StartsWith("HomeView:"))
+                .Select(a => a.Bounds.Width)
+                .ToArray();
+
+            widths.Length.ShouldBe(3);
+            foreach (var w in widths)
+            {
+                // 26 design units is 3.25 cells at PixelAuthored's 8px cell; a Star segment on this board
+                // came out at ~47.
+                w.ShouldBeLessThanOrEqualTo(5, "a segment is fixed-width, not Star");
+                w.ShouldBeGreaterThan(1);
+            }
+        }
+
         [Fact]
         public void ABoardWithNowhereToStoreTheChoiceDrawsNoSelector()
         {
@@ -496,6 +558,51 @@ namespace TianWen.Lib.Tests
             // expression tree, which cannot contain an `is` pattern.
             arranged.Count(a =>
                     a.Node.Hit is HitResult.ButtonHit { Action: var action } && action.StartsWith("HomeView:"))
+                .ShouldBe(0);
+        }
+
+        /// <summary>
+        /// The theme control shows the state it is IN, not the one a click reaches. With four states no
+        /// single mark can say "what happens next", and the reader's actual question is which scheme they
+        /// are looking at.
+        /// </summary>
+        [Theory]
+        [InlineData(UiThemeState.System, "System")]
+        [InlineData(UiThemeState.Light, "Light")]
+        [InlineData(UiThemeState.Dark, "Dark")]
+        [InlineData(UiThemeState.Night, "Night")]
+        public void TheThemeControlNamesTheStateItIsIn(UiThemeState state, string label)
+        {
+            var tree = HomeBoardLayout.Build(
+                ImmutableArray.Create(Card("A")), HomeBoardStyle.Default, 200 * 8f, Now,
+                theme: state, onCycleTheme: _ => { });
+
+            var arranged = Layout.Engine.Arrange(
+                tree, new Rect<int>(0, 0, 200, 56), CellMeasureContext.PixelAuthored);
+
+            Texts(arranged).ShouldContain(label);
+
+            arranged.Count(a =>
+                    a.Node.Hit is HitResult.ButtonHit { Action: var action }
+                    && action == $"HomeTheme:{state}")
+                .ShouldBe(1);
+        }
+
+        [Fact]
+        public void ABoardWithNoThemeCallbackDrawsNoThemeControl()
+        {
+            // Same rule as the shape selector: the callback IS the permission to offer the control, so a
+            // host with no theme to change does not get a button that silently does nothing.
+            var tree = HomeBoardLayout.Build(
+                ImmutableArray.Create(Card("A")), HomeBoardStyle.Default, 200 * 8f, Now,
+                onSelectView: _ => _ => { });
+
+            var arranged = Layout.Engine.Arrange(
+                tree, new Rect<int>(0, 0, 200, 56), CellMeasureContext.PixelAuthored);
+
+            arranged.Count(a =>
+                    a.Node.Hit is HitResult.ButtonHit { Action: var action }
+                    && action.StartsWith("HomeTheme:"))
                 .ShouldBe(0);
         }
 

--- a/src/TianWen.UI.Abstractions/AppSignalHandler.cs
+++ b/src/TianWen.UI.Abstractions/AppSignalHandler.cs
@@ -918,6 +918,12 @@ namespace TianWen.UI.Abstractions
                 _appState.NeedsRedraw = true;
             });
 
+            bus.Subscribe<CycleUiThemeSignal>(_ =>
+            {
+                GuiTheme.CycleTheme();
+                _appState.NeedsRedraw = true;
+            });
+
             // Store autocomplete cache setter as a public action
             SetAutoCompleteCache = cache => _autoCompleteCache = cache;
         }

--- a/src/TianWen.UI.Abstractions/GuiSignals.cs
+++ b/src/TianWen.UI.Abstractions/GuiSignals.cs
@@ -111,6 +111,13 @@ public readonly record struct ToggleFullscreenSignal;
 public readonly record struct ToggleNightModeSignal;
 
 /// <summary>
+/// Advance to the next of the four theme states (System, Light, Dark, Night). Posted by the Home
+/// screen's theme control; <see cref="ToggleNightModeSignal"/> stays the F12 gesture and the two compose,
+/// since both go through the same remember-where-Night-came-from path.
+/// </summary>
+public readonly record struct CycleUiThemeSignal;
+
+/// <summary>
 /// Open an external URL in the user's default browser. Posted by desktop (SDL/Vulkan) hosts, which have
 /// no DOM and handle it through the OS shell; the web host renders links as real &lt;a&gt; elements and
 /// never posts this. A host with no subscriber simply drops it (no-op), so it is safe to post anywhere.

--- a/src/TianWen.UI.Abstractions/GuiTheme.cs
+++ b/src/TianWen.UI.Abstractions/GuiTheme.cs
@@ -364,6 +364,27 @@ namespace TianWen.UI.Abstractions
         }
 
         /// <summary>
+        /// Advances to the next state in <see cref="UiThemeStateExtensions"/>' order, which is what a
+        /// four-state theme control on a screen posts. Same return contract as <see cref="Apply"/>.
+        /// </summary>
+        /// <remarks>
+        /// It remembers the state it entered Night FROM, exactly as <see cref="ToggleNight"/> does, so the
+        /// two controls compose: cycling into Night and then pressing F12 lands back where the cycle came
+        /// from rather than on whatever the last toggle happened to record. Without this the memory would
+        /// be stale precisely when both are used, which is the case an observer at the mount is in.
+        /// </remarks>
+        public static bool CycleTheme()
+        {
+            var next = State.Next();
+            if (next == UiThemeState.Night)
+            {
+                _stateBeforeNight = State;
+            }
+
+            return Apply(next, DesktopIsDark);
+        }
+
+        /// <summary>
         /// Which palette a state resolves to. Pure, so the settings UI can preview a state without
         /// adopting it. <see cref="UiThemeState.System"/> never resolves to
         /// <see cref="NightPalette"/>: a desktop has no way to ask for dark adaptation, and

--- a/src/TianWen.UI.Abstractions/HomeBoardLayout.cs
+++ b/src/TianWen.UI.Abstractions/HomeBoardLayout.cs
@@ -202,6 +202,10 @@ namespace TianWen.UI.Abstractions
         /// <param name="view">The user's choice from the header selector; Auto reacts to <paramref name="height"/>.</param>
         /// <param name="onSelectView">Posts the header selector's choice, or null to draw no selector -- which
         /// is what a caller that has nowhere to persist the choice should do.</param>
+        /// <param name="theme">Which of the four theme states the control SHOWS. Passed in rather than read
+        /// off <see cref="GuiTheme"/> for the same reason <paramref name="style"/> is: this builder stays a
+        /// pure function of its arguments, so a test can arrange any state without touching global state.</param>
+        /// <param name="onCycleTheme">Advances the theme, or null to draw no theme control.</param>
         public static Layout.Node Build(
             ImmutableArray<RigCard> cards,
             HomeBoardStyle style,
@@ -210,7 +214,9 @@ namespace TianWen.UI.Abstractions
             float height = float.PositiveInfinity,
             HomeBoardView view = HomeBoardView.Auto,
             Func<RigCard, Action<InputModifier>?>? onSelect = null,
-            Func<HomeBoardView, Action<InputModifier>?>? onSelectView = null)
+            Func<HomeBoardView, Action<InputModifier>?>? onSelectView = null,
+            UiThemeState theme = UiThemeState.Dark,
+            Action<InputModifier>? onCycleTheme = null)
         {
             var cardArea = width - BodyPadding * 2f;
             var columns = ColumnsFor(cardArea, cards.Length);
@@ -240,7 +246,7 @@ namespace TianWen.UI.Abstractions
             }
 
             return Layout.Builder.VStack(
-                    Header(cards, style, view, fellBack, onSelectView),
+                    Header(cards, style, view, fellBack, onSelectView, theme, onCycleTheme),
                     body)
                 .Bg(style.ContentBg);
         }
@@ -292,7 +298,8 @@ namespace TianWen.UI.Abstractions
         /// event into the nudge that the window is too small.</param>
         private static Layout.Node Header(
             ImmutableArray<RigCard> cards, HomeBoardStyle style, HomeBoardView view, bool fellBackToTable,
-            Func<HomeBoardView, Action<InputModifier>?>? onSelectView)
+            Func<HomeBoardView, Action<InputModifier>?>? onSelectView,
+            UiThemeState theme, Action<InputModifier>? onCycleTheme)
         {
             var waiting = 0;
             foreach (var card in cards)
@@ -311,7 +318,7 @@ namespace TianWen.UI.Abstractions
 
             // A leading spacer rather than padding on the text, so the bar's background stays full-bleed
             // while the label lines up with the cards inset below it.
-            var children = ImmutableArray.CreateBuilder<Layout.Node>(6);
+            var children = ImmutableArray.CreateBuilder<Layout.Node>(8);
             children.Add(Layout.Builder.Spacer().WFixed(BodyPadding).HStar());
             children.Add(Layout.Builder
                 .Text(label, BaseFontSize * 1.05f, style.HeaderText, TextAlign.Near, TextAlign.Center)
@@ -323,7 +330,18 @@ namespace TianWen.UI.Abstractions
                 {
                     children.Add(ViewButton(option, view, style, onSelectView));
                 }
+            }
 
+            if (onCycleTheme is not null)
+            {
+                // Set off from the view segments, which are one control: adjacent buttons at the same gap
+                // would read as a four-cell selector whose fourth cell does something unrelated.
+                children.Add(Layout.Builder.Spacer().WFixed(8f).HStar());
+                children.Add(ThemeButton(theme, style, onCycleTheme));
+            }
+
+            if (onSelectView is not null || onCycleTheme is not null)
+            {
                 children.Add(Layout.Builder.Spacer().WFixed(BodyPadding).HStar());
             }
 
@@ -333,17 +351,72 @@ namespace TianWen.UI.Abstractions
                 .Bg(style.HeaderBg);
         }
 
+        /// <summary>Width of the theme cycler. Fixed, and sized for its longest label ("System").</summary>
+        private const float ThemeButtonWidth = 56f;
+
+        /// <summary>
+        /// The four-state theme control: one button that SHOWS the current state and advances on click.
+        /// <para>
+        /// <b>A word rather than a pictogram, unlike the view segments beside it.</b> Two reasons, and the
+        /// second is the load-bearing one. A sun / crescent / half-disc set needs a fourth mark for
+        /// <see cref="UiThemeState.Night"/> that reads as distinct from Dark at 13 px, and the obvious one
+        /// (a red crescent) is a colour difference on a control the user is looking at precisely because
+        /// they are unsure which scheme is on. And a crescent is drawn by over-painting an offset disc in
+        /// the button's own background, which the shared icon painter cannot do: it is handed an ink
+        /// colour and no ground. So the states that would need icons are exactly the states an icon
+        /// cannot say here, while "Night" is unambiguous on both surfaces and needs no font that a
+        /// terminal might lack.
+        /// </para>
+        /// </summary>
+        private static Layout.Node ThemeButton(
+            UiThemeState theme, HomeBoardStyle style, Action<InputModifier>? onCycleTheme) =>
+            Layout.Builder
+                .Text(theme.Label(), BaseFontSize * 0.85f, style.BodyText, TextAlign.Center, TextAlign.Center)
+                // HFixed rather than RowH, for the reason spelt out in ViewButton.
+                .WFixed(ThemeButtonWidth)
+                .HFixed(HeaderHeight - 8f)
+                .Radius(4f)
+                .Bg(style.ViewedCardBg)
+                // Named by the state it currently SHOWS, not the one a click reaches: that is what an
+                // inspector snapshot and a test both want to assert, and it matches the label.
+                .Clickable(new HitResult.ButtonHit($"HomeTheme:{theme}"), onCycleTheme);
+
         /// <summary>Selector order, and the single list both the buttons and the tests read.</summary>
         private static readonly ImmutableArray<HomeBoardView> ViewOptions =
             [HomeBoardView.Auto, HomeBoardView.Cards, HomeBoardView.Table];
 
-        /// <summary>Width of one selector button. Fixed, so the label cannot squeeze the rig count out.</summary>
-        private const float ViewButtonWidth = 54f;
+        /// <summary>
+        /// Width of one selector segment. A square-ish cell now that the segments carry a pictogram rather
+        /// than a word, which is most of what the icons bought: three words cost 162 units of a header that
+        /// also has to hold the rig count, and the count is the thing the board exists to state.
+        /// </summary>
+        private const float ViewButtonWidth = 26f;
+
+        /// <summary>Icon side within a segment. Leaves a couple of units of breathing room either side.</summary>
+        private const float ViewIconSize = 13f;
 
         /// <summary>
-        /// One segmented-selector button. Segments rather than a dropdown: there are three, they are all
-        /// short, and the current one has to be readable at a glance from across the room -- a dropdown would
-        /// hide two of the three behind a click and still cost the same width.
+        /// What each shape LOOKS like, which is the whole reason <see cref="Layout.Content.Icon"/> names a
+        /// meaning rather than a drawing: the GPU board gets rectangles and the TUI gets a block-element
+        /// glyph from one tree.
+        /// </summary>
+        private static Layout.IconKind IconFor(HomeBoardView view) => view switch
+        {
+            HomeBoardView.Cards => Layout.IconKind.Grid,
+            HomeBoardView.Table => Layout.IconKind.List,
+            _ => Layout.IconKind.Auto,
+        };
+
+        /// <summary>
+        /// One segmented-selector button. Segments rather than a dropdown: there are three, and the current
+        /// one has to be readable at a glance from across the room -- a dropdown would hide two of the three
+        /// behind a click and still cost the same width.
+        /// <para>
+        /// <b>All three stay visible, Auto included.</b> Auto is a real state and the default one, so
+        /// hiding it behind "no segment lit" would make the board's most common configuration the one with
+        /// no indication of what it is doing. The camera-style bracketed A is the affordance that makes it
+        /// showable at icon size at all.
+        /// </para>
         /// </summary>
         private static Layout.Node ViewButton(
             HomeBoardView option, HomeBoardView selected, HomeBoardStyle style,
@@ -351,10 +424,14 @@ namespace TianWen.UI.Abstractions
         {
             var isSelected = option == selected;
             var node = Layout.Builder
-                .Text(option.ToString(), BaseFontSize * 0.85f,
-                    isSelected ? style.BodyText : style.DimText, TextAlign.Center, TextAlign.Center)
+                .Icon(IconFor(option), ViewIconSize, isSelected ? style.BodyText : style.DimText)
+                // HFixed, NOT RowH: RowH is "a full-width row of fixed height" and sets Width = Star, which
+                // silently discards the WFixed above it. That is what the segments were doing before the
+                // icons landed -- ViewButtonWidth was inert and the three buttons sprawled across the whole
+                // header, which is only obvious once you look at an arranged rect. Same trap the card's
+                // width hit (see HomeTabLayoutTests' class remarks).
                 .WFixed(ViewButtonWidth)
-                .RowH(HeaderHeight - 8f)
+                .HFixed(HeaderHeight - 8f)
                 .Radius(4f)
                 .Clickable(new HitResult.ButtonHit($"HomeView:{option}"), onSelectView(option));
 

--- a/src/TianWen.UI.Abstractions/HomeBoardLayout.cs
+++ b/src/TianWen.UI.Abstractions/HomeBoardLayout.cs
@@ -120,6 +120,33 @@ namespace TianWen.UI.Abstractions
     }
 
     /// <summary>
+    /// How the theme control presents itself. A code-level choice, not a user setting: a host knows how much
+    /// header it has, and a reader should never have to configure their way to a legible control.
+    /// <para>
+    /// <b><see cref="IconOnly"/> is a real option and is the wrong default</b>, which is worth stating
+    /// because it is the obvious one. Four states share three marks: <see cref="UiThemeState.Night"/> is a
+    /// dark scheme, so it takes the same crescent as <see cref="UiThemeState.Dark"/>, and inside Night the
+    /// entire UI is red, so the colour that would otherwise separate them says nothing. A control whose only
+    /// job is telling an observer at the mount which scheme they are in cannot be ambiguous about exactly
+    /// that pair. Keep it for a header too tight for anything else, where two dark states reading alike
+    /// beats the control being dropped.
+    /// </para>
+    /// </summary>
+    public enum ThemeControlStyle
+    {
+        /// <summary>The mark plus the state's name. The default: the mark carries the family at a glance and
+        /// the word settles Dark from Night.</summary>
+        IconAndLabel,
+
+        /// <summary>The mark alone, at one segment's width. See the type remarks before choosing it.</summary>
+        IconOnly,
+
+        /// <summary>The word alone. Unambiguous, but a text pill beside three pictograms reads as a
+        /// different species of control.</summary>
+        LabelOnly
+    }
+
+    /// <summary>
     /// Builds the whole home screen as ONE <see cref="Layout.Node"/> tree, the way
     /// <see cref="EquipmentPanelLayout"/> builds the equipment panel: a static function from data to a tree,
     /// so every rect is arranged by the engine and assertable in a unit test.
@@ -173,6 +200,24 @@ namespace TianWen.UI.Abstractions
         /// <summary>Height of the full-bleed header bar.</summary>
         public const float HeaderHeight = 28f;
 
+        /// <summary>
+        /// Slack left above and below the header bar's controls, which is what separates them from the app's
+        /// own top bar directly above.
+        /// <para>
+        /// Both bars paint <c>Palette.HeaderBg</c>, so controls that stop short of the bar's edge leave a
+        /// band of that same colour above them: space without a seam. An earlier attempt put a strip of
+        /// <c>ContentBg</c> between the two bars instead, which reads as a dark rule drawn across the window.
+        /// </para>
+        /// <para>
+        /// The controls are CENTRED by <c>Layout.CrossAlign.Center</c> (DIR.Lib 7.21), not by this number. A
+        /// Stack used to place every child at the cross-axis start, so a Fixed-height button in a taller bar
+        /// hugged the top and sat half the slack high; the workaround here was to pad the bar and make every
+        /// child Star-height, which also inset the label horizontally as a side effect. The engine knows both
+        /// extents, so it is the right place for the arithmetic.
+        /// </para>
+        /// </summary>
+        public const float HeaderControlSlack = 4f;
+
         /// <summary>Inset of the card area from the content edges.</summary>
         public const float BodyPadding = 12f;
 
@@ -206,6 +251,8 @@ namespace TianWen.UI.Abstractions
         /// off <see cref="GuiTheme"/> for the same reason <paramref name="style"/> is: this builder stays a
         /// pure function of its arguments, so a test can arrange any state without touching global state.</param>
         /// <param name="onCycleTheme">Advances the theme, or null to draw no theme control.</param>
+        /// <param name="themeControl">How that control presents itself; see <see cref="ThemeControlStyle"/>
+        /// before reaching for <see cref="ThemeControlStyle.IconOnly"/>.</param>
         public static Layout.Node Build(
             ImmutableArray<RigCard> cards,
             HomeBoardStyle style,
@@ -216,7 +263,8 @@ namespace TianWen.UI.Abstractions
             Func<RigCard, Action<InputModifier>?>? onSelect = null,
             Func<HomeBoardView, Action<InputModifier>?>? onSelectView = null,
             UiThemeState theme = UiThemeState.Dark,
-            Action<InputModifier>? onCycleTheme = null)
+            Action<InputModifier>? onCycleTheme = null,
+            ThemeControlStyle themeControl = ThemeControlStyle.IconAndLabel)
         {
             var cardArea = width - BodyPadding * 2f;
             var columns = ColumnsFor(cardArea, cards.Length);
@@ -246,7 +294,7 @@ namespace TianWen.UI.Abstractions
             }
 
             return Layout.Builder.VStack(
-                    Header(cards, style, view, fellBack, onSelectView, theme, onCycleTheme),
+                    Header(cards, style, view, fellBack, onSelectView, theme, onCycleTheme, themeControl),
                     body)
                 .Bg(style.ContentBg);
         }
@@ -299,7 +347,8 @@ namespace TianWen.UI.Abstractions
         private static Layout.Node Header(
             ImmutableArray<RigCard> cards, HomeBoardStyle style, HomeBoardView view, bool fellBackToTable,
             Func<HomeBoardView, Action<InputModifier>?>? onSelectView,
-            UiThemeState theme, Action<InputModifier>? onCycleTheme)
+            UiThemeState theme, Action<InputModifier>? onCycleTheme,
+            ThemeControlStyle themeControl)
         {
             var waiting = 0;
             foreach (var card in cards)
@@ -337,7 +386,7 @@ namespace TianWen.UI.Abstractions
                 // Set off from the view segments, which are one control: adjacent buttons at the same gap
                 // would read as a four-cell selector whose fourth cell does something unrelated.
                 children.Add(Layout.Builder.Spacer().WFixed(8f).HStar());
-                children.Add(ThemeButton(theme, style, onCycleTheme));
+                children.Add(ThemeButton(theme, style, themeControl, onCycleTheme));
             }
 
             if (onSelectView is not null || onCycleTheme is not null)
@@ -347,53 +396,107 @@ namespace TianWen.UI.Abstractions
 
             return Layout.Builder.HStack([.. children])
                 .RowH(HeaderHeight)
+                .CrossCenter()
                 .WithGap(4f)
                 .Bg(style.HeaderBg);
         }
 
-        /// <summary>Width of the theme cycler. Fixed, and sized for its longest label ("System").</summary>
-        private const float ThemeButtonWidth = 56f;
+        /// <summary>Width of the label-only control, sized for its longest label ("System").</summary>
+        private const float ThemeLabelWidth = 56f;
+
+        /// <summary>Width of the icon-plus-label control: a square icon cell, the gap, then the word.</summary>
+        private const float ThemeIconLabelWidth = 76f;
+
+        /// <summary>
+        /// Which mark stands for a state. Three marks cover four states because
+        /// <see cref="UiThemeState.Night"/> IS a dark scheme; the label is what separates the two, which is
+        /// why <see cref="ThemeControlStyle.IconOnly"/> carries the caveat it does.
+        /// </summary>
+        private static Layout.IconKind IconFor(UiThemeState theme) => theme switch
+        {
+            UiThemeState.Light => Layout.IconKind.ThemeLight,
+            UiThemeState.System => Layout.IconKind.ThemeSystem,
+            _ => Layout.IconKind.ThemeDark,
+        };
 
         /// <summary>
         /// The four-state theme control: one button that SHOWS the current state and advances on click.
         /// <para>
-        /// <b>A word rather than a pictogram, unlike the view segments beside it.</b> Two reasons, and the
-        /// second is the load-bearing one. A sun / crescent / half-disc set needs a fourth mark for
-        /// <see cref="UiThemeState.Night"/> that reads as distinct from Dark at 13 px, and the obvious one
-        /// (a red crescent) is a colour difference on a control the user is looking at precisely because
-        /// they are unsure which scheme is on. And a crescent is drawn by over-painting an offset disc in
-        /// the button's own background, which the shared icon painter cannot do: it is handed an ink
-        /// colour and no ground. So the states that would need icons are exactly the states an icon
-        /// cannot say here, while "Night" is unambiguous on both surfaces and needs no font that a
-        /// terminal might lack.
+        /// It shows the state it is IN rather than the one a click reaches, because with four states no
+        /// single mark can say "what happens next", and the reader's actual question is which scheme they
+        /// are looking at.
         /// </para>
         /// </summary>
         private static Layout.Node ThemeButton(
-            UiThemeState theme, HomeBoardStyle style, Action<InputModifier>? onCycleTheme) =>
-            Layout.Builder
-                .Text(theme.Label(), BaseFontSize * 0.85f, style.BodyText, TextAlign.Center, TextAlign.Center)
+            UiThemeState theme, HomeBoardStyle style, ThemeControlStyle presentation,
+            Action<InputModifier>? onCycleTheme)
+        {
+            var font = BaseFontSize * 0.85f;
+
+            Layout.Node Label(TextAlign hAlign) =>
+                Layout.Builder.Text(theme.Label(), font, style.BodyText, hAlign, TextAlign.Center);
+
+            var (content, width) = presentation switch
+            {
+                ThemeControlStyle.LabelOnly => (Label(TextAlign.Center), ThemeLabelWidth),
+                ThemeControlStyle.IconOnly => (
+                    Layout.Builder.Icon(IconFor(theme), ViewIconSize, style.BodyText), ViewButtonWidth),
+                // The icon takes a SQUARE cell and the label the remainder. Splitting the pill by eye
+                // instead squeezes the mark: these are drawn to a square, so a 13-unit icon in an 18-unit
+                // cell is drawn at 13 and the sun's rays lose their gap first.
+                _ => (Layout.Builder.HStack(
+                        Layout.Builder.Icon(IconFor(theme), ThemeIconSize, style.BodyText)
+                            .WFixed(ControlHeight).HStar(),
+                        Label(TextAlign.Near).WStar().HStar())
+                    .WithGap(2f), ThemeIconLabelWidth),
+            };
+
+            return content
                 // HFixed rather than RowH, for the reason spelt out in ViewButton.
-                .WFixed(ThemeButtonWidth)
-                .HFixed(HeaderHeight - 8f)
+                .WFixed(width)
+                .HFixed(ControlHeight)
                 .Radius(4f)
                 .Bg(style.ViewedCardBg)
                 // Named by the state it currently SHOWS, not the one a click reaches: that is what an
                 // inspector snapshot and a test both want to assert, and it matches the label.
                 .Clickable(new HitResult.ButtonHit($"HomeTheme:{theme}"), onCycleTheme);
+        }
 
         /// <summary>Selector order, and the single list both the buttons and the tests read.</summary>
         private static readonly ImmutableArray<HomeBoardView> ViewOptions =
             [HomeBoardView.Auto, HomeBoardView.Cards, HomeBoardView.Table];
 
         /// <summary>
-        /// Width of one selector segment. A square-ish cell now that the segments carry a pictogram rather
-        /// than a word, which is most of what the icons bought: three words cost 162 units of a header that
-        /// also has to hold the rig count, and the count is the thing the board exists to state.
+        /// Height of every control in the header bar: the bar less its padding on both edges. One constant,
+        /// because the requirement is that they share a top and a bottom, and three call sites computing the
+        /// same difference is how one of them ends up a unit off.
         /// </summary>
-        private const float ViewButtonWidth = 26f;
+        private const float ControlHeight = HeaderHeight - HeaderControlSlack * 2f;
 
-        /// <summary>Icon side within a segment. Leaves a couple of units of breathing room either side.</summary>
-        private const float ViewIconSize = 13f;
+        /// <summary>
+        /// Width of one selector segment. SQUARE, hence the same constant as the height: a pictogram button
+        /// wider than it is tall reads as a text button someone forgot to label, and the three sit side by
+        /// side where any inconsistency is obvious. Square is also most of what the icons bought: three
+        /// words cost 162 units of a header that also has to hold the rig count, which is the thing the
+        /// board exists to state.
+        /// </summary>
+        private const float ViewButtonWidth = ControlHeight;
+
+        /// <summary>
+        /// Mark size inside a shape segment, inset within the square button rather than filling it, so the
+        /// selected segment's fill reads as a button carrying a mark. DIR.Lib 7.20 draws an icon at the size
+        /// it DECLARES rather than stretching it to its cell, so this is the real drawn size and not merely
+        /// an intrinsic hint.
+        /// </summary>
+        private const float ViewIconSize = 14f;
+
+        /// <summary>
+        /// Mark size inside the theme pill, which is SMALLER than a segment's because it sits beside a word.
+        /// Measured rather than guessed: at 13 the crescent inks about 8.75 design units against the label's
+        /// 9.75 of cap height, so the mark reads as part of the same line. At the segment's 20 it stood 38%
+        /// taller than the word and looked vertically misaligned even though both were centred on the row.
+        /// </summary>
+        private const float ThemeIconSize = 13f;
 
         /// <summary>
         /// What each shape LOOKS like, which is the whole reason <see cref="Layout.Content.Icon"/> names a
@@ -431,7 +534,7 @@ namespace TianWen.UI.Abstractions
                 // header, which is only obvious once you look at an arranged rect. Same trap the card's
                 // width hit (see HomeTabLayoutTests' class remarks).
                 .WFixed(ViewButtonWidth)
-                .HFixed(HeaderHeight - 8f)
+                .HFixed(ControlHeight)
                 .Radius(4f)
                 .Clickable(new HitResult.ButtonHit($"HomeView:{option}"), onSelectView(option));
 

--- a/src/TianWen.UI.Abstractions/HomeTab.cs
+++ b/src/TianWen.UI.Abstractions/HomeTab.cs
@@ -42,13 +42,20 @@ namespace TianWen.UI.Abstractions
                 HomeBoardLayout.Build(
                     appState.HomeCards, HomeBoardStyle.Default,
                     contentRect.Width / scale, now, contentRect.Height / scale,
-                    appState.HomeBoardView, SelectAction, SelectViewAction),
+                    appState.HomeBoardView, SelectAction, SelectViewAction,
+                    GuiTheme.State, CycleThemeAction),
                 contentRect);
         }
 
         /// <summary>Posts the header selector's choice; the handler stores it and nothing else happens.</summary>
         private Action<InputModifier>? SelectViewAction(HomeBoardView view) =>
             _ => PostSignal(new SetHomeBoardViewSignal(view));
+
+        /// <summary>
+        /// Advances the theme. Routed through the signal rather than calling <see cref="GuiTheme"/> here, so
+        /// the control and F12 land on one path and every host gets the same behaviour.
+        /// </summary>
+        private void CycleThemeAction(InputModifier _) => PostSignal(new CycleUiThemeSignal());
 
         /// <summary>
         /// Looking at a rig, not driving it. Local and remote go through the same two signals the profile

--- a/src/TianWen.UI.Abstractions/UiThemeState.cs
+++ b/src/TianWen.UI.Abstractions/UiThemeState.cs
@@ -41,4 +41,46 @@ namespace TianWen.UI.Abstractions
         /// </summary>
         Night,
     }
+
+    /// <summary>
+    /// The two questions a theme CONTROL has to answer that the enum itself cannot: what comes next, and
+    /// what to call the state on screen. Pure, so a control can preview a state without adopting it, and
+    /// separate from <see cref="GuiTheme"/> because neither answer needs the resolved palette.
+    /// </summary>
+    public static class UiThemeStateExtensions
+    {
+        extension(UiThemeState theme)
+        {
+            /// <summary>
+            /// The next state in the cycler's order: System, Light, Dark, Night, and back.
+            /// <para>
+            /// <b>Night is in the cycle on purpose, and that does not contradict
+            /// <see cref="UiThemeState.Night"/>'s "never by accident".</b> What must never happen is
+            /// <see cref="UiThemeState.System"/> RESOLVING to Night, which would drop an observer into red
+            /// chrome because their desktop happens to be dark. Reaching it by clicking a control that
+            /// names the state it is about to select is the opposite of that: it is the explicit choice
+            /// the enum asks for. F12 stays the fast gesture, for the observer already at the mount.
+            /// </para>
+            /// </summary>
+            public UiThemeState Next() => theme switch
+            {
+                UiThemeState.System => UiThemeState.Light,
+                UiThemeState.Light => UiThemeState.Dark,
+                UiThemeState.Dark => UiThemeState.Night,
+                _ => UiThemeState.System,
+            };
+
+            /// <summary>
+            /// What to call the state on a control. <see cref="UiThemeState.System"/> is the one whose enum
+            /// name says nothing to a reader, since what it means is "whatever the desktop is set to".
+            /// </summary>
+            public string Label() => theme switch
+            {
+                UiThemeState.Light => "Light",
+                UiThemeState.Dark => "Dark",
+                UiThemeState.Night => "Night",
+                _ => "System",
+            };
+        }
+    }
 }


### PR DESCRIPTION
Replaces the Home board's three word buttons (Auto / Cards / Table) with icon
segments, adds a four-state theme control beside them, and follows the sibling
family to DIR.Lib 7.21.

## What you see

The header's right end goes from `[Auto][Cards][Table]` to three square
pictogram segments plus a theme pill that shows the state it is in:

```
Home . 1 rig                              [A] # =   ( Dark
```

Auto keeps a visible segment. It is the default state, so lighting nothing would
leave the board's commonest configuration unlabelled, and the camera-convention
bracketed A is what makes it sayable at icon size.

## Why an icon leaf and not a glyph

Both surfaces render this tree, and a `Text` run carrying a symbol character
fails in opposite directions on them. On a pixel surface the glyph must exist in
the bound font and a missing one arrives as .notdef, an empty box exactly where
the icon belongs; a cell surface cannot draw rectangles at all but is relied on
for the block-element ranges. `Layout.Content.Icon` names the MEANING, so the GPU
board draws rectangles and the TUI picks a glyph from one authoring pass. Both
are verified: a cell probe shows the terminal painting the selected mark in
BodyText on Selection against a bare DimText neighbour.

## The theme control is a word plus a mark, on purpose

`ThemeControlStyle` makes the presentation a code-level choice (IconAndLabel
default, IconOnly, LabelOnly). Icon-only is a real option and the wrong default:
three marks cover four states because Night IS a dark scheme and shares Dark's
crescent, and inside Night the whole UI is red, so the colour that would separate
them says nothing on the one control whose job is telling an observer at the
mount which scheme they are in.

Cycling into Night records the state it came from, so a later F12 restores that
rather than a stale toggle memory. The two controls compose, which is the case an
observer at the mount is actually in.

## Three bugs found on the way, two of them upstream

- `.RowH(h)` sets `Width = Star` and silently ate the `.WFixed(w)` before it, so
  `ViewButtonWidth` had been inert for the selector's whole life and three
  buttons sprawled across the bar. Only an arranged rect shows this.
- A `Stack` placed every child at the cross-axis START, so the 20-unit controls
  in a 28-unit bar hugged the top and sat 4 units above centre. Fixed upstream as
  `Layout.CrossAlign` (DIR.Lib 7.21) rather than worked around with padding here,
  which is what the first attempt did and which also inset the label sideways.
- An icon drew at its CELL rather than its declared size, and the kinds inked
  between 63% and 100% of that size. Both fixed upstream (7.20, 7.21). Neither is
  visible in an arranged rect, only in rendered ink.

## Verification

Release build clean and 4122 unit tests green on the CI package path
(`-p:UseLocalSiblings=false`). Driven live through the inspector on both
surfaces; every header control reports the same top and height, and the segments
are square.

Six new tests pin behaviour rather than mechanism, which is why they survived the
padding-to-CrossCenter switch unchanged.

