### PR TITLE
Bake the Horizons comet overlay for the browser, and back off a failed fetch

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -86,18 +86,30 @@ jobs:
       - name: Install wasm-tools workload
         run: dotnet workload install wasm-tools
 
-      # Bake the comet snapshot BEFORE publish so it rides the static-web-assets pipeline.
-      # Same query string as SbdbCometSource.DefaultQueryUrl - keep them in sync.
-      - name: Bake comets-sbdb.json (JPL SBDB has no CORS headers)
+      # Bake the comet assets BEFORE publish so they ride the static-web-assets pipeline.
+      #
+      # JPL sends no CORS headers from EITHER host it serves comets from, so BOTH have to be baked:
+      # the bulk SBDB query (comets-sbdb.json) and the per-object Horizons current-apparition overlay
+      # (comets-apparitions.json). Baking only the first is what left the deployed atlas retrying a
+      # request that could never succeed -- 45 attempts and 50 s of request time for a single comet in
+      # one four-minute session. The overlay is written sealed, so the browser does not try at all.
+      #
+      # This runs our own code rather than curl+jq because both halves need it: staleness is
+      # CometElements.IsElementSetStale and the Horizons reply needs HorizonsCometSource's parser. It
+      # also takes the SBDB query string from SbdbCometSource.DefaultQueryUrl instead of restating it
+      # here, which is one fewer pair of things that have to agree.
+      #
+      # --seed is the CURRENTLY DEPLOYED overlay, which makes the published site its own incremental
+      # state: only entries past their per-comet TTL are re-resolved (~30 requests on a day that
+      # deploys, against ~520 for a full bake). A 404 on the first ever run is a cold bake, which the
+      # cap turns into "as much as fits, the rest next run" rather than a stall.
+      - name: Bake comet assets (JPL sends no CORS headers, for SBDB or Horizons)
         run: |
           set -euo pipefail
-          curl -sf --retry 3 --retry-delay 10 \
-            'https://ssd-api.jpl.nasa.gov/sbdb_query.api?sb-kind=c&fields=prefix,pdes,name,M1,K1,e,q,i,om,w,tp,epoch' \
-            -o src/TianWen.UI.Web/wwwroot/comets-sbdb.json
-          # Shape check: the parser needs fields+data; a JPL error page must fail the build,
-          # not deploy as a corrupt asset the app then chokes on.
-          jq -e '.fields and .data and (.count | tonumber > 0)' src/TianWen.UI.Web/wwwroot/comets-sbdb.json > /dev/null
-          echo "baked $(jq -r '.count' src/TianWen.UI.Web/wwwroot/comets-sbdb.json) comets"
+          dotnet run --project tools/bake-comets/BakeComets.csproj -c Release --nologo -- \
+            --out src/TianWen.UI.Web/wwwroot \
+            --seed https://sharpastro.github.io/tianwen/comets-apparitions.json \
+            --max-fetches 120
 
       # Stage the full Tycho-2 catalog as a same-origin static asset. Lightweight strips the ~30 MB
       # tyc2.bin.lz from the WASM bundle (keeps the bundle small); the atlas fetches it on first

--- a/.gitignore
+++ b/.gitignore
@@ -29,8 +29,10 @@ src/TianWen.Lib/Astrometry/Catalogs/*.gs.gz
 # Lavapipe min-repro zip (built artifact for upstream bug filing)
 LavapipeMinRepro.zip
 __pycache__/
-# CI-baked comet snapshot (pages.yml curls JPL SBDB into wwwroot on the runner)
+# CI-baked comet assets (pages.yml runs tools/bake-comets into wwwroot on the runner): the bulk SBDB
+# query response, and the per-object Horizons current-apparition overlay seeded from the live site
 src/TianWen.UI.Web/wwwroot/comets-sbdb.json
+src/TianWen.UI.Web/wwwroot/comets-apparitions.json
 # CI-staged Tycho-2 catalog (pages.yml copies the LFS .lz into wwwroot on the runner; the atlas
 # fetches it at runtime - it must never be committed into the source tree's wwwroot)
 src/TianWen.UI.Web/wwwroot/tyc2.bin.lz

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -641,6 +641,32 @@ Full design + phasing: [`docs/plans/comet-ephemeris.md`](docs/plans/comet-epheme
   stale fallback, `FetchedUtc` envelope, `ITimeProvider`-driven). Position + magnitude at any time are
   then **pure local computation, offline**. `ICometRepository.TryGetPosition` / `TryGet`. DI in
   `AddAstrometry`. AOT-safe via `SbdbJsonContext` + `CometDesignationJsonConverter`.
+- **A failed per-object Horizons fetch MUST be remembered, and `ApparitionRetryCooldown` is what does
+  it.** `RequestCurrentApparition` is called per drawn marker per frame, and its single-flight key is
+  released in the `finally` while only SUCCESS writes an entry -- so before the cooldown nothing recorded
+  that the last attempt failed, and an endpoint that can never answer was retried at whatever rate the
+  request settled. Measured on the deployed web build: **45 requests and 50 s of cumulative request time
+  in one four-minute session, all for comet 5D**. An offline desktop and a JPL outage take the same path.
+  The comment "calling it per drawn marker per frame is free" (`SkyMapTab`) is true only once a fetch
+  *can* succeed.
+- **JPL sends no CORS headers from EITHER comet host, so the browser bakes BOTH.** SBDB (bulk) was baked
+  long ago; **Horizons (the per-object apparition refinement) is a different host reached from a
+  different class**, and was missed -- which is what the retry storm above actually was.
+  `tools/bake-comets` writes `comets-sbdb.json` (verbatim query response) **and**
+  `comets-apparitions.json` (the overlay, resolved on the runner) into `wwwroot`;
+  `AddAstrometry(cometQueryUri:, apparitionSeedUri:)` takes both as plain same-origin URLs.
+  **Nothing detects the host** -- a dev server 404s both and degrades along the identical path, which is
+  the point: a host check would make dev diverge from production exactly where the bug lived.
+  - **`ApparitionCacheFile.NoRemoteRefresh` is a POLICY ("do not ask"), not a completeness claim.** As a
+    completeness claim it would need a hash guard tying it to the bulk snapshot (the
+    `SimbadMergeSnapshot` pattern) and a missing comet would be a correctness bug; as policy, an unbaked
+    comet just keeps its bulk record and stays flagged approximate. That is what lets the bake be
+    partial, which it must be: **518 of 4,071 comets are stale enough to warrant an upgrade.**
+  - **The bake is incremental and seeds from the LIVE SITE**, so the published assets are their own CI
+    state (no `actions/cache` to be evicted between infrequent deploys). Per-comet TTL tiered on
+    peak-ish magnitude `M1 + K1*log10(q)` -- the planner's own gate, not a new threshold: daily <=12,
+    weekly <=15, monthly <=18, once beyond. ~30 requests per deploying day. **The tiers are a relevance
+    budget, not physics** -- osculating elements decay with time, not with brightness.
 - **Invariant -- comets are NOT in `ICelestialObjectDB`** (which is immutable after init). Every
   consumer augments at its own layer from `ICometRepository`: the sky-map F3 search merges comet keys
   into its index (`SkyMapSearchActions.BuildSearchIndex` + `SkyMapSearchState.CometEntries`); the

--- a/docs/plans/web-showcase.md
+++ b/docs/plans/web-showcase.md
@@ -199,11 +199,25 @@ lands; **P2 -> P3** then adds the atlas. P2 gates P3 across the NuGet release bo
   `_framework/blazor.webassembly#[.{fingerprint}].js` - or the published page 404s (only
   fingerprinted asset names exist in `_framework`). The dev server tolerates plain names, so this
   only bites on publish. Mirrors Chess.Web.
-- **JPL SBDB has no CORS headers** - browser-side comet fetch is impossible, permanently. The
-  repository degrades gracefully (DSO-only). Fix = **bake comets in CI**: the Pages workflow curls
-  the same SBDB query on the runner, ships `comets.json` as a static asset, and the app seeds it
-  into `CometRepository`'s cache path in MEMFS (the repo's own TTL/stale logic then applies;
-  weekly redeploys keep it fresh). Zero Lib changes.
+- **JPL has no CORS headers, from EITHER comet host** - browser-side fetch is impossible,
+  permanently. The repository degrades gracefully (DSO-only). Fix = **bake comets in CI**:
+  `tools/bake-comets` runs on the runner before publish and writes both assets into `wwwroot`, which
+  `Program.cs` points `AddAstrometry` at as plain same-origin URLs.
+  - `comets-sbdb.json` - the bulk query response, verbatim, so `SbdbCometSource` parses it unchanged.
+  - `comets-apparitions.json` - the per-object **Horizons** current-apparition overlay. This was
+    missed for a long time, because it is a *different JPL host* reached from a *different* class:
+    the deployed atlas kept retrying it forever, since only a SUCCESSFUL fetch was recorded and the
+    single-flight key cleared on failure. Measured on the live site: **45 requests, 50 s of
+    cumulative request time, in one four-minute session, all for comet 5D**. The asset carries
+    `NoRemoteRefresh`, which switches the per-object fetch off rather than merely feeding it.
+  - **Incremental, seeded from the deployed site**: entries carry their own `FetchedUtc` and are
+    re-resolved on a per-comet TTL tiered by peak-ish magnitude (daily <=12, weekly <=15, monthly
+    <=18, once beyond). ~30 requests on a day that deploys, against 518 stale comets in total. The
+    tiers are a *relevance* budget, not physics - elements decay with time, not with brightness.
+  - **`NoRemoteRefresh` is a policy, not a completeness claim**, which is what lets the bake be
+    partial: an unbaked comet keeps its bulk record and stays flagged approximate.
+  - The backstop for hosts with no seed (the dev server below, an offline desktop, a JPL outage) is
+    a per-comet retry cooldown in `CometRepository` - the actual bug, and platform-independent.
 - **Caching layers**: browser HTTP cache already covers the payload (fingerprinted assets); the
   site + planner-session persistence SHIPPED via localStorage (see the interaction round below);
   the comets cache stays MEMFS pending the CI bake; a decoded-DB snapshot (generalize the
@@ -343,9 +357,12 @@ read-only `SdfGlyphDiskCache` mode (the single-threaded-WASM-friendly variant).
   catalog designation (x2 canonical forms) + sorts - measured 7.4 s INTERPRETED on :5099 (fine
   under AOT). It builds in the background task after first paint (search commit works without
   it) and rebuilds with comet designations once comets load.
-- **Local dev comets**: `wwwroot/comets-sbdb.json` is CI-baked and gitignored, so :5099 404s it
-  by default (comet-less dev session). Bake it locally with the same curl as pages.yml when
-  comets are needed in dev; the dev server serves the source wwwroot directly, no rebuild.
+- **Local dev comets**: `wwwroot/comets-sbdb.json` and `comets-apparitions.json` are CI-baked and
+  gitignored, so :5099 404s both by default (comet-less dev session). Bake them locally with
+  `dotnet run --project tools/bake-comets/BakeComets.csproj -- --out src/TianWen.UI.Web/wwwroot`;
+  the dev server serves the source wwwroot directly, no rebuild. **Nothing detects the host** - dev
+  and Pages differ only in whether the assets are there, so a dev session degrades along exactly the
+  path a seed-less host takes rather than down a branch that production never exercises.
 
 ## Selectable text + fullscreen round (2026-07-20, fifth session)
 

--- a/src/TianWen.Lib.Tests/CometRepositoryTests.cs
+++ b/src/TianWen.Lib.Tests/CometRepositoryTests.cs
@@ -56,8 +56,14 @@ public class CometRepositoryTests(ITestOutputHelper output)
     private FakeExternal CreateExternal()
         => CreateExternal(new FakeTimeProviderWrapper(new DateTimeOffset(2026, 7, 10, 0, 0, 0, TimeSpan.Zero)));
 
-    private CometRepository NewRepository(FakeExternal external, ISbdbCometSource source, IHorizonsCometSource? horizons = null)
-        => new(source, horizons ?? new NeverFetchesHorizons(), external, external.TimeProvider, NullLogger<CometRepository>.Instance);
+    private CometRepository NewRepository(FakeExternal external, ISbdbCometSource source, IHorizonsCometSource? horizons = null, ApparitionCacheFile? seed = null)
+        => new(source, horizons ?? new NeverFetchesHorizons(), new FakeApparitionSeed(seed), external, external.TimeProvider, NullLogger<CometRepository>.Instance);
+
+    /// <summary>The publish-time overlay a browser host is given. Null = the desktop shape (no seed).</summary>
+    private sealed class FakeApparitionSeed(ApparitionCacheFile? seed) : IApparitionSeedSource
+    {
+        public ValueTask<ApparitionCacheFile?> TryFetchAsync(CancellationToken cancellationToken) => ValueTask.FromResult(seed);
+    }
 
     /// <summary>The default for the bulk-cache tests: they are about SBDB and must never depend on the
     /// per-object overlay, so this one answers "no refinement available" without touching a network.</summary>
@@ -189,8 +195,13 @@ public class CometRepositoryTests(ITestOutputHelper output)
 
     private sealed class ThrowingHorizons : IHorizonsCometSource
     {
+        public int FetchCount;
+
         public Task<CometElements?> TryFetchCurrentApparitionAsync(CometElements baseElements, DateTimeOffset at, CancellationToken cancellationToken)
-            => throw new HttpRequestException("offline");
+        {
+            Interlocked.Increment(ref FetchCount);
+            throw new HttpRequestException("offline");
+        }
     }
 
     // A stale periodic comet: epoch two revolutions back, which is the shape that puts a marker degrees
@@ -205,9 +216,9 @@ public class CometRepositoryTests(ITestOutputHelper output)
     private static CometElements RefreshedComet()
         => StaleComet() with { PerihelionJdTt = 2461254.615, EpochJdTt = 2461258.5 };
 
-    private static async Task<CometRepository> LoadedWithStaleCometAsync(FakeExternal external, IHorizonsCometSource horizons, CancellationToken ct)
+    private static async Task<CometRepository> LoadedWithStaleCometAsync(FakeExternal external, IHorizonsCometSource horizons, ApparitionCacheFile? seed, CancellationToken ct)
     {
-        var repo = new CometRepository(new FakeSbdbCometSource([StaleComet()]), horizons, external, external.TimeProvider, NullLogger<CometRepository>.Instance);
+        var repo = new CometRepository(new FakeSbdbCometSource([StaleComet()]), horizons, new FakeApparitionSeed(seed), external, external.TimeProvider, NullLogger<CometRepository>.Instance);
         await repo.EnsureLoadedAsync(ct);
         return repo;
     }
@@ -229,7 +240,7 @@ public class CometRepositoryTests(ITestOutputHelper output)
         var ct = TestContext.Current.CancellationToken;
         var external = CreateExternal(new FakeTimeProviderWrapper(new DateTimeOffset(2026, 8, 6, 0, 0, 0, TimeSpan.Zero)));
         var horizons = new FakeHorizons(RefreshedComet());
-        var repo = await LoadedWithStaleCometAsync(external, horizons, ct);
+        var repo = await LoadedWithStaleCometAsync(external, horizons, seed: null, ct);
         var index = StaleComet().CatalogIndex.ShouldNotBeNull();
 
         // Before: the bulk record, whose perihelion is the previous apparition.
@@ -250,7 +261,7 @@ public class CometRepositoryTests(ITestOutputHelper output)
         var ct = TestContext.Current.CancellationToken;
         var external = CreateExternal(new FakeTimeProviderWrapper(new DateTimeOffset(2026, 8, 6, 0, 0, 0, TimeSpan.Zero)));
         var horizons = new FakeHorizons(RefreshedComet());
-        var repo = await LoadedWithStaleCometAsync(external, horizons, ct);
+        var repo = await LoadedWithStaleCometAsync(external, horizons, seed: null, ct);
         var index = StaleComet().CatalogIndex.ShouldNotBeNull();
 
         repo.RequestCurrentApparition(index);
@@ -273,7 +284,7 @@ public class CometRepositoryTests(ITestOutputHelper output)
         var horizons = new FakeHorizons(RefreshedComet());
         // Epoch inside the current apparition: nothing to gain, so no round-trip.
         var fresh = StaleComet() with { EpochJdTt = 2461200.0, PerihelionJdTt = 2461254.615 };
-        var repo = new CometRepository(new FakeSbdbCometSource([fresh]), horizons, external, external.TimeProvider, NullLogger<CometRepository>.Instance);
+        var repo = new CometRepository(new FakeSbdbCometSource([fresh]), horizons, new FakeApparitionSeed(null), external, external.TimeProvider, NullLogger<CometRepository>.Instance);
         await repo.EnsureLoadedAsync(ct);
 
         repo.RequestCurrentApparition(fresh.CatalogIndex.ShouldNotBeNull());
@@ -289,7 +300,7 @@ public class CometRepositoryTests(ITestOutputHelper output)
         // must keep saying the position is approximate so the UI keeps showing its marker.
         var ct = TestContext.Current.CancellationToken;
         var external = CreateExternal(new FakeTimeProviderWrapper(new DateTimeOffset(2026, 8, 6, 0, 0, 0, TimeSpan.Zero)));
-        var repo = await LoadedWithStaleCometAsync(external, new ThrowingHorizons(), ct);
+        var repo = await LoadedWithStaleCometAsync(external, new ThrowingHorizons(), seed: null, ct);
         var index = StaleComet().CatalogIndex.ShouldNotBeNull();
 
         repo.RequestCurrentApparition(index);
@@ -298,6 +309,94 @@ public class CometRepositoryTests(ITestOutputHelper output)
         repo.TryGet(index, out var elements).ShouldBeTrue();
         elements.PerihelionJdTt.ShouldBe(2457340.741, tolerance: 0.001);
         elements.IsElementSetStale(2461258.5).ShouldBeTrue();
+    }
+
+    /// <summary>
+    /// A publish-time seed with an EXPIRED entry, so the TTL check cannot be what stops the fetch --
+    /// only the seal can. This is the browser's configuration: Horizons sends no CORS headers, so a
+    /// request from that host can never succeed and must not be made at all.
+    /// </summary>
+    [Fact]
+    public async Task ASealedSeedMeansHorizonsIsNeverAsked()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var now = new DateTimeOffset(2026, 8, 6, 0, 0, 0, TimeSpan.Zero);
+        var external = CreateExternal(new FakeTimeProviderWrapper(now));
+        var horizons = new FakeHorizons(RefreshedComet());
+        var seed = new ApparitionCacheFile([new ApparitionEntry(now - TimeSpan.FromDays(30), RefreshedComet())]) { NoRemoteRefresh = true };
+        var repo = await LoadedWithStaleCometAsync(external, horizons, seed, ct);
+        var index = StaleComet().CatalogIndex.ShouldNotBeNull();
+
+        // Called per drawn marker per frame, which is exactly how the unsealed build reached 45
+        // requests for one comet in a single session.
+        for (var i = 0; i < 50; i++)
+        {
+            repo.RequestCurrentApparition(index);
+        }
+        await Task.Delay(100, ct);
+
+        horizons.FetchCount.ShouldBe(0);
+
+        // ...and the seeded elements are in use, so sealing costs the atlas nothing.
+        repo.TryGet(index, out var elements).ShouldBeTrue();
+        elements.PerihelionJdTt.ShouldBe(2461254.615, tolerance: 0.001);
+    }
+
+    /// <summary>
+    /// The counterpart that keeps the test above honest: the SAME expired seed without the flag still
+    /// upgrades live. Without this, sealing could be doing nothing and the assertion above would pass
+    /// because some other gate happened to stop the fetch.
+    /// </summary>
+    [Fact]
+    public async Task AnUnsealedSeedStillUpgradesFromHorizons()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var now = new DateTimeOffset(2026, 8, 6, 0, 0, 0, TimeSpan.Zero);
+        var external = CreateExternal(new FakeTimeProviderWrapper(now));
+        var horizons = new FakeHorizons(RefreshedComet());
+        var seed = new ApparitionCacheFile([new ApparitionEntry(now - TimeSpan.FromDays(30), RefreshedComet())]);
+        var repo = await LoadedWithStaleCometAsync(external, horizons, seed, ct);
+
+        repo.RequestCurrentApparition(StaleComet().CatalogIndex.ShouldNotBeNull());
+
+        (await WaitForAsync(() => horizons.FetchCount == 1)).ShouldBeTrue();
+    }
+
+    /// <summary>
+    /// A failed fetch has to cost ONE request per cooldown window, not one per frame that draws the
+    /// marker. The single-flight key clears when the fetch settles and only success writes an entry, so
+    /// before the cooldown existed nothing remembered the failure: the browser build issued 45 requests
+    /// and spent 50 s of request time on one comet in four minutes. An offline desktop, a dev server
+    /// without the baked seed, and a JPL outage all take this same path.
+    /// </summary>
+    [Fact]
+    public async Task AFailedFetchIsNotRetriedUntilItsCooldownExpires()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var tp = new FakeTimeProviderWrapper(new DateTimeOffset(2026, 8, 6, 0, 0, 0, TimeSpan.Zero));
+        var external = CreateExternal(tp);
+        var horizons = new ThrowingHorizons();
+        var repo = await LoadedWithStaleCometAsync(external, horizons, seed: null, ct);
+        var index = StaleComet().CatalogIndex.ShouldNotBeNull();
+
+        repo.RequestCurrentApparition(index);
+        (await WaitForAsync(() => Volatile.Read(ref horizons.FetchCount) == 1)).ShouldBeTrue();
+        await Task.Delay(100, ct); // let the failure stamp land in the fetch task's finally
+
+        // Well inside the cooldown: a frame-rate storm of requests must buy exactly nothing.
+        tp.Advance(TimeSpan.FromMinutes(30));
+        for (var i = 0; i < 50; i++)
+        {
+            repo.RequestCurrentApparition(index);
+        }
+        await Task.Delay(100, ct);
+        Volatile.Read(ref horizons.FetchCount).ShouldBe(1);
+
+        // Past it, one more attempt is made -- a transient outage must still recover on its own.
+        tp.Advance(TimeSpan.FromHours(2));
+        repo.RequestCurrentApparition(index);
+
+        (await WaitForAsync(() => Volatile.Read(ref horizons.FetchCount) == 2)).ShouldBeTrue();
     }
 
     /// <summary>
@@ -320,7 +419,7 @@ public class CometRepositoryTests(ITestOutputHelper output)
         var ct = TestContext.Current.CancellationToken;
         var when = new DateTimeOffset(2026, 8, 6, 0, 0, 0, TimeSpan.Zero);
         var external = CreateExternal(new FakeTimeProviderWrapper(when));
-        var repo = await LoadedWithStaleCometAsync(external, new FakeHorizons(RefreshedComet()), ct);
+        var repo = await LoadedWithStaleCometAsync(external, new FakeHorizons(RefreshedComet()), seed: null, ct);
         var index = StaleComet().CatalogIndex.ShouldNotBeNull();
 
         CometEphemeris.TryGetEarthState(when, out var earth).ShouldBeTrue();

--- a/src/TianWen.Lib/Astrometry/Comets/ApparitionSeedSource.cs
+++ b/src/TianWen.Lib/Astrometry/Comets/ApparitionSeedSource.cs
@@ -1,0 +1,78 @@
+using System;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+
+namespace TianWen.Lib.Astrometry.Comets;
+
+/// <summary>
+/// Reads the current-apparition overlay baked at publish time, when the host has one.
+/// </summary>
+internal interface IApparitionSeedSource
+{
+    /// <summary>The baked overlay, or <c>null</c> when this host has none (the desktop default, and a
+    /// dev server serving the app without the CI-baked asset).</summary>
+    ValueTask<ApparitionCacheFile?> TryFetchAsync(CancellationToken cancellationToken);
+}
+
+/// <summary>
+/// Fetches the publish-time apparition overlay from a same-origin URL, mirroring how
+/// <see cref="SbdbCometSource"/> takes an endpoint override: a browser cannot reach JPL Horizons at all
+/// (it sends no <c>Access-Control-Allow-Origin</c>), so the CI deploy resolves the per-object element
+/// sets on a machine that can and bakes them as a static asset beside the bulk snapshot.
+///
+/// <para><b>A null URI is the whole desktop configuration.</b> Rather than a second implementation and a
+/// branch at the repository, "this host has no seed" is just the absent URI -- the same shape as
+/// <see cref="SbdbCometSource"/>, where null means the live API.</para>
+///
+/// <para><b>Every failure is a miss, deliberately.</b> A dev server without the CI-baked asset 404s here
+/// exactly as it already does for <c>comets-sbdb.json</c>, and the app must behave the same way it would
+/// on a host that never had a seed: keep the bulk elements, keep flagging positions approximate, and
+/// leave the per-object fetch enabled. That is what keeps this asset-driven rather than host-sniffed --
+/// nothing here asks WHERE it is running, so dev and production degrade along the same path.</para>
+/// </summary>
+internal sealed class ApparitionSeedSource : IApparitionSeedSource
+{
+    private static readonly HttpClient s_httpClient = new()
+    {
+        Timeout = TimeSpan.FromSeconds(30)
+    };
+
+    private readonly HttpClient _httpClient;
+    private readonly Uri? _seedUri;
+    private readonly ILogger _logger;
+
+    public ApparitionSeedSource(Uri? seedUri, ILogger<ApparitionSeedSource> logger)
+        : this(s_httpClient, seedUri, logger)
+    {
+    }
+
+    // Test seam, mirroring SbdbCometSource: lets a suite point at a stub handler.
+    internal ApparitionSeedSource(HttpClient httpClient, Uri? seedUri, ILogger logger)
+    {
+        _httpClient = httpClient;
+        _seedUri = seedUri;
+        _logger = logger;
+    }
+
+    public async ValueTask<ApparitionCacheFile?> TryFetchAsync(CancellationToken cancellationToken)
+    {
+        if (_seedUri is null)
+        {
+            return null;
+        }
+
+        try
+        {
+            await using var stream = await _httpClient.GetStreamAsync(_seedUri, cancellationToken);
+            return await JsonSerializer.DeserializeAsync(stream, SbdbJsonContext.Default.ApparitionCacheFile, cancellationToken);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _logger.LogDebug(ex, "No comet apparition seed at {Uri}; per-object Horizons refresh stays enabled", _seedUri);
+            return null;
+        }
+    }
+}

--- a/src/TianWen.Lib/Astrometry/Comets/CometRepository.cs
+++ b/src/TianWen.Lib/Astrometry/Comets/CometRepository.cs
@@ -23,7 +23,24 @@ internal sealed record ApparitionEntry(DateTimeOffset FetchedUtc, CometElements 
 
 /// <summary>The Horizons per-object overlay cache: current-apparition elements for the comets someone
 /// has actually looked at.</summary>
-internal sealed record ApparitionCacheFile(ApparitionEntry[] Entries);
+internal sealed record ApparitionCacheFile(ApparitionEntry[] Entries)
+{
+    /// <summary>
+    /// When true, the repository must not attempt a per-object Horizons fetch: whatever
+    /// <see cref="Entries"/> carries is the whole overlay this host will ever have. Set only by the
+    /// publish-time bake, for a host that cannot reach JPL at all (a browser -- Horizons sends no
+    /// CORS headers), never by the local write-back.
+    ///
+    /// <para><b>It is a policy, NOT a completeness claim, and the difference is load-bearing.</b> If it
+    /// meant "every comet that needed upgrading is in here" it would have to be tied to the bulk
+    /// snapshot it was baked against (a hash guard, as <c>SimbadMergeSnapshot</c> carries), and a comet
+    /// missing from it would be a correctness bug. Meaning only "do not ask", a comet that was never
+    /// baked simply keeps its bulk record and stays flagged approximate -- which is what the host did
+    /// anyway, minus a request that could only ever fail. That is what lets the bake cover the comets
+    /// worth covering instead of having to be exhaustive.</para>
+    /// </summary>
+    public bool NoRemoteRefresh { get; init; }
+}
 
 /// <summary>
 /// Default <see cref="ICometRepository"/>: SBDB elements cached to <c>AppData/SmallBodies/comets.json</c>
@@ -44,8 +61,26 @@ internal sealed class CometRepository : ICometRepository
     // while matching the bulk cadence, so the two caches expire on the same rhythm.
     private static readonly TimeSpan ApparitionTtl = TimeSpan.FromDays(7);
 
+    /// <summary>
+    /// How long a comet whose Horizons fetch FAILED is left alone before it is tried again.
+    ///
+    /// <para>Without this, a permanently-unreachable endpoint is retried at whatever rate the request
+    /// settles: the single-flight key clears in the <c>finally</c> and only SUCCESS writes an entry, so
+    /// nothing remembers that the last attempt failed. Measured on the browser build, where Horizons
+    /// can never answer (no CORS headers): <b>45 attempts and 50 s of cumulative request time in one
+    /// four-minute session, all for the same comet</b>. An offline desktop and a JPL outage take the
+    /// identical path.</para>
+    ///
+    /// <para>An hour is far below the <see cref="ApparitionTtl"/> this feeds and the upgrade is a
+    /// background nicety nobody is waiting on -- the marker is already drawn from the bulk record and
+    /// labelled approximate -- so delaying a recovery from a genuinely transient failure by up to an
+    /// hour costs nothing observable.</para>
+    /// </summary>
+    private static readonly TimeSpan ApparitionRetryCooldown = TimeSpan.FromHours(1);
+
     private readonly ISbdbCometSource _source;
     private readonly IHorizonsCometSource _horizons;
+    private readonly IApparitionSeedSource _seed;
     private readonly IExternal _external;
     private readonly ITimeProvider _timeProvider;
     private readonly ILogger<CometRepository> _logger;
@@ -60,14 +95,24 @@ internal sealed class CometRepository : ICometRepository
     private volatile ImmutableDictionary<CatalogIndex, ApparitionEntry> _apparitions = ImmutableDictionary<CatalogIndex, ApparitionEntry>.Empty;
 
     // Single-flight per comet. A key present means a fetch is in the air; it is removed when that fetch
-    // settles, so a failure is retried on a later request rather than being latched forever.
+    // settles, so a failure is retried on a later request rather than being latched forever -- bounded
+    // by ApparitionRetryCooldown below, which is what stops "later" meaning "immediately, forever".
     private readonly ConcurrentDictionary<CatalogIndex, byte> _apparitionInFlight = new();
-    private bool _apparitionsLoaded;
 
-    public CometRepository(ISbdbCometSource source, IHorizonsCometSource horizons, IExternal external, ITimeProvider timeProvider, ILogger<CometRepository> logger)
+    // When each comet's last Horizons attempt failed, so the retry can be spaced out. Written from the
+    // fetch continuation (a thread-pool thread) and read from the render/poll path, hence concurrent.
+    private readonly ConcurrentDictionary<CatalogIndex, DateTimeOffset> _apparitionFailedAtUtc = new();
+
+    // Set from a seed that declares itself sealed; latched for the process, never cleared.
+    private volatile bool _noRemoteRefresh;
+    private bool _apparitionsLoaded;
+    private readonly SemaphoreSlim _apparitionLoadGate = new(1, 1);
+
+    public CometRepository(ISbdbCometSource source, IHorizonsCometSource horizons, IApparitionSeedSource seed, IExternal external, ITimeProvider timeProvider, ILogger<CometRepository> logger)
     {
         _source = source;
         _horizons = horizons;
+        _seed = seed;
         _external = external;
         _timeProvider = timeProvider;
         _logger = logger;
@@ -128,6 +173,12 @@ internal sealed class CometRepository : ICometRepository
 
     public async Task RefreshAsync(bool forceRefetch = false, CancellationToken cancellationToken = default)
     {
+        // Before the bulk set, so the overlay (and the seal it may carry) is in place by the time any
+        // consumer resolves a position. Doing it lazily inside the fetch task -- where it used to be its
+        // only caller -- meant the first drawn marker fired a request BEFORE learning it must not.
+        // Its own gate, so this is safe to await while holding _loadGate below.
+        await LoadApparitionCacheAsync(cancellationToken);
+
         await _loadGate.WaitAsync(cancellationToken);
         try
         {
@@ -194,11 +245,25 @@ internal sealed class CometRepository : ICometRepository
             return;
         }
 
+        // A sealed seed says this host cannot reach Horizons at all, so there is nothing to ask.
+        if (_noRemoteRefresh)
+        {
+            return;
+        }
+
         // Nothing to gain: the bulk record is already stated within this apparition, which is the
         // common case (a freshly discovered comet, or one whose solution epoch is recent). Only a set
         // that is a revolution or more old produces the phase error worth a network round-trip for.
         now.ToSOFAUtcJdTT(out _, out _, out var tt1, out var tt2);
         if (!baseElements.IsElementSetStale(tt1 + tt2))
+        {
+            return;
+        }
+
+        // The last attempt failed and is still cooling off (see ApparitionRetryCooldown). This is what
+        // an UNSEALED host that cannot reach Horizons falls back on -- a dev server serving the app
+        // without the CI-baked seed, an offline desktop, a JPL outage.
+        if (_apparitionFailedAtUtc.TryGetValue(index, out var failedAt) && now - failedAt < ApparitionRetryCooldown)
         {
             return;
         }
@@ -210,12 +275,26 @@ internal sealed class CometRepository : ICometRepository
 
         _ = Task.Run(async () =>
         {
+            // Anything that did NOT settle the question counts as a failure for backoff purposes,
+            // including the null return (Horizons answered with no usable element record, which repeats
+            // deterministically for that comet). Defaulting to false and setting it only on the paths
+            // that genuinely resolved means a new early return backs off rather than silently spinning.
+            var resolved = false;
             try
             {
                 await LoadApparitionCacheAsync(CancellationToken.None);
+
+                // The seed may have arrived with the load above and sealed this host.
+                if (_noRemoteRefresh)
+                {
+                    resolved = true; // not a failure: there is nothing to back off from
+                    return;
+                }
+
                 if (_apparitions.TryGetValue(index, out var fromDisk) && _timeProvider.GetUtcNow() - fromDisk.FetchedUtc <= ApparitionTtl)
                 {
-                    return; // the disk cache already had it
+                    resolved = true; // the disk cache already had it
+                    return;
                 }
 
                 var refined = await _horizons.TryFetchCurrentApparitionAsync(baseElements, _timeProvider.GetUtcNow(), CancellationToken.None);
@@ -226,6 +305,8 @@ internal sealed class CometRepository : ICometRepository
 
                 var entry = new ApparitionEntry(_timeProvider.GetUtcNow(), elements);
                 _apparitions = _apparitions.SetItem(index, entry);
+                _apparitionFailedAtUtc.TryRemove(index, out _);
+                resolved = true;
                 _logger.LogInformation(
                     "Upgraded {Comet} to current-apparition elements (epoch {Epoch:F1}); its bulk record was {Revolutions:F1} revolutions old",
                     elements.DisplayName, elements.EpochJdTt, baseElements.RevolutionsSinceEpoch(tt1 + tt2));
@@ -240,6 +321,11 @@ internal sealed class CometRepository : ICometRepository
             }
             finally
             {
+                if (!resolved)
+                {
+                    _apparitionFailedAtUtc[index] = _timeProvider.GetUtcNow();
+                }
+
                 _apparitionInFlight.TryRemove(index, out _);
             }
         });
@@ -248,6 +334,13 @@ internal sealed class CometRepository : ICometRepository
     private string ApparitionCachePath
         => Path.Combine(_external.CreateSubDirectoryInAppDataFolder("SmallBodies").FullName, "apparitions.json");
 
+    /// <summary>
+    /// Populates the apparition overlay once, from the publish-time seed and then the local cache.
+    ///
+    /// <para>Order matters: the seed is the baked snapshot, the local cache is only ever written by a
+    /// fetch that succeeded on THIS machine, so where both carry a comet the local entry is the fresher
+    /// one and layers on top.</para>
+    /// </summary>
     private async Task LoadApparitionCacheAsync(CancellationToken cancellationToken)
     {
         if (Volatile.Read(ref _apparitionsLoaded))
@@ -255,10 +348,46 @@ internal sealed class CometRepository : ICometRepository
             return;
         }
 
-        var cached = await _external.TryReadJsonAsync(ApparitionCachePath, SbdbJsonContext.Default.ApparitionCacheFile, _logger, cancellationToken);
-        if (cached?.Entries is { Length: > 0 } entries)
+        // Gated because the fire-and-forget fetch path can reach this concurrently with the load, and
+        // two builders taken from the same base would drop whichever upgrade committed in between.
+        await _apparitionLoadGate.WaitAsync(cancellationToken);
+        try
         {
+            if (Volatile.Read(ref _apparitionsLoaded))
+            {
+                return;
+            }
+
             var builder = _apparitions.ToBuilder();
+
+            if (await _seed.TryFetchAsync(cancellationToken) is { } seed)
+            {
+                Merge(builder, seed.Entries);
+                if (seed.NoRemoteRefresh)
+                {
+                    _noRemoteRefresh = true;
+                    _logger.LogInformation(
+                        "Comet apparition overlay is a sealed publish-time snapshot ({Count} entries); per-object Horizons refresh is disabled on this host",
+                        seed.Entries.Length);
+                }
+            }
+
+            var cached = await _external.TryReadJsonAsync(ApparitionCachePath, SbdbJsonContext.Default.ApparitionCacheFile, _logger, cancellationToken);
+            if (cached?.Entries is { } entries)
+            {
+                Merge(builder, entries);
+            }
+
+            _apparitions = builder.ToImmutable();
+            Volatile.Write(ref _apparitionsLoaded, true);
+        }
+        finally
+        {
+            _apparitionLoadGate.Release();
+        }
+
+        static void Merge(ImmutableDictionary<CatalogIndex, ApparitionEntry>.Builder builder, ApparitionEntry[] entries)
+        {
             foreach (var entry in entries)
             {
                 if (entry.Elements.CatalogIndex is { } index)
@@ -266,10 +395,7 @@ internal sealed class CometRepository : ICometRepository
                     builder[index] = entry;
                 }
             }
-            _apparitions = builder.ToImmutable();
         }
-
-        Volatile.Write(ref _apparitionsLoaded, true);
     }
 
     private Task PersistApparitionsAsync(CancellationToken cancellationToken)

--- a/src/TianWen.Lib/Extensions/AstrometryServiceCollectionExtensions.cs
+++ b/src/TianWen.Lib/Extensions/AstrometryServiceCollectionExtensions.cs
@@ -20,8 +20,16 @@ public static class AstrometryServiceCollectionExtensions
     /// its CI deploy bakes the query result as a same-origin static asset and points this at it.
     /// Null (default) = the live JPL API.
     /// </param>
+    /// <param name="apparitionSeedUri">
+    /// Points at a publish-time snapshot of the per-object current-apparition overlay. Same reason as
+    /// <paramref name="cometQueryUri"/> and a second endpoint, because JPL serves the two from different
+    /// hosts: the bulk set comes from the SBDB query API, the per-object refinement from Horizons, and
+    /// NEITHER sends CORS headers. Baking only the first left the browser retrying the second forever.
+    /// A snapshot that declares itself sealed also switches the per-object fetch off entirely.
+    /// Null (default) = no seed, so the overlay is built live from Horizons as before.
+    /// </param>
     /// <returns></returns>
-    public static IServiceCollection AddAstrometry(this IServiceCollection services, Uri? cometQueryUri = null) => services
+    public static IServiceCollection AddAstrometry(this IServiceCollection services, Uri? cometQueryUri = null, Uri? apparitionSeedUri = null) => services
         // Factory lambda so the typed ILogger<CatalogPlateSolver> gets resolved and
         // upcast to the non-generic ILogger ctor parameter. The shorter
         // AddSingleton<IPlateSolver, CatalogPlateSolver>() form leaves DI unable to
@@ -46,5 +54,9 @@ public static class AstrometryServiceCollectionExtensions
         // revolution or more old -- which is the case that puts a marker degrees off (10P: 9.3).
         .AddSingleton<IHorizonsCometSource>(sp => new HorizonsCometSource(
             sp.GetRequiredService<ILogger<HorizonsCometSource>>()))
+        // The publish-time overlay snapshot, when the host has one. A null URI is the desktop
+        // configuration: no seed, so the source reports a miss and the live path above is used.
+        .AddSingleton<IApparitionSeedSource>(sp => new ApparitionSeedSource(
+            apparitionSeedUri, sp.GetRequiredService<ILogger<ApparitionSeedSource>>()))
         .AddSingleton<ICometRepository, CometRepository>();
 }

--- a/src/TianWen.Lib/LibraryAttributes.cs
+++ b/src/TianWen.Lib/LibraryAttributes.cs
@@ -9,3 +9,4 @@
 [assembly: InternalsVisibleTo("TianWen.UI.Shared")]
 [assembly: InternalsVisibleTo("PrecomputeHdHipCross")]
 [assembly: InternalsVisibleTo("PrecomputeSimbadMerge")]
+[assembly: InternalsVisibleTo("BakeComets")]

--- a/src/TianWen.UI.Web/Program.cs
+++ b/src/TianWen.UI.Web/Program.cs
@@ -26,6 +26,18 @@ builder.Services.AddSingleton<IExternal, BrowserExternal>();
 // (comets-sbdb.json, curled in CI) and the comet source fetches that instead - the response
 // shape, parser, and cache layers are all unchanged. On a dev server without the baked file the
 // fetch 404s and the repository degrades to a DSO-only session exactly like the CORS failure did.
-builder.Services.AddAstrometry(cometQueryUri: new Uri(new Uri(builder.HostEnvironment.BaseAddress), "comets-sbdb.json"));
+//
+// The SAME is true of JPL Horizons, which serves the per-object current-apparition refinement from a
+// different host and likewise sends no CORS headers. Baking only the bulk set left every stale comet
+// drawn on the atlas retrying a request that could never succeed (measured: 45 attempts, 50 s of
+// request time in one four-minute session). comets-apparitions.json is that overlay, resolved in CI,
+// and it declares itself sealed so the per-object fetch is not attempted here at all.
+//
+// Both are plain same-origin URLs relative to the app base, so NOTHING here asks whether it is running
+// on Pages: the dev server 404s both and degrades along exactly the path a seed-less host takes.
+var baseAddress = new Uri(builder.HostEnvironment.BaseAddress);
+builder.Services.AddAstrometry(
+    cometQueryUri: new Uri(baseAddress, "comets-sbdb.json"),
+    apparitionSeedUri: new Uri(baseAddress, "comets-apparitions.json"));
 
 await builder.Build().RunAsync();

--- a/tools/bake-comets/BakeComets.csproj
+++ b/tools/bake-comets/BakeComets.csproj
@@ -1,0 +1,34 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    Build-time tool: bake the two comet assets the browser build serves same-origin, because JPL
+    sends no CORS headers from EITHER host it serves them from.
+
+      comets-sbdb.json         the bulk SBDB query response, verbatim (SbdbCometSource parses it
+                               unchanged, so this is a mirror and not a format of our own)
+      comets-apparitions.json  the per-object Horizons current-apparition overlay, resolved here
+                               and marked NoRemoteRefresh so the browser does not attempt it
+
+    Incremental: seeded from the currently deployed overlay, it re-resolves only the entries whose
+    per-comet TTL has expired, so a deploy costs ~30 Horizons requests rather than ~520.
+
+    Not part of the solution; not packed; not shipped. See tools/bake-comets/README.md and the
+    "Bake comet assets" step in .github/workflows/pages.yml. Sibling of precompute-simbad-merge.
+  -->
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <AssemblyName>BakeComets</AssemblyName>
+    <RootNamespace>BakeComets</RootNamespace>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsAotCompatible>false</IsAotCompatible>
+    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\TianWen.Lib\TianWen.Lib.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tools/bake-comets/Program.cs
+++ b/tools/bake-comets/Program.cs
@@ -1,0 +1,249 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using TianWen.Lib.Astrometry;
+using TianWen.Lib.Astrometry.Catalogs;
+using TianWen.Lib.Astrometry.Comets;
+
+namespace BakeComets;
+
+/// <summary>
+/// Bakes the two comet assets the browser build serves same-origin. See the csproj header for what and
+/// the pages.yml step for when; this file carries the WHY of the incremental scheme.
+/// </summary>
+internal static class Program
+{
+    /// <summary>
+    /// How long a baked entry stays good, by how bright the comet can ever get -- its peak-ish total
+    /// magnitude <c>M1 + K1*log10(q)</c>, which is the same static candidacy gate the planner already
+    /// uses, rather than a threshold invented here.
+    ///
+    /// <para><b>This is a relevance budget, not physics.</b> Osculating elements decay with TIME, so a
+    /// magnitude-19 comet's set goes stale at exactly the same rate as 45P's. What brightness changes is
+    /// how much along-track error is worth a request: nobody is pointing a telescope at the faint end,
+    /// and a comet that is never drawn and never proposed does not need arcsecond placement. Do not read
+    /// the tiers as a claim about accuracy.</para>
+    ///
+    /// <para>Measured against the live SBDB set (4,071 comets, 1,764 periodic): 518 are stale enough to
+    /// warrant an upgrade at all, of which 16 fall in the daily tier, 63 in the weekly, 209 in the
+    /// monthly and 230 in fetch-once. Steady state is about 30 requests on a day that deploys, against
+    /// 518 for a bake that re-resolved everything.</para>
+    /// </summary>
+    private static TimeSpan RefreshIntervalFor(double peakMagnitude) => peakMagnitude switch
+    {
+        <= 12.0 => TimeSpan.FromDays(1),
+        <= 15.0 => TimeSpan.FromDays(7),
+        <= 18.0 => TimeSpan.FromDays(30),
+        // Fainter than 18, or no photometric model at all (NaN fails every comparison above and lands
+        // here): resolve once if it is missing and then leave it alone forever.
+        _ => TimeSpan.MaxValue,
+    };
+
+    private static async Task<int> Main(string[] args)
+    {
+        string? outDir = null, seed = null;
+        var maxFetches = 200;
+        var delay = TimeSpan.FromMilliseconds(250);
+
+        for (var i = 0; i < args.Length; i++)
+        {
+            switch (args[i])
+            {
+                case "--out" when i + 1 < args.Length: outDir = args[++i]; break;
+                case "--seed" when i + 1 < args.Length: seed = args[++i]; break;
+                case "--max-fetches" when i + 1 < args.Length: maxFetches = int.Parse(args[++i], CultureInfo.InvariantCulture); break;
+                case "--delay-ms" when i + 1 < args.Length: delay = TimeSpan.FromMilliseconds(int.Parse(args[++i], CultureInfo.InvariantCulture)); break;
+                default:
+                    Console.Error.WriteLine($"unknown argument '{args[i]}'");
+                    return Usage();
+            }
+        }
+
+        if (outDir is null)
+        {
+            return Usage();
+        }
+
+        Directory.CreateDirectory(outDir);
+        using var http = new HttpClient { Timeout = TimeSpan.FromMinutes(2) };
+        var now = DateTimeOffset.UtcNow;
+
+        var comets = await BakeBulkAsync(http, outDir, CancellationToken.None);
+        if (comets.Count == 0)
+        {
+            Console.Error.WriteLine("SBDB returned no usable comets; refusing to write a corrupt asset");
+            return 1;
+        }
+
+        await BakeApparitionsAsync(http, outDir, seed, comets, now, maxFetches, delay, CancellationToken.None);
+        return 0;
+    }
+
+    private static int Usage()
+    {
+        Console.Error.WriteLine("usage: BakeComets --out <wwwroot> [--seed <url|path>] [--max-fetches N] [--delay-ms N]");
+        return 2;
+    }
+
+    /// <summary>
+    /// Mirrors the SBDB query response to <c>comets-sbdb.json</c> VERBATIM, then parses the same bytes
+    /// with the app's own parser so the staleness pass below sees exactly what the browser will.
+    /// Writing the raw response rather than a mapped form is what lets the browser keep using the
+    /// unmodified <see cref="SbdbCometSource"/>, and taking the URL from that class rather than
+    /// restating it here is what stops the two drifting (the shell step this replaced restated the
+    /// query string in YAML under a "keep them in sync" comment).
+    /// </summary>
+    private static async Task<IReadOnlyList<CometElements>> BakeBulkAsync(HttpClient http, string outDir, CancellationToken ct)
+    {
+        var json = await http.GetStringAsync(SbdbCometSource.DefaultQueryUrl, ct);
+        var response = JsonSerializer.Deserialize(json, SbdbJsonContext.Default.SbdbQueryResponse);
+
+        // The shape check the shell step did with jq: a JPL error page must fail the bake rather than
+        // deploy as an asset the app then chokes on.
+        if (response?.Fields is not { Length: > 0 } || response.Data is not { Length: > 0 })
+        {
+            throw new InvalidOperationException("SBDB response has no fields/data; refusing to write it");
+        }
+
+        var path = Path.Combine(outDir, "comets-sbdb.json");
+        await File.WriteAllTextAsync(path, json, ct);
+
+        var comets = SbdbCometSource.Parse(response, NullLogger.Instance);
+        Console.WriteLine($"[bake-comets] comets-sbdb.json: {comets.Count} comets ({json.Length / 1024} KiB)");
+        return comets;
+    }
+
+    private static async Task BakeApparitionsAsync(
+        HttpClient http,
+        string outDir,
+        string? seed,
+        IReadOnlyList<CometElements> comets,
+        DateTimeOffset now,
+        int maxFetches,
+        TimeSpan delay,
+        CancellationToken ct)
+    {
+        var existing = await TryLoadSeedAsync(http, seed, ct);
+        Console.WriteLine($"[bake-comets] seed: {existing.Count} entries from {seed ?? "(none)"}");
+
+        now.ToSOFAUtcJdTT(out _, out _, out var tt1, out var tt2);
+        var jdTt = tt1 + tt2;
+
+        // Only a bulk record a revolution or more old is worth refining -- the same test the repository
+        // applies before it would ask at runtime.
+        var candidates = new List<(CometElements Comet, CatalogIndex Index, TimeSpan Interval)>();
+        foreach (var comet in comets)
+        {
+            if (comet.CatalogIndex is not { } index || !comet.IsElementSetStale(jdTt))
+            {
+                continue;
+            }
+
+            var peak = comet.HasMagnitudeModel && comet.PerihelionDistanceAu > 0.0
+                ? comet.AbsoluteMagnitudeM1 + comet.SlopeK1 * Math.Log10(comet.PerihelionDistanceAu)
+                : double.NaN;
+            candidates.Add((comet, index, RefreshIntervalFor(peak)));
+        }
+
+        // Anything the bulk set no longer lists, or whose published solution has caught up so its record
+        // is no longer stale, is dead weight -- drop it rather than carry it forever.
+        var live = candidates.Select(c => c.Index).ToHashSet();
+        var kept = existing.Where(kv => live.Contains(kv.Key)).ToDictionary(kv => kv.Key, kv => kv.Value);
+        var pruned = existing.Count - kept.Count;
+
+        // Brightest first, so a run that hits its cap has spent it on the comets anyone might look at.
+        var due = candidates
+            .Where(c => !kept.TryGetValue(c.Index, out var e) || now - e.FetchedUtc > c.Interval)
+            .OrderBy(c => c.Interval)
+            .ToList();
+
+        var horizons = new HorizonsCometSource(http, apiUri: null, NullLogger.Instance);
+        int fetched = 0, failed = 0;
+        foreach (var candidate in due)
+        {
+            if (fetched + failed >= maxFetches)
+            {
+                break;
+            }
+
+            try
+            {
+                if (await horizons.TryFetchCurrentApparitionAsync(candidate.Comet, now, ct) is { } refined)
+                {
+                    kept[candidate.Index] = new ApparitionEntry(now, refined);
+                    fetched++;
+                }
+                else
+                {
+                    failed++;
+                }
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                // One comet Horizons will not answer for must not fail the deploy: the asset is written
+                // without it, that comet keeps its bulk record, and the next run tries again.
+                Console.WriteLine($"[bake-comets]   {candidate.Comet.DisplayName}: {ex.Message}");
+                failed++;
+            }
+
+            await Task.Delay(delay, ct);
+        }
+
+        // A cap that silently truncated would read as "everything is covered"; say what was left.
+        var deferred = due.Count - Math.Min(due.Count, maxFetches);
+        Console.WriteLine(
+            $"[bake-comets] apparitions: {candidates.Count} stale, {due.Count} due, {fetched} fetched, "
+            + $"{failed} failed, {pruned} pruned, {deferred} deferred to the next run");
+
+        var file = new ApparitionCacheFile([.. kept.Values]) { NoRemoteRefresh = true };
+        var path = Path.Combine(outDir, "comets-apparitions.json");
+        await File.WriteAllTextAsync(path, JsonSerializer.Serialize(file, SbdbJsonContext.Default.ApparitionCacheFile), ct);
+        Console.WriteLine($"[bake-comets] comets-apparitions.json: {kept.Count} entries (sealed)");
+    }
+
+    /// <summary>
+    /// Reads the previous overlay so this run only refreshes what has expired. The seed is normally the
+    /// CURRENTLY DEPLOYED asset, which makes the published site its own incremental state: nothing to
+    /// keep in sync with what is live, and no cache to be evicted out from under a deploy that happens
+    /// less often than a CI cache is retained. Any failure -- the first ever run, a 404, a truncated
+    /// file -- is a cold start, which is a slow bake and never a wrong one.
+    /// </summary>
+    private static async Task<Dictionary<CatalogIndex, ApparitionEntry>> TryLoadSeedAsync(HttpClient http, string? seed, CancellationToken ct)
+    {
+        var result = new Dictionary<CatalogIndex, ApparitionEntry>();
+        if (string.IsNullOrWhiteSpace(seed))
+        {
+            return result;
+        }
+
+        try
+        {
+            var json = Uri.TryCreate(seed, UriKind.Absolute, out var uri) && uri.Scheme is "http" or "https"
+                ? await http.GetStringAsync(uri, ct)
+                : await File.ReadAllTextAsync(seed, ct);
+
+            foreach (var entry in JsonSerializer.Deserialize(json, SbdbJsonContext.Default.ApparitionCacheFile)?.Entries ?? [])
+            {
+                if (entry.Elements.CatalogIndex is { } index)
+                {
+                    result[index] = entry;
+                }
+            }
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            Console.WriteLine($"[bake-comets] no usable seed ({ex.Message}); this run is a cold bake");
+            result.Clear();
+        }
+
+        return result;
+    }
+}

--- a/tools/bake-comets/README.md
+++ b/tools/bake-comets/README.md
@@ -1,0 +1,59 @@
+# bake-comets
+
+Bakes the two comet assets the browser build serves same-origin, because **JPL sends no CORS headers
+from either host it serves comets from**:
+
+| Asset | Source | Consumed by |
+|---|---|---|
+| `comets-sbdb.json` | SBDB query API, mirrored **verbatim** | `SbdbCometSource`, unmodified |
+| `comets-apparitions.json` | Horizons, per object, resolved here | `ApparitionSeedSource` → `CometRepository` |
+
+```bash
+dotnet run --project tools/bake-comets/BakeComets.csproj -- \
+  --out src/TianWen.UI.Web/wwwroot \
+  [--seed <url|path>] [--max-fetches 200] [--delay-ms 250]
+```
+
+Both outputs are gitignored; `pages.yml` runs this before publish so they ride the static-web-assets
+pipeline. For a local dev session with comets, run it with just `--out`.
+
+## Why a tool and not curl + jq
+
+The step this replaced curled SBDB and shape-checked it with `jq`. That cannot do the second asset:
+deciding *which* comets need refining is `CometElements.IsElementSetStale`, and reading Horizons' reply
+is `HorizonsCometSource`'s parser. Running our own code also means the SBDB query string comes from
+`SbdbCometSource.DefaultQueryUrl` rather than being restated in YAML under a "keep them in sync"
+comment.
+
+## Why the overlay exists at all
+
+Only a *successful* Horizons fetch was ever recorded, and the single-flight key cleared in a `finally`,
+so a host that could never reach Horizons retried forever. Measured on the deployed site: **45 requests
+and 50 s of cumulative request time in one four-minute session, all for comet 5D/Brorsen**. The overlay
+is written with `NoRemoteRefresh`, which switches the per-object fetch off rather than merely feeding it.
+
+`CometRepository` also gained a per-comet retry cooldown, which is the real fix — a dev server without
+these assets, an offline desktop and a JPL outage all take that same path.
+
+## Incremental, seeded from the live site
+
+`--seed` is normally the **currently deployed** overlay, which makes the published site its own
+incremental state: nothing to keep in sync with what is live, and no CI cache to be evicted between
+deploys that may be weeks apart. Entries carry their own `FetchedUtc` and are re-resolved on a per-comet
+TTL tiered by peak-ish magnitude `M1 + K1*log10(q)` — the planner's own candidacy gate rather than a
+threshold invented here:
+
+| Peak magnitude | TTL | Comets |
+|---|---|---:|
+| ≤ 12 | daily | 16 |
+| ≤ 15 | weekly | 63 |
+| ≤ 18 | monthly | 209 |
+| fainter, or no M1/K1 | fetch once | 230 |
+| | | **518 stale of 4,071** |
+
+≈30 requests on a day that deploys. **The tiers are a relevance budget, not physics** — osculating
+elements decay with time, so a magnitude-19 comet's set goes stale exactly as fast as 45P's; brightness
+only sets how much along-track error is worth a request.
+
+A cold start (first run, or an unreachable seed) is bounded by `--max-fetches` and reports what it
+deferred; the next run picks those up, because a missing entry is simply a miss.


### PR DESCRIPTION
A HAR capture of the deployed Sky Atlas showed **45 requests to JPL Horizons in one four-minute session, every one blocked by CORS, all for the same comet** (5D/Brorsen), burning 50 s of cumulative request time. Two independent causes.

## 1. A failed fetch was not remembered (the actual bug)

`RequestCurrentApparition` is called per drawn marker per frame. Its single-flight key is released in the `finally`, and only a **successful** fetch writes an entry, so nothing recorded that the last attempt failed and an endpoint that can never answer was retried at whatever rate the request settled.

`ApparitionRetryCooldown` (1 h, per comet) fixes it, and it is platform-independent: an offline desktop, a dev server without the baked assets, and a JPL outage all took this same path. The existing comment "calling it per drawn marker per frame is free" is true only once a fetch *can* succeed.

## 2. JPL sends no CORS headers from *either* comet host

SBDB (the bulk set) has been baked into `wwwroot` for a long time. **Horizons is a different host, reached from a different class**, and was missed. `tools/bake-comets` now writes both assets, and the overlay carries `NoRemoteRefresh` so the browser does not attempt the per-object fetch at all.

`AddAstrometry` grows `apparitionSeedUri` beside the existing `cometQueryUri`, and `ApparitionSeedSource` mirrors `SbdbCometSource`: a null URI is the whole desktop configuration.

## Design notes worth reviewing

**`NoRemoteRefresh` is a policy, not a completeness claim.** As a completeness claim it would need a hash guard tying it to the bulk snapshot (the `SimbadMergeSnapshot` pattern) and a missing comet would be a correctness bug. Meaning only "do not ask", an unbaked comet keeps its bulk record and stays flagged approximate. That is what lets the bake be partial, which it has to be: **518 of 4,071 comets are stale enough to warrant an upgrade**, and Horizons takes exactly one object per request. (Verified: a comma-separated `COMMAND` returns HTTP 200 with a valid record for the **first** object only and silently drops the rest, so a naive batch would have looked like it worked.)

**The bake is incremental and seeds from the live site**, which makes the published assets their own CI state, with no `actions/cache` to be evicted between deploys that may be weeks apart. Entries carry their own `FetchedUtc` and are re-resolved on a per-comet TTL tiered by peak-ish magnitude `M1 + K1*log10(q)` (the planner's own candidacy gate, not a new threshold):

| Peak magnitude | TTL | Comets |
|---|---|---:|
| <= 12 | daily | 16 |
| <= 15 | weekly | 63 |
| <= 18 | monthly | 209 |
| fainter / no M1,K1 | fetch once | 230 |

About 30 requests on a day that deploys, against 518 for a bake that re-resolved everything. **The tiers are a relevance budget, not physics** - osculating elements decay with time, so a magnitude-19 comet's set goes stale exactly as fast as 45P's; brightness only sets how much along-track error is worth a request.

**Nothing detects the host.** Both assets are plain same-origin URLs, so a dev server 404s them and degrades along exactly the path a seed-less host takes, rather than down a branch production never exercises. That is also why fix 1 is still needed after fix 2.

**A tool rather than curl + jq**, because both halves need our own code: staleness is `CometElements.IsElementSetStale` and the reply needs `HorizonsCometSource`'s parser. It also takes the SBDB query string from `SbdbCometSource.DefaultQueryUrl` instead of restating it in YAML under a "keep them in sync" comment.

## Verification

- Run against **live JPL**: a cold bake resolves 518 candidates; a re-run seeded from its own output drops to 515 due, so it converges. 5D/Brorsen is now baked.
- New tests: sealed seed never asks (with an **expired** entry, so the TTL cannot be what stops it), the same seed unsealed still upgrades live (which keeps the first honest), and a failed fetch is not retried until its cooldown expires.
- Suite green on the **CI package path** (`-p:UseLocalSiblings=false`, so DIR.Lib 7.29 from NuGet rather than a dirty sibling working copy): **4212 unit + 338 functional, 0 failures**.

## Not in scope

Seeding the **desktop** release with the same overlay (unsealed, so it still refreshes). The seam is here already, but it needs a file-backed seed source and would put a JPL round-trip on every release build. Worth doing for the offline dark-site case, as its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YYnrhjBmgaqrqrXn7tZaoP
