### PR TITLE
Cull the web star field on magnitude and sky region instead of drawing all 2.5M every frame

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1792,6 +1792,34 @@ frame and draw any reticle/rings on top after `Render` returns. **`LiveFramePrev
 must be non-empty + channel-sized** -- the renderer's `ComputePostStretchBackground` indexes `[0]`
 unconditionally (an empty array crashed the GUI; pinned by `LiveFramePreviewSourceTests`).
 
+### The star field is ALWAYS drawn as a magnitude prefix, never as the whole buffer
+
+`StarMagnitudeIndex` (`TianWen.UI.Abstractions`) is the one implementation: sort a star buffer
+brightest-first at build time, index it into a 0.5-mag prefix table, and let the draw be a smaller
+instance count at `SkyMapState.EffectiveMagnitudeLimit`. No per-frame CPU pass, no re-upload.
+
+- **Submitting the whole ~2.5M-star Tycho-2 buffer every frame is not merely slow.** On the desktop
+  the unbounded form **TDR'd an Adreno X1-85**, which is why `VkSkyMapPipeline` has culled for a
+  while. The WebGL pipeline was written without it and the deployed atlas paid for it: a trace of a
+  real drag showed the GPU process 59% busy and **944 of 1287 frames dropped**. Fixed by sharing the
+  arithmetic rather than reimplementing it.
+- **Measured on the real catalog** (`StarMagnitudeIndexTests`, 2,557,481 stars): V<=6 draws 5,043
+  instances (0.20%), V<=8.5 (the default 60-degree FOV) draws 78,422 (3.07%), V<=12 draws 2,084,175
+  (81.49%).
+- **A limit past the last bin must clamp to "everything", never wrap to zero** -- the effective limit
+  climbs with zoom and readily exceeds the table's 15-magnitude span, and zero there blanks the star
+  field at exactly the zoom the user cares about. Pinned by a `[Theory]`.
+- **The sort is allocation-free and must stay that way**: the buffer is reinterpreted as 5-float
+  records (`MemoryMarshal.Cast`) and sorted in place with a **struct** comparer, so there is no index
+  array and no scatter buffer. The obvious index-sort-then-scatter form costs ~70 MB of transient
+  arrays at exactly the moment the user is waiting for the atlas, which on single-threaded WASM is
+  not free. `VisibleCount` is the only per-frame member and is an array index plus a clamp.
+- **Vulkan culls per spatial chunk, WebGL over the whole buffer**, and that asymmetry is a WebGL2
+  limitation, not a preference: there is no base-instance, so a chunked draw needs an instance-offset
+  API `WebGl.Renderer` does not have yet. Consequence: a deep zoom on web still submits most of the
+  catalog (see the table). The cone cull is the remaining refinement, tracked in
+  [docs/plans/web-tycho2.md](docs/plans/web-tycho2.md).
+
 ### Sky Map / FITS Viewer GLSL (pre-baked SPIR-V, no runtime shaderc)
 
 TianWen.UI.Shared's Vulkan shaders (`VkFitsImagePipeline`, `VkSkyMapPipeline`) are authored as GLSL

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1792,11 +1792,17 @@ frame and draw any reticle/rings on top after `Render` returns. **`LiveFramePrev
 must be non-empty + channel-sized** -- the renderer's `ComputePostStretchBackground` indexes `[0]`
 unconditionally (an empty array crashed the GUI; pinned by `LiveFramePreviewSourceTests`).
 
-### The star field is ALWAYS drawn as a magnitude prefix, never as the whole buffer
+### The star field is culled on TWO axes, and both are load-bearing
 
-`StarMagnitudeIndex` (`TianWen.UI.Abstractions`) is the one implementation: sort a star buffer
-brightest-first at build time, index it into a 0.5-mag prefix table, and let the draw be a smaller
-instance count at `SkyMapState.EffectiveMagnitudeLimit`. No per-frame CPU pass, no re-upload.
+`StarMagnitudeIndex` + `StarChunkIndex` (`TianWen.UI.Abstractions`) are the one implementation, shared
+by `VkSkyMapPipeline` and `WebGlSkyMapPipeline`: group the buffer by sky region, sort brightest-first
+within each region and index it into a 0.5-mag prefix table, then draw only the regions the view cone
+reaches and only their prefix. No per-frame CPU pass, no re-upload.
+
+- **Neither axis covers the other.** Magnitude bounds a WIDE field (~3% of Tycho-2 at 60 degrees) and
+  stops bounding anything as the effective limit climbs with zoom (81% at V<=12); the cone bounds a
+  deep zoom and does nothing at full sky. Shipping only the magnitude half leaves a one-degree field
+  submitting ~2M instances for a patch of sky that holds almost none of them.
 
 - **Submitting the whole ~2.5M-star Tycho-2 buffer every frame is not merely slow.** On the desktop
   the unbounded form **TDR'd an Adreno X1-85**, which is why `VkSkyMapPipeline` has culled for a
@@ -1814,11 +1820,15 @@ instance count at `SkyMapState.EffectiveMagnitudeLimit`. No per-frame CPU pass, 
   array and no scatter buffer. The obvious index-sort-then-scatter form costs ~70 MB of transient
   arrays at exactly the moment the user is waiting for the atlas, which on single-threaded WASM is
   not free. `VisibleCount` is the only per-frame member and is an array index plus a clamp.
-- **Vulkan culls per spatial chunk, WebGL over the whole buffer**, and that asymmetry is a WebGL2
-  limitation, not a preference: there is no base-instance, so a chunked draw needs an instance-offset
-  API `WebGl.Renderer` does not have yet. Consequence: a deep zoom on web still submits most of the
-  catalog (see the table). The cone cull is the remaining refinement, tracked in
-  [docs/plans/web-tycho2.md](docs/plans/web-tycho2.md).
+- **A per-chunk draw needs an instance offset, and WebGL2 has no base-instance draw argument** (that is
+  desktop GL 4.2; WebGL2 never picked it up). Vulkan passes `firstInstance` to `vkCmdDraw`; the WebGL
+  backend expresses it by pointing the per-instance attributes at `firstInstance * iStride` before the
+  draw, added as `DrawInstanced(..., firstInstance)` in **WebGl.Renderer 1.24**. Equivalent for a
+  divisor-1 attribute, and free, because the draw re-binds those attributes anyway.
+- **The cone radius spans ~8 degrees on a 30x15-degree cell, on top of the distance to the nearest
+  chunk axis.** So a cull threshold narrower than the grid it culls correctly answers "nothing is
+  visible" — which reads as a broken cull if you assert against it. A test asserting the cull is tight
+  needs a view wider than the star spacing it is culling.
 
 ### Sky Map / FITS Viewer GLSL (pre-baked SPIR-V, no runtime shaderc)
 

--- a/docs/plans/web-tycho2.md
+++ b/docs/plans/web-tycho2.md
@@ -125,10 +125,18 @@ measured problem P1 surfaces.
    culled this way for a while -- there the unbounded form did not merely drop frames, it **TDR'd an
    Adreno X1-85**. That is the whole reason this is shared rather than reimplemented.
 
-   **Still open: the spatial cone cull at deep zoom.** The table above shows why -- past V~11 the
-   magnitude prefix stops bounding anything, and a 1-degree field still submits 80% of the catalog.
-   Vulkan solves it by drawing per spatial chunk with a `firstInstance` offset; WebGL2 has no
-   base-instance, so this needs an instance-offset draw in WebGl.Renderer first.
+7. **Spatial cone cull. SHIPPED**, in the same cut, because the table above shows the magnitude prefix
+   alone is not enough: past V~11 it stops bounding anything, so a 1-degree field would still submit
+   80% of the catalog for a patch of sky holding almost none of it. `StarChunkIndex` (Abstractions,
+   shared with Vulkan) groups the buffer into a 12x12 RA/Dec grid, sorts + indexes within each chunk,
+   and gives each a bounding cone; the draw submits only the chunks whose cone can meet the view cone,
+   and only their prefix. The two axes are complementary -- magnitude for a wide field, the cone for a
+   deep zoom -- and neither substitutes for the other.
+
+   This needed **WebGl.Renderer 1.24**: a per-chunk draw is an instance sub-range, and WebGL2 has no
+   base-instance draw argument (desktop GL 4.2 does). `DrawInstanced` now takes a `firstInstance` that
+   the JS side turns into a per-instance attribute byte offset -- equivalent for a divisor-1 attribute
+   and free, since the draw re-binds those attributes anyway.
 
 ## P2: parallel decode (measurement-gated)
 

--- a/docs/plans/web-tycho2.md
+++ b/docs/plans/web-tycho2.md
@@ -106,9 +106,29 @@ measured problem P1 surfaces.
    **split by magnitude**: HR for the brightest (better color/photometry) + tyc2 for mag > HR-limit.
    Pick (b) if HR's colors look better on the bright end; else (a) is simpler. Upload as a second
    persistent instance buffer + a second `DrawInstanced`, or rebuild the one buffer.
-6. **Zoom-aware mag limit.** 2.5M stars at full-sky zoom is visual mush + overdraw; gate the drawn
-   magnitude limit on zoom (the sky map already has a zoom-aware mag limit for markers) so only the
-   appropriate density draws per view.
+6. **Zoom-aware mag limit. SHIPPED** (it was missed on the first cut, and the deployed atlas paid for
+   it: a trace of a real drag showed the GPU process 59% busy and **944 of 1287 frames dropped**,
+   because every frame submitted all ~2.5M instances -- ~15M vertices -- whatever the view showed).
+   Both star buffers are sorted brightest-first at build time and indexed into a 0.5-mag prefix
+   table, so the draw at `SkyMapState.EffectiveMagnitudeLimit` is a smaller instance count and
+   nothing else: no per-frame CPU pass, no re-upload. Measured on the real catalog
+   (`StarMagnitudeIndexTests`, 2,557,481 stars):
+
+   | Limit | Instances | Share |
+   |---|---:|---:|
+   | V<=6 (zoomed out) | 5,043 | 0.20% |
+   | V<=8.5 (default 60 deg FOV) | 78,422 | 3.07% |
+   | V<=10 | 359,375 | 14.05% |
+   | V<=12 (deep zoom) | 2,084,175 | 81.49% |
+
+   The arithmetic is `StarMagnitudeIndex` in Abstractions, shared with `VkSkyMapPipeline`, which has
+   culled this way for a while -- there the unbounded form did not merely drop frames, it **TDR'd an
+   Adreno X1-85**. That is the whole reason this is shared rather than reimplemented.
+
+   **Still open: the spatial cone cull at deep zoom.** The table above shows why -- past V~11 the
+   magnitude prefix stops bounding anything, and a 1-degree field still submits 80% of the catalog.
+   Vulkan solves it by drawing per spatial chunk with a `firstInstance` offset; WebGL2 has no
+   base-instance, so this needs an instance-offset draw in WebGl.Renderer first.
 
 ## P2: parallel decode (measurement-gated)
 

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -591,7 +591,7 @@
          shape that cost SdlVulkan.Renderer its DrawTriangles override one release earlier, which is the
          second time this family has paid for the same mistake. 1.22 also resets the clip stack at the
          frame boundary and pins DIR.Lib as a FLOOR (ApplyClip does not exist before 7.27). -->
-    <PackageVersion Include="WebGl.Renderer" Version="1.23.*" />
+    <PackageVersion Include="WebGl.Renderer" Version="1.24.*" />
     <PackageVersion Include="SDL3-CS" Version="3.5.0-preview.20260213-150035" />
     <PackageVersion Include="SDL3-CS.Native" Version="3.5.0-preview.20260205-174353" />
     <!-- Canon DSLR. Both packages ship from the FC.SDK repo at one release line, so they move

--- a/src/TianWen.Lib.Tests/StarChunkIndexTests.cs
+++ b/src/TianWen.Lib.Tests/StarChunkIndexTests.cs
@@ -1,0 +1,188 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Shouldly;
+using TianWen.UI.Abstractions;
+using Xunit;
+
+namespace TianWen.Lib.Tests
+{
+    /// <summary>
+    /// The spatial half of the star cull. Magnitude bounds a wide field and stops bounding anything as
+    /// the limit climbs with zoom; the cone bounds a deep zoom and does nothing at full sky. Neither
+    /// covers the other, so both are pinned -- and the property that matters most is that culling
+    /// never LOSES a star that should have been drawn.
+    /// </summary>
+    public class StarChunkIndexTests
+    {
+        private const int Stride = SkyMapState.FloatsPerStar;
+
+        /// <summary>A star at a known sky position, with its identity encoded in the colour field so a
+        /// regrouping that scrambled records is detectable.</summary>
+        private static void Write(Span<float> verts, int index, double raHours, double decDeg, float mag)
+        {
+            var (x, y, z) = SkyMapState.RaDecToUnitVec(raHours, decDeg);
+            var b = index * Stride;
+            verts[b] = x;
+            verts[b + 1] = y;
+            verts[b + 2] = z;
+            verts[b + 3] = mag;
+            verts[b + 4] = index;
+        }
+
+        /// <summary>A spread over the whole sphere, magnitudes cycling so every chunk holds a mix.</summary>
+        private static float[] WholeSkyField(int perAxis = 24)
+        {
+            var verts = new float[perAxis * perAxis * Stride];
+            var i = 0;
+            for (var ra = 0; ra < perAxis; ra++)
+            {
+                for (var dec = 0; dec < perAxis; dec++)
+                {
+                    var raHours = 24.0 * ra / perAxis;
+                    var decDeg = -85.0 + 170.0 * dec / (perAxis - 1);
+                    Write(verts, i, raHours, decDeg, 1f + (i % 24) * 0.5f);
+                    i++;
+                }
+            }
+            return verts;
+        }
+
+        [Fact]
+        public void ChunksPartitionTheBufferExactlyWithNoGapsOrOverlap()
+        {
+            var verts = WholeSkyField();
+            var total = verts.Length / Stride;
+
+            var chunks = StarChunkIndex.Build(verts);
+
+            chunks.Length.ShouldBe(StarChunkIndex.ChunkCount);
+            chunks.Sum(c => (int)c.Count).ShouldBe(total, "every star must land in exactly one chunk");
+
+            // Ranges are contiguous and ascending, so an offset is a valid firstInstance into the buffer.
+            uint expectedOffset = 0;
+            foreach (var chunk in chunks.Where(c => c.Count > 0))
+            {
+                chunk.Offset.ShouldBe(expectedOffset);
+                expectedOffset += chunk.Count;
+            }
+            expectedOffset.ShouldBe((uint)total);
+        }
+
+        [Fact]
+        public void EveryStarSurvivesTheRegroupingWithItsRecordIntact()
+        {
+            var verts = WholeSkyField();
+            var total = verts.Length / Stride;
+
+            StarChunkIndex.Build(verts);
+
+            // The colour field carries each star's original index; regrouping must permute records,
+            // never split one across two.
+            var seen = new HashSet<int>();
+            for (var i = 0; i < total; i++)
+            {
+                var b = i * Stride;
+                var identity = (int)verts[b + 4];
+                seen.Add(identity).ShouldBeTrue($"star {identity} appears twice");
+
+                // Its unit vector must still be a unit vector -- a torn record would not be.
+                var len = MathF.Sqrt(verts[b] * verts[b] + verts[b + 1] * verts[b + 1] + verts[b + 2] * verts[b + 2]);
+                len.ShouldBe(1f, 1e-3f, $"star at slot {i} has a torn position");
+            }
+            seen.Count.ShouldBe(total);
+        }
+
+        [Fact]
+        public void EachChunkIsSortedBrightestFirstSoItsPrefixIsMeaningful()
+        {
+            var verts = WholeSkyField();
+
+            var chunks = StarChunkIndex.Build(verts);
+
+            foreach (var chunk in chunks.Where(c => c.Count > 1))
+            {
+                for (var i = 1; i < chunk.Count; i++)
+                {
+                    var prev = verts[(int)(chunk.Offset + i - 1) * Stride + 3];
+                    var cur = verts[(int)(chunk.Offset + i) * Stride + 3];
+                    cur.ShouldBeGreaterThanOrEqualTo(prev, $"chunk at {chunk.Offset} is not brightest-first");
+                }
+            }
+        }
+
+        /// <summary>
+        /// The safety property: at a whole-sky view with a limit past every star, the cull must submit
+        /// every instance. A cone test that is even slightly too tight shows up here as missing stars
+        /// rather than as anything that looks like an error.
+        /// </summary>
+        [Fact]
+        public void AWholeSkyViewDrawsEveryStar()
+        {
+            var verts = WholeSkyField();
+            var total = verts.Length / Stride;
+            var chunks = StarChunkIndex.Build(verts);
+
+            var (vx, vy, vz) = SkyMapState.RaDecToUnitVec(6.0, 20.0);
+            var drawn = chunks
+                .Where(c => c.Count > 0 && StarChunkIndex.IsVisible(c, vx, vy, vz, (float)double.DegreesToRadians(180.0)))
+                .Sum(c => (int)StarMagnitudeIndex.VisibleCount(c.MagBins, 30f));
+
+            drawn.ShouldBe(total);
+        }
+
+        /// <summary>
+        /// A zoomed-in view must reject most of the sky -- otherwise the cull compiles, passes the
+        /// safety test above, and buys nothing, which is exactly the state the web pipeline was in.
+        ///
+        /// <para>15 degrees, not 2: a chunk cone spans ~8 degrees on top of the ~10 degrees to the
+        /// nearest chunk axis, so at 2 degrees the correct answer is that NOTHING is visible. That is
+        /// not a bug -- this field's stars are 7 to 15 degrees apart, so a 2-degree field really does
+        /// contain none of them -- but it makes the test assert the cull is broken rather than tight.
+        /// The threshold has to be wider than the grid it is culling.</para>
+        /// </summary>
+        [Fact]
+        public void AZoomedInViewCullsMostOfTheSky()
+        {
+            var verts = WholeSkyField();
+            var chunks = StarChunkIndex.Build(verts);
+            var populated = chunks.Count(c => c.Count > 0);
+
+            var (vx, vy, vz) = SkyMapState.RaDecToUnitVec(6.0, 0.0);
+            var visible = chunks.Count(c => c.Count > 0
+                && StarChunkIndex.IsVisible(c, vx, vy, vz, (float)double.DegreesToRadians(15.0)));
+
+            visible.ShouldBeGreaterThan(0, "the view direction's own neighbourhood must survive");
+            visible.ShouldBeLessThan(populated / 4, $"only {visible} of {populated} chunks should survive a 15-degree view");
+        }
+
+        [Fact]
+        public void AChunkOnTheOppositeSideOfTheSkyIsNeverVisibleToANarrowView()
+        {
+            var verts = WholeSkyField();
+            var chunks = StarChunkIndex.Build(verts);
+            var (vx, vy, vz) = SkyMapState.RaDecToUnitVec(0.0, 0.0);
+
+            // The antipode's chunk: RA 12h, Dec 0.
+            var (ax, ay, az) = SkyMapState.RaDecToUnitVec(12.0, 0.0);
+            var antipodal = chunks.Where(c => c.Count > 0)
+                .OrderByDescending(c => c.ConeX * ax + c.ConeY * ay + c.ConeZ * az)
+                .First();
+
+            StarChunkIndex.IsVisible(antipodal, vx, vy, vz, (float)double.DegreesToRadians(5.0)).ShouldBeFalse();
+        }
+
+        [Fact]
+        public void AnEmptyBufferProducesAFullyCulledChunkTable()
+        {
+            var chunks = StarChunkIndex.Build([]);
+
+            chunks.Length.ShouldBe(StarChunkIndex.ChunkCount);
+            chunks.ShouldAllBe(c => c.Count == 0);
+        }
+
+        [Fact]
+        public void APartialRecordThrowsRatherThanRegroupingGarbage()
+            => Should.Throw<ArgumentException>(() => StarChunkIndex.Build(new float[Stride + 2]));
+    }
+}

--- a/src/TianWen.Lib.Tests/StarMagnitudeIndexTests.cs
+++ b/src/TianWen.Lib.Tests/StarMagnitudeIndexTests.cs
@@ -1,0 +1,222 @@
+using System;
+using System.IO;
+using System.Linq;
+using Shouldly;
+using TianWen.Lib.Astrometry.Catalogs;
+using TianWen.UI.Abstractions;
+using Xunit;
+
+namespace TianWen.Lib.Tests
+{
+    /// <summary>
+    /// The magnitude-prefix cull both sky-map pipelines draw through. The invariant that matters is
+    /// simple to state and expensive to get wrong: after sorting, the stars at or above a magnitude
+    /// limit are exactly the first N instances, so a draw can be bounded by a count alone.
+    /// </summary>
+    public class StarMagnitudeIndexTests(ITestOutputHelper output)
+    {
+        private const int Stride = SkyMapState.FloatsPerStar;
+
+        /// <summary>Builds a star buffer whose non-magnitude fields encode the star's identity, so a
+        /// sort that moved a magnitude without its payload is detectable.</summary>
+        private static float[] Buffer(params float[] magnitudes)
+        {
+            var verts = new float[magnitudes.Length * Stride];
+            for (var i = 0; i < magnitudes.Length; i++)
+            {
+                var b = i * Stride;
+                verts[b] = i;            // x  \
+                verts[b + 1] = i * 10;   // y   > identity payload
+                verts[b + 2] = i * 100;  // z  /
+                verts[b + 3] = magnitudes[i];
+                verts[b + 4] = i * 1000; // colour index
+            }
+            return verts;
+        }
+
+        private static float MagnitudeAt(ReadOnlySpan<float> verts, int star) => verts[star * Stride + 3];
+
+        [Fact]
+        public void SortingOrdersStarsBrightestFirst()
+        {
+            var verts = Buffer(7.5f, 2.0f, 11.25f, 0.5f, 4.0f);
+
+            StarMagnitudeIndex.SortBrightestFirst(verts);
+
+            Enumerable.Range(0, 5).Select(i => MagnitudeAt(verts, i))
+                .ShouldBe([0.5f, 2.0f, 4.0f, 7.5f, 11.25f]);
+        }
+
+        /// <summary>
+        /// The failure this guards is the classic one for a key-and-payload sort: the magnitudes come
+        /// out ordered while the positions and colours stay put, which renders as a correctly-culled
+        /// field of stars in all the wrong places. Every field is checked against the identity the
+        /// star was built with.
+        /// </summary>
+        [Fact]
+        public void SortingCarriesEachStarsWholeRecordWithIt()
+        {
+            var verts = Buffer(7.5f, 2.0f, 11.25f, 0.5f, 4.0f);
+
+            StarMagnitudeIndex.SortBrightestFirst(verts);
+
+            // Brightest-first order of the original indices: 3 (0.5), 1 (2.0), 4 (4.0), 0 (7.5), 2 (11.25)
+            foreach (var (position, original) in new[] { (0, 3), (1, 1), (2, 4), (3, 0), (4, 2) })
+            {
+                var b = position * Stride;
+                verts[b].ShouldBe(original);
+                verts[b + 1].ShouldBe(original * 10);
+                verts[b + 2].ShouldBe(original * 100);
+                verts[b + 4].ShouldBe(original * 1000);
+            }
+        }
+
+        [Fact]
+        public void VisibleCountIsThePrefixOfStarsAtOrAboveTheLimit()
+        {
+            var verts = Buffer(0.5f, 2.0f, 4.0f, 7.5f, 11.25f);
+            StarMagnitudeIndex.SortBrightestFirst(verts);
+            var bins = StarMagnitudeIndex.ComputeBins(verts);
+
+            StarMagnitudeIndex.VisibleCount(bins, 0.5f).ShouldBe(1u);
+            StarMagnitudeIndex.VisibleCount(bins, 2.0f).ShouldBe(2u);
+            StarMagnitudeIndex.VisibleCount(bins, 4.0f).ShouldBe(3u);
+            StarMagnitudeIndex.VisibleCount(bins, 8.5f).ShouldBe(4u);
+            StarMagnitudeIndex.VisibleCount(bins, 12.0f).ShouldBe(5u);
+        }
+
+        /// <summary>
+        /// A limit past the last bin must mean "everything", not "nothing". The sky map's
+        /// <see cref="SkyMapState.EffectiveMagnitudeLimit"/> climbs with zoom and readily exceeds the
+        /// table's 15-magnitude span, and a wrap to zero there would blank the star field at exactly
+        /// the zoom where the user is looking hardest.
+        /// </summary>
+        [Theory]
+        [InlineData(15.0f)]
+        [InlineData(20.0f)]
+        [InlineData(1000.0f)]
+        public void ALimitBeyondTheTableDrawsEverything(float limit)
+        {
+            var verts = Buffer(0.5f, 2.0f, 4.0f, 7.5f, 11.25f);
+            StarMagnitudeIndex.SortBrightestFirst(verts);
+
+            StarMagnitudeIndex.VisibleCount(StarMagnitudeIndex.ComputeBins(verts), limit).ShouldBe(5u);
+        }
+
+        [Fact]
+        public void ALimitBrighterThanEveryStarDrawsNothing()
+        {
+            var verts = Buffer(6.0f, 7.0f, 8.0f);
+            StarMagnitudeIndex.SortBrightestFirst(verts);
+
+            StarMagnitudeIndex.VisibleCount(StarMagnitudeIndex.ComputeBins(verts), 0.5f).ShouldBe(0u);
+        }
+
+        /// <summary>
+        /// A length that is not a whole number of records must fail loudly. The cast underneath
+        /// truncates, so the quiet outcome would be a sorted prefix with a stale tail still holding
+        /// another star's fields: a plausible-looking field with stars in the wrong places, no crash,
+        /// and nothing pointing at the caller that computed the length wrong.
+        /// </summary>
+        [Theory]
+        [InlineData(1)]
+        [InlineData(4)]
+        [InlineData(6)]
+        [InlineData(11)]
+        public void APartialRecordThrowsInsteadOfBeingSilentlyDropped(int length)
+        {
+            var verts = new float[length];
+
+            Should.Throw<ArgumentException>(() => StarMagnitudeIndex.SortBrightestFirst(verts));
+            Should.Throw<ArgumentException>(() => StarMagnitudeIndex.ComputeBins(verts));
+        }
+
+        [Fact]
+        public void AnEmptyBufferIndexesAndCullsWithoutThrowing()
+        {
+            var verts = Array.Empty<float>();
+
+            StarMagnitudeIndex.SortBrightestFirst(verts);
+            var bins = StarMagnitudeIndex.ComputeBins(verts);
+
+            bins.Length.ShouldBe(StarMagnitudeIndex.BinCount);
+            StarMagnitudeIndex.VisibleCount(bins, 8.5f).ShouldBe(0u);
+            StarMagnitudeIndex.VisibleCount([], 8.5f).ShouldBe(0u);
+        }
+
+        /// <summary>
+        /// The property the pipelines actually rely on, over a spread wide enough to exercise every
+        /// bin boundary: the culled prefix is exactly the set of stars at or above the limit, so no
+        /// star that should be drawn is dropped and none that should not is drawn.
+        /// </summary>
+        [Fact]
+        public void ThePrefixMatchesADirectCountAtEveryBinBoundary()
+        {
+            var magnitudes = Enumerable.Range(0, 300).Select(i => i * 0.05f).ToArray();
+            var verts = Buffer(magnitudes);
+            StarMagnitudeIndex.SortBrightestFirst(verts);
+            var bins = StarMagnitudeIndex.ComputeBins(verts);
+
+            for (var bin = 1; bin <= StarMagnitudeIndex.BinCount; bin++)
+            {
+                var limit = bin * 0.5f;
+                var expected = (uint)magnitudes.Count(m => m <= limit);
+                StarMagnitudeIndex.VisibleCount(bins, limit).ShouldBe(expected, $"limit V<={limit}");
+            }
+        }
+
+        /// <summary>
+        /// The whole point of the cull, measured on the REAL catalog rather than a synthetic spread:
+        /// at the sky map's default limit the star draw must be a small fraction of the ~2.5M-star
+        /// buffer. The web pipeline used to submit every instance every frame regardless of the view,
+        /// which pinned the GPU process at 59% during a drag and dropped 944 of 1287 frames; on the
+        /// desktop the same unbounded form TDR'd an Adreno X1-85.
+        ///
+        /// <para>The bound is deliberately loose (a tenth of the catalog) because it is guarding
+        /// against the cull being lost or inverted, not pinning Tycho-2's magnitude distribution --
+        /// a catalog refresh must not turn this red. The measured figures are logged.</para>
+        /// </summary>
+        [Fact]
+        public void OnTheRealCatalogTheDefaultLimitDrawsASmallFractionOfTheBuffer()
+        {
+            var asm = typeof(ICelestialObjectDB).Assembly;
+            var name = asm.GetManifestResourceNames().FirstOrDefault(n => n.EndsWith(".tyc2.bin.lz", StringComparison.Ordinal));
+            name.ShouldNotBeNull("tyc2.bin.lz must be embedded in the (non-Lightweight) test build");
+
+            using var stream = asm.GetManifestResourceStream(name).ShouldNotBeNull();
+            using var ms = new MemoryStream();
+            stream.CopyTo(ms);
+
+            var db = new CelestialObjectDB();
+            db.TryLoadTycho2BulkFromCompressed(ms.ToArray()).ShouldBeTrue();
+
+            var total = ((ICelestialObjectDB)db).Tycho2StarCount;
+            var verts = new float[total * Stride];
+            var written = SkyMapState.FillTycho2StarVertices(db, dtJulianYears: 0.0, verts);
+            var span = verts.AsSpan(0, written * Stride);
+
+            StarMagnitudeIndex.SortBrightestFirst(span);
+            var bins = StarMagnitudeIndex.ComputeBins(span);
+
+            var atDefault = StarMagnitudeIndex.VisibleCount(bins, new SkyMapState().MagnitudeLimit);
+            output.WriteLine($"Tycho-2: {written} stars indexed");
+            foreach (var limit in new[] { 6.0f, 8.5f, 10.0f, 12.0f })
+            {
+                var n = StarMagnitudeIndex.VisibleCount(bins, limit);
+                output.WriteLine($"  V<={limit,-5} -> {n,9} instances ({100.0 * n / written:F2}% of the buffer)");
+            }
+
+            atDefault.ShouldBeGreaterThan(0u, "a cull that draws nothing is a blank sky, not a fast one");
+            atDefault.ShouldBeLessThan((uint)(written / 10), "the default limit must bound the draw well below the whole catalog");
+
+            // Sorted brightest-first is what makes the visible set a prefix at all.
+            for (var i = 1; i < written; i++)
+            {
+                if (MagnitudeAt(span, i) < MagnitudeAt(span, i - 1))
+                {
+                    Assert.Fail($"star buffer is not brightest-first at index {i}");
+                }
+            }
+        }
+    }
+}

--- a/src/TianWen.UI.Abstractions/StarChunkIndex.cs
+++ b/src/TianWen.UI.Abstractions/StarChunkIndex.cs
@@ -1,0 +1,173 @@
+using System;
+
+namespace TianWen.UI.Abstractions
+{
+    /// <summary>
+    /// One spatial chunk's slice of a chunk-grouped star buffer: its instance range
+    /// (<see cref="Offset"/> + <see cref="Count"/>), the per-chunk magnitude prefix table
+    /// (<see cref="StarMagnitudeIndex"/>), and a bounding cone (axis unit vector + angular radius in
+    /// radians) used to cull the whole chunk against the view cone before any of it is submitted.
+    /// </summary>
+    public readonly record struct StarChunk(
+        uint Offset, uint Count, uint[] MagBins,
+        float ConeX, float ConeY, float ConeZ, float ConeRadiusRad);
+
+    /// <summary>
+    /// Spatial chunking for a star-instance buffer: partition into a coarse RA/Dec grid, group the
+    /// buffer so each chunk is contiguous, then sort + magnitude-index within each chunk.
+    ///
+    /// <para><b>Why chunking is needed on top of the magnitude prefix.</b> The magnitude cull alone
+    /// bounds a WIDE view well (at the default 60-degree field it draws ~3% of Tycho-2), but it stops
+    /// bounding anything as the effective limit climbs: at V&lt;=12 the prefix is 81% of the catalog,
+    /// so a one-degree field still submits ~2M instances for a patch of sky that holds almost none of
+    /// them. The cone cull is what makes a deep zoom cheap -- it is the axis that magnitude cannot
+    /// cover, and vice versa.</para>
+    ///
+    /// <para>Surface-agnostic because both backends can now draw an instance sub-range: Vulkan via
+    /// <c>firstInstance</c>, WebGL via a per-instance attribute offset (WebGl.Renderer 1.24). The
+    /// geometry and the grouping have exactly one implementation.</para>
+    /// </summary>
+    public static class StarChunkIndex
+    {
+        /// <summary>RA slices (2h / 30 degrees each).</summary>
+        public const int GridCols = 12;
+
+        /// <summary>Dec slices (15 degrees each).</summary>
+        public const int GridRows = 12;
+
+        /// <summary>Chunks per buffer; the returned array is always this long.</summary>
+        public const int ChunkCount = GridCols * GridRows;
+
+        /// <summary>
+        /// Groups <paramref name="verts"/> by sky region IN PLACE and returns the per-chunk layout.
+        /// Every chunk is sorted brightest-first and carries its own magnitude prefix table, so a draw
+        /// is "for each visible chunk, submit its prefix".
+        /// </summary>
+        /// <exception cref="ArgumentException">
+        /// <paramref name="verts"/>'s length is not a multiple of the star record size.
+        /// </exception>
+        public static StarChunk[] Build(Span<float> verts)
+        {
+            // Same reason as StarMagnitudeIndex: integer division would quietly ignore a partial tail
+            // and regroup around it, and the result renders as a plausible sky rather than as an error.
+            StarMagnitudeIndex.EnsureWholeRecords(verts.Length, nameof(verts));
+
+            const int floatsPerStar = SkyMapState.FloatsPerStar;
+            var count = verts.Length / floatsPerStar;
+            var chunks = new StarChunk[ChunkCount];
+            if (count == 0)
+            {
+                return chunks; // every chunk Count == 0 -> all culled at draw
+            }
+
+            const float raCellDeg = 360f / GridCols;
+            const float decCellDeg = 180f / GridRows;
+            const float rad2deg = 180f / MathF.PI;
+
+            // 1. Assign each star to a chunk (RA column x Dec row) from its unit vector.
+            var chunkOf = new int[count];
+            var counts = new int[ChunkCount];
+            for (var i = 0; i < count; i++)
+            {
+                var b = i * floatsPerStar;
+                float x = verts[b], y = verts[b + 1], z = verts[b + 2];
+                var decDeg = MathF.Asin(Math.Clamp(z, -1f, 1f)) * rad2deg;            // [-90, 90]
+                var raDeg = MathF.Atan2(y, x) * rad2deg;                              // (-180, 180]
+                if (raDeg < 0f)
+                {
+                    raDeg += 360f;                                                    // [0, 360)
+                }
+                var col = Math.Clamp((int)(raDeg / raCellDeg), 0, GridCols - 1);
+                var row = Math.Clamp((int)((decDeg + 90f) / decCellDeg), 0, GridRows - 1);
+                var c = row * GridCols + col;
+                chunkOf[i] = c;
+                counts[c]++;
+            }
+
+            // 2. Prefix offsets: the instance index where each chunk begins in the grouped buffer.
+            var offsets = new int[ChunkCount];
+            for (int c = 0, running = 0; c < ChunkCount; c++)
+            {
+                offsets[c] = running;
+                running += counts[c];
+            }
+
+            // 3. Stable scatter into a chunk-grouped copy, then write it back over the input span.
+            var grouped = new float[count * floatsPerStar];
+            var cursor = (int[])offsets.Clone();
+            for (var i = 0; i < count; i++)
+            {
+                var dst = cursor[chunkOf[i]]++ * floatsPerStar;
+                verts.Slice(i * floatsPerStar, floatsPerStar).CopyTo(grouped.AsSpan(dst, floatsPerStar));
+            }
+            grouped.AsSpan().CopyTo(verts);
+
+            // 4. Per chunk: sort by magnitude, then compute prefix bins + bounding cone.
+            for (var c = 0; c < ChunkCount; c++)
+            {
+                var n = counts[c];
+                if (n == 0)
+                {
+                    chunks[c] = new StarChunk(0, 0, [], 0f, 0f, 1f, 0f);
+                    continue;
+                }
+                var sub = verts.Slice(offsets[c] * floatsPerStar, n * floatsPerStar);
+                StarMagnitudeIndex.SortBrightestFirst(sub);
+                var bins = StarMagnitudeIndex.ComputeBins(sub);
+                var (cx, cy, cz, radRad) = ComputeCone(sub, floatsPerStar);
+                chunks[c] = new StarChunk((uint)offsets[c], (uint)n, bins, cx, cy, cz, radRad);
+            }
+            return chunks;
+        }
+
+        /// <summary>
+        /// Whether a chunk can contribute to a view: false only when the angular separation of the two
+        /// cone axes exceeds the sum of their radii, i.e. the cones provably cannot intersect.
+        ///
+        /// <para>Rotation-invariant, so it is correct in equatorial AND horizon mode without the
+        /// caller knowing which. The view axis is the look-at direction and the view radius should be
+        /// the FULL field of view -- generous enough to cover the viewport diagonal at any reasonable
+        /// aspect, so chunks never pop in and out at the screen edges.</para>
+        /// </summary>
+        public static bool IsVisible(in StarChunk chunk, float viewX, float viewY, float viewZ, float viewRadiusRad)
+        {
+            var dot = viewX * chunk.ConeX + viewY * chunk.ConeY + viewZ * chunk.ConeZ;
+            var sep = MathF.Acos(Math.Clamp(dot, -1f, 1f));
+            return sep <= viewRadiusRad + chunk.ConeRadiusRad;
+        }
+
+        /// <summary>
+        /// Bounding cone for a chunk's stars: axis = the normalized mean of the member unit vectors,
+        /// radius = the maximum angular distance (radians) from that axis to any member.
+        /// </summary>
+        private static (float X, float Y, float Z, float RadiusRad) ComputeCone(
+            ReadOnlySpan<float> span, int floatsPerStar)
+        {
+            var n = span.Length / floatsPerStar;
+            double sx = 0, sy = 0, sz = 0;
+            for (var i = 0; i < n; i++)
+            {
+                var b = i * floatsPerStar;
+                sx += span[b]; sy += span[b + 1]; sz += span[b + 2];
+            }
+            var len = Math.Sqrt(sx * sx + sy * sy + sz * sz);
+            if (len < 1e-9)
+            {
+                return (0f, 0f, 1f, MathF.PI); // antipodal cancellation -> whole-sky cone, never culled
+            }
+            float ax = (float)(sx / len), ay = (float)(sy / len), az = (float)(sz / len);
+
+            var minDot = 1f;
+            for (var i = 0; i < n; i++)
+            {
+                var b = i * floatsPerStar;
+                var dot = ax * span[b] + ay * span[b + 1] + az * span[b + 2];
+                if (dot < minDot)
+                {
+                    minDot = dot;
+                }
+            }
+            return (ax, ay, az, MathF.Acos(Math.Clamp(minDot, -1f, 1f)));
+        }
+    }
+}

--- a/src/TianWen.UI.Abstractions/StarMagnitudeIndex.cs
+++ b/src/TianWen.UI.Abstractions/StarMagnitudeIndex.cs
@@ -1,0 +1,153 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace TianWen.UI.Abstractions
+{
+    /// <summary>
+    /// Magnitude-prefix indexing over a flat star-instance buffer: sort brightest-first once, then
+    /// answer "how many instances are at or above this magnitude limit" as an array lookup.
+    ///
+    /// <para><b>Why this exists.</b> The Tycho-2 star buffer holds ~2.5 million instances. Submitting
+    /// all of them every frame is unbounded GPU work that does not shrink when the view does, and at
+    /// a typical field most of those stars are below the magnitude limit and contribute nothing.
+    /// The unbounded form is not merely slow: it <b>TDR'd an Adreno X1-85</b> on the desktop path,
+    /// which is why <see cref="VkSkyMapPipeline"/> already culls this way. Sorting brightest-first
+    /// makes the visible set a PREFIX of the buffer, so the cull costs one lookup and a smaller draw
+    /// count -- no per-frame CPU pass, no re-upload, nothing to keep in sync.</para>
+    ///
+    /// <para>Surface-agnostic on purpose: the Vulkan pipeline applies these per spatial chunk (it can
+    /// offset a draw by <c>firstInstance</c>), while the WebGL pipeline applies them across the whole
+    /// buffer (WebGL2 has no base-instance, so it draws one prefix). Same primitives, different
+    /// granularity -- and the magnitude arithmetic has exactly one implementation.</para>
+    /// </summary>
+    public static class StarMagnitudeIndex
+    {
+        /// <summary>Bin count: V 0..15 in 0.5-magnitude steps.</summary>
+        public const int BinCount = 30;
+
+        /// <summary>
+        /// One star exactly as <see cref="SkyMapState.FloatsPerStar"/> lays it out, so a star buffer
+        /// can be reinterpreted as records instead of being indexed by hand. Blittable and exactly
+        /// 20 bytes, which is what makes the <see cref="MemoryMarshal.Cast{TFrom, TTo}(Span{TFrom})"/>
+        /// below a free reinterpretation rather than a copy.
+        /// </summary>
+        [StructLayout(LayoutKind.Sequential)]
+        private readonly struct StarRecord
+        {
+            public readonly float X;
+            public readonly float Y;
+            public readonly float Z;
+            public readonly float Magnitude;
+            public readonly float ColourIndex;
+        }
+
+        /// <summary>
+        /// A STRUCT comparer, used with the generic <c>Sort&lt;T, TComparer&gt;</c> overload so it is
+        /// constrained rather than boxed. A <see cref="Comparison{T}"/> would be wrapped in a class
+        /// internally, which is the one allocation this whole approach exists to avoid.
+        /// </summary>
+        private readonly struct ByMagnitude : IComparer<StarRecord>
+        {
+            public int Compare(StarRecord a, StarRecord b) => a.Magnitude.CompareTo(b.Magnitude);
+        }
+
+        /// <summary>
+        /// Sorts a star buffer brightest-first, in place and <b>without allocating</b>.
+        ///
+        /// <para>This runs on the buffer build (once per catalog load, off the render thread), not per
+        /// frame -- but the buffer is ~2.5 million stars, so the obvious index-sort-then-scatter form
+        /// costs ~70 MB of transient arrays at exactly the moment the user is waiting for the atlas,
+        /// and on single-threaded WASM that is not free. Reinterpreting the floats as records lets
+        /// <c>Span.Sort</c> do it in place with a struct comparer: no index array, no scatter buffer,
+        /// no GC pressure.</para>
+        ///
+        /// <para>Throws on a span that is not a whole number of records -- see
+        /// <see cref="EnsureWholeRecords"/> for why that is not merely pedantic.</para>
+        /// </summary>
+        /// <exception cref="ArgumentException">
+        /// <paramref name="span"/>'s length is not a multiple of the record size.
+        /// </exception>
+        public static void SortBrightestFirst(Span<float> span)
+        {
+            EnsureWholeRecords(span.Length, nameof(span));
+            MemoryMarshal.Cast<float, StarRecord>(span).Sort(default(ByMagnitude));
+        }
+
+        /// <summary>
+        /// Rejects a span that is not a whole number of star records.
+        ///
+        /// <para><b>Why this throws instead of coping.</b> <see cref="MemoryMarshal.Cast{TFrom, TTo}(Span{TFrom})"/>
+        /// TRUNCATES: a span of 12 floats reinterprets as 2 records and the trailing 2 floats are
+        /// simply not there. Nothing fails. The sort then reorders the records it can see while those
+        /// trailing floats stay where they are, so they end up describing a different star than the
+        /// one whose fields precede them, and <see cref="ComputeBins"/> indexes a buffer that no
+        /// longer matches what will be drawn. The symptom is a plausible-looking star field with
+        /// stars in the wrong places -- not a crash, not a blank screen, and nothing that points at
+        /// the caller who computed a length wrong. A bad length here is always a programming error
+        /// (every caller derives it from a star count), so failing loudly at the boundary is strictly
+        /// better than rendering a subtly wrong sky.</para>
+        ///
+        /// <para>The unit comes from the record type itself rather than from
+        /// <see cref="SkyMapState.FloatsPerStar"/>, so it is by construction the same unit the cast
+        /// truncates on and cannot drift from it.</para>
+        /// </summary>
+        private static void EnsureWholeRecords(int length, string paramName)
+        {
+            var floatsPerRecord = Unsafe.SizeOf<StarRecord>() / sizeof(float);
+            if (length % floatsPerRecord != 0)
+            {
+                throw new ArgumentException(
+                    $"Star buffer length {length} is not a whole number of {floatsPerRecord}-float records; "
+                    + "the partial tail would be silently dropped and left describing the wrong star.",
+                    paramName);
+            }
+        }
+
+        /// <summary>
+        /// Builds the magnitude to instance-count lookup from a buffer already sorted by
+        /// <see cref="SortBrightestFirst"/>. Allocates only the 30-entry table it returns.
+        /// </summary>
+        /// <exception cref="ArgumentException">
+        /// <paramref name="sortedSpan"/>'s length is not a multiple of the record size.
+        /// </exception>
+        public static uint[] ComputeBins(ReadOnlySpan<float> sortedSpan)
+        {
+            EnsureWholeRecords(sortedSpan.Length, nameof(sortedSpan));
+            var records = MemoryMarshal.Cast<float, StarRecord>(sortedSpan);
+            var magBins = new uint[BinCount];
+
+            uint idx = 0;
+            for (var bin = 0; bin < BinCount; bin++)
+            {
+                var magThreshold = (bin + 1) * 0.5f;
+                while (idx < records.Length && records[(int)idx].Magnitude <= magThreshold)
+                {
+                    idx++;
+                }
+                magBins[bin] = idx;
+            }
+            return magBins;
+        }
+
+        /// <summary>
+        /// Instances to draw for the given magnitude limit. Because the buffer is sorted
+        /// brightest-first this is a prefix count, so the caller draws instances <c>[0, n)</c>.
+        /// A limit beyond the last bin clamps to "everything indexed", never to zero.
+        ///
+        /// <para>This is the only member on the per-frame path (once per visible chunk on Vulkan, once
+        /// per buffer on WebGL) and it is an array index plus a clamp -- no allocation, nothing to
+        /// pool. The sort and the bin build above are one-time buffer-build work.</para>
+        /// </summary>
+        public static uint VisibleCount(uint[] magBins, float magLimit)
+        {
+            if (magBins.Length == 0)
+            {
+                return 0;
+            }
+            var bin = Math.Clamp((int)(magLimit * 2) - 1, 0, magBins.Length - 1);
+            return magBins[bin];
+        }
+    }
+}

--- a/src/TianWen.UI.Abstractions/StarMagnitudeIndex.cs
+++ b/src/TianWen.UI.Abstractions/StarMagnitudeIndex.cs
@@ -93,7 +93,7 @@ namespace TianWen.UI.Abstractions
         /// <see cref="SkyMapState.FloatsPerStar"/>, so it is by construction the same unit the cast
         /// truncates on and cannot drift from it.</para>
         /// </summary>
-        private static void EnsureWholeRecords(int length, string paramName)
+        internal static void EnsureWholeRecords(int length, string paramName)
         {
             var floatsPerRecord = Unsafe.SizeOf<StarRecord>() / sizeof(float);
             if (length % floatsPerRecord != 0)

--- a/src/TianWen.UI.Shared/VkSkyMapPipeline.cs
+++ b/src/TianWen.UI.Shared/VkSkyMapPipeline.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Numerics;
 using System.Runtime.CompilerServices;
@@ -131,9 +131,6 @@ public sealed unsafe class VkSkyMapPipeline : IDisposable
     // magnitude-prefix -- so a deep zoom touches a handful of chunks instead of
     // streaming the whole catalog to the GPU (the unbounded version TDR'd the
     // Adreno X1-85, which froze the UI thread in the swapchain-recovery path).
-    private const int StarGridCols = 12;                  // RA slices  (2h / 30deg each)
-    private const int StarGridRows = 12;                  // Dec slices (15deg each)
-    private const int StarChunkCount = StarGridCols * StarGridRows;
     private StarChunk[] _starChunks = [];
 #if DEBUG
     // Slow-frame attribution: the star draw is GPU-side (instanced quads), so its cost never
@@ -196,17 +193,6 @@ public sealed unsafe class VkSkyMapPipeline : IDisposable
     /// (and either install or get discarded as stale) before starting.
     /// </summary>
     private Task<StarBuildResult>? _starRebuildTask;
-
-    /// <summary>
-    /// One spatial chunk's slice of the contiguous star buffer: its instance range
-    /// (<see cref="Offset"/> + <see cref="Count"/> within the magnitude-sorted, chunk-grouped
-    /// buffer), the per-chunk magnitude -> prefix-count lookup (brightest-first, same 0.5-mag
-    /// bins as the old global table), and a bounding cone (axis unit vector + angular radius in
-    /// radians) used to cull the chunk against the view cone at draw time.
-    /// </summary>
-    private readonly record struct StarChunk(
-        uint Offset, uint Count, uint[] MagBins,
-        float ConeX, float ConeY, float ConeZ, float ConeRadiusRad);
 
     /// <summary>
     /// Output of an async star-buffer rebuild: a flat float[] of star vertices
@@ -353,7 +339,7 @@ public sealed unsafe class VkSkyMapPipeline : IDisposable
             var tycCount = db.Tycho2StarCount;
             var verts = new float[tycCount * floatsPerStar];
             var written = SkyMapState.FillTycho2StarVertices(db, dtYr, verts);
-            var chunks = ChunkAndSortStars(verts.AsSpan(0, written * floatsPerStar), floatsPerStar);
+            var chunks = StarChunkIndex.Build(verts.AsSpan(0, written * floatsPerStar));
             System.Console.Error.WriteLine(
                 $"[VkSkyMapPipeline] async star build month-key {monthKey} (dtYr={dtYr:F3}): " +
                 $"{sw.Elapsed.TotalMilliseconds:N0} ms incl. decode wait ({written} stars)");
@@ -697,11 +683,8 @@ public sealed unsafe class VkSkyMapPipeline : IDisposable
                     continue;
                 }
 
-                // View-cone cull: skip when the two cones cannot intersect, i.e. the angular
-                // separation of their axes exceeds the sum of their radii.
-                var dot = vx * chunk.ConeX + vy * chunk.ConeY + vz * chunk.ConeZ;
-                var sep = MathF.Acos(Math.Clamp(dot, -1f, 1f));
-                if (sep > viewRadiusRad + chunk.ConeRadiusRad)
+                // View-cone cull: skip when the two cones provably cannot intersect.
+                if (!StarChunkIndex.IsVisible(chunk, vx, vy, vz, viewRadiusRad))
                 {
                     continue;
                 }
@@ -836,117 +819,6 @@ public sealed unsafe class VkSkyMapPipeline : IDisposable
     // ────────────────────────────────────────────────── Geometry builders
 
     /// <summary>
-    /// Partitions the flat star vertex span into a coarse RA/Dec grid, reorders it in place so
-    /// each chunk's stars are contiguous, sorts each chunk brightest-first, and returns the
-    /// per-chunk layout (instance range + 0.5-mag prefix bins + bounding cone). The draw then
-    /// culls whole chunks by view cone and submits only each visible chunk's magnitude prefix,
-    /// bounding GPU work so a deep zoom can't stream the whole catalog and TDR the GPU.
-    /// </summary>
-    private static StarChunk[] ChunkAndSortStars(Span<float> verts, int floatsPerStar)
-    {
-        var count = verts.Length / floatsPerStar;
-        var chunks = new StarChunk[StarChunkCount];
-        if (count == 0)
-        {
-            return chunks; // every chunk Count == 0 -> all culled at draw
-        }
-
-        const float raCellDeg = 360f / StarGridCols;
-        const float decCellDeg = 180f / StarGridRows;
-        const float rad2deg = 180f / MathF.PI;
-
-        // 1. Assign each star to a chunk (RA column x Dec row) from its unit vector.
-        var chunkOf = new int[count];
-        var counts = new int[StarChunkCount];
-        for (var i = 0; i < count; i++)
-        {
-            var b = i * floatsPerStar;
-            float x = verts[b], y = verts[b + 1], z = verts[b + 2];
-            var decDeg = MathF.Asin(Math.Clamp(z, -1f, 1f)) * rad2deg;            // [-90, 90]
-            var raDeg = MathF.Atan2(y, x) * rad2deg;                              // (-180, 180]
-            if (raDeg < 0f)
-            {
-                raDeg += 360f;                                                    // [0, 360)
-            }
-            var col = Math.Clamp((int)(raDeg / raCellDeg), 0, StarGridCols - 1);
-            var row = Math.Clamp((int)((decDeg + 90f) / decCellDeg), 0, StarGridRows - 1);
-            var c = row * StarGridCols + col;
-            chunkOf[i] = c;
-            counts[c]++;
-        }
-
-        // 2. Prefix offsets: the instance index where each chunk begins in the grouped buffer.
-        var offsets = new int[StarChunkCount];
-        for (int c = 0, running = 0; c < StarChunkCount; c++)
-        {
-            offsets[c] = running;
-            running += counts[c];
-        }
-
-        // 3. Stable scatter into a chunk-grouped copy, then write it back over the input span.
-        var grouped = new float[count * floatsPerStar];
-        var cursor = (int[])offsets.Clone();
-        for (var i = 0; i < count; i++)
-        {
-            var dst = cursor[chunkOf[i]]++ * floatsPerStar;
-            verts.Slice(i * floatsPerStar, floatsPerStar).CopyTo(grouped.AsSpan(dst, floatsPerStar));
-        }
-        grouped.AsSpan().CopyTo(verts);
-
-        // 4. Per chunk: sort by magnitude, then compute prefix bins + bounding cone.
-        for (var c = 0; c < StarChunkCount; c++)
-        {
-            var n = counts[c];
-            if (n == 0)
-            {
-                chunks[c] = new StarChunk(0, 0, [], 0f, 0f, 1f, 0f);
-                continue;
-            }
-            var sub = verts.Slice(offsets[c] * floatsPerStar, n * floatsPerStar);
-            StarMagnitudeIndex.SortBrightestFirst(sub);
-            var bins = StarMagnitudeIndex.ComputeBins(sub);
-            var (cx, cy, cz, radRad) = ComputeChunkCone(sub, floatsPerStar);
-            chunks[c] = new StarChunk((uint)offsets[c], (uint)n, bins, cx, cy, cz, radRad);
-        }
-        return chunks;
-    }
-
-    /// <summary>
-    /// Bounding cone for a chunk's stars: axis = the normalized mean of the member unit vectors,
-    /// radius = the maximum angular distance (radians) from that axis to any member. Drives the
-    /// rotation-invariant view-cone cull in <see cref="Draw"/> (correct in equatorial + horizon).
-    /// </summary>
-    private static (float X, float Y, float Z, float RadiusRad) ComputeChunkCone(
-        ReadOnlySpan<float> span, int floatsPerStar)
-    {
-        var n = span.Length / floatsPerStar;
-        double sx = 0, sy = 0, sz = 0;
-        for (var i = 0; i < n; i++)
-        {
-            var b = i * floatsPerStar;
-            sx += span[b]; sy += span[b + 1]; sz += span[b + 2];
-        }
-        var len = Math.Sqrt(sx * sx + sy * sy + sz * sz);
-        if (len < 1e-9)
-        {
-            return (0f, 0f, 1f, MathF.PI); // antipodal cancellation -> whole-sky cone, never culled
-        }
-        float ax = (float)(sx / len), ay = (float)(sy / len), az = (float)(sz / len);
-
-        var minDot = 1f;
-        for (var i = 0; i < n; i++)
-        {
-            var b = i * floatsPerStar;
-            var dot = ax * span[b] + ay * span[b + 1] + az * span[b + 2];
-            if (dot < minDot)
-            {
-                minDot = dot;
-            }
-        }
-        return (ax, ay, az, MathF.Acos(Math.Clamp(minDot, -1f, 1f)));
-    }
-
-    /// <summary>
     /// Instant seed star buffer: just the ~1000 HIP stars referenced by the constellation
     /// figures (<see cref="ConstellationFigures.AllFigureStarHipNumbers"/>), so the figures sit
     /// on visible dots the moment the tab opens. Bounding to that set is what makes the seed
@@ -962,7 +834,7 @@ public sealed unsafe class VkSkyMapPipeline : IDisposable
         var floats = SkyMapGpuGeometry.BuildFigureStarInstances(db);
         _starCount = (uint)(floats.Count / SkyMapState.FloatsPerStar);
         var floatsSpan = System.Runtime.InteropServices.CollectionsMarshal.AsSpan(floats);
-        _starChunks = ChunkAndSortStars(floatsSpan, SkyMapState.FloatsPerStar);
+        _starChunks = StarChunkIndex.Build(floatsSpan);
         (_starBuffer, _starMemory) = _ctx.CreatePersistentVertexBuffer(floatsSpan);
     }
 

--- a/src/TianWen.UI.Shared/VkSkyMapPipeline.cs
+++ b/src/TianWen.UI.Shared/VkSkyMapPipeline.cs
@@ -707,7 +707,7 @@ public sealed unsafe class VkSkyMapPipeline : IDisposable
                 }
 
                 // Magnitude cull: only this chunk's brightest-first prefix at the current limit.
-                var n = GetVisibleStarCount(chunk.MagBins, effMag);
+                var n = StarMagnitudeIndex.VisibleCount(chunk.MagBins, effMag);
                 if (n == 0)
                 {
                     continue;
@@ -836,37 +836,6 @@ public sealed unsafe class VkSkyMapPipeline : IDisposable
     // ────────────────────────────────────────────────── Geometry builders
 
     /// <summary>
-    /// Sorts the flat star float array by the magnitude field (index 3 of each 5-float record).
-    /// Uses Array.Sort on a temporary index array to avoid copying 20-byte records.
-    /// </summary>
-    private static void SortStarsByMagnitude(Span<float> span, int floatsPerStar)
-    {
-        var count = span.Length / floatsPerStar;
-        if (count <= 1) return;
-
-        // Build index + magnitude arrays for sorting
-        var indices = new int[count];
-        var mags = new float[count];
-        for (var i = 0; i < count; i++)
-        {
-            indices[i] = i;
-            mags[i] = span[i * floatsPerStar + 3]; // vMag field
-        }
-
-        Array.Sort(mags, indices);
-
-        // Reorder the float data according to sorted indices
-        var sorted = new float[span.Length];
-        for (var i = 0; i < count; i++)
-        {
-            var srcOff = indices[i] * floatsPerStar;
-            var dstOff = i * floatsPerStar;
-            span.Slice(srcOff, floatsPerStar).CopyTo(sorted.AsSpan(dstOff, floatsPerStar));
-        }
-        sorted.AsSpan().CopyTo(span);
-    }
-
-    /// <summary>
     /// Partitions the flat star vertex span into a coarse RA/Dec grid, reorders it in place so
     /// each chunk's stars are contiguous, sorts each chunk brightest-first, and returns the
     /// per-chunk layout (instance range + 0.5-mag prefix bins + bounding cone). The draw then
@@ -934,8 +903,8 @@ public sealed unsafe class VkSkyMapPipeline : IDisposable
                 continue;
             }
             var sub = verts.Slice(offsets[c] * floatsPerStar, n * floatsPerStar);
-            SortStarsByMagnitude(sub, floatsPerStar);
-            var bins = ComputeMagBins(sub, floatsPerStar);
+            StarMagnitudeIndex.SortBrightestFirst(sub);
+            var bins = StarMagnitudeIndex.ComputeBins(sub);
             var (cx, cy, cz, radRad) = ComputeChunkCone(sub, floatsPerStar);
             chunks[c] = new StarChunk((uint)offsets[c], (uint)n, bins, cx, cy, cz, radRad);
         }
@@ -975,44 +944,6 @@ public sealed unsafe class VkSkyMapPipeline : IDisposable
             }
         }
         return (ax, ay, az, MathF.Acos(Math.Clamp(minDot, -1f, 1f)));
-    }
-
-    /// <summary>
-    /// Computes the magnitude → instance-count lookup table from a brightest-first sorted star
-    /// vertex span. 30 bins covering V 0..15 in 0.5-mag steps. Pure function so the async rebuild
-    /// can compute each chunk's table on a background thread.
-    /// </summary>
-    private static uint[] ComputeMagBins(ReadOnlySpan<float> sortedSpan, int floatsPerStar)
-    {
-        const int bins = 30;
-        var magBins = new uint[bins];
-        var count = (uint)(sortedSpan.Length / floatsPerStar);
-
-        uint idx = 0;
-        for (var bin = 0; bin < bins; bin++)
-        {
-            var magThreshold = (bin + 1) * 0.5f;
-            while (idx < count && sortedSpan[(int)(idx * floatsPerStar + 3)] <= magThreshold)
-            {
-                idx++;
-            }
-            magBins[bin] = idx;
-        }
-        return magBins;
-    }
-
-    /// <summary>
-    /// Number of star instances to draw from a chunk for the given magnitude limit. Stars are
-    /// sorted brightest-first within the chunk, so this is just the prefix count from its bins.
-    /// </summary>
-    private static uint GetVisibleStarCount(uint[] magBins, float magLimit)
-    {
-        if (magBins.Length == 0)
-        {
-            return 0;
-        }
-        var bin = Math.Clamp((int)(magLimit * 2) - 1, 0, magBins.Length - 1);
-        return magBins[bin];
     }
 
     /// <summary>

--- a/src/TianWen.UI.Web/SkyMap/WebGlSkyMapPipeline.cs
+++ b/src/TianWen.UI.Web/SkyMap/WebGlSkyMapPipeline.cs
@@ -324,6 +324,11 @@ namespace TianWen.UI.Web.SkyMap
         private GpuBufferHandle _stars;
         private int _starCount;
 
+        // Magnitude -> instance-count prefix tables for the two star buffers, both of which are kept
+        // sorted brightest-first so the draw can cull to a prefix. See the star draw in Draw.
+        private uint[] _starMagBins = [];
+        private uint[] _tycho2MagBins = [];
+
         // The full ~2.5M-star Tycho-2 field, lazily fetched + decoded on first atlas-open (the
         // ~30 MB catalog is stripped from the WASM bundle, so the browser host fetches it as a
         // static asset and hands the built instance buffer to SubmitTycho2Stars). Until it lands
@@ -335,6 +340,7 @@ namespace TianWen.UI.Web.SkyMap
         private bool _tycho2Applied;
         private float[]? _pendingTycho2Verts;
         private int _pendingTycho2Count;
+        private uint[] _pendingTycho2MagBins = [];
         private GpuBufferHandle _figures;
         private int _figureVertexCount;
         private GpuBufferHandle _boundaries;
@@ -397,7 +403,13 @@ namespace TianWen.UI.Web.SkyMap
             // Lightweight build has no Tycho-2, and HR needs no HIP cross-identity resolution).
             var stars = SkyMapGpuGeometry.BuildHrStarInstances(db);
             _starCount = stars.Count / SkyMapState.FloatsPerStar;
-            _stars = _renderer.CreateBuffer(CollectionsMarshal.AsSpan(stars));
+            // Sorted + indexed before upload, on the same terms as the Tycho-2 buffer, so the seed
+            // and the full field cull identically instead of the switch between them changing which
+            // stars a given zoom shows.
+            var starSpan = CollectionsMarshal.AsSpan(stars);
+            StarMagnitudeIndex.SortBrightestFirst(starSpan);
+            _starMagBins = StarMagnitudeIndex.ComputeBins(starSpan);
+            _stars = _renderer.CreateBuffer(starSpan);
 
             var figures = SkyMapGpuGeometry.BuildConstellationFigureLines(db);
             _figureVertexCount = figures.Count / 3;
@@ -432,6 +444,16 @@ namespace TianWen.UI.Web.SkyMap
         /// </summary>
         public void SubmitTycho2Stars(float[] verts, int starCount)
         {
+            // Sort + index HERE, not in ApplyPendingTycho2: this is the off-render-loop entry point
+            // (the host's fetch task), while the apply step runs on the render thread and has to stay
+            // cheap. Sorting brightest-first is what makes the magnitude cull in Draw a prefix count.
+            if (starCount > 0)
+            {
+                var span = verts.AsSpan(0, starCount * SkyMapState.FloatsPerStar);
+                StarMagnitudeIndex.SortBrightestFirst(span);
+                _pendingTycho2MagBins = StarMagnitudeIndex.ComputeBins(span);
+            }
+
             _pendingTycho2Verts = verts;
             _pendingTycho2Count = starCount;
         }
@@ -455,8 +477,12 @@ namespace TianWen.UI.Web.SkyMap
 
             _tycho2Stars = _renderer.CreateBuffer(verts.AsSpan(0, _pendingTycho2Count * SkyMapState.FloatsPerStar));
             _tycho2StarCount = _pendingTycho2Count;
+            _tycho2MagBins = _pendingTycho2MagBins;
+            _pendingTycho2MagBins = [];
             _tycho2Applied = true;
-            Console.WriteLine($"[tianwen-web] sky geometry: upgraded to Tycho-2 ({_tycho2StarCount} stars)");
+            Console.WriteLine(
+                $"[tianwen-web] sky geometry: upgraded to Tycho-2 ({_tycho2StarCount} stars, "
+                + $"{StarMagnitudeIndex.VisibleCount(_tycho2MagBins, 8.5f)} of them at V<=8.5)");
         }
 
         /// <summary>Uploads the shared 112-byte view block to both pipelines (each has its own
@@ -598,15 +624,36 @@ namespace TianWen.UI.Web.SkyMap
             // Star field on top: the full Tycho-2 catalog once it has been fetched + swapped in,
             // otherwise the HR bright-star seed (the bundle bootstrap). Never both - additive blend
             // would double every star the two share, so this is a switch, not an overlay.
+            //
+            // MAGNITUDE CULL. Both buffers are sorted brightest-first, so the stars at or above the
+            // view's effective limit are a PREFIX and drawing them is just a smaller instance count.
+            // Without it every frame submitted all ~2.5M Tycho-2 instances (~15M vertices) whatever
+            // the view showed, which is what pinned the GPU process at 59% during a drag and dropped
+            // 944 of 1287 frames. The desktop pipeline has culled this way for a while -- there the
+            // unbounded form did not merely drop frames, it TDR'd an Adreno X1-85.
+            //
+            // Unlike Vulkan this is ONE prefix over the whole buffer rather than a per-chunk prefix
+            // over the spatially-culled chunks: WebGL2 has no base-instance, so a chunked draw would
+            // need an instance offset the renderer cannot express today. The magnitude prefix is the
+            // large win and needs no such support; the spatial cone cull is the remaining refinement.
+            var magLimit = state.EffectiveMagnitudeLimit;
             if (_tycho2Applied && _tycho2StarCount > 0)
             {
-                _renderer.UsePipeline(_starPipeline);
-                _renderer.DrawInstanced(_cornerQuad, 6, _tycho2Stars, _tycho2StarCount);
+                var visible = (int)StarMagnitudeIndex.VisibleCount(_tycho2MagBins, magLimit);
+                if (visible > 0)
+                {
+                    _renderer.UsePipeline(_starPipeline);
+                    _renderer.DrawInstanced(_cornerQuad, 6, _tycho2Stars, visible);
+                }
             }
             else if (_starCount > 0)
             {
-                _renderer.UsePipeline(_starPipeline);
-                _renderer.DrawInstanced(_cornerQuad, 6, _stars, _starCount);
+                var visible = (int)StarMagnitudeIndex.VisibleCount(_starMagBins, magLimit);
+                if (visible > 0)
+                {
+                    _renderer.UsePipeline(_starPipeline);
+                    _renderer.DrawInstanced(_cornerQuad, 6, _stars, visible);
+                }
             }
         }
     }

--- a/src/TianWen.UI.Web/SkyMap/WebGlSkyMapPipeline.cs
+++ b/src/TianWen.UI.Web/SkyMap/WebGlSkyMapPipeline.cs
@@ -324,10 +324,10 @@ namespace TianWen.UI.Web.SkyMap
         private GpuBufferHandle _stars;
         private int _starCount;
 
-        // Magnitude -> instance-count prefix tables for the two star buffers, both of which are kept
-        // sorted brightest-first so the draw can cull to a prefix. See the star draw in Draw.
-        private uint[] _starMagBins = [];
-        private uint[] _tycho2MagBins = [];
+        // Both star buffers are grouped by sky region, brightest-first within each region, so the draw
+        // submits only the regions the view can see and only their magnitude prefix. See the star draw.
+        private StarChunk[] _starChunks = [];
+        private StarChunk[] _tycho2Chunks = [];
 
         // The full ~2.5M-star Tycho-2 field, lazily fetched + decoded on first atlas-open (the
         // ~30 MB catalog is stripped from the WASM bundle, so the browser host fetches it as a
@@ -340,7 +340,7 @@ namespace TianWen.UI.Web.SkyMap
         private bool _tycho2Applied;
         private float[]? _pendingTycho2Verts;
         private int _pendingTycho2Count;
-        private uint[] _pendingTycho2MagBins = [];
+        private StarChunk[] _pendingTycho2Chunks = [];
         private GpuBufferHandle _figures;
         private int _figureVertexCount;
         private GpuBufferHandle _boundaries;
@@ -407,8 +407,7 @@ namespace TianWen.UI.Web.SkyMap
             // and the full field cull identically instead of the switch between them changing which
             // stars a given zoom shows.
             var starSpan = CollectionsMarshal.AsSpan(stars);
-            StarMagnitudeIndex.SortBrightestFirst(starSpan);
-            _starMagBins = StarMagnitudeIndex.ComputeBins(starSpan);
+            _starChunks = StarChunkIndex.Build(starSpan);
             _stars = _renderer.CreateBuffer(starSpan);
 
             var figures = SkyMapGpuGeometry.BuildConstellationFigureLines(db);
@@ -444,14 +443,12 @@ namespace TianWen.UI.Web.SkyMap
         /// </summary>
         public void SubmitTycho2Stars(float[] verts, int starCount)
         {
-            // Sort + index HERE, not in ApplyPendingTycho2: this is the off-render-loop entry point
-            // (the host's fetch task), while the apply step runs on the render thread and has to stay
-            // cheap. Sorting brightest-first is what makes the magnitude cull in Draw a prefix count.
+            // Group + sort + index HERE, not in ApplyPendingTycho2: this is the off-render-loop entry
+            // point (the host's fetch task), while the apply step runs on the render thread and has to
+            // stay cheap. This is what makes the cull in Draw a pair of array lookups.
             if (starCount > 0)
             {
-                var span = verts.AsSpan(0, starCount * SkyMapState.FloatsPerStar);
-                StarMagnitudeIndex.SortBrightestFirst(span);
-                _pendingTycho2MagBins = StarMagnitudeIndex.ComputeBins(span);
+                _pendingTycho2Chunks = StarChunkIndex.Build(verts.AsSpan(0, starCount * SkyMapState.FloatsPerStar));
             }
 
             _pendingTycho2Verts = verts;
@@ -477,12 +474,18 @@ namespace TianWen.UI.Web.SkyMap
 
             _tycho2Stars = _renderer.CreateBuffer(verts.AsSpan(0, _pendingTycho2Count * SkyMapState.FloatsPerStar));
             _tycho2StarCount = _pendingTycho2Count;
-            _tycho2MagBins = _pendingTycho2MagBins;
-            _pendingTycho2MagBins = [];
+            _tycho2Chunks = _pendingTycho2Chunks;
+            _pendingTycho2Chunks = [];
             _tycho2Applied = true;
+
+            uint atDefault = 0;
+            foreach (var chunk in _tycho2Chunks)
+            {
+                atDefault += StarMagnitudeIndex.VisibleCount(chunk.MagBins, 8.5f);
+            }
             Console.WriteLine(
-                $"[tianwen-web] sky geometry: upgraded to Tycho-2 ({_tycho2StarCount} stars, "
-                + $"{StarMagnitudeIndex.VisibleCount(_tycho2MagBins, 8.5f)} of them at V<=8.5)");
+                $"[tianwen-web] sky geometry: upgraded to Tycho-2 ({_tycho2StarCount} stars in "
+                + $"{StarChunkIndex.ChunkCount} chunks, {atDefault} of them at V<=8.5)");
         }
 
         /// <summary>Uploads the shared 112-byte view block to both pipelines (each has its own
@@ -625,34 +628,50 @@ namespace TianWen.UI.Web.SkyMap
             // otherwise the HR bright-star seed (the bundle bootstrap). Never both - additive blend
             // would double every star the two share, so this is a switch, not an overlay.
             //
-            // MAGNITUDE CULL. Both buffers are sorted brightest-first, so the stars at or above the
-            // view's effective limit are a PREFIX and drawing them is just a smaller instance count.
-            // Without it every frame submitted all ~2.5M Tycho-2 instances (~15M vertices) whatever
-            // the view showed, which is what pinned the GPU process at 59% during a drag and dropped
-            // 944 of 1287 frames. The desktop pipeline has culled this way for a while -- there the
+            // TWO-AXIS CULL, matching the desktop pipeline. The buffer is grouped by sky region and
+            // sorted brightest-first within each region, so a frame submits only the regions the view
+            // cone can reach and only their magnitude prefix. Without it every frame submitted all
+            // ~2.5M Tycho-2 instances (~15M vertices) whatever the view showed, which pinned the GPU
+            // process at 59% during a drag and dropped 944 of 1287 frames; on the desktop the same
             // unbounded form did not merely drop frames, it TDR'd an Adreno X1-85.
             //
-            // Unlike Vulkan this is ONE prefix over the whole buffer rather than a per-chunk prefix
-            // over the spatially-culled chunks: WebGL2 has no base-instance, so a chunked draw would
-            // need an instance offset the renderer cannot express today. The magnitude prefix is the
-            // large win and needs no such support; the spatial cone cull is the remaining refinement.
+            // Both axes are load-bearing and neither covers the other: magnitude bounds a WIDE field
+            // (~3% of the catalog at 60 degrees) but stops bounding anything as the limit climbs with
+            // zoom (81% at V<=12), while the cone is what makes a deep zoom cheap and does nothing at
+            // full sky. The per-chunk draw needs WebGl.Renderer 1.24's firstInstance, because WebGL2
+            // has no base-instance draw argument.
             var magLimit = state.EffectiveMagnitudeLimit;
-            if (_tycho2Applied && _tycho2StarCount > 0)
+            var (chunks, buffer) = _tycho2Applied && _tycho2StarCount > 0
+                ? (_tycho2Chunks, _tycho2Stars)
+                : (_starChunks, _stars);
+            if (chunks.Length > 0)
             {
-                var visible = (int)StarMagnitudeIndex.VisibleCount(_tycho2MagBins, magLimit);
-                if (visible > 0)
+                // View cone in J2000: axis = the look-at direction, radius = the FULL field of view,
+                // generous enough to cover the viewport diagonal at any aspect so chunks never pop in
+                // and out at the screen edges.
+                var (vx, vy, vz) = SkyMapState.RaDecToUnitVec(state.CenterRA, state.CenterDec);
+                var viewRadiusRad = (float)double.DegreesToRadians(Math.Min(180.0, state.FieldOfViewDeg));
+
+                var pipelineBound = false;
+                foreach (var chunk in chunks)
                 {
-                    _renderer.UsePipeline(_starPipeline);
-                    _renderer.DrawInstanced(_cornerQuad, 6, _tycho2Stars, visible);
-                }
-            }
-            else if (_starCount > 0)
-            {
-                var visible = (int)StarMagnitudeIndex.VisibleCount(_starMagBins, magLimit);
-                if (visible > 0)
-                {
-                    _renderer.UsePipeline(_starPipeline);
-                    _renderer.DrawInstanced(_cornerQuad, 6, _stars, visible);
+                    if (chunk.Count == 0 || !StarChunkIndex.IsVisible(chunk, vx, vy, vz, viewRadiusRad))
+                    {
+                        continue;
+                    }
+
+                    var visible = (int)StarMagnitudeIndex.VisibleCount(chunk.MagBins, magLimit);
+                    if (visible == 0)
+                    {
+                        continue;
+                    }
+
+                    if (!pipelineBound)
+                    {
+                        _renderer.UsePipeline(_starPipeline);
+                        pipelineBound = true;
+                    }
+                    _renderer.DrawInstanced(_cornerQuad, 6, buffer, visible, (int)chunk.Offset);
                 }
             }
         }


### PR DESCRIPTION
A trace of a real drag on the deployed atlas:

| | |
|---|---|
| Frames | **944 dropped / 343 drawn** (73%) |
| Effective rate | 32.6 fps |
| GPU process main | **59% busy** |
| Renderer main | 37% busy |

The cause is neither the Blazor event path nor the canvas size. Every frame submitted the **entire** Tycho-2 instance buffer regardless of what the view showed: ~2.5M instances, ~15M vertices, identical whether the field was 1 degree or 180.

The desktop pipeline has culled this way for a while, and its comment puts it more strongly than dropped frames: *"the unbounded version TDR'd the Adreno X1-85"*. The WebGL pipeline was written without it. `web-tycho2.md` even listed **"zoom-aware mag limit"** as step 6, and it was never implemented.

## Two axes, both load-bearing

Culling on magnitude alone is not enough, and the numbers say why. Measured on the real catalog (`StarMagnitudeIndexTests`, 2,557,481 stars):

| Limit | Instances | Share |
|---|---:|---:|
| V ≤ 6 (zoomed out) | 5,043 | 0.20% |
| **V ≤ 8.5 (default 60° FOV)** | **78,422** | **3.07%** |
| V ≤ 10 | 359,375 | 14.05% |
| V ≤ 12 (deep zoom) | 2,084,175 | 81.49% |

Magnitude bounds a **wide** field beautifully — 78k instead of 2.56M at the default view, a 32x cut — and stops bounding anything as the effective limit climbs with zoom. So a one-degree field would still submit ~2M instances for a patch of sky holding almost none of them. The cone cull is the axis magnitude cannot cover, and vice versa.

- `StarMagnitudeIndex` — sort brightest-first at build time, index into a 0.5-mag prefix table, draw a prefix.
- `StarChunkIndex` — group into a 12x12 RA/Dec grid, sort + index within each chunk, give each a bounding cone; draw only the chunks whose cone can meet the view cone.

Neither costs a per-frame CPU pass or a re-upload.

## Shared, not reimplemented

Both live in `TianWen.UI.Abstractions`. The desktop's private helpers (the magnitude sort/bins, the chunking, the cone) move there and `VkSkyMapPipeline` now calls them, so the whole two-axis algorithm has one implementation instead of the magnitude half being shared and the spatial half duplicated.

A per-chunk draw is an instance sub-range, and **WebGL2 has no base-instance draw argument** (desktop GL 4.2 does; WebGL2 never picked it up). So this needs **WebGl.Renderer 1.24**, where `DrawInstanced` takes a `firstInstance` the JS side turns into a per-instance attribute byte offset — equivalent for a divisor-1 attribute, and free, since the draw re-binds those attributes anyway.

## Details worth a look

**The sort is allocation-free.** The buffer is reinterpreted as 5-float records (`MemoryMarshal.Cast`) and sorted in place with a **struct** comparer, so there is no index array and no scatter buffer. The index-sort-then-scatter form this replaced costs ~70 MB of transient arrays at exactly the moment the user is waiting for the atlas, which on single-threaded WASM is not free. `VisibleCount`, the only per-frame member, is an array index plus a clamp.

**A partial record throws rather than being dropped.** `MemoryMarshal.Cast` truncates and integer division ignores a remainder, so the quiet outcome would be a sorted prefix with a stale tail still holding another star's fields: a plausible-looking sky with stars in the wrong places, no crash, and nothing pointing at the caller that computed the length wrong. Every caller derives its length from a star count, so a bad one is always a programming error.

**A limit past the last bin clamps to "everything", never wraps to zero** — the effective limit climbs with zoom and readily exceeds the table's 15-magnitude span, and zero there would blank the star field at exactly the zoom the user is looking hardest at.

**One test lesson, recorded in CLAUDE.md.** A chunk cone spans ~8 degrees on a 30x15-degree cell, on top of the ~10 degrees to the nearest chunk axis. So a cull threshold narrower than the grid it culls correctly answers "nothing is visible" — the first version of the tightness test asserted against that and read as a broken cull. Measuring the geometry is what showed the code was right and the test was wrong.

## Verification

- 22 new tests, including the real-catalog measurement, exact chunk partitioning (no gaps or overlap, so an offset is a valid `firstInstance`), whole-sky completeness (culling must never lose a star), and record-integrity through the regrouping.
- Suite green on the **CI package path** (`-p:UseLocalSiblings=false`, against the published WebGl.Renderer 1.24): **4234 unit + 338 functional, 0 failures**.

## Not addressed here

The renderer-main half — 37% busy, ~11 ms per pointermove for a full synchronous repaint — and the 4.9 Mpx backing store at DPR 1.5. The GPU side was the larger consumer; a DPR cap is a fill-rate lever and fill rate was not the bottleneck, so it deserves a fresh measurement now that the vertex load is 32x smaller rather than a speculative change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YYnrhjBmgaqrqrXn7tZaoP
