### PR TITLE
Non-Latin text input, and per-window values read instead of pushed

### DIFF
--- a/docs/todo/ui.md
+++ b/docs/todo/ui.md
@@ -77,6 +77,26 @@ state through the terminal is a small addition that follows an existing pattern:
   (`{tab icon} {tab} - {profile} · {phase} - {target}`, `TianWen.UI.Gui/Program.cs`); the TUI
   currently writes `\U0001F52D {profile} — {tab}` with the phase folded into the tab name.
 
+
+## An overlay's keyboard routing lives nowhere near the overlay (found + fixed 2026-08-14)
+
+- [x] **An open overlay now claims the keyboard by being PAINTED, and the host asks once: DONE.**
+  `DropdownMenuState.HandleKeyDown` always knew how to handle arrows / Enter / Escape, but only ran if a
+  host added a case for it in its own `HandleInput` switch, in a different file from both the widget and
+  its declaration. There were four dropdowns; three had that case and the Live Session mode pill did not,
+  which is why it had no keyboard highlight at all. Nothing reported it: the menu opened, drew and took
+  mouse clicks, so the only symptom was arrow keys doing nothing.
+
+  `RenderDropdownMenu` sets `Ui.KeyboardClaimant` as it draws (`IKeyboardClaimant`, on the per-window
+  `WindowUiSettings`), and each host asks once before its own routing. **Four per-widget routing cases
+  became zero.** Paint order is z-order, so the topmost overlay claims last and wins with no host
+  arbitrating; a claimant no longer displayed returns false, so a stale claim needs no clearing (which is
+  what makes this simpler than `CaretRect`, where a per-frame reset would be wrong because `PaintLayout`
+  runs twice a frame).
+
+  Same shape `Layout.Builder.TextInput` retired for text fields: the declaration IS the registration.
+  A new overlay is keyboard-navigable by existing.
+
 ## FITS Viewer
 
 - [ ] Rename HDR button/label to "Compress Highlights"

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -288,7 +288,7 @@
          consumed before the release rather than after, because validating a library API at its real call
          sites is what stops a wrong one being frozen in a package, and it caught both of those
          shapes. -->
-    <PackageVersion Include="DIR.Lib" Version="7.28.*" />
+    <PackageVersion Include="DIR.Lib" Version="7.29.*" />
     <!-- DIR.Lib 3.0 extracted its codec layer to these sibling packages, which
          ship as a lockstep family from the Codecs repo. 3.0 brought a
          binary-breaking SharpAstro.Tiff change (TiffPageOptions.IccProfile is
@@ -428,7 +428,7 @@
          field, the caret is the terminal's real one, and an over-long value scrolls instead of
          ellipsizing. CellLayout.TextInputs(arranged) feeds TextInputInteraction's TabFields, so the
          TUI shares Tab cycling too. -->
-    <PackageVersion Include="Console.Lib" Version="4.24.*" />
+    <PackageVersion Include="Console.Lib" Version="4.25.*" />
     <!-- SdlVulkan.Renderer 5.0 adds a multi-page SDF glyph atlas (no more grow
          stall / Adreno submit-wedge) on top of 4.1's SetSystemCursor + anisotropic
          glyph xScale. 5.1 implements DIR.Lib 4.4's PushClip/PopClip via Vulkan
@@ -562,7 +562,7 @@
     <!-- 7.19 follows DIR.Lib to 7.28: describe_layout reports a text field, what it holds and
          whether it has the keyboard. "Which box is focused" is where every text-input bug starts
          and was unanswerable from a layout dump. -->
-    <PackageVersion Include="SdlVulkan.Renderer" Version="7.19.*" />
+    <PackageVersion Include="SdlVulkan.Renderer" Version="7.20.*" />
     <!-- The WebGL2 backend for the same DIR.Lib Renderer, consumed ONLY by TianWen.UI.Web (which sits
          outside TianWen.slnx). It lives here, next to its desktop counterpart, because it used to be
          pinned inline in that csproj instead: a sibling-family bump that swept this file could not see
@@ -591,7 +591,7 @@
          shape that cost SdlVulkan.Renderer its DrawTriangles override one release earlier, which is the
          second time this family has paid for the same mistake. 1.22 also resets the clip stack at the
          frame boundary and pins DIR.Lib as a FLOOR (ApplyClip does not exist before 7.27). -->
-    <PackageVersion Include="WebGl.Renderer" Version="1.22.*" />
+    <PackageVersion Include="WebGl.Renderer" Version="1.23.*" />
     <PackageVersion Include="SDL3-CS" Version="3.5.0-preview.20260213-150035" />
     <PackageVersion Include="SDL3-CS.Native" Version="3.5.0-preview.20260205-174353" />
     <!-- Canon DSLR. Both packages ship from the FC.SDK repo at one release line, so they move

--- a/src/TianWen.UI.Abstractions/EquipmentTab.FilterTable.cs
+++ b/src/TianWen.UI.Abstractions/EquipmentTab.FilterTable.cs
@@ -104,27 +104,33 @@ namespace TianWen.UI.Abstractions
                         {
                             var existingCustom = capturedF < filters.Count ? filters[capturedF].CustomName : null;
                             var a = anchor[0];
+                            // The "Custom…" row is now simply the last entry, carrying its own action rather
+                            // than three parameters and an index-past-the-end special case.
+                            var names = EquipmentActions.CommonFilterNames
+                                .Select(DropdownItem.Text)
+                                .ToImmutableArray()
+                                .Add(DropdownItem<string>.Action(
+                                    existingCustom is { Length: > 0 } ? $"Custom: {existingCustom}" : "Custom...",
+                                    () =>
+                                    {
+                                        State.CustomFilterSlotIndex = capturedF;
+                                        var preservedName = capturedF < filters.Count && filters[capturedF].CustomName is { } cn ? cn : "";
+                                        State.CustomFilterNameInput.Text = preservedName;
+                                        State.CustomFilterNameInput.CursorPos = preservedName.Length;
+                                        PostSignal(new ActivateTextInputSignal(State.CustomFilterNameInput));
+                                    }));
+
                             State.FilterNameDropdown.Open(
                                 a.X, a.Y + a.Height, a.Width,
-                                EquipmentActions.CommonFilterNames,
-                                (idx, name) =>
+                                names,
+                                item =>
                                 {
                                     if (capturedF < filters.Count)
                                     {
-                                        filters[capturedF] = new InstalledFilter(name, filters[capturedF].Position);
+                                        filters[capturedF] = new InstalledFilter(item.Value, filters[capturedF].Position);
                                         State.FiltersDirty = true;
                                     }
-                                },
-                                hasCustomEntry: true,
-                                onCustom: () =>
-                                {
-                                    State.CustomFilterSlotIndex = capturedF;
-                                    var preservedName = capturedF < filters.Count && filters[capturedF].CustomName is { } cn ? cn : "";
-                                    State.CustomFilterNameInput.Text = preservedName;
-                                    State.CustomFilterNameInput.CursorPos = preservedName.Length;
-                                    PostSignal(new ActivateTextInputSignal(State.CustomFilterNameInput));
-                                },
-                                customEntryLabel: existingCustom is { Length: > 0 } ? $"Custom: {existingCustom}" : null);
+                                });
                         });
                 }
 

--- a/src/TianWen.UI.Abstractions/EquipmentTab.ProfilePanel.cs
+++ b/src/TianWen.UI.Abstractions/EquipmentTab.ProfilePanel.cs
@@ -104,29 +104,27 @@ namespace TianWen.UI.Abstractions
             var rigLabels = LanPeer.ResolveLabels(rigs);
             var bound = State.BoundRigs;
 
-            var items = ImmutableArray.CreateBuilder<string>();
-            var actions = new List<Action>();
+            // Each row carries its own action, so there is no second list indexed by position: adding a
+            // row cannot get out of step with what choosing it does.
+            var items = ImmutableArray.CreateBuilder<DropdownItem<string>>();
 
             // "This computer" first, and only while a rig is on screen -- offering it otherwise would be
             // a no-op row on the overwhelmingly common local-only path.
             if (State.RemoteContextActive)
             {
-                items.Add("← This computer");
-                actions.Add(() => PostSignal(new SelectLocalContextSignal()));
+                items.Add(DropdownItem<string>.Action("← This computer", () => PostSignal(new SelectLocalContextSignal())));
             }
 
             foreach (var p in profiles)
             {
-                items.Add(p.DisplayName);
                 var profileId = p.ProfileId;
-                actions.Add(() => PostSignal(new SwitchProfileSignal(profileId)));
+                items.Add(DropdownItem<string>.Action(p.DisplayName, () => PostSignal(new SwitchProfileSignal(profileId))));
             }
 
             for (var i = 0; i < rigs.Count; i++)
             {
                 var label = rigLabels[i];
-                items.Add($"{label} (remote)");
-                actions.Add(() => PostSignal(new SelectRemoteRigSignal(label)));
+                items.Add(DropdownItem<string>.Action($"{label} (remote)", () => PostSignal(new SelectRemoteRigSignal(label))));
             }
 
             // Bound rigs discovery has not seen this run. Matched on node id, so a rig that is announcing
@@ -138,15 +136,11 @@ namespace TianWen.UI.Abstractions
                     continue;
                 }
 
-                items.Add($"{binding.Alias} (offline)");
                 var alias = binding.Alias;
-                actions.Add(() => PostSignal(new SelectRemoteRigSignal(alias)));
+                items.Add(DropdownItem<string>.Action($"{alias} (offline)", () => PostSignal(new SelectRemoteRigSignal(alias))));
             }
 
-            State.ProfileDropdown.Open(x, y, width, items.ToImmutable(), (idx, _) =>
-            {
-                if (idx >= 0 && idx < actions.Count) actions[idx]();
-            });
+            State.ProfileDropdown.Open(x, y, width, items.ToImmutable());
         }
 
         /// <summary>

--- a/src/TianWen.UI.Abstractions/EquipmentTab.cs
+++ b/src/TianWen.UI.Abstractions/EquipmentTab.cs
@@ -84,8 +84,8 @@ namespace TianWen.UI.Abstractions
 
         public override bool HandleInput(InputEvent evt) => evt switch
         {
-            InputEvent.KeyDown(var key, _) when State.FilterNameDropdown.HandleKeyDown(key) => true,
-            InputEvent.KeyDown(var key, _) when State.ProfileDropdown.HandleKeyDown(key) => true,
+            // (The two dropdowns' key routing is gone: an open menu claims the keyboard when it paints, and
+            // the host asks once. See WindowUiSettings.KeyboardClaimant.)
             // ESC dismisses any active selection/confirmation before bubbling to quit
             InputEvent.KeyDown(InputKey.Escape, _) => DismissActiveState(),
             // An open, overflowing filter-name dropdown claims the wheel first (no-op when closed / fits /

--- a/src/TianWen.UI.Abstractions/EquipmentTabState.cs
+++ b/src/TianWen.UI.Abstractions/EquipmentTabState.cs
@@ -128,11 +128,11 @@ public class EquipmentTabState
     }
 
     // Filter name dropdown
-    public DropdownMenuState FilterNameDropdown { get; } = new();
+    public DropdownMenuState<string> FilterNameDropdown { get; } = new();
 
     // Profile-switcher dropdown, opened from the profile panel header. Lists AllProfiles plus
     // discovered "tianwen-server" rigs (docs/plans/remote-profile.md).
-    public DropdownMenuState ProfileDropdown { get; } = new();
+    public DropdownMenuState<string> ProfileDropdown { get; } = new();
 
     /// <summary>
     /// When non-null, the profile-switch-refused dialog is up showing this explanation (from

--- a/src/TianWen.UI.Abstractions/GuiEventHandlerBase.cs
+++ b/src/TianWen.UI.Abstractions/GuiEventHandlerBase.cs
@@ -72,6 +72,14 @@ namespace TianWen.UI.Abstractions
         /// </summary>
         public bool HandleInput(InputEvent evt) => evt switch
         {
+            // An open overlay owns the keyboard, and says so by having been PAINTED. Asked here, once, so
+            // that no widget owning a dropdown has to remember a routing case of its own. That step is
+            // exactly what was missing for the Live Session mode pill, and its absence showed only as the
+            // arrow keys doing nothing: the menu still opened, drew and took clicks. A claimant no longer on
+            // screen declines, so this falls straight through.
+            InputEvent.KeyDown(var claimKey, _) when _chrome.Ui.KeyboardClaimant?.HandleKeyDown(claimKey) == true
+                => Redraw(),
+
             InputEvent.KeyDown(var key, var modifiers) => HandleKeyDown(key, modifiers),
             InputEvent.MouseDown(var px, var py, _, var mods, var clicks) => HandleMouseDown(px, py, mods, (byte)clicks),
             InputEvent.MouseMove(var px, var py) => HandleMouseMove(px, py),
@@ -81,6 +89,13 @@ namespace TianWen.UI.Abstractions
             InputEvent.Pinch or InputEvent.PinchEnd => _chrome.ActiveTab?.HandleInput(evt) ?? false,
             _ => false
         };
+
+        /// <summary>Marks the frame dirty and reports the event as consumed.</summary>
+        private bool Redraw()
+        {
+            _appState.NeedsRedraw = true;
+            return true;
+        }
 
         // ===================================================================
         // Event routing: generic, no tab-specific logic

--- a/src/TianWen.UI.Abstractions/ImageRendererBase.Input.cs
+++ b/src/TianWen.UI.Abstractions/ImageRendererBase.Input.cs
@@ -57,10 +57,12 @@ namespace TianWen.UI.Abstractions
                 return false;
             }
 
-            // Dropdowns get first crack at keyboard so Escape/Enter/Arrows route
-            // to the open overlay before falling through to global shortcuts
-            // (e.g. Escape would otherwise quit via RequestExitSignal).
-            if (state.ToolbarDropdown.HandleKeyDown(key))
+            // An open overlay gets first crack at the keyboard, so Escape/Enter/Arrows reach it before
+            // falling through to global shortcuts (Escape would otherwise quit via RequestExitSignal).
+            // Asked of whatever CLAIMED the keyboard by painting, not of one named dropdown: this viewer is
+            // its own host when it runs standalone (tianwen-fits), so a second overlay added here would
+            // otherwise need its own line, which is the omission this whole mechanism removes.
+            if (Ui.KeyboardClaimant?.HandleKeyDown(key) == true)
             {
                 state.NeedsRedraw = true;
                 return true;

--- a/src/TianWen.UI.Abstractions/ImageRendererBase.Toolbar.cs
+++ b/src/TianWen.UI.Abstractions/ImageRendererBase.Toolbar.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using DIR.Lib;
@@ -381,15 +382,17 @@ namespace TianWen.UI.Abstractions
                     width = labelWidth;
                 }
             }
+            // These entries ARE their labels, and the callers still think in indices, so the value carried
+            // is the label and the index comes from the array. Open seeds the highlight with the current
+            // selection directly -- it used to be assigned straight afterwards to undo Open resetting it.
+            var items = labels.Select(DropdownItem.Text).ToImmutableArray();
             state.ToolbarDropdown.Open(
                 bounds.X,
                 bounds.Y + bounds.Height,
                 width,
-                labels,
-                onSelect);
-            // Mark the current selection so the menu shows the active item on open
-            // (RenderDropdownMenu highlights HighlightIndex; Open resets it to -1).
-            state.ToolbarDropdown.HighlightIndex = selectedIndex;
+                items,
+                item => onSelect(items.IndexOf(item), item.Value),
+                highlightIndex: selectedIndex);
             state.NeedsRedraw = true;
         }
 

--- a/src/TianWen.UI.Abstractions/ImageRendererBase.cs
+++ b/src/TianWen.UI.Abstractions/ImageRendererBase.cs
@@ -411,6 +411,16 @@ namespace TianWen.UI.Abstractions
 
         protected void ResolveFontPath()
         {
+            // Only when nothing has given us one. A STANDALONE host (tianwen-fits) is the whole app and has
+            // no chrome to inherit from, so it must resolve a face itself. EMBEDDED in a window that already
+            // has one, keep it: this viewer sits inside that window and should not label itself in a
+            // different face, and it certainly must not overwrite the window's font for everyone else
+            // sharing those settings.
+            if (!string.IsNullOrEmpty(FontPath))
+            {
+                return;
+            }
+
             var resolved = FontResolver.ResolveSystemFont();
             if (resolved.Length > 0)
             {

--- a/src/TianWen.UI.Abstractions/LiveSessionState.cs
+++ b/src/TianWen.UI.Abstractions/LiveSessionState.cs
@@ -370,7 +370,7 @@ namespace TianWen.UI.Abstractions
         /// active posts <c>CancelPolarAlignmentSignal</c>. Hidden during sessions
         /// (the pill becomes the read-only phase indicator).
         /// </summary>
-        public DropdownMenuState ModeDropdown { get; } = new();
+        public DropdownMenuState<LiveSessionMode> ModeDropdown { get; } = new();
 
         /// <summary>Needs redraw flag, set from thread-pool callbacks and consumed
         /// by the render loop. Backed by <see cref="Interlocked.Exchange(ref int, int)"/>

--- a/src/TianWen.UI.Abstractions/LiveSessionTab.Strips.cs
+++ b/src/TianWen.UI.Abstractions/LiveSessionTab.Strips.cs
@@ -77,18 +77,26 @@ namespace TianWen.UI.Abstractions
                             dropdown.Close();
                             return;
                         }
+                        // Polar align is gated on real preconditions (a connected mount, a guide camera).
+                        // Stating that HERE, as a disabled entry carrying its reason, is what stopped the
+                        // row from being clickable-but-inert: the check used to run after the selection and
+                        // write its reason into the polar panel -- a panel you only reach by making the
+                        // selection that just failed, so the click simply looked dead.
+                        var (polarOk, polarWhy) = EvaluatePolarPreconditions(state);
+                        var modes = ImmutableArray.Create(
+                            new DropdownItem<LiveSessionMode>("Preview", LiveSessionMode.Preview),
+                            DropdownItem<LiveSessionMode>.When(polarOk, "Polar Align", LiveSessionMode.PolarAlign, polarWhy),
+                            new DropdownItem<LiveSessionMode>("Planetary", LiveSessionMode.Planetary),
+                            new DropdownItem<LiveSessionMode>("Flats", LiveSessionMode.Flats));
+
                         dropdown.Open(
                             pillX, pillY + pillH, pillW,
-                            ImmutableArray.Create("Preview", "Polar Align", "Planetary", "Flats"),
-                            (idx, _) =>
+                            modes,
+                            item =>
                             {
-                                var target = idx switch
-                                {
-                                    1 => LiveSessionMode.PolarAlign,
-                                    2 => LiveSessionMode.Planetary,
-                                    3 => LiveSessionMode.Flats,
-                                    _ => LiveSessionMode.Preview,
-                                };
+                                // The entry IS the mode: no index-to-enum switch to keep in step with the
+                                // label order.
+                                var target = item.Value;
                                 if (target == state.Mode)
                                 {
                                     return;
@@ -136,25 +144,20 @@ namespace TianWen.UI.Abstractions
                                 {
                                     case LiveSessionMode.PolarAlign:
                                     {
-                                        var (polarEnabled, polarReason) = EvaluatePolarPreconditions(state);
-                                        if (polarEnabled)
+                                        // No precondition re-check: the entry could not have been chosen
+                                        // unless it was enabled, and re-testing here would be a second
+                                        // verdict free to disagree with the one the user was shown.
+                                        // Switch into PolarAlign setup (PolarPhase.Idle); the panel's
+                                        // Start button fires StartPolarAlignmentSignal after the user
+                                        // reviews the config. Auto-enable the WCS grid so meridians
+                                        // appear once the first probe frame solves.
+                                        if (PreviewView is not null)
                                         {
-                                            // Switch into PolarAlign setup (PolarPhase.Idle); the panel's
-                                            // Start button fires StartPolarAlignmentSignal after the user
-                                            // reviews the config. Auto-enable the WCS grid so meridians
-                                            // appear once the first probe frame solves.
-                                            if (PreviewView is not null)
-                                            {
-                                                _previewState.ShowGrid = true;
-                                            }
-                                            state.Mode = LiveSessionMode.PolarAlign;
-                                            state.PolarPhase = PolarAlignmentPhase.Idle;
-                                            state.PolarStatusMessage = "Configure and click Start";
+                                            _previewState.ShowGrid = true;
                                         }
-                                        else
-                                        {
-                                            state.PolarStatusMessage = polarReason;
-                                        }
+                                        state.Mode = LiveSessionMode.PolarAlign;
+                                        state.PolarPhase = PolarAlignmentPhase.Idle;
+                                        state.PolarStatusMessage = "Configure and click Start";
                                         break;
                                     }
                                     case LiveSessionMode.Planetary:

--- a/src/TianWen.UI.Abstractions/ViewerState.cs
+++ b/src/TianWen.UI.Abstractions/ViewerState.cs
@@ -168,7 +168,7 @@ public sealed class ViewerState
     /// <see cref="ImageRendererBase{TSurface}.Render"/> so its clickables win
     /// hit-test z-order (paint order = z-order).
     /// </summary>
-    public DropdownMenuState ToolbarDropdown { get; } = new();
+    public DropdownMenuState<string> ToolbarDropdown { get; } = new();
 
     /// <summary>
     /// True while an overlay owns the pointer, so chrome underneath must not react to hover. Clicks

--- a/src/TianWen.UI.Gui/Program.cs
+++ b/src/TianWen.UI.Gui/Program.cs
@@ -301,6 +301,19 @@ var loop = new SdlEventLoop(sdlWindow, renderer)
 
     OnTextInput = text => handlers.HandleInput(new InputEvent.TextInput(text)),
 
+    // The IME's in-progress composition. This goes STRAIGHT to the focused field rather than through
+    // handlers.HandleInput, because it is not input to be interpreted: nothing may bind it, consume it, or
+    // treat it as a shortcut. It is the input method telling us what to draw until it commits, and the
+    // committed characters then arrive through OnTextInput above like any other text.
+    OnTextEditing = (text, cursor, length) =>
+    {
+        if (appState.TextInputFocus.Current is { } field)
+        {
+            field.SetComposition(text, cursor, length);
+            appState.NeedsRedraw = true;
+        }
+    },
+
     CheckNeedsRedraw = () =>
     {
         // Recompute targets when site/date changes (shared logic in AppSignalHandler)
@@ -392,6 +405,16 @@ var loop = new SdlEventLoop(sdlWindow, renderer)
         if (appState.TextInputFocus.BlurIfUnpainted(guiRenderer.PaintedTextInputs()))
         {
             appState.NeedsRedraw = true;
+        }
+
+        // Tell the platform where the caret is, so an input method puts its candidate window beside the text
+        // rather than over it. SDL does not track our caret and has no other way to find out, so without this
+        // a CJK IME has nothing to anchor to. Sent after the paint, from the rect the caret was actually drawn
+        // at (the BlurIfUnpainted above guarantees a focused field was painted this frame), and only while a
+        // field is focused -- there is no area to report otherwise, and text input is stopped anyway.
+        if (appState.TextInputFocus.Current is not null && guiRenderer.FocusedCaretRect is { Width: > 0 } caret)
+        {
+            sdlWindow.SetTextInputArea(caret.UpperLeft.X, caret.UpperLeft.Y, (int)caret.Width, (int)caret.Height, 0);
         }
 
         // Only log frames that take meaningfully long, and rate-limit to once per

--- a/src/TianWen.UI.Gui/VkGuiRenderer.cs
+++ b/src/TianWen.UI.Gui/VkGuiRenderer.cs
@@ -32,82 +32,20 @@ namespace TianWen.UI.Gui
         private readonly VkImageRenderer _guiderViewer;
         private readonly VkImageRenderer _previewViewer;
         private readonly VkPlanetaryTab _planetaryTab;
+
         private ScheduledObservationTree? _cachedSchedule;
         private Target? _cachedActiveTarget;
         private uint _width;
         private uint _height;
 
-        /// <summary>
-        /// DPI scale factor, set by the host from the SDL window's DisplayScale (startup + resize).
-        /// Overrides the <see cref="PixelWidgetBase{T}.DpiScale"/> setter to propagate the new scale to
-        /// every child widget this chrome hosts, so tab layout + input math all read one owner -- no
-        /// per-Render parameter threading.
-        /// </summary>
-        public override float DpiScale
-        {
-            get => base.DpiScale;
-            set
-            {
-                base.DpiScale = value;
-                _plannerTab.DpiScale = value;
-                _equipmentTab.DpiScale = value;
-                _sessionTab.DpiScale = value;
-                _skyMapTab.DpiScale = value;
-                _liveSessionTab.DpiScale = value;
-                _guiderTab.DpiScale = value;
-                _notificationsTab.DpiScale = value;
-                _homeTab.DpiScale = value;
-                _guiderViewer.DpiScale = value;
-                _previewViewer.DpiScale = value;
-                _planetaryTab.DpiScale = value;
-            }
-        }
+        // No DpiScale / FontPath / EmojiFontPath / FontFallback overrides here any more. Every widget this
+        // chrome composes -- the eight tabs AND the three embedded viewers -- reads this chrome's
+        // PixelWidgetBase.Ui, so the host's one assignment is theirs too. The four propagation blocks that
+        // used to sit here each named all eight tabs, and the viewers were then hand-fed the DPI they could
+        // not be excluded from: display scale is a property of the WINDOW, and these all draw into one.
 
-        /// <summary>
-        /// The window's primary text font, resolved once by this chrome (<see cref="ResolveFontPath"/>).
-        /// Overrides the <see cref="PixelWidgetBase{T}.FontPath"/> setter to push the font to the seven plain
-        /// child tabs, so their layout + text math all read one owner -- no per-Render fontPath argument.
-        /// The two embedded image viewers and the planetary tab are <see cref="VkImageRenderer"/>s that
-        /// self-resolve their own font in their ctor, so they are deliberately not pushed here (unchanged).
-        /// </summary>
-        public override string FontPath
-        {
-            get => base.FontPath;
-            set
-            {
-                base.FontPath = value;
-                _plannerTab.FontPath = value;
-                _equipmentTab.FontPath = value;
-                _sessionTab.FontPath = value;
-                _skyMapTab.FontPath = value;
-                _liveSessionTab.FontPath = value;
-                _guiderTab.FontPath = value;
-                _notificationsTab.FontPath = value;
-                _homeTab.FontPath = value;
-            }
-        }
 
-        /// <summary>
-        /// Optional emoji/symbol fallback font, propagated to the same seven tabs as <see cref="FontPath"/>.
-        /// Only the Planner + Equipment tabs consume it today (planet/weather glyphs on the altitude chart);
-        /// the others ignore it harmlessly.
-        /// </summary>
-        public override string? EmojiFontPath
-        {
-            get => base.EmojiFontPath;
-            set
-            {
-                base.EmojiFontPath = value;
-                _plannerTab.EmojiFontPath = value;
-                _equipmentTab.EmojiFontPath = value;
-                _sessionTab.EmojiFontPath = value;
-                _skyMapTab.EmojiFontPath = value;
-                _liveSessionTab.EmojiFontPath = value;
-                _guiderTab.EmojiFontPath = value;
-                _notificationsTab.EmojiFontPath = value;
-                _homeTab.EmojiFontPath = value;
-            }
-        }
+
 
         /// <summary>Exposes the planner tab for external scroll control.</summary>
         public VkPlannerTab PlannerTab => _plannerTab;
@@ -175,6 +113,30 @@ namespace TianWen.UI.Gui
             }
 
             return painted;
+        }
+
+        /// <summary>
+        /// Where the focused field's caret was painted this frame, across chrome AND the active tab, or
+        /// <c>default</c> if no active field was drawn. The host hands this to
+        /// <c>SdlVulkanWindow.SetTextInputArea</c> so an input method can place its candidate window beside
+        /// the caret instead of over the text being typed.
+        /// <para>
+        /// It lives here for the same reason <see cref="CursorAt"/> does: which surfaces compose a frame is
+        /// this renderer's own knowledge, and a host asking just one of them would miss a field on the other.
+        /// The tab is asked first, mirroring paint order.
+        /// </para>
+        /// </summary>
+        public RectInt FocusedCaretRect
+        {
+            get
+            {
+                if (_activeTab is { } tab && tab.CaretRect is { Width: > 0 } fromTab)
+                {
+                    return fromTab;
+                }
+
+                return CaretRect;
+            }
         }
 
         /// <inheritdoc/>
@@ -344,6 +306,17 @@ namespace TianWen.UI.Gui
             _planetaryTab = new VkPlanetaryTab(renderer, width, height) { Bus = bus };
             // The planetary tab IS also the Live Session planetary-mode view (one instance, one ViewerState).
             _liveSessionTab.PlanetaryView = _planetaryTab;
+            // One assignment, after every child exists and before the first per-window value is resolved
+            // below: from here on they READ this chrome's settings instead of holding copies, so DPI, font,
+            // emoji face and fallback chain all reach them without being pushed -- and so will anything
+            // added later. The embedded viewers are included: they self-resolve a font only when nothing
+            // gave them one (the standalone tianwen-fits case), and they share this window's display scale
+            // because that is what a window HAS. Adopting these settings discards the face they resolved
+            // during their own construction, which is the intent -- a viewer inside this chrome should
+            // label itself in the chrome's face.
+            ShareUiContext(_plannerTab, _equipmentTab, _sessionTab, _skyMapTab,
+                           _liveSessionTab, _guiderTab, _notificationsTab, _homeTab,
+                           _guiderViewer, _previewViewer, _planetaryTab);
             ResolveFontPath();
         }
 
@@ -1058,6 +1031,39 @@ namespace TianWen.UI.Gui
                     FontPath = resolved;
                 }
             }
+
+            BuildFontFallback();
+        }
+
+        /// <summary>
+        /// The per-script fallback chain. Without one, ANY codepoint the primary face lacks renders as
+        /// nothing at all -- which is what made the search box look broken for Chinese input: the IME
+        /// committed correctly and the field held the right characters, but DejaVu Sans has no CJK cmap
+        /// entry, so there was nothing to draw and the field simply stayed blank.
+        /// </summary>
+        /// <remarks>
+        /// The per-OS script faces come from <see cref="FontResolver.ResolveSystemScriptFonts"/>, so this
+        /// app carries no font-name knowledge of its own -- every DIR.Lib consumer that draws user-supplied
+        /// text needs the same list, and each working it out separately would get a different, quietly
+        /// incomplete answer. Nothing is bundled for CJK on purpose: a Noto CJK face is ~17 MB each, a full
+        /// set is ~68 MB on every one of six AOT publishes, and binary releases here are already manual
+        /// specifically to stay inside the 1 GB/month LFS budget. Anyone who can TYPE Chinese has a Chinese
+        /// face installed.
+        /// </remarks>
+        private void BuildFontFallback()
+        {
+            if (string.IsNullOrEmpty(FontPath))
+            {
+                return;
+            }
+
+            // The emoji face rides the emoji ROLE, not the script list, so it is consulted ahead of the CJK
+            // faces: several of those incidentally carry the odd pictograph, and drawing one out of a
+            // multi-megabyte face when a dedicated colour font is present is both wrong and heavier.
+            FontFallback = FontFallbackResolver.FromRoles(
+                FontPath,
+                emojiFontPath: string.IsNullOrEmpty(EmojiFontPath) ? null : EmojiFontPath,
+                scriptFontPaths: FontResolver.ResolveSystemScriptFonts());
         }
     }
 }


### PR DESCRIPTION
Repins to **DIR.Lib 7.29 / Console.Lib 4.25 / SdlVulkan.Renderer 7.20 / WebGl.Renderer 1.23** and adopts them. All four published from this session's sibling releases.

## The reported bug was not the actual bug

Chinese input showed nothing. I instrumented the choke point rather than keep theorising, and the trace settled it immediately:

```
TEXT_INPUT text='你' cps=[4F60] focus=yes active=True → handled=True textNow='你'
TEXT_INPUT text='好' cps=[597D] focus=yes active=True → handled=True textNow='你好'
```

The characters arrived, were handled, and the field held `你好` the whole time. **It was font coverage** — DejaVu Sans has `A` but no U+4F60 / U+597D, so there was nothing to draw. I had signed the text-input feature off using `type_text`, which injects committed text straight at the field and therefore exercises neither composition nor glyph coverage.

Two things were needed, and the first alone would not have worked:

- **A fallback chain** — primary, emoji role, then the platform's script faces.
- **The field routed through it.** The layout painter splits *text leaves* into coverage runs, and a field's content is not a leaf. The caret is measured through the same chain, or every measurement past the first CJK character comes out short.

The IME plumbing this began as is still needed: `SDL_SetTextInputArea` is what fixed the candidate-window placement, and `OnTextEditing` goes straight to the focused field rather than through `HandleInput` — a composition is not input to be interpreted.

## The mode dropdown's two bugs were both symptoms

- **Polar Align looked dead** because its precondition check ran *after* the selection and wrote the reason into a panel you only reach by making the selection that just failed. It is now a disabled entry: greys out, states the reason **on the row**, is skipped by the arrows, and swallows its click rather than falling through to the backdrop — which would have closed the menu and made it behave exactly like a working row.
- **No keyboard highlight** because it was the one dropdown of four with no key-routing case in its own input switch. An open overlay now claims the keyboard **by being painted** and the host asks once, so **four routing cases became zero** and a new overlay is navigable by existing.

Entries are also typed now, so choosing one hands back the entry instead of an index mapped through a `switch` that had to agree with the label order. The profile menu's parallel `actions` list and the custom-entry special case both fall out.

## Per-window values stop being copied per widget

The chrome had **four** overridden setters over the same eight tabs, and the embedded viewers were then hand-fed the DPI they could not be excluded from — display scale is a property of the *window*, and they all draw into one. They now share one `WindowUiSettings`; `ShareUiContext` is called once and all four overrides are gone. Viewers resolve a font only when nothing gave them one, so standalone `tianwen-fits` is unaffected.

## Verification

- CI package path (`-p:UseLocalSiblings=false`) against the published packages: **4209 unit + 338 functional, 0 failures**.
- Chinese confirmed rendering in the running GUI, caret landing correctly after the last character.
- Upstream: DIR.Lib **821 pass**, Console.Lib **510 pass**.

**One visible change to be aware of:** embedded viewers (planetary tab, preview, guider) now label themselves in the chrome's bundled DejaVu instead of a resolved system font. That is the intended consequence of sharing the window's settings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
