### PR TITLE
Sky map ephemeris caches missed every frame, and Earth was solved per comet

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -234,8 +234,15 @@
          child at the cross-axis START, so a Fixed-height control in a taller bar hugged the top and sat
          half the slack high. The workaround was padding the bar and making every child Star-height, which
          also inset the label horizontally as a side effect; .CrossCenter() states the intent and lets the
-         engine, which knows both extents, do the arithmetic. -->
-    <PackageVersion Include="DIR.Lib" Version="7.21.*" />
+         engine, which knows both extents, do the arithmetic.
+         7.22 is a FLOOR bump, not an adoption: nothing here calls its new cursor API yet. SdlVulkan.Renderer
+         7.15 republished a patch (7.15.2351) that requires DIR.Lib >= 7.22.2191, and because our pins float
+         on the patch segment, restore picked that patch up against a 7.21.* DIR.Lib and failed NU1605 as an
+         error. No commit caused it, which is why main was green on its last run and would fail if re-run:
+         a floating pin makes any consumer's transitive floor OUR problem the moment they publish. Raise the
+         floor to keep the graph on ONE DIR.Lib rather than pinning SdlVulkan.Renderer back to an older
+         patch, which would only defer the same failure to the next republish. -->
+    <PackageVersion Include="DIR.Lib" Version="7.22.*" />
     <!-- DIR.Lib 3.0 extracted its codec layer to these sibling packages, which
          ship as a lockstep family from the Codecs repo. 3.0 brought a
          binary-breaking SharpAstro.Tiff change (TiffPageOptions.IccProfile is

--- a/src/TianWen.Lib.Tests/CometEphemerisTests.cs
+++ b/src/TianWen.Lib.Tests/CometEphemerisTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using TianWen.Lib.Astrometry;
 using TianWen.Lib.Astrometry.Catalogs;
 using TianWen.Lib.Astrometry.Comets;
 using Shouldly;
@@ -227,6 +228,63 @@ public class CometEphemerisTests
         noPhotometry.HasMagnitudeModel.ShouldBeFalse();
 
         CometEphemeris.PredictTotalMagnitude(noPhotometry, 1.5, 0.6).ShouldBe(double.NaN);
+    }
+
+    /// <summary>
+    /// The hoisted <see cref="CometEphemeris.EarthState"/> overloads must be the SAME arithmetic as the
+    /// <see cref="DateTimeOffset"/> ones, not merely close: they exist purely so a sweep over ~1,600
+    /// comets at one instant evaluates the ~3,500-term VSOP87a Earth series once instead of 1,600
+    /// times, and the moment that refactor is allowed to move a position it stops being free and every
+    /// Horizons bound pinned above is measuring a different code path from the one the sky map runs.
+    /// So this asserts EXACT equality, with no tolerance -- the two paths perform identical operations
+    /// in identical order and any difference at all means one of them diverged.
+    /// </summary>
+    [Fact]
+    public void GivenTheHoistedEarthStateThenItReducesIdenticallyToThePerCallOverload()
+    {
+        var time = DateTimeOffset.Parse("2026-08-06T00:00:00Z", System.Globalization.CultureInfo.InvariantCulture, System.Globalization.DateTimeStyles.AdjustToUniversal);
+        CometEphemeris.TryGetEarthState(time, out var earth).ShouldBeTrue();
+
+        // One elliptic, one near-parabolic, one propagated far past its epoch: all three Stumpff
+        // branches and both the converging and the drifting regime.
+        foreach (var elements in new[] { PonsBrooks, TsuchinshanAtlas, TempelTwo })
+        {
+            var name = elements.DisplayName;
+
+            CometEphemeris.TryGetEquatorialJ2000(elements, time, out var raPerCall, out var decPerCall, out var rPerCall, out var deltaPerCall)
+                .ShouldBeTrue(name);
+            CometEphemeris.TryGetEquatorialJ2000(elements, earth, out var raHoisted, out var decHoisted, out var rHoisted, out var deltaHoisted)
+                .ShouldBeTrue(name);
+
+            raHoisted.ShouldBe(raPerCall, name);
+            decHoisted.ShouldBe(decPerCall, name);
+            rHoisted.ShouldBe(rPerCall, name);
+            deltaHoisted.ShouldBe(deltaPerCall, name);
+
+            CometEphemeris.TryGetEquatorialJ2000WithMagnitude(elements, time, out _, out _, out var magPerCall)
+                .ShouldBeTrue(name);
+            CometEphemeris.TryGetEquatorialJ2000WithMagnitude(elements, earth, out _, out _, out var magHoisted)
+                .ShouldBeTrue(name);
+            magHoisted.ShouldBe(magPerCall, name);
+        }
+    }
+
+    /// <summary>
+    /// The hoisted state carries the instant it was resolved for, so a caller that needs the TT Julian
+    /// date (the sky map judges element-set staleness against it) takes it from here rather than
+    /// running its own second conversion of the same <see cref="DateTimeOffset"/>.
+    /// </summary>
+    [Fact]
+    public void GivenAnEarthStateThenItCarriesTheTtJulianDateOfThatInstant()
+    {
+        var time = DateTimeOffset.Parse("2026-08-06T00:00:00Z", System.Globalization.CultureInfo.InvariantCulture, System.Globalization.DateTimeStyles.AdjustToUniversal);
+        CometEphemeris.TryGetEarthState(time, out var earth).ShouldBeTrue();
+
+        time.ToSOFAUtcJdTT(out _, out _, out var tt1, out var tt2);
+        earth.JdTt.ShouldBe(tt1 + tt2);
+
+        // And it really is a heliocentric position, not a zeroed default: Earth sits ~1 AU from the Sun.
+        Math.Sqrt(earth.X * earth.X + earth.Y * earth.Y + earth.Z * earth.Z).ShouldBe(1.0, tolerance: 0.02);
     }
 
     private static CometDesignation Parse(string s)

--- a/src/TianWen.Lib.Tests/CometRepositoryTests.cs
+++ b/src/TianWen.Lib.Tests/CometRepositoryTests.cs
@@ -299,4 +299,55 @@ public class CometRepositoryTests(ITestOutputHelper output)
         elements.PerihelionJdTt.ShouldBe(2457340.741, tolerance: 0.001);
         elements.IsElementSetStale(2461258.5).ShouldBeTrue();
     }
+
+    /// <summary>
+    /// The bulk <see cref="CometEphemeris.EarthState"/> overload has to resolve through the SAME
+    /// apparition-aware lookup as the per-instant one. It exists so a catalogue-wide sweep evaluates
+    /// Earth once instead of ~1,800 times, and the tempting way to get that -- iterate
+    /// <see cref="ICometRepository.All"/> and call <see cref="CometEphemeris"/> directly at the call
+    /// site -- would quietly sweep the STALE element set, because the upgrade is applied inside
+    /// <see cref="ICometRepository.TryGet"/>. For 10P in 2026 that is 9.3 degrees of sky, and nothing
+    /// would look broken: every marker would simply be in the wrong place.
+    ///
+    /// <para>So this pins both halves. The overloads must agree exactly (same lookup, same
+    /// arithmetic), AND the answer must have moved once the upgrade landed -- without the second
+    /// assertion the first would still pass for a bulk overload that had bypassed the upgrade
+    /// entirely, since then both would be consistently stale.</para>
+    /// </summary>
+    [Fact]
+    public async Task TheBulkOverloadResolvesThroughTheCurrentApparitionToo()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var when = new DateTimeOffset(2026, 8, 6, 0, 0, 0, TimeSpan.Zero);
+        var external = CreateExternal(new FakeTimeProviderWrapper(when));
+        var repo = await LoadedWithStaleCometAsync(external, new FakeHorizons(RefreshedComet()), ct);
+        var index = StaleComet().CatalogIndex.ShouldNotBeNull();
+
+        CometEphemeris.TryGetEarthState(when, out var earth).ShouldBeTrue();
+        repo.TryGetPosition(index, earth, out var staleRa, out var staleDec, out _).ShouldBeTrue();
+
+        repo.RequestCurrentApparition(index);
+        (await WaitForAsync(() => repo.TryGet(index, out var e) && e.EpochJdTt > 2461000)).ShouldBeTrue();
+
+        repo.TryGetPosition(index, earth, out var bulkRa, out var bulkDec, out var bulkMag).ShouldBeTrue();
+        repo.TryGetPosition(index, when, out var perInstantRa, out var perInstantDec, out var perInstantMag).ShouldBeTrue();
+
+        bulkRa.ShouldBe(perInstantRa);
+        bulkDec.ShouldBe(perInstantDec);
+        bulkMag.ShouldBe(perInstantMag);
+
+        // MEASURED at 9.3 degrees (see CometEphemerisTests, which decomposes it as a pure timing error
+        // from the two-body period); bounded well below that so a restated JPL solution cannot fail it.
+        SeparationDeg(staleRa, staleDec, bulkRa, bulkDec).ShouldBeGreaterThan(5.0);
+    }
+
+    private static double SeparationDeg(double ra1Hours, double dec1Deg, double ra2Hours, double dec2Deg)
+    {
+        const double d2r = Math.PI / 180.0;
+        var d1 = dec1Deg * d2r;
+        var d2 = dec2Deg * d2r;
+        var dRa = (ra1Hours - ra2Hours) * 15.0 * d2r;
+        var cosSep = Math.Sin(d1) * Math.Sin(d2) + Math.Cos(d1) * Math.Cos(d2) * Math.Cos(dRa);
+        return Math.Acos(Math.Clamp(cosSep, -1.0, 1.0)) / d2r;
+    }
 }

--- a/src/TianWen.Lib.Tests/SkyMapEphemerisCacheTests.cs
+++ b/src/TianWen.Lib.Tests/SkyMapEphemerisCacheTests.cs
@@ -1,0 +1,187 @@
+using System;
+using System.Threading.Tasks;
+using DIR.Lib;
+using Shouldly;
+using TianWen.Lib.Astrometry.Catalogs;
+using TianWen.Lib.Astrometry.SOFA;
+using TianWen.UI.Abstractions;
+using Xunit;
+
+namespace TianWen.Lib.Tests;
+
+/// <summary>
+/// Guards the two per-instant ephemeris caches on <see cref="SkyMapState"/> (planet positions, comet
+/// markers) against the failure they actually suffered: a cache key that was correct only because the
+/// PRODUCER happened to round its input, silently defeated the day the producer stopped.
+///
+/// <para>Both were keyed on exact <see cref="DateTimeOffset"/> equality, which held while
+/// <c>SkyMapTab.Render</c> fed a viewingTime taken from a 1 s clock cache. It later began
+/// interpolating between those syncs -- correctly, because a once-a-second step moved the view matrix
+/// in visible 1 Hz jumps -- and from then on every frame carried a distinct instant and both caches
+/// missed 100% of the time. Nothing failed: the markers were right, just recomputed. The comet sweep
+/// is ~1,600 candidates each needing a ~3,500-term VSOP87a Earth series, so it cost 91 ms PER FRAME,
+/// on every pointer move in the browser and on every frame of the desktop GPU map.</para>
+///
+/// <para>So the load-bearing test here is <see cref="ASecondOfLiveFramesCostsOneEphemerisSweep"/>: it
+/// drives the REAL <see cref="SkyMapTab{TSurface}.Render"/> over a fake clock instead of feeding
+/// hand-picked timestamps to the cache. Hand-picked timestamps would re-encode the very assumption
+/// that broke -- a test that asserts what I think the producer emits cannot notice the producer
+/// changing. Driving the real render couples the two sides, so the next person to touch the clock
+/// derivation gets a red test rather than a silent 91 ms.</para>
+/// </summary>
+[Collection("Astrometry")]
+public sealed class SkyMapEphemerisCacheTests
+{
+    // Mirrors the OverlayTestSkyMapTab harness: a SkyMapTab over the CPU surface that publishes the
+    // view matrix each frame the way the real GPU pipelines do. Nothing here overrides the label
+    // passes, which is the point -- DrawPlanetLabels / DrawCometLabels are shared base-class code, so
+    // this exercises the same path the Vulkan desktop tab and the WebGL browser tab both run.
+    private sealed class CacheTestSkyMapTab(RgbaImageRenderer renderer) : SkyMapTab<RgbaImage>(renderer)
+    {
+        protected override void RenderSkyMap(
+            ICelestialObjectDB db, RectF32 contentRect,
+            DateTimeOffset viewingTime, double siteLat, double siteLon, SiteContext site)
+        {
+            base.RenderSkyMap(db, contentRect, viewingTime, siteLat, siteLon, site);
+            State.CurrentViewMatrix = State.ComputeViewMatrix();
+        }
+    }
+
+    private const int Size = 400;
+    private static readonly TimeSpan FrameInterval = TimeSpan.FromMilliseconds(16); // ~60 fps
+
+    private static PlannerState LiveState(ICelestialObjectDB db) => new()
+    {
+        ObjectDb = db,
+        SiteLatitude = 48.0,
+        SiteLongitude = 11.0,
+        SiteTimeZone = TimeSpan.FromHours(1),
+        // PlanningDate stays NULL on purpose: that is live mode, the only branch that interpolates the
+        // clock, and so the only one where this regression is reachable. A planner date pins
+        // viewingTime to a constant and would hit any cache key at all, including the broken one.
+        Comets = new StubCometRepository(
+            StubCometRepository.Comet("12P", "Pons-Brooks"),
+            StubCometRepository.Comet("C/2023 A3", "Tsuchinshan-ATLAS")),
+    };
+
+    /// <summary>
+    /// THE regression test. Sixty consecutive live frames spanning 944 ms must cost ONE planet
+    /// reduction and ONE comet sweep between them -- not sixty of each.
+    /// </summary>
+    [Fact]
+    public async Task ASecondOfLiveFramesCostsOneEphemerisSweep()
+    {
+        var db = await SharedCatalogDB.InitAsync(TestContext.Current.CancellationToken);
+        using var renderer = new RgbaImageRenderer(Size, Size);
+        var tab = new CacheTestSkyMapTab(renderer) { FontPath = FontResolver.ResolveSystemFont() };
+        var state = LiveState(db);
+        var time = new FakeTimeProviderWrapper(new DateTimeOffset(2026, 8, 6, 21, 0, 0, TimeSpan.Zero));
+        var content = new RectF32(0, 0, Size, Size);
+
+        for (var frame = 0; frame < 60; frame++)
+        {
+            tab.Render(state, content, time);
+            time.Advance(FrameInterval);
+        }
+
+        // Exactly one, not "a small number": 60 frames x 16 ms = 944 ms sits inside a single refresh
+        // window, so the arithmetic is deterministic and a loose bound would hide a partial regression.
+        tab.State.CometCacheRebuilds.ShouldBe(1);
+        tab.State.PlanetCacheRebuilds.ShouldBe(1);
+    }
+
+    /// <summary>
+    /// The other half of the guard: a cache that NEVER refreshed would also pass the test above, and
+    /// would freeze every planet and comet on the map at the instant the atlas was opened.
+    /// </summary>
+    [Fact]
+    public async Task PastTheRefreshWindowTheEphemerisIsRecomputed()
+    {
+        var db = await SharedCatalogDB.InitAsync(TestContext.Current.CancellationToken);
+        using var renderer = new RgbaImageRenderer(Size, Size);
+        var tab = new CacheTestSkyMapTab(renderer) { FontPath = FontResolver.ResolveSystemFont() };
+        var state = LiveState(db);
+        var time = new FakeTimeProviderWrapper(new DateTimeOffset(2026, 8, 6, 21, 0, 0, TimeSpan.Zero));
+        var content = new RectF32(0, 0, Size, Size);
+
+        tab.Render(state, content, time);
+        tab.State.CometCacheRebuilds.ShouldBe(1);
+
+        time.Advance(TimeSpan.FromSeconds(3));
+        tab.Render(state, content, time);
+
+        tab.State.CometCacheRebuilds.ShouldBe(2);
+        tab.State.PlanetCacheRebuilds.ShouldBe(2);
+    }
+
+    /// <summary>
+    /// Keeps the two tests above from being vacuous. They count sweeps, and a sweep over an empty
+    /// candidate set is free -- so if the stub repository's comets stopped passing the candidacy gate,
+    /// or the propagator stopped converging for them, the counters would still read 1 and the guard
+    /// would quietly stop guarding anything.
+    /// </summary>
+    [Fact]
+    public void TheSweptCandidateSetIsNotEmpty()
+    {
+        var state = new SkyMapState();
+        var comets = new StubCometRepository(
+            StubCometRepository.Comet("12P", "Pons-Brooks"),
+            StubCometRepository.Comet("C/2023 A3", "Tsuchinshan-ATLAS"));
+
+        var markers = state.GetCometPositionsCached(comets, new DateTimeOffset(2026, 8, 6, 21, 0, 0, TimeSpan.Zero));
+
+        markers.Length.ShouldBe(2);
+        state.CometCacheRebuilds.ShouldBe(1);
+        foreach (var marker in markers)
+        {
+            double.IsNaN(marker.RA).ShouldBeFalse(marker.Label);
+            double.IsNaN(marker.Dec).ShouldBeFalse(marker.Label);
+            float.IsNaN(marker.VMag).ShouldBeFalse(marker.Label);
+        }
+    }
+
+    /// <summary>
+    /// A time scrub or a planner-date change jumps far past the refresh window, so it must land on the
+    /// new instant immediately rather than showing up to a second late. This is the behaviour the
+    /// tolerance has to preserve, and the reason it is a second rather than something generous.
+    /// </summary>
+    [Fact]
+    public void AScrubbedInstantIsResolvedAtOnce()
+    {
+        var state = new SkyMapState();
+        var comets = new StubCometRepository(StubCometRepository.Comet("12P", "Pons-Brooks"));
+        var start = new DateTimeOffset(2026, 8, 6, 21, 0, 0, TimeSpan.Zero);
+
+        var before = state.GetCometPositionsCached(comets, start)[0];
+        // A month later: the comet has to have moved, and the planets with it.
+        var after = state.GetCometPositionsCached(comets, start.AddDays(30))[0];
+
+        state.CometCacheRebuilds.ShouldBe(2);
+        after.RA.ShouldNotBe(before.RA);
+
+        state.GetPlanetPositionsCached(start);
+        state.GetPlanetPositionsCached(start.AddDays(30));
+        state.PlanetCacheRebuilds.ShouldBe(2);
+    }
+
+    /// <summary>
+    /// Swapping in a different repository invalidates the markers even at the same instant -- the
+    /// candidate set is drawn from it, so an unchanged clock is not enough to make the cache valid.
+    /// </summary>
+    [Fact]
+    public void ADifferentRepositoryInvalidatesTheMarkersAtTheSameInstant()
+    {
+        var state = new SkyMapState();
+        var when = new DateTimeOffset(2026, 8, 6, 21, 0, 0, TimeSpan.Zero);
+
+        state.GetCometPositionsCached(new StubCometRepository(StubCometRepository.Comet("12P", "Pons-Brooks")), when)
+            .Length.ShouldBe(1);
+        state.GetCometPositionsCached(
+            new StubCometRepository(
+                StubCometRepository.Comet("12P", "Pons-Brooks"),
+                StubCometRepository.Comet("C/2023 A3", "Tsuchinshan-ATLAS")),
+            when).Length.ShouldBe(2);
+
+        state.CometCacheRebuilds.ShouldBe(2);
+    }
+}

--- a/src/TianWen.Lib.Tests/StubCometRepository.cs
+++ b/src/TianWen.Lib.Tests/StubCometRepository.cs
@@ -52,7 +52,15 @@ internal sealed class StubCometRepository(params CometElements[] comets) : ICome
     /// </summary>
     public Dictionary<CatalogIndex, (double RaHours, double DecDeg, double VMag)> Positions { get; } = [];
 
+    // Both overloads answer from the same fixed table: this stub is time-independent by design (see
+    // Positions above), so the bulk form's pre-resolved EarthState has nothing to contribute here.
     public bool TryGetPosition(CatalogIndex index, DateTimeOffset time, out double raJ2000Hours, out double decJ2000Deg, out double magnitude)
+        => TryGetFixedPosition(index, out raJ2000Hours, out decJ2000Deg, out magnitude);
+
+    public bool TryGetPosition(CatalogIndex index, in CometEphemeris.EarthState earth, out double raJ2000Hours, out double decJ2000Deg, out double magnitude)
+        => TryGetFixedPosition(index, out raJ2000Hours, out decJ2000Deg, out magnitude);
+
+    private bool TryGetFixedPosition(CatalogIndex index, out double raJ2000Hours, out double decJ2000Deg, out double magnitude)
     {
         if (Positions.TryGetValue(index, out var p))
         {

--- a/src/TianWen.Lib.Tests/TonightsBestTests.cs
+++ b/src/TianWen.Lib.Tests/TonightsBestTests.cs
@@ -122,7 +122,16 @@ public class TonightsBestTests
             return false;
         }
 
+        // Both overloads answer from the same fixed table -- the stub is time-independent, so the
+        // scheduler's hoisted EarthState changes nothing it can observe. That is what makes the
+        // existing scheduler assertions below a valid check on the hoist: they must not move.
         public bool TryGetPosition(CatalogIndex index, DateTimeOffset time, out double raJ2000Hours, out double decJ2000Deg, out double magnitude)
+            => TryGetFixedPosition(index, out raJ2000Hours, out decJ2000Deg, out magnitude);
+
+        public bool TryGetPosition(CatalogIndex index, in CometEphemeris.EarthState earth, out double raJ2000Hours, out double decJ2000Deg, out double magnitude)
+            => TryGetFixedPosition(index, out raJ2000Hours, out decJ2000Deg, out magnitude);
+
+        private bool TryGetFixedPosition(CatalogIndex index, out double raJ2000Hours, out double decJ2000Deg, out double magnitude)
         {
             foreach (var c in comets)
             {

--- a/src/TianWen.Lib/Astrometry/Comets/CometEphemeris.cs
+++ b/src/TianWen.Lib/Astrometry/Comets/CometEphemeris.cs
@@ -37,7 +37,8 @@ public static class CometEphemeris
     /// Kepler solves it accompanies, so computing it per comet -- as the <see cref="DateTimeOffset"/>
     /// overloads necessarily do -- makes Earth almost the entire cost of the sweep rather than a
     /// rounding error: the sky map's marker rebuild over the real 1,630-candidate SBDB set measures
-    /// 37.2 ms that way and 2.2 ms with this, and 91 ms/frame in the browser build. A caller looping
+    /// 29 ms that way and 1.6 ms with this (fastest of 25 runs, native arm64), and 91 ms/frame in the
+    /// browser build, which is where it was found. A caller looping
     /// over comets should take this once and pass it in; a caller asking about one comet at one time
     /// should keep using the <see cref="DateTimeOffset"/> overload, which is exactly that plus
     /// this.</para>

--- a/src/TianWen.Lib/Astrometry/Comets/CometEphemeris.cs
+++ b/src/TianWen.Lib/Astrometry/Comets/CometEphemeris.cs
@@ -28,6 +28,45 @@ public static class CometEphemeris
     private const double Mu = GaussK * GaussK;
 
     /// <summary>
+    /// Everything in a comet reduction that depends on the INSTANT alone and not on the comet: Earth's
+    /// heliocentric ecliptic position (AU, the VSOP87 dynamical frame the elements are referred to) and
+    /// the TT Julian date it was computed for.
+    ///
+    /// <para>Hoisted into its own type so a sweep over many comets AT ONE TIME evaluates it once. The
+    /// VSOP87a Earth series is ~3,500 cosine terms against the few dozen transcendentals of the two
+    /// Kepler solves it accompanies, so computing it per comet -- as the <see cref="DateTimeOffset"/>
+    /// overloads necessarily do -- makes Earth almost the entire cost of the sweep rather than a
+    /// rounding error: the sky map's marker rebuild over the real 1,630-candidate SBDB set measures
+    /// 37.2 ms that way and 2.2 ms with this, and 91 ms/frame in the browser build. A caller looping
+    /// over comets should take this once and pass it in; a caller asking about one comet at one time
+    /// should keep using the <see cref="DateTimeOffset"/> overload, which is exactly that plus
+    /// this.</para>
+    /// </summary>
+    /// <param name="JdTt">TT Julian date of the instant.</param>
+    public readonly record struct EarthState(double JdTt, double X, double Y, double Z);
+
+    /// <summary>
+    /// Resolves the per-instant state a comet reduction needs (see <see cref="EarthState"/>). Returns
+    /// false if the Earth ephemeris is unavailable at <paramref name="time"/>.
+    /// </summary>
+    public static bool TryGetEarthState(DateTimeOffset time, out EarthState earth)
+    {
+        time.ToSOFAUtcJdTT(out _, out _, out var tt1, out var tt2);
+        // Julian millennia from J2000, kept in the split (tt1, tt2) form for precision.
+        var et = (tt1 - Constants.J2000BASE + tt2) / 365250.0;
+
+        Span<double> position = stackalloc double[3];
+        if (!VSOP87a.GetBody(CatalogIndex.Earth, et, position))
+        {
+            earth = default;
+            return false;
+        }
+
+        earth = new EarthState(tt1 + tt2, position[0], position[1], position[2]);
+        return true;
+    }
+
+    /// <summary>
     /// Computes the comet's geocentric J2000 equatorial position and the helio-/geocentric distances
     /// at <paramref name="time"/>. Returns false only if the underlying Earth ephemeris is unavailable
     /// or the Kepler solve fails to converge (returned outputs are then NaN).
@@ -44,16 +83,31 @@ public static class CometEphemeris
         out double heliocentricDistanceAu,
         out double geocentricDistanceAu)
     {
-        time.ToSOFAUtcJdTT(out _, out _, out var tt1, out var tt2);
-        var jdTt = tt1 + tt2;
-        var et = (tt1 - Constants.J2000BASE + tt2) / 365250.0;
-
-        Span<double> earth = stackalloc double[3];
-        if (!VSOP87a.GetBody(CatalogIndex.Earth, et, earth))
+        if (!TryGetEarthState(time, out var earth))
         {
             raJ2000Hours = decJ2000Deg = heliocentricDistanceAu = geocentricDistanceAu = double.NaN;
             return false;
         }
+
+        return TryGetEquatorialJ2000(elements, earth, out raJ2000Hours, out decJ2000Deg,
+            out heliocentricDistanceAu, out geocentricDistanceAu);
+    }
+
+    /// <summary>
+    /// The instant-hoisted form of <see cref="TryGetEquatorialJ2000(in CometElements, DateTimeOffset,
+    /// out double, out double, out double, out double)"/>: identical arithmetic, with the shared
+    /// per-instant <see cref="EarthState"/> supplied by the caller instead of recomputed. Use this when
+    /// reducing many comets at one time.
+    /// </summary>
+    public static bool TryGetEquatorialJ2000(
+        in CometElements elements,
+        in EarthState earth,
+        out double raJ2000Hours,
+        out double decJ2000Deg,
+        out double heliocentricDistanceAu,
+        out double geocentricDistanceAu)
+    {
+        var jdTt = earth.JdTt;
 
         Span<double> helio = stackalloc double[3];
         if (!TryHeliocentricEcliptic(elements, jdTt, helio, out heliocentricDistanceAu))
@@ -64,9 +118,9 @@ public static class CometEphemeris
 
         // Geocentric ecliptic vector. VSOP87's dynamical ecliptic differs from the ecliptic-J2000 the
         // elements use by a fixed-frame bias of order 0.05" -- negligible against our arcminute target.
-        var gx = helio[0] - earth[0];
-        var gy = helio[1] - earth[1];
-        var gz = helio[2] - earth[2];
+        var gx = helio[0] - earth.X;
+        var gy = helio[1] - earth.Y;
+        var gz = helio[2] - earth.Z;
         geocentricDistanceAu = Math.Sqrt(gx * gx + gy * gy + gz * gz);
 
         // Light-time: light seen now left the comet delta/c days ago. Earth stays at time t.
@@ -78,9 +132,9 @@ public static class CometEphemeris
         }
 
         Span<double> geo = stackalloc double[3];
-        geo[0] = helio[0] - earth[0];
-        geo[1] = helio[1] - earth[1];
-        geo[2] = helio[2] - earth[2];
+        geo[0] = helio[0] - earth.X;
+        geo[1] = helio[1] - earth.Y;
+        geo[2] = helio[2] - earth.Z;
         geocentricDistanceAu = Math.Sqrt(geo[0] * geo[0] + geo[1] * geo[1] + geo[2] * geo[2]);
 
         // Ecliptic-J2000 -> equatorial-J2000 (same rotation the planet path applies).
@@ -115,6 +169,28 @@ public static class CometEphemeris
         out double magnitude)
     {
         if (TryGetEquatorialJ2000(elements, time, out raJ2000Hours, out decJ2000Deg, out var r, out var delta))
+        {
+            magnitude = PredictTotalMagnitude(elements, r, delta);
+            return true;
+        }
+
+        magnitude = double.NaN;
+        return false;
+    }
+
+    /// <summary>
+    /// The instant-hoisted form of <see cref="TryGetEquatorialJ2000WithMagnitude(in CometElements,
+    /// DateTimeOffset, out double, out double, out double)"/>, for sweeping many comets at one time.
+    /// See <see cref="EarthState"/>.
+    /// </summary>
+    public static bool TryGetEquatorialJ2000WithMagnitude(
+        in CometElements elements,
+        in EarthState earth,
+        out double raJ2000Hours,
+        out double decJ2000Deg,
+        out double magnitude)
+    {
+        if (TryGetEquatorialJ2000(elements, earth, out raJ2000Hours, out decJ2000Deg, out var r, out var delta))
         {
             magnitude = PredictTotalMagnitude(elements, r, delta);
             return true;

--- a/src/TianWen.Lib/Astrometry/Comets/CometRepository.cs
+++ b/src/TianWen.Lib/Astrometry/Comets/CometRepository.cs
@@ -92,9 +92,24 @@ internal sealed class CometRepository : ICometRepository
 
     public bool TryGetPosition(CatalogIndex index, DateTimeOffset time, out double raJ2000Hours, out double decJ2000Deg, out double magnitude)
     {
+        // Resolving Earth first and then delegating keeps ONE reduction here: the two overloads differ
+        // only in who pays for the per-instant state.
+        if (CometEphemeris.TryGetEarthState(time, out var earth))
+        {
+            return TryGetPosition(index, earth, out raJ2000Hours, out decJ2000Deg, out magnitude);
+        }
+
+        raJ2000Hours = decJ2000Deg = magnitude = double.NaN;
+        return false;
+    }
+
+    public bool TryGetPosition(CatalogIndex index, in CometEphemeris.EarthState earth, out double raJ2000Hours, out double decJ2000Deg, out double magnitude)
+    {
+        // TryGet, not _byIndex: that is where the current-apparition upgrade is applied, and it is the
+        // whole reason this overload lives on the repository instead of at the sweeping call site.
         if (TryGet(index, out var elements))
         {
-            return CometEphemeris.TryGetEquatorialJ2000WithMagnitude(elements, time, out raJ2000Hours, out decJ2000Deg, out magnitude);
+            return CometEphemeris.TryGetEquatorialJ2000WithMagnitude(elements, earth, out raJ2000Hours, out decJ2000Deg, out magnitude);
         }
 
         raJ2000Hours = decJ2000Deg = magnitude = double.NaN;

--- a/src/TianWen.Lib/Astrometry/Comets/ICometRepository.cs
+++ b/src/TianWen.Lib/Astrometry/Comets/ICometRepository.cs
@@ -25,6 +25,21 @@ public interface ICometRepository
     /// </summary>
     bool TryGetPosition(CatalogIndex index, DateTimeOffset time, out double raJ2000Hours, out double decJ2000Deg, out double magnitude);
 
+    /// <summary>
+    /// The bulk form of <see cref="TryGetPosition(CatalogIndex, DateTimeOffset, out double, out double,
+    /// out double)"/>: the same resolution, current-apparition upgrade included, against an
+    /// <see cref="CometEphemeris.EarthState"/> the caller has already resolved. Use it when sweeping
+    /// many comets at ONE instant -- the <see cref="DateTimeOffset"/> form necessarily re-solves the
+    /// ~3,500-term VSOP87a Earth series per comet, which over a catalogue-wide sweep is almost the
+    /// entire cost (measured at 29 ms against 1.6 ms over 1,630 candidates).
+    ///
+    /// <para>It is a member of this interface rather than something a caller composes from
+    /// <see cref="TryGet"/> plus <see cref="CometEphemeris"/> for the reason stated on
+    /// <see cref="TryGet"/>: resolving a comet's elements is where the apparition upgrade is applied,
+    /// and a bulk caller that reached around it would silently sweep the stale element set.</para>
+    /// </summary>
+    bool TryGetPosition(CatalogIndex index, in CometEphemeris.EarthState earth, out double raJ2000Hours, out double decJ2000Deg, out double magnitude);
+
     /// <summary>Loads the comet set once (from fresh cache, else a network fetch). Idempotent + concurrency-safe.</summary>
     Task EnsureLoadedAsync(CancellationToken cancellationToken = default);
 

--- a/src/TianWen.Lib/Sequencing/ObservationScheduler.cs
+++ b/src/TianWen.Lib/Sequencing/ObservationScheduler.cs
@@ -934,7 +934,13 @@ internal static class ObservationScheduler
         // bonus so they surface prominently; faint ones (fainter than the floor) and those with no
         // photometric model are skipped. A cheap static gate avoids the ephemeris solve for comets that
         // could never reach the floor even at their own perihelion.
-        if (comets is not null)
+        //
+        // Every candidate resolves at the SAME instant, so Earth is hoisted out of the loop: the
+        // per-comet DateTimeOffset overload re-solves a ~3,500-term VSOP87a series each time, which over
+        // this sweep's 1,812 candidates is almost the whole cost (32 ms against 1.8 ms, measured over the
+        // real SBDB set). A failed Earth solve skips the block, which is what resolving per comet did
+        // anyway -- every candidate would simply have failed one at a time.
+        if (comets is not null && CometEphemeris.TryGetEarthState(astroMidnight, out var cometEarth))
         {
             foreach (var el in comets.All)
             {
@@ -953,7 +959,7 @@ internal static class ObservationScheduler
                 {
                     continue;
                 }
-                if (!comets.TryGetPosition(cometIdx, astroMidnight, out var cometRa, out var cometDec, out var cometMag)
+                if (!comets.TryGetPosition(cometIdx, cometEarth, out var cometRa, out var cometDec, out var cometMag)
                     || double.IsNaN(cometMag) || cometMag > CometPlannerMagnitudeFloor)
                 {
                     continue;

--- a/src/TianWen.UI.Abstractions/SkyMapState.cs
+++ b/src/TianWen.UI.Abstractions/SkyMapState.cs
@@ -280,21 +280,44 @@ namespace TianWen.UI.Abstractions
             return _cachedSunAltitudeDeg;
         }
 
-        // Planet positions at the current viewingTime. Keyed on the exact
-        // DateTimeOffset: SkyMapTab feeds viewingTime from _cachedLiveTime which
-        // is quantized to 1 s (or jumps in bulk when the planner date shifts),
-        // so bit equality is sufficient for the 59 out of 60 frames per second
-        // that carry an identical viewingTime. Planets move at most ~0.5"/s
-        // (the Moon; planets much slower), so even at 1 deg FOV the per-frame
-        // drift is deeply sub-pixel; 1 s refresh is already over-accurate.
+        /// <summary>
+        /// How stale a cached ephemeris may be before it is recomputed. Planets move at most ~0.5"/s
+        /// (the Moon; the planets much slower) and comets are the same order even on a close approach,
+        /// so at the tightest FOV this map offers a 1 s refresh is still sub-pixel -- already
+        /// over-accurate for a marker.
+        /// </summary>
+        /// <remarks>
+        /// This is a TOLERANCE, and deliberately not the exact-equality key it replaced. That key was
+        /// correct only while the producer happened to quantize: <c>SkyMapTab</c> fed a viewingTime
+        /// taken from a 1 s clock cache, so bit equality hit on 59 of every 60 frames. It then began
+        /// INTERPOLATING between those syncs -- rightly, because a once-a-second step moved the alt-az
+        /// roll reference and the whole horizon view matrix in visible 1 Hz jumps -- and every frame
+        /// started carrying a distinct <see cref="DateTimeOffset"/>. Both caches below then missed
+        /// 100% of the time, silently, with nothing at either site to say so: the comet sweep alone
+        /// measured 91 ms per frame in the browser build (~1,600 candidates x a ~3,500-term VSOP87a
+        /// Earth series each), landing on every single pointer move. A cache key must state the
+        /// staleness the cache can tolerate; it must not encode an assumption about how finely its
+        /// caller happens to round, which the caller can invalidate without ever touching this file.
+        /// </remarks>
+        private static readonly TimeSpan EphemerisCacheRefreshInterval = TimeSpan.FromSeconds(1);
+
+        // Planet positions at the current viewingTime, refreshed on the tolerance above (the planner
+        // date shifting, or a time scrub, jumps far past it and so recomputes at once).
         private DateTimeOffset _planetCacheTime = DateTimeOffset.MinValue;
         private readonly (CatalogIndex Index, double RA, double Dec)[] _planetCache
             = new (CatalogIndex, double, double)[SkyMapRenderer.PlanetIndices.Length];
         private int _planetCacheCount;
 
         /// <summary>
-        /// Planet J2000 RA/Dec positions at <paramref name="viewingTime"/>, cached
-        /// until viewingTime changes. Entries for bodies whose VSOP87a reduction
+        /// How many times <see cref="GetPlanetPositionsCached"/> has actually evaluated VSOP87a. A test
+        /// seam: a hit and a miss return identical positions, so only a counter can show the cache is
+        /// working, which is exactly how it came to miss on every frame unnoticed.
+        /// </summary>
+        internal int PlanetCacheRebuilds { get; private set; }
+
+        /// <summary>
+        /// Planet J2000 RA/Dec positions at <paramref name="viewingTime"/>, cached for
+        /// <see cref="EphemerisCacheRefreshInterval"/>. Entries for bodies whose VSOP87a reduction
         /// fails are omitted from the returned span.
         /// </summary>
         /// <remarks>
@@ -305,11 +328,12 @@ namespace TianWen.UI.Abstractions
         /// </remarks>
         public ReadOnlySpan<(CatalogIndex Index, double RA, double Dec)> GetPlanetPositionsCached(DateTimeOffset viewingTime)
         {
-            if (viewingTime == _planetCacheTime)
+            if ((viewingTime - _planetCacheTime).Duration() < EphemerisCacheRefreshInterval)
             {
                 return _planetCache.AsSpan(0, _planetCacheCount);
             }
 
+            PlanetCacheRebuilds++;
             var count = 0;
             foreach (var idx in SkyMapRenderer.PlanetIndices)
             {
@@ -355,10 +379,10 @@ namespace TianWen.UI.Abstractions
         private int _cometCandidatesAllLength = -1;
         private CometElements[] _cometCandidates = [];
 
-        // Per-viewingTime marker cache (positions + magnitudes for the candidate set), keyed on the exact
-        // viewingTime + repository identity, mirroring the planet cache. Zoom-independent: it holds every
-        // candidate with a finite magnitude, and each consumer (draw / click / info panel) applies its own
-        // magnitude limit -- so zooming never invalidates it.
+        // Per-viewingTime marker cache (positions + magnitudes for the candidate set), keyed on
+        // EphemerisCacheRefreshInterval + repository identity, mirroring the planet cache.
+        // Zoom-independent: it holds every candidate with a finite magnitude, and each consumer
+        // (draw / click / info panel) applies its own magnitude limit -- so zooming never invalidates it.
         private DateTimeOffset _cometCacheTime = DateTimeOffset.MinValue;
         private ICometRepository? _cometCacheRepo;
         private CometMarker[] _cometCache = [];
@@ -392,6 +416,14 @@ namespace TianWen.UI.Abstractions
         public static bool ShouldDrawCometMarker(bool cometLayerOn, bool isPinned, double vmag, double magnitudeLimit)
             => isPinned || (cometLayerOn && !(vmag > magnitudeLimit));
 
+        /// <summary>
+        /// How many times <see cref="GetCometPositionsCached"/> has actually swept the candidate set.
+        /// The counterpart of <see cref="PlanetCacheRebuilds"/>, and the more load-bearing of the two:
+        /// this sweep is ~1,600 comets, so a miss costs about two orders of magnitude more than the
+        /// planet one.
+        /// </summary>
+        internal int CometCacheRebuilds { get; private set; }
+
         public ReadOnlySpan<CometMarker> GetCometPositionsCached(ICometRepository? comets, DateTimeOffset viewingTime)
         {
             if (comets is null)
@@ -401,19 +433,34 @@ namespace TianWen.UI.Abstractions
 
             RebuildCometCandidatesIfNeeded(comets);
 
-            if (viewingTime == _cometCacheTime && ReferenceEquals(comets, _cometCacheRepo))
+            if ((viewingTime - _cometCacheTime).Duration() < EphemerisCacheRefreshInterval
+                && ReferenceEquals(comets, _cometCacheRepo))
             {
                 return _cometCache.AsSpan(0, _cometCacheCount);
             }
 
+            CometCacheRebuilds++;
             if (_cometCache.Length < _cometCandidates.Length)
             {
                 _cometCache = new CometMarker[_cometCandidates.Length];
             }
 
-            // One conversion for the whole rebuild: staleness is per element set but the instant is not.
-            viewingTime.ToSOFAUtcJdTT(out _, out _, out var tt1, out var tt2);
-            var jdTt = tt1 + tt2;
+            _cometCacheTime = viewingTime;
+            _cometCacheRepo = comets;
+
+            // ONE Earth ephemeris + time conversion for the whole sweep. Both depend on the instant
+            // alone, and the Earth half is a ~3,500-term VSOP87a series against the few dozen
+            // transcendentals of the two Kepler solves it feeds -- so resolving it per comet (which is
+            // what the DateTimeOffset overload of TryGetEquatorialJ2000WithMagnitude must do) made
+            // Earth essentially the whole cost of this loop: MEASURED at 37.2 ms per sweep over the
+            // real 1,630-candidate SBDB set, against 2.2 ms hoisted. Also gives the staleness check its
+            // jdTt: staleness is per element set, but the instant it is judged against is not.
+            if (!CometEphemeris.TryGetEarthState(viewingTime, out var earth))
+            {
+                _cometCacheCount = 0;
+                return default;
+            }
+            var jdTt = earth.JdTt;
 
             var count = 0;
             foreach (var el in _cometCandidates)
@@ -422,7 +469,7 @@ namespace TianWen.UI.Abstractions
                 {
                     continue;
                 }
-                if (!CometEphemeris.TryGetEquatorialJ2000WithMagnitude(el, viewingTime, out var ra, out var dec, out var mag)
+                if (!CometEphemeris.TryGetEquatorialJ2000WithMagnitude(el, earth, out var ra, out var dec, out var mag)
                     || double.IsNaN(mag))
                 {
                     continue;
@@ -435,8 +482,6 @@ namespace TianWen.UI.Abstractions
                     PositionUncertain: el.IsElementSetStale(jdTt));
             }
             _cometCacheCount = count;
-            _cometCacheTime = viewingTime;
-            _cometCacheRepo = comets;
             return _cometCache.AsSpan(0, count);
         }
 

--- a/src/TianWen.UI.Abstractions/SkyMapState.cs
+++ b/src/TianWen.UI.Abstractions/SkyMapState.cs
@@ -452,9 +452,9 @@ namespace TianWen.UI.Abstractions
             // alone, and the Earth half is a ~3,500-term VSOP87a series against the few dozen
             // transcendentals of the two Kepler solves it feeds -- so resolving it per comet (which is
             // what the DateTimeOffset overload of TryGetEquatorialJ2000WithMagnitude must do) made
-            // Earth essentially the whole cost of this loop: MEASURED at 37.2 ms per sweep over the
-            // real 1,630-candidate SBDB set, against 2.2 ms hoisted. Also gives the staleness check its
-            // jdTt: staleness is per element set, but the instant it is judged against is not.
+            // Earth essentially the whole cost of this loop: MEASURED at 29 ms per sweep over the real
+            // 1,630-candidate SBDB set against 1.6 ms hoisted (fastest of 25 runs, native arm64). Also
+            // gives the staleness check its jdTt: staleness is per element set, the instant is not.
             if (!CometEphemeris.TryGetEarthState(viewingTime, out var earth))
             {
                 _cometCacheCount = 0;


### PR DESCRIPTION
A Chrome trace of the deployed web build spent **76% of its 12.3 s window** inside one Blazor delegated event: 96 dispatches, 91 ms median, on every pointer move. All of it was a single call 91 stack frames deep with no phase structure, and only ~25 ms of the whole trace ever reached WebGL, so it was managed CPU rather than GPU. That call was the sky map's comet marker sweep.

Two independent defects, both needed.

## 1. The cache key was defeated by its own producer

`SkyMapState.GetCometPositionsCached` and `GetPlanetPositionsCached` keyed on exact `DateTimeOffset` equality. That was correct only while the producer happened to quantize: `SkyMapTab` fed a viewingTime taken from a 1 s clock cache, so bit equality hit on 59 of every 60 frames, and the comment said so explicitly.

It later began interpolating between those syncs (commit 1d8ace74), rightly, since a once-a-second step moved the alt-az roll reference and the whole horizon view matrix in visible 1 Hz jumps. From then on every frame carried a distinct instant and both caches missed 100% of the time. Nothing failed. The markers were right, just recomputed.

Replaced with a 1 s tolerance window, the shape `GetSunAltitudeDegCached` in the same file already used. A cache key must state the staleness it tolerates; it must not encode an assumption about how finely its caller rounds, which the caller can invalidate without ever touching that file.

## 2. Earth was resolved inside each comet's reduction

`CometEphemeris.TryGetEquatorialJ2000` called `VSOP87a.GetBody(Earth)` per comet: a ~3,500-term cosine series, recomputed 1,630 times per sweep for a value identical across the loop. Hoisted into `CometEphemeris.EarthState` (Earth's heliocentric position plus the TT Julian date); the `DateTimeOffset` overloads now delegate, so there is still one implementation of the reduction.

`ObservationScheduler.TonightsBest` had the same defect at its own gate. Fixed through a new `EarthState` overload on `ICometRepository` rather than the shorter route of iterating `All` and calling `CometEphemeris` at the call site. That shortcut looks equivalent and is not: resolving a comet's elements is where the current-apparition upgrade is applied, so a bulk caller reaching around it would silently sweep the stale element set. For 10P in 2026 that is 9.3 degrees of sky, with nothing looking broken. Implemented in all three implementers, no default interface method.

## Measured

Real 4,071-comet SBDB set, native arm64 Release, fastest of 25 runs:

| sweep | candidates | before | after |
|---|---|---|---|
| sky map, **per frame** | 1,630 | 29 ms | 1.6 ms |
| planner recompute | 1,812 | 32 ms | 1.8 ms |

Combined with the cache fix, the sky map goes from 29 ms every frame to 1.6 ms once a second.

## This was not web-only

`DrawPlanetLabels` and `DrawCometLabels` are shared `SkyMapTab` code and `VkSkyMapTab` overrides neither, so the desktop Vulkan map paid the same cost on every frame. It never read as input lag there because it redraws continuously anyway; it read as the sky map burning a core.

## Tests

The regression test drives the **real** `SkyMapTab.Render` over a fake clock in live mode, rather than feeding hand-picked timestamps to the cache. Hand-picked timestamps would re-encode the very assumption that broke: a test asserting what I think the producer emits cannot notice the producer changing. 60 frames at 16 ms must cost one sweep, and it fails if the refresh interval is put back to zero (verified).

Supporting coverage:

- the cache must still refresh past the window, a scrub resolves at once, a repository swap invalidates, and the swept set is non-empty (so counting sweeps is not vacuous)
- `CometEphemerisTests` pins the hoisted overload as bit-identical to the per-call one, no tolerance, across all three pinned comets
- `CometRepositoryTests` pins that the bulk overload still resolves through the current apparition: both overloads must agree exactly AND the answer must have moved off the pre-upgrade position. The second assertion is load-bearing, since without it the first would pass for an overload that bypassed the upgrade entirely. Verified red by pointing it at the raw index map.

Full suite: 4209 passed, 0 failed, 25 skipped. Solution, GUI and web all build clean.

## Not included

`CLAUDE.md` should gain a line in its comet "Cache invariant" bullet noting that the planet/comet position caches key on a 1 s tolerance and never on exact equality. It is left out because that file has unrelated uncommitted work in the same tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01982Gqn57BggKrtSJ87aSdv
