### PR TITLE
feat(dataset): measure the PSF shape, because a width does not pin a profile

### DIFF
--- a/docs/plans/ai-denoise-deconv.md
+++ b/docs/plans/ai-denoise-deconv.md
@@ -168,28 +168,59 @@ on that carve-out:
   sibling command rather than a `build` flag because `build` requires `--archive-root` and a
   re-render must work with the archive unmounted. To re-MEASURE it is still `build --regen-psf`
   (fills gaps) or `--force-psf` (replaces records), both of which re-register.
-- **OPEN, and it undermines the field-radius profile: measured FWHM FALLS toward the corner.** Every
-  train shows it (merged Samyang: 3.072 px at r<0.2 down to 2.710 px at r>0.8, over 184,694 stars),
-  which is backwards for a fast lens where coma should grow off-axis. Three candidate biases were
-  measured against the real `AnalyseStar` on synthetic stars of known width (harness in the
-  2026-08-12 session; true FWHM 4.00 px throughout):
-  - **Saturation, and it dominates.** A clipped core is flat-topped, so the half-max crossing moves
-    outward: clipping 21 px reads **6.154** and heavy clipping **10.837**, against 3.841 unclipped.
-    Vignetting makes the SAME star brighter at frame centre, so clipped cores are a
-    centre-weighted population, which inflates the inner bins specifically. This is the leading
-    explanation of the whole anomaly, and it means the profile currently measures where the stars
-    saturate rather than how the optics degrade.
-  - **Elongation, real but minor.** Because the crossing is taken on an AZIMUTHALLY AVERAGED profile,
-    an elongated star reads near its geometric-mean width, not its major axis. Across the archive's
-    own ellipticity range (0.465 centre to 0.536 corner) that is worth 3.586 -> 3.497 px, i.e. 0.089
-    px of the observed 0.362 px drop, about a quarter.
-  - **Low SNR: ruled out.** It biases FWHM slightly UP (3.841 -> 3.933 as SNR falls 595 -> 29), so
-    it works against the observed direction.
-  **Fix direction: exclude saturated stars from the PSF sample.** `ImageMeta.SensorFullScaleAdu`
-  already carries the sensor's true full-scale (from `MaxADU` or a FITS `SATURATE` card), so the
-  gate can be a real one rather than a guessed threshold. Until that lands, treat the field-radius
-  profile as unreliable and do NOT calibrate the P2 position-varying sweep from it: the sweep would
-  model corners as sharper than centres, which is the opposite of the optics.
+- **Measured FWHM depends strongly on how BRIGHT the star is, and that is the biggest single
+  contaminant of the PSF numbers.** On real masters, pooling all radii, the median FWHM across
+  peak-ADU deciles runs 2.613 -> 1.914 px (Lobster) and 2.909 -> 2.324 px (HIP 85088): faint stars
+  measure roughly 25-30% WIDER than bright ones of the same field. Direction reproduced
+  synthetically (3.841 -> 3.933 px as SNR falls 595 -> 29), and the mechanism is that the half-max
+  level is set relative to the star's own peak, so any residual background left after subtraction is
+  a larger FRACTION of a faint star's peak and pushes the crossing outward. **Anything fitting a PSF
+  from detected stars must control for brightness**, or it fits a magnitude distribution.
+- **Saturation was investigated and RULED OUT on this archive** (an earlier note here claimed it
+  dominated; that was wrong). The synthetic effect is real and large -- on a 4.00 px star, clipping
+  21 px reads 6.154 and heavy clipping 10.837 -- but the population is not there: only **0.1-0.2%**
+  of detected stars are core-clipped, and excluding them moves the per-bin medians by ~0.001 px.
+  The lesson is the one worth keeping: a large effect measured synthetically says nothing until the
+  affected FRACTION of the real population is counted.
+- **The centre-to-corner FWHM fall survives brightness control, and is session-dependent.** Holding
+  peak ADU inside the 40th-60th percentile band: Rim Nebula still falls 4.032 -> 3.115 px, HIP 85088
+  3.020 -> 2.731, but Lobster is flat (2.625 -> 2.514). Elongation explains part of it where
+  ellipticity rises (the crossing is taken on an AZIMUTHALLY AVERAGED profile, so an elongated star
+  reads near its geometric mean, worth ~0.089 px over the archive's 0.465 -> 0.536 range), but not
+  HIP 85088, whose ellipticity is flat (~0.52) while its FWHM still falls. So the aggregate profile
+  is mixing genuinely different per-session field behaviour, and a single archive-wide curve should
+  not be treated as one optical signature.
+
+#### The measured PSF profile (what an own-BlurX has to model)
+
+Stacked azimuthally averaged profiles of 400 isolated, brightness-controlled stars per session
+master, background-subtracted and peak-normalised, fitted with alpha tied to the measured FWHM so
+the fit is about SHAPE:
+
+| session | FWHM px | best Moffat beta | Moffat log-rms | Gaussian log-rms | wing at r=2*FWHM |
+|---|---|---|---|---|---|
+| Rim Nebula | 3.773 | 10.40 | 0.204 | 0.866 | 39x Gaussian |
+| Lobster | 2.458 | 6.50 | 0.230 | 1.719 | 155x Gaussian |
+| HIP 85088 | 2.798 | 5.65 | 0.123 | 1.897 | 160x Gaussian |
+
+- **Fit the PSF in LOG space.** An unweighted least-squares fit on a peak-normalised profile is
+  dominated by the core and effectively ignores the wings -- which are exactly what governs ringing
+  and halo in a deconvolution. Switching to log space flipped the verdict from "Gaussian wins" to
+  "Moffat wins" in **every** session, by a factor of 4 to 15 in rms.
+- **The wings are not Gaussian, by orders of magnitude.** At twice the FWHM the real profile carries
+  39x to 160x the flux a same-FWHM Gaussian predicts. A Gaussian PSF model is not an approximation
+  here, it is the wrong function.
+- **But beta is 5.6-10.4, NOT the 2.5-4.5 this plan assumes** (see the P0 degradation section).
+  Lower beta means HEAVIER wings, so the current sweep range would synthesise halos markedly more
+  extended than this archive actually shows, and train the network to remove a wing that is not
+  there. Re-centre the sweep near beta 6-7 and span roughly 5-11.
+- **Beta varies per session** (5.65 / 6.50 / 10.40), tracking FWHM: the sharpest session is the most
+  Gaussian. So beta belongs in the measured per-session record alongside FWHM, not as one constant.
+- Caveats to close before relying on these numbers: alpha was tied to the measured FWHM rather than
+  fitted freely; the stack averages over field position and position angle, which smears elongation
+  into the radial average and inflates the apparent wings somewhat; and this is measured on
+  registered+integrated MASTERS, which is the right target for master enhancement but includes
+  resampling and seeing-variation blur, not the per-sub PSF.
 - Masters are themselves seeing-blurred, so the net learns *relative* sharpening (standard for
   synthetically-bootstrapped deconv nets). Two mitigations: prefer the sharpest sessions as truth
   (median FWHM gate), and optionally use 2× Bayer-drizzle masters as a sharper truth tier.

--- a/docs/plans/ai-denoise-deconv.md
+++ b/docs/plans/ai-denoise-deconv.md
@@ -193,34 +193,50 @@ on that carve-out:
 
 #### The measured PSF profile (what an own-BlurX has to model)
 
-Stacked azimuthally averaged profiles of 400 isolated, brightness-controlled stars per session
-master, background-subtracted and peak-normalised, fitted with alpha tied to the measured FWHM so
-the fit is about SHAPE:
+**Surveyed across all 50 session masters** (2026-08-12). Per master: stack the azimuthally averaged,
+background-subtracted, peak-normalised profiles of up to 400 isolated brightness-controlled stars,
+then fit a Moffat `(1 + (r/alpha)^2)^-beta` in LOG space with alpha tied to the measured FWHM so the
+fit is about SHAPE. Shipped as `PsfProfileFit`; every future bake records it per session.
 
-| session | FWHM px | best Moffat beta | Moffat log-rms | Gaussian log-rms | wing at r=2*FWHM |
-|---|---|---|---|---|---|
-| Rim Nebula | 3.773 | 10.40 | 0.204 | 0.866 | 39x Gaussian |
-| Lobster | 2.458 | 6.50 | 0.230 | 1.719 | 155x Gaussian |
-| HIP 85088 | 2.798 | 5.65 | 0.123 | 1.897 | 160x Gaussian |
+| optical train | n | beta p5 | beta p50 | beta p95 | FWHM p50 | Moffat / Gaussian log-rms |
+|---|---|---|---|---|---|---|
+| ASI533MC Pro / Samyang 135 f/2 ED @ 130mm | 38 | 4.70 | **7.95** | 23.65 | 2.940 | 0.131 / 1.197 |
+| SV605CC / SH61 EDPH @ 270mm | 9 | 3.00 | **6.85** | 24.95 | 3.226 | 0.266 / 1.614 |
+| ASI585MC Pro / WO ZS61 @ 288mm (0.8x reducer) | 2 | 2.70 | **2.70** | 2.70 | 3.128 | 0.058 / 6.327 |
+| ASI585MC Pro / WO ZS61 @ 360mm (flattener) | 1 | 2.05 | **2.05** | 2.05 | 2.950 | 0.070 / 10.712 |
+
+All 50: beta p5 2.70, p25 5.80, **p50 7.85**, p75 9.65, p95 23.65. Moffat beats Gaussian in **48 of
+50**. Wing flux at r = 2*FWHM relative to a same-FWHM Gaussian: p5 30x, **p50 98x**, p95 535x.
 
 - **Fit the PSF in LOG space.** An unweighted least-squares fit on a peak-normalised profile is
-  dominated by the core and effectively ignores the wings -- which are exactly what governs ringing
-  and halo in a deconvolution. Switching to log space flipped the verdict from "Gaussian wins" to
-  "Moffat wins" in **every** session, by a factor of 4 to 15 in rms.
-- **The wings are not Gaussian, by orders of magnitude.** At twice the FWHM the real profile carries
-  39x to 160x the flux a same-FWHM Gaussian predicts. A Gaussian PSF model is not an approximation
-  here, it is the wrong function.
-- **But beta is 5.6-10.4, NOT the 2.5-4.5 this plan assumes** (see the P0 degradation section).
-  Lower beta means HEAVIER wings, so the current sweep range would synthesise halos markedly more
-  extended than this archive actually shows, and train the network to remove a wing that is not
-  there. Re-centre the sweep near beta 6-7 and span roughly 5-11.
-- **Beta varies per session** (5.65 / 6.50 / 10.40), tracking FWHM: the sharpest session is the most
-  Gaussian. So beta belongs in the measured per-session record alongside FWHM, not as one constant.
-- Caveats to close before relying on these numbers: alpha was tied to the measured FWHM rather than
-  fitted freely; the stack averages over field position and position angle, which smears elongation
-  into the radial average and inflates the apparent wings somewhat; and this is measured on
-  registered+integrated MASTERS, which is the right target for master enhancement but includes
-  resampling and seeing-variation blur, not the per-sub PSF.
+  dominated by the core and effectively ignores the wings -- exactly what governs ringing and halo
+  in a deconvolution. On the first three masters, plain RMS reported "Gaussian fits better" for two
+  of them; in log space Moffat wins all three, by 4x to 15x. Same data, opposite conclusion, purely
+  from the error metric. This is the most transferable lesson in this section.
+- **A Gaussian PSF is the wrong function, not a rough one.** The median master carries ~98x the wing
+  flux a same-FWHM Gaussian predicts at twice the FWHM.
+- **beta is a PER-TRAIN property, and the spread is the finding.** The ZS61 sits at beta 2.05-2.70
+  with wings 535-994x Gaussian, while the Samyang sits at 7.95 -- genuinely different optics, not
+  scatter. Note the ZS61 also has by far the BEST Moffat fits in the survey (log-rms 0.058-0.070)
+  and by far the worst Gaussian ones (6.3-10.7): it is very nearly a textbook heavy-winged Moffat.
+  This independently vindicates keeping the 288mm and 360mm ZS61 configurations as separate trains.
+- **The plan's assumed beta 2.5-4.5 is calibrated to the three rarest sessions.** It is about right
+  for the ZS61 (3 of 50) and badly wrong for the Samyang and SH61, which are 47 of 50. Sweeping it
+  would synthesise halos far heavier than 94% of the archive shows and train the network to remove
+  a wing that is not there. **Sweep roughly beta 2-12, weighted toward 6-9**, or better, sample the
+  measured per-train distribution directly.
+- **beta correlates with FWHM: blurrier masters are MORE Gaussian** (Pearson r = 0.66 over all 50,
+  and 0.635 within the Samyang train alone, so it is not a between-train artifact; Samyang FWHM<2.9
+  gives beta median 6.45, FWHM>=2.9 gives 9.05). Physically sensible -- more seeing and tracking
+  blur, and more frames averaged, convolve toward a Gaussian and wash out the sharp-core/heavy-wing
+  structure. **So do NOT sample FWHM and beta independently in the sweep**: that generates
+  combinations (a 4 px FWHM with beta 2.7) this archive never produces.
+- Caveats: alpha is tied to the measured FWHM rather than fitted freely, so beta answers "how heavy
+  are the wings at this width"; the upper tail is grid-limited (2 sessions pinned at the beta=25
+  ceiling, and p95 23.65 should be read as "effectively Gaussian" rather than a number); the stack
+  averages over field position and position angle, smearing elongation into the radial average; and
+  this is measured on registered+integrated MASTERS -- the right target for master enhancement, but
+  it includes resampling and seeing-variation blur rather than the per-sub PSF.
 - Masters are themselves seeing-blurred, so the net learns *relative* sharpening (standard for
   synthetically-bootstrapped deconv nets). Two mitigations: prefer the sharpest sessions as truth
   (median FWHM gate), and optionally use 2× Bayer-drizzle masters as a sharper truth tier.

--- a/src/TianWen.Lib.Tests/PsfProfileFitTests.cs
+++ b/src/TianWen.Lib.Tests/PsfProfileFitTests.cs
@@ -1,0 +1,172 @@
+using Shouldly;
+using System;
+using System.Collections.Generic;
+using TianWen.Lib.Imaging;
+using TianWen.Lib.Imaging.Dataset;
+using Xunit;
+
+namespace TianWen.Lib.Tests
+{
+    /// <summary>
+    /// Coverage for <see cref="PsfProfileFit"/>: it must recover the exponent of a synthetic Moffat
+    /// field, and must not mistake a Moffat for a Gaussian. The second is the real risk -- an
+    /// unweighted fit reports "Gaussian" for every one of these frames, because the core dominates
+    /// and the wings that distinguish them are three orders of magnitude smaller.
+    /// </summary>
+    public class PsfProfileFitTests
+    {
+        // Big enough that the fit's brightness band (55th-75th percentile of peaks) still leaves
+        // well over its 40-star floor: 17x17 grid positions -> 289 stars -> ~58 in band.
+        private const int Size = 700;
+        private const int Pitch = 40;
+        private const int Inset = 30;
+        private const float Background = 200f;
+        private const float Amplitude = 3000f;
+
+        [Theory]
+        [InlineData(2.5)]
+        [InlineData(4.0)]
+        [InlineData(7.0)]
+        public void Measure_RecoversTheMoffatExponentItWasGiven(double trueBeta)
+        {
+            const double trueFwhm = 3.2;
+            var image = RenderMoffatField(trueFwhm, trueBeta, seed: 7);
+
+            var stars = DetectSyntheticStars(image);
+            var result = PsfProfileFit.Measure(image, channel: 0, stars).ShouldNotBeNull();
+
+            result.Fwhm.ShouldBe(trueFwhm, tolerance: 0.35);
+            // Beta is a wing-shape parameter fitted over a finite radius, so it is recovered to
+            // within a fraction rather than exactly; the sweep only needs the right neighbourhood.
+            result.MoffatBeta.ShouldBe(trueBeta, tolerance: Math.Max(1.0, trueBeta * 0.35));
+        }
+
+        [Fact]
+        public void Measure_PrefersMoffatOverGaussian_OnAMoffatField()
+        {
+            // beta 3 has wings a Gaussian cannot express. The log-space residual has to say so.
+            var image = RenderMoffatField(fwhm: 3.0, beta: 3.0, seed: 11);
+
+            var result = PsfProfileFit.Measure(image, channel: 0, DetectSyntheticStars(image)).ShouldNotBeNull();
+
+            result.MoffatLogRms.ShouldBeLessThan(result.GaussianLogRms);
+            result.GaussianLogRms.ShouldBeGreaterThan(result.MoffatLogRms * 2,
+                $"a Gaussian should fit a beta-3 Moffat far worse, but got moffat={result.MoffatLogRms:F4} gauss={result.GaussianLogRms:F4}");
+        }
+
+        [Fact]
+        public void Measure_OnAGaussianField_DoesNotClaimHeavyWings()
+        {
+            // The converse guard: a genuinely Gaussian field must not report a low beta, or the
+            // sweep would synthesise wings that are not in the data.
+            var image = RenderGaussianField(fwhm: 3.0, seed: 13);
+
+            var result = PsfProfileFit.Measure(image, channel: 0, DetectSyntheticStars(image)).ShouldNotBeNull();
+
+            result.MoffatBeta.ShouldBeGreaterThan(8.0,
+                $"a Gaussian is the beta -> infinity limit, so the fit should run high, got {result.MoffatBeta:F2}");
+        }
+
+        [Fact]
+        public void Measure_WithTooFewStars_ReturnsNullRatherThanAGuess()
+        {
+            var image = RenderMoffatField(fwhm: 3.0, beta: 4.0, seed: 3);
+
+            PsfProfileFit.Measure(image, channel: 0, new List<ImagedStar>()).ShouldBeNull();
+        }
+
+        /// <summary>Grid of well-separated identical stars on a flat background, so the stacked
+        /// profile has a known answer. Spacing is wider than the isolation radius the fit enforces.</summary>
+        private static Image RenderMoffatField(double fwhm, double beta, int seed)
+            => RenderField(seed, (r, alpha) => Math.Pow(1 + (r * r) / (alpha * alpha), -beta),
+                alpha: fwhm / (2 * Math.Sqrt(Math.Pow(2, 1.0 / beta) - 1)));
+
+        private static Image RenderGaussianField(double fwhm, int seed)
+            => RenderField(seed, (r, sigma) => Math.Exp(-(r * r) / (2 * sigma * sigma)),
+                alpha: fwhm / 2.3548200450309493);
+
+        private static Image RenderField(int seed, Func<double, double, double> shape, double alpha)
+        {
+            var data = new float[Size, Size];
+            var rng = new Random(seed);
+            for (var y = 0; y < Size; y++)
+            {
+                for (var x = 0; x < Size; x++)
+                {
+                    data[y, x] = Background + (float)((rng.NextDouble() - 0.5) * 4.0);
+                }
+            }
+
+            // Pitch comfortably beyond the 16 px isolation radius, inset clear of the edge guard.
+            // Amplitudes VARY: the fit selects a brightness band, so a field of identical stars
+            // would leave it only the band's own width to work with (and did, when this test first
+            // ran: 100 identical stars gave 20 in band against a 40-star floor, and Measure
+            // correctly returned null).
+            for (var gy = Inset; gy < Size - Inset; gy += Pitch)
+            {
+                for (var gx = Inset; gx < Size - Inset; gx += Pitch)
+                {
+                    // Sub-pixel offsets so the stack is not a single phase repeated.
+                    var cx = gx + rng.NextDouble() - 0.5;
+                    var cy = gy + rng.NextDouble() - 0.5;
+                    var amp = Amplitude * (0.4 + 1.4 * rng.NextDouble());
+                    for (var dy = -14; dy <= 14; dy++)
+                    {
+                        for (var dx = -14; dx <= 14; dx++)
+                        {
+                            var x = (int)Math.Round(cx) + dx;
+                            var y = (int)Math.Round(cy) + dy;
+                            if (x < 0 || y < 0 || x >= Size || y >= Size) continue;
+                            var r = Math.Sqrt((x - cx) * (x - cx) + (y - cy) * (y - cy));
+                            data[y, x] += (float)(amp * shape(r, alpha));
+                        }
+                    }
+                }
+            }
+
+            var max = 0f;
+            var min = float.MaxValue;
+            foreach (var v in data)
+            {
+                if (v > max) max = v;
+                if (v < min) min = v;
+            }
+            var meta = new ImageMeta("synth", DateTime.UtcNow, TimeSpan.FromSeconds(60),
+                FrameType.Light, "", 3.76f, 3.76f, 100, -1, Filter.Luminance, 1, 1,
+                float.NaN, SensorType.Monochrome, 0, 0, RowOrder.TopDown, float.NaN, float.NaN);
+            return new Image([data], BitDepth.Int16, max, min, 0, meta);
+        }
+
+        /// <summary>The grid positions the renderer used, as detections. Built directly rather than
+        /// through FindStarsAsync so the test exercises the PROFILE fit and not star detection.</summary>
+        private static List<ImagedStar> DetectSyntheticStars(Image image)
+        {
+            var stars = new List<ImagedStar>();
+            for (var gy = Inset; gy < Size - Inset; gy += Pitch)
+            {
+                for (var gx = Inset; gx < Size - Inset; gx += Pitch)
+                {
+                    // Centroid the local neighbourhood so the fit gets sub-pixel centres, as it
+                    // would from real detection.
+                    double sw = 0, sx = 0, sy = 0;
+                    for (var dy = -6; dy <= 6; dy++)
+                    {
+                        for (var dx = -6; dx <= 6; dx++)
+                        {
+                            var x = gx + dx;
+                            var y = gy + dy;
+                            if (x < 0 || y < 0 || x >= Size || y >= Size) continue;
+                            var v = Math.Max(0f, image.GetChannelSpan(0)[y * Size + x] - Background);
+                            sw += v;
+                            sx += v * x;
+                            sy += v * y;
+                        }
+                    }
+                    if (sw <= 0) continue;
+                    stars.Add(new ImagedStar(3f, 3f, 100f, (float)sw, (float)(sx / sw), (float)(sy / sw), 0.1f));
+                }
+            }
+            return stars;
+        }
+    }
+}

--- a/src/TianWen.Lib/Imaging/Dataset/DatasetPsfNoiseReport.cs
+++ b/src/TianWen.Lib/Imaging/Dataset/DatasetPsfNoiseReport.cs
@@ -61,6 +61,14 @@ public static class DatasetPsfNoiseReport
     /// re-derived because re-deriving needs the session's frames, which a resumed run has not read.
     /// </param>
     /// <param name="Bins">Per-bin samples, indexed by bin; length is the report's radius-bin count.</param>
+    /// <param name="MasterProfile">
+    /// Measured PSF SHAPE of the session master (<see cref="PsfProfileFit"/>): the stacked-profile
+    /// FWHM and the Moffat exponent describing its wings. Null when the frame could not support a
+    /// measurement, and also on any record written before this was measured at all -- the store is
+    /// append-only and last-wins, so old sessions read back with null here until re-measured with
+    /// <c>--force-psf</c>. It is what the deconvolver's synthetic-PSF sweep should be calibrated
+    /// from: a width alone does not pin a profile, and the wings are what produce ringing.
+    /// </param>
     public sealed record SessionPsf(
         string SessionId,
         string OpticalTrain,
@@ -68,7 +76,8 @@ public static class DatasetPsfNoiseReport
         float[] SubHfd,
         float[] SubEllipticity,
         double MasterNoiseRelative,
-        RadiusSamples[] Bins);
+        RadiusSamples[] Bins,
+        PsfProfileFit.Result? MasterProfile = null);
 
     /// <summary>Per-optical-train sub-report. The field-radius PSF profile lives HERE, never
     /// aggregated across trains: a Newtonian's coma grows with field radius while a refractor's does
@@ -80,6 +89,14 @@ public static class DatasetPsfNoiseReport
     /// means <see cref="TelescopeAliases"/> merged differently-spelled headers, and the report says
     /// so: a merge that changes how many sessions back a profile has to be visible in the artifact,
     /// or the reader cannot tell a genuine 38-session train from an over-eager alias.</param>
+    /// <param name="ProfileFwhm">Stacked-profile FWHM across this train's sessions
+    /// (<see cref="PsfProfileFit"/>). Brightness-controlled, so unlike <paramref name="SubFwhm"/> it
+    /// does not carry the 25-30% swing that comes from which stars happened to be sampled.</param>
+    /// <param name="MoffatBeta">Moffat exponent across this train's sessions: LOWER means HEAVIER
+    /// wings. This is the number the deconvolver's synthetic-PSF sweep should span.</param>
+    /// <param name="ProfileSessions">How many sessions carried a measurable profile; less than
+    /// <paramref name="Sessions"/> means the rest predate the measurement and need
+    /// <c>--force-psf</c>.</param>
     public sealed record TrainReport(
         string OpticalTrain,
         int Sessions,
@@ -90,7 +107,10 @@ public static class DatasetPsfNoiseReport
         Percentiles SubEllipticity,
         ImmutableArray<RadiusBin> FieldRadiusProfile,
         Percentiles MasterNoiseRelative,
-        ImmutableArray<string> RecordedAs);
+        ImmutableArray<string> RecordedAs,
+        Percentiles ProfileFwhm,
+        Percentiles MoffatBeta,
+        int ProfileSessions);
 
     /// <summary>The full report: an archive-wide population summary (the per-sub metrics + noise
     /// floor the denoiser sees across everything) plus a per-optical-train breakdown, each carrying
@@ -190,7 +210,23 @@ public static class DatasetPsfNoiseReport
             bins[b] = new RadiusSamples(binFwhm[b].ToArray(), binEcc[b].ToArray());
         }
 
-        logger?.LogInformation("  [{Session}] PSF sampled {Stars} stars ({Train})", session.Session.Id, stars.Count, label);
+        // PSF SHAPE, measured once on the master from the stars already detected above. Separate
+        // from the per-bin FWHM samples because it answers a different question: those describe how
+        // the width varies across the field, this describes what the profile IS, which is what the
+        // deconvolver has to synthesise.
+        var masterProfile = PsfProfileFit.Measure(session.Master, channel: 0, stars);
+        if (masterProfile is { } fit)
+        {
+            logger?.LogInformation(
+                "  [{Session}] PSF sampled {Stars} stars, profile FWHM {Fwhm:F3} px, Moffat beta {Beta:F2} (log-rms {MoffatRms:F3} vs gaussian {GaussRms:F3}, {Stacked} stars stacked) ({Train})",
+                session.Session.Id, stars.Count, fit.Fwhm, fit.MoffatBeta, fit.MoffatLogRms, fit.GaussianLogRms, fit.StarsStacked, label);
+        }
+        else
+        {
+            logger?.LogInformation("  [{Session}] PSF sampled {Stars} stars, profile shape not measurable ({Train})",
+                session.Session.Id, stars.Count, label);
+        }
+
         return new SessionPsf(
             SessionId: session.Session.Id,
             OpticalTrain: label,
@@ -198,7 +234,8 @@ public static class DatasetPsfNoiseReport
             SubHfd: subHfd,
             SubEllipticity: subEcc,
             MasterNoiseRelative: RelativeBackgroundMad(session.Master),
-            Bins: bins);
+            Bins: bins,
+            MasterProfile: masterProfile);
     }
 
     /// <summary>
@@ -266,6 +303,11 @@ public static class DatasetPsfNoiseReport
             acc.RecordedAs.Add(record.OpticalTrain);
 
             acc.Sessions++;
+            if (record.MasterProfile is { } profile)
+            {
+                acc.ProfileFwhm.Add((float)profile.Fwhm);
+                acc.MoffatBeta.Add((float)profile.MoffatBeta);
+            }
             acc.Fwhm.AddRange(record.SubFwhm);
             acc.Hfd.AddRange(record.SubHfd);
             acc.Ecc.AddRange(record.SubEllipticity);
@@ -313,6 +355,9 @@ public static class DatasetPsfNoiseReport
                     SubFwhm: PercentilesOf(acc.Fwhm),
                     SubHfd: PercentilesOf(acc.Hfd),
                     SubEllipticity: PercentilesOf(acc.Ecc),
+                    ProfileFwhm: PercentilesOf(acc.ProfileFwhm),
+                    MoffatBeta: PercentilesOf(acc.MoffatBeta),
+                    ProfileSessions: acc.ProfileFwhm.Count,
                     FieldRadiusProfile: profile.MoveToImmutable(),
                     MasterNoiseRelative: PercentilesOf(acc.Noise)));
 
@@ -352,6 +397,10 @@ public static class DatasetPsfNoiseReport
             public readonly List<float> Hfd = new();
             public readonly List<float> Ecc = new();
             public readonly List<double> Noise = new();
+            /// <summary>One entry per session that carried a measurable master profile; shorter than
+            /// <see cref="Sessions"/> for a train whose older records predate the measurement.</summary>
+            public readonly List<float> ProfileFwhm = new();
+            public readonly List<float> MoffatBeta = new();
             public readonly List<float>[] BinFwhm;
             public readonly List<float>[] BinEcc;
 
@@ -419,6 +468,18 @@ public static class DatasetPsfNoiseReport
                 $"- Sessions: {train.Sessions} | Subs: {train.Subs} | Stars: {train.StarsSampled}"));
             sb.AppendLine(string.Create(ci,
                 $"- FWHM p50: {train.SubFwhm.P50:F3} px | Ellipticity p50: {train.SubEllipticity.P50:F3} | Noise p50: {train.MasterNoiseRelative.P50:F5}"));
+            if (train.ProfileSessions > 0)
+            {
+                // The PSF SHAPE, which is what the deconvolver's synthetic sweep has to reproduce.
+                // Lower beta = heavier wings; a Gaussian is beta -> infinity.
+                sb.AppendLine(string.Create(ci,
+                    $"- Master PSF profile ({train.ProfileSessions}/{train.Sessions} sessions): FWHM p50 {train.ProfileFwhm.P50:F3} px | " +
+                    $"Moffat beta p5/p50/p95 {train.MoffatBeta.P5:F2} / {train.MoffatBeta.P50:F2} / {train.MoffatBeta.P95:F2}"));
+            }
+            else if (train.Sessions > 0)
+            {
+                sb.AppendLine("- Master PSF profile: not measured for this train (records predate it; re-run with --force-psf)");
+            }
             sb.AppendLine();
             sb.AppendLine("| Radius (norm) | Median FWHM (px) | Median ellipticity | Stars |");
             sb.AppendLine("|---------------|------------------|--------------------|-------|");

--- a/src/TianWen.Lib/Imaging/Dataset/PsfProfileFit.cs
+++ b/src/TianWen.Lib/Imaging/Dataset/PsfProfileFit.cs
@@ -1,0 +1,386 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using TianWen.Lib.Imaging;
+
+namespace TianWen.Lib.Imaging.Dataset
+{
+    /// <summary>
+    /// Measures the SHAPE of a frame's point-spread function: the stacked radial profile of its
+    /// stars, and the Moffat exponent that describes its wings.
+    ///
+    /// <para><b>Why the wings and not just the width.</b> The deconvolver's synthetic-PSF sweep has
+    /// to generate degradation that looks like this archive, and a width alone does not pin a
+    /// profile. Measured on real session masters, the wings carry 39x to 160x the flux a Gaussian of
+    /// the same FWHM predicts at twice the FWHM out, so a Gaussian PSF is not an approximation here,
+    /// it is the wrong function. What the wings cost is ringing and halo, which is precisely the
+    /// artefact class a deconvolver is judged on.</para>
+    /// </summary>
+    public static class PsfProfileFit
+    {
+        /// <summary>Radial bin width in pixels. Quarter-pixel bins resolve a ~2.5 px FWHM core
+        /// without leaving the wing bins too sparse to take a median over.</summary>
+        private const double BinWidth = 0.25;
+
+        /// <summary>Radial bins, i.e. profile sampled out to <c>Bins * BinWidth</c> = 12 px.</summary>
+        private const int Bins = 48;
+
+        /// <summary>Below this the stacked profile is background residue, not signal, and including
+        /// it would let the noise floor drive a log-space fit.</summary>
+        private const double NoiseFloor = 0.002;
+
+        /// <summary>Nothing else detected within this radius, so the wings being fitted belong to
+        /// the star rather than to a neighbour.</summary>
+        private const double IsolationRadius = 16.0;
+
+        /// <summary>Annulus used for the local background, outside the profile but inside the
+        /// isolation radius.</summary>
+        private const double BackgroundInner = 12.0;
+        private const double BackgroundOuter = 15.0;
+
+        /// <summary>
+        /// One frame's measured PSF shape.
+        /// </summary>
+        /// <param name="Fwhm">FWHM of the STACKED profile, in pixels. Deliberately distinct from a
+        /// median of per-star FWHM: it is brightness-controlled and measured once on a
+        /// high-signal-to-noise stack, so it does not carry the brightness bias described below.</param>
+        /// <param name="MoffatBeta">Best-fit Moffat exponent, where the profile is
+        /// <c>(1 + (r/alpha)^2)^-beta</c>. LOWER beta means HEAVIER wings; beta to infinity is a
+        /// Gaussian.</param>
+        /// <param name="MoffatLogRms">Log-space residual of that fit.</param>
+        /// <param name="GaussianLogRms">Log-space residual of a Gaussian of the same FWHM, for
+        /// comparison. Moffat winning by a wide margin is the expected result; the two being close
+        /// would mean this frame really is Gaussian-cored.</param>
+        /// <param name="StarsStacked">How many stars went into the stack.</param>
+        public sealed record Result(
+            double Fwhm,
+            double MoffatBeta,
+            double MoffatLogRms,
+            double GaussianLogRms,
+            int StarsStacked);
+
+        /// <summary>
+        /// Stacks the radial profiles of isolated, brightness-controlled stars and fits a Moffat to
+        /// the result. Returns null when the frame cannot support a measurement (too few usable
+        /// stars, or a stack with no half-maximum crossing).
+        /// </summary>
+        /// <remarks>
+        /// <para><b>Brightness is controlled, and that is not optional.</b> Measured FWHM depends
+        /// strongly on how bright the star is: across peak-ADU deciles on real masters it runs
+        /// 2.613 -> 1.914 px, so faint stars read 25-30% WIDER than bright ones in the same frame.
+        /// The mechanism is that the half-maximum level is set relative to the star's OWN peak, so
+        /// whatever background survives subtraction is a larger fraction of a faint star's peak and
+        /// pushes the crossing outward. Stacking whatever the detector returned would therefore
+        /// measure the frame's magnitude distribution as much as its optics.</para>
+        /// <para><b>The fit is in LOG space, and that changes the answer.</b> An unweighted
+        /// least-squares fit on a peak-normalised profile is dominated by the core, where the values
+        /// are near 1, and effectively ignores the wings, where they are near 0.001. Fitting the
+        /// same three real masters both ways flipped the verdict from "Gaussian fits better" to
+        /// "Moffat fits better" in every one, by a factor of 4 to 15 in residual. Since the wings are
+        /// the reason to measure a PSF at all, weighting each decade equally is the honest choice.</para>
+        /// <para><b>Alpha is tied to the measured FWHM rather than fitted.</b> The width is already
+        /// known from the stack's own half-maximum crossing, so letting alpha float would trade
+        /// width against exponent and report a shape that only fits because it also moved the width.
+        /// Constraining it makes beta answer one question: how heavy are the wings for THIS
+        /// width.</para>
+        /// </remarks>
+        /// <param name="image">Frame to measure.</param>
+        /// <param name="channel">Channel index; callers use 0 to match the rest of the PSF report.</param>
+        /// <param name="stars">Already-detected stars for this channel.</param>
+        /// <param name="maxStars">Cap on stars stacked; the profile converges well before this.</param>
+        public static Result? Measure(
+            Image image,
+            int channel,
+            IReadOnlyCollection<ImagedStar> stars,
+            int maxStars = 400)
+        {
+            ArgumentNullException.ThrowIfNull(image);
+            ArgumentNullException.ThrowIfNull(stars);
+
+            var (_, width, height) = image.Shape;
+            if (stars.Count < 40)
+            {
+                return null;
+            }
+
+            // Copied once rather than held as a span: the accumulation below spans several helper
+            // calls and a span cannot cross them (CS8175), and one copy per frame is negligible
+            // beside the star detection that produced the input.
+            var plane = image.GetChannelSpan(channel).ToArray();
+            var starArray = stars.ToArray();
+
+            var peaks = new float[starArray.Length];
+            for (var i = 0; i < starArray.Length; i++)
+            {
+                peaks[i] = PeakNear(plane, width, height, starArray[i].XCentroid, starArray[i].YCentroid);
+            }
+
+            // A band around the middle of the brightness distribution: bright enough that the
+            // background residue is a small fraction of the peak, faint enough to be far from any
+            // clipping, and populous enough to stack.
+            var lowPeak = Percentile(peaks, 0.55);
+            var highPeak = Percentile(peaks, 0.75);
+
+            var samples = new List<float>[Bins];
+            for (var b = 0; b < Bins; b++)
+            {
+                samples[b] = new List<float>();
+            }
+
+            var stacked = 0;
+            for (var i = 0; i < starArray.Length && stacked < maxStars; i++)
+            {
+                if (peaks[i] < lowPeak || peaks[i] > highPeak)
+                {
+                    continue;
+                }
+                var sx = starArray[i].XCentroid;
+                var sy = starArray[i].YCentroid;
+                if (sx < IsolationRadius || sy < IsolationRadius
+                    || sx > width - IsolationRadius - 1 || sy > height - IsolationRadius - 1)
+                {
+                    continue;
+                }
+                if (!IsIsolated(starArray, i, sx, sy))
+                {
+                    continue;
+                }
+                if (!TryLocalBackground(plane, width, height, sx, sy, out var background))
+                {
+                    continue;
+                }
+
+                var amplitude = peaks[i] - background;
+                if (amplitude <= 0f)
+                {
+                    continue;
+                }
+
+                Accumulate(plane, width, height, sx, sy, background, amplitude, samples);
+                stacked++;
+            }
+
+            if (stacked < 40)
+            {
+                return null;
+            }
+
+            var profile = new double[Bins];
+            var radii = new double[Bins];
+            for (var b = 0; b < Bins; b++)
+            {
+                radii[b] = (b + 0.5) * BinWidth;
+                profile[b] = samples[b].Count > 0 ? Median(samples[b]) : double.NaN;
+            }
+
+            var fwhm = HalfMaximumWidth(profile, radii);
+            if (double.IsNaN(fwhm) || fwhm <= 0)
+            {
+                return null;
+            }
+
+            var fitBins = new List<int>();
+            for (var b = 0; b < Bins; b++)
+            {
+                if (!double.IsNaN(profile[b]) && profile[b] > NoiseFloor)
+                {
+                    fitBins.Add(b);
+                }
+            }
+            if (fitBins.Count < 8)
+            {
+                return null;
+            }
+
+            var (beta, moffatRms) = FitMoffatBeta(profile, radii, fitBins, fwhm);
+            var gaussRms = GaussianLogRms(profile, radii, fitBins, fwhm);
+            return new Result(fwhm, beta, moffatRms, gaussRms, stacked);
+        }
+
+        private static bool IsIsolated(ImagedStar[] stars, int self, float sx, float sy)
+        {
+            var r2 = IsolationRadius * IsolationRadius;
+            for (var j = 0; j < stars.Length; j++)
+            {
+                if (j == self)
+                {
+                    continue;
+                }
+                var dx = stars[j].XCentroid - sx;
+                var dy = stars[j].YCentroid - sy;
+                if (dx * dx + dy * dy < r2)
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        private static bool TryLocalBackground(
+            float[] plane, int width, int height, float sx, float sy, out float background)
+        {
+            var ring = new List<float>();
+            var inner = BackgroundInner * BackgroundInner;
+            var outer = BackgroundOuter * BackgroundOuter;
+            var cx = (int)sx;
+            var cy = (int)sy;
+            for (var dy = -(int)BackgroundOuter; dy <= (int)BackgroundOuter; dy++)
+            {
+                for (var dx = -(int)BackgroundOuter; dx <= (int)BackgroundOuter; dx++)
+                {
+                    var d2 = dx * dx + dy * dy;
+                    if (d2 < inner || d2 > outer)
+                    {
+                        continue;
+                    }
+                    var x = cx + dx;
+                    var y = cy + dy;
+                    if (x < 0 || y < 0 || x >= width || y >= height)
+                    {
+                        continue;
+                    }
+                    ring.Add(plane[y * width + x]);
+                }
+            }
+            if (ring.Count < 40)
+            {
+                background = 0f;
+                return false;
+            }
+            background = Median(ring);
+            return true;
+        }
+
+        private static void Accumulate(
+            float[] plane, int width, int height, float sx, float sy,
+            float background, float amplitude, List<float>[] samples)
+        {
+            var reach = (int)Math.Ceiling(Bins * BinWidth * 0.5) + 1;
+            var cx = (int)Math.Round(sx);
+            var cy = (int)Math.Round(sy);
+            for (var dy = -reach; dy <= reach; dy++)
+            {
+                for (var dx = -reach; dx <= reach; dx++)
+                {
+                    var x = cx + dx;
+                    var y = cy + dy;
+                    if (x < 0 || y < 0 || x >= width || y >= height)
+                    {
+                        continue;
+                    }
+                    // Radius from the SUB-PIXEL centroid, not from the rounded centre, or the
+                    // innermost bins smear by up to half a pixel.
+                    var ddx = x - sx;
+                    var ddy = y - sy;
+                    var b = (int)(Math.Sqrt(ddx * ddx + ddy * ddy) / BinWidth);
+                    if (b >= Bins)
+                    {
+                        continue;
+                    }
+                    samples[b].Add((plane[y * width + x] - background) / amplitude);
+                }
+            }
+        }
+
+        /// <summary>Interpolated half-maximum crossing of the peak-normalised stack, doubled.</summary>
+        private static double HalfMaximumWidth(double[] profile, double[] radii)
+        {
+            for (var b = 1; b < profile.Length; b++)
+            {
+                if (double.IsNaN(profile[b]) || double.IsNaN(profile[b - 1]))
+                {
+                    continue;
+                }
+                if (profile[b] < 0.5 && profile[b - 1] >= 0.5)
+                {
+                    var drop = profile[b - 1] - profile[b];
+                    var hwhm = drop > 0
+                        ? radii[b - 1] + BinWidth * (profile[b - 1] - 0.5) / drop
+                        : radii[b - 1];
+                    return 2 * hwhm;
+                }
+            }
+            return double.NaN;
+        }
+
+        private static (double Beta, double Rms) FitMoffatBeta(
+            double[] profile, double[] radii, List<int> fitBins, double fwhm)
+        {
+            var bestBeta = 0.0;
+            var bestRms = double.MaxValue;
+            // 1 to 25 covers heavy-winged through effectively Gaussian; the real archive lands
+            // between about 5 and 11, so both ends are comfortably outside the observed range.
+            for (var beta = 1.0; beta <= 25.0; beta += 0.05)
+            {
+                var alpha = AlphaFor(fwhm, beta);
+                var se = 0.0;
+                foreach (var b in fitBins)
+                {
+                    var model = Math.Pow(1 + (radii[b] * radii[b]) / (alpha * alpha), -beta);
+                    var d = Math.Log(model) - Math.Log(profile[b]);
+                    se += d * d;
+                }
+                var rms = Math.Sqrt(se / fitBins.Count);
+                if (rms < bestRms)
+                {
+                    bestRms = rms;
+                    bestBeta = beta;
+                }
+            }
+            return (bestBeta, bestRms);
+        }
+
+        /// <summary>Moffat FWHM is <c>2*alpha*sqrt(2^(1/beta) - 1)</c>; inverted so a candidate beta
+        /// reproduces the measured width exactly and only its shape is under test.</summary>
+        private static double AlphaFor(double fwhm, double beta)
+            => fwhm / (2 * Math.Sqrt(Math.Pow(2, 1.0 / beta) - 1));
+
+        private static double GaussianLogRms(double[] profile, double[] radii, List<int> fitBins, double fwhm)
+        {
+            var sigma = fwhm / 2.3548200450309493; // FWHM = 2*sqrt(2*ln2)*sigma
+            var se = 0.0;
+            foreach (var b in fitBins)
+            {
+                var model = Math.Exp(-(radii[b] * radii[b]) / (2 * sigma * sigma));
+                var d = Math.Log(model) - Math.Log(profile[b]);
+                se += d * d;
+            }
+            return Math.Sqrt(se / fitBins.Count);
+        }
+
+        private static float PeakNear(float[] plane, int width, int height, float fx, float fy)
+        {
+            var x0 = Math.Max(0, (int)fx - 2);
+            var x1 = Math.Min(width - 1, (int)fx + 2);
+            var y0 = Math.Max(0, (int)fy - 2);
+            var y1 = Math.Min(height - 1, (int)fy + 2);
+            var peak = float.MinValue;
+            for (var y = y0; y <= y1; y++)
+            {
+                for (var x = x0; x <= x1; x++)
+                {
+                    var v = plane[y * width + x];
+                    if (v > peak)
+                    {
+                        peak = v;
+                    }
+                }
+            }
+            return peak;
+        }
+
+        private static float Median(List<float> values)
+        {
+            var copy = values.ToArray();
+            Array.Sort(copy);
+            return copy[copy.Length / 2];
+        }
+
+        private static float Percentile(float[] values, double p)
+        {
+            var copy = (float[])values.Clone();
+            Array.Sort(copy);
+            return copy[Math.Clamp((int)(copy.Length * p), 0, copy.Length - 1)];
+        }
+    }
+}


### PR DESCRIPTION
Measures the actual PSF shape of the archive, because the own-BlurX deconvolver (P2) has to
model a profile and a width alone does not pin one. Two commits: the measurement, and the
corrected findings it produced.

## What it adds

`PsfProfileFit` (`TianWen.Lib/Imaging/Dataset/`) stacks the azimuthally averaged,
background-subtracted, peak-normalised profiles of up to 400 isolated stars and fits a Moffat
`(1 + (r/alpha)^2)^-beta` with alpha tied to the measured FWHM, so beta answers shape only. It
reports the Moffat and Gaussian log-RMS side by side, so "which function fits" is data rather
than an assumption. Wired into `DatasetPsfNoiseReport`, so every future bake records it per
session on `SessionPsf.MasterProfile`; records predating it read null and need `--force-psf`.

## Findings from surveying all 50 calgated masters

Moffat beats Gaussian **48 of 50**. Wing flux at r = 2*FWHM against a same-FWHM Gaussian is
**98x** at the median (535x at p95), so a Gaussian PSF is the wrong function here, not a rough
one. Beta is a per-train property and the spread is the point:

| train | n | beta p50 | FWHM p50 |
|---|---|---|---|
| ASI533MC / Samyang 135 f/2 @ 130mm | 38 | 7.95 | 2.940 |
| SV605CC / SH61 EDPH @ 270mm | 9 | 6.85 | 3.226 |
| ASI585MC / WO ZS61 @ 288mm (0.8x reducer) | 2 | 2.70 | 3.128 |
| ASI585MC / WO ZS61 @ 360mm (flattener) | 1 | 2.05 | 2.950 |

The plan's assumed beta 2.5 to 4.5 was calibrated to the three rarest sessions and is wrong for
the 47 that dominate. Beta also correlates with FWHM (Pearson r = 0.66 overall, 0.635 within the
Samyang train alone, so not a between-train artifact): blurrier is more Gaussian, which is
physically sensible and means the synthetic sweep must not sample FWHM and beta independently.

## Two method notes worth keeping

**Fit in log space.** Unweighted least squares on a peak-normalised profile is core-dominated
and effectively ignores the wings, which are exactly what governs ringing and halo in a
deconvolution. On the first three masters plain RMS said "Gaussian fits better" for two of them;
in log space Moffat wins all three by 4x to 15x. Same data, opposite conclusion, from the error
metric alone.

**Control for star brightness.** Measured FWHM runs 25 to 30 percent wider for faint stars,
because half max is set relative to the star's own peak and residual background is a larger
fraction of a faint one. `PsfProfileFit` uses a 55th to 75th percentile peak band; anything
fitting a PSF from detected stars must do the same or it fits a magnitude distribution.

## Corrections to previously merged claims

The first commit corrects `docs/plans/ai-denoise-deconv.md`, whose merged state asserts the
falling field-radius profile is measuring saturation. That was concluded from a synthetic test
alone. The synthetic effect is real and large, but only 0.1 to 0.2 percent of detected stars are
core-clipped on real masters, and excluding them moves per-bin medians by about 0.001 px. The
lesson is recorded with it: a large effect measured synthetically says nothing until the
affected fraction of the real population is counted. The residual fall survives brightness
control and is session-dependent, so it stays an open question rather than a solved one.

An earlier three-session reading also had the beta/FWHM direction backwards; the 50-session
survey reverses it.

## Testing

`PsfProfileFitTests` recovers beta at 2.5, 4.0 and 7.0 from synthetic fields, prefers Moffat on
a Moffat field, declines to claim heavy wings on a Gaussian one, and returns null below the
star-count floor. Full unit suite green at 4172 passed, 0 failed, 20 environment-gated skips.

Note that the local build needs `-p:UseLocalSiblings=false` at the moment unless the DIR.Lib
sibling clone is on 7.18 or newer; `HomeBoardLayout` on main uses `DIR.Lib.Layout.IconKind`,
which 7.17 source does not have. CI is unaffected, since it always restores packages.

Raw per-session numbers are kept beside the data at
`stats/psf-profile-survey-2026-08-12.csv`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AbXdVLeiJALjm946tEyarD
