### PR TITLE
fix(skymap): a zoom re-gathered the overlay per event, and the web painted per event

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1830,6 +1830,55 @@ reaches and only their prefix. No per-frame CPU pass, no re-upload.
   visible" — which reads as a broken cull if you assert against it. A test asserting the cull is tight
   needs a view wider than the star spacing it is culling.
 
+### A quantized cache key must not derive its grid from a continuous input
+
+The object-overlay candidate cache exists twice — `SkyMapTab.BuildOverlayKey` (CPU/browser) and
+`VkSkyMapTab`'s `OverlayGatherKey` (desktop GPU), hand-maintained mirrors — and **both** quantized the
+view centre into `FOV/8` cells using the **raw** FOV while separately bucketing the FOV itself into ~10%
+steps. So during a zoom the grid rescaled continuously and the rounded centre moved on **every event**
+even with the centre held perfectly still: the "quantization" quantized nothing, and the FOV bucketing
+right beside it bought nothing. Take the step from the **bucketed** value.
+
+- **Measured, CPU path, a 60→30 degree pinch with a fixed centre: 69 gathers against 8.** A pure pan of
+  1.4h of RA costs 3. That asymmetry is the tell — the cache was designed for pan, tested by panning,
+  and a *zoom* is what broke it.
+- **It presented completely differently on each path, which is why one is easy to miss.** The browser
+  gathers inline, so it stalled frames (touchmove p95 91 ms, max 246 ms, 91% of the main thread's busy
+  time inside move handling). The desktop gathers on a background task and keeps drawing the last-good
+  list, so it showed as no jank at all — just a 60-170ms catalog walk re-running forever without
+  settling, which is precisely the "slow gather → the view had already moved → cache miss → slow gather"
+  loop that async design was introduced to escape.
+- **Assert the gather COUNT, never the output.** A stale-keyed rebuild draws the byte-identical frame,
+  so nothing observable — pixels included — separates a cache that holds from one that misses per event.
+  Hence `SkyMapTab.PrimOverlayGathers`, the same reasoning as `SkyMapState.PlanetCacheRebuilds`.
+- **A bound like `gathers <= 12` passes on `gathers == 0`.** `ShowObjectOverlay` is **off by default**,
+  so the first version of the E2E turned nothing on, measured nothing, and passed with the fix reverted.
+  Any such test needs `gathers > 0` beside the bound, and must be seen to FAIL with the fix removed.
+
+### The web host paints per event, so continuous gestures must coalesce onto rAF
+
+There is no render loop in the browser build: every input handler ends in a synchronous full repaint
+(`Planner.RenderFrame`). For a one-shot event that is right — painting immediately is the lowest latency
+available. For a **continuous** gesture it is waste: a drag or a trackpad pinch delivers several events
+between two vsyncs and each paints a frame the next overwrites before the compositor sees it. Measured in
+a touch trace: **1096 of 1535 move-driven repaints (71%) superseded inside their own 16.67 ms window**,
+275 windows carrying four each.
+
+- `RequestRenderCoalesced()` (marks dirty, schedules one repaint via `wwwroot/raf-pump.js`) is for
+  `OnPointerMove` / `OnWheel` / `OnPinch` only. Everything else keeps calling `RenderFrame()` directly.
+- **The pending flag lives on the .NET side**, so an already-dirty frame costs nothing — not even an
+  interop crossing. Steady state is two crossings per *painted* frame regardless of event rate.
+- **A trackpad pinch is `ctrl`+`wheel`, a different path from the touchscreen pinch** (Blazor's
+  `@onwheel` binding vs the canvas touch bridge), so it is not covered by anything done to the bridge.
+  It is also the densest gesture the app sees.
+- **Clear the flag BEFORE painting** in the rAF callback, and clear it on the schedule-failure path: a
+  latched flag is a permanently frozen canvas. Absent the module the call falls back to painting
+  synchronously — never to skipping.
+- **A burst test must dispatch its events inside ONE JS task** (`CanvasGestures.TrackpadPinchAsync`
+  with `burst: true`), or the browser paints between them and the assertion becomes timing-dependent.
+  The paced variant (`burst: false`) is the opposite tool: it is what lets per-repaint work like the
+  gather above be measured at all, since a burst collapses it to a single repaint and hides it.
+
 ### Sky Map / FITS Viewer GLSL (pre-baked SPIR-V, no runtime shaderc)
 
 TianWen.UI.Shared's Vulkan shaders (`VkFitsImagePipeline`, `VkSkyMapPipeline`) are authored as GLSL

--- a/src/TianWen.Lib.Tests/SkyMapOverlayCacheKeyTests.cs
+++ b/src/TianWen.Lib.Tests/SkyMapOverlayCacheKeyTests.cs
@@ -1,0 +1,162 @@
+using System.Collections.Generic;
+using DIR.Lib;
+using Shouldly;
+using TianWen.UI.Abstractions;
+using Xunit;
+
+namespace TianWen.Lib.Tests
+{
+    /// <summary>
+    /// The CPU object-overlay candidate cache (the browser sky map's Phase-A grid walk) is keyed on a
+    /// QUANTIZED view, so panning or zooming a little must reuse the gathered set. These pin the
+    /// quantization's one job: the number of gathers a gesture costs.
+    ///
+    /// <para><b>Why a count and not an image.</b> A cache miss draws the byte-identical frame, just
+    /// slower, so nothing about the output can distinguish a key that holds from one that misses on
+    /// every event -- only a count can. This is the same reason
+    /// <see cref="SkyMapState.PlanetCacheRebuilds"/> exists.</para>
+    ///
+    /// <para><b>The bug these were written for.</b> The centre grid step was derived from the RAW field
+    /// of view rather than the bucketed one, so a zoom rescaled the grid continuously and the rounded
+    /// centre moved on every single event even with the centre held perfectly still. A pinch therefore
+    /// re-gathered per tick -- the exact opposite of what the FOV bucketing exists for, and measured in
+    /// a browser trace as touchmove p95 91 ms / max 246 ms, with 91% of the main thread's busy time
+    /// inside move handling.</para>
+    /// </summary>
+    [Collection("UI")]
+    public class SkyMapOverlayCacheKeyTests(ITestOutputHelper output)
+    {
+        private const float Width = 800f;
+        private const float Height = 600f;
+
+        private static SkyMapTab<RgbaImage> BuildTab()
+            => new SkyMapTab<RgbaImage>(new RgbaImageRenderer((int)Width, (int)Height)) { Bus = new SignalBus() };
+
+        /// <summary>Keys the tab's overlay cache for the current view, as a render would.</summary>
+        private static object KeyFor(SkyMapTab<RgbaImage> tab, double centreRa, double centreDec, double fov)
+        {
+            tab.State.CenterRA = centreRa;
+            tab.State.CenterDec = centreDec;
+            tab.State.FieldOfViewDeg = fov;
+            tab.State.CurrentViewMatrix = tab.State.ComputeViewMatrix();
+
+            var rect = new RectF32(0f, 0f, Width, Height);
+            var cx = rect.X + rect.Width * 0.5f;
+            var cy = rect.Y + rect.Height * 0.5f;
+            var ppr = SkyMapProjection.PixelsPerRadian(rect.Height, fov);
+            return tab.BuildOverlayKeyForTest(rect, fov, cx, cy, ppr, new PlannerState());
+        }
+
+        /// <summary>Gathers a gesture would cost: one per key change, plus the first.</summary>
+        private static int GathersOver(IEnumerable<object> keys)
+        {
+            var gathers = 0;
+            object? last = null;
+            foreach (var k in keys)
+            {
+                if (last is null || !k.Equals(last))
+                {
+                    gathers++;
+                }
+                last = k;
+            }
+            return gathers;
+        }
+
+        /// <summary>
+        /// The regression itself. A pinch zoom with the centre held EXACTLY still must cost a gather per
+        /// FOV bucket, not one per event. The bound is the bucket count over the range (~10% steps over
+        /// a 2x range is ~8) with headroom, not the measured number -- this guards the coupling, not the
+        /// bucket width.
+        /// </summary>
+        [Fact]
+        public void AZoomWithAStillCentreGathersPerFovBucketNotPerEvent()
+        {
+            var tab = BuildTab();
+            var keys = new List<object>();
+            for (var fov = 60.0; fov > 30.0; fov *= 0.99) // ~1% per event, as a trackpad pinch arrives
+            {
+                keys.Add(KeyFor(tab, centreRa: 6.5, centreDec: 40.0, fov));
+            }
+
+            var gathers = GathersOver(keys);
+            output.WriteLine($"zoom 60->30 deg over {keys.Count} events, centre fixed: {gathers} gathers");
+
+            gathers.ShouldBeLessThanOrEqualTo(12,
+                "a zoom must re-gather per FOV bucket; per-event means the centre grid is riding the raw FOV");
+            gathers.ShouldBeGreaterThan(1, "the FOV genuinely changed, so the set cannot be gathered once");
+        }
+
+        /// <summary>
+        /// The other half of the same coupling, and the one a bucket-count assertion alone would miss: a
+        /// zoom that stays INSIDE one FOV bucket must not gather again at all.
+        /// </summary>
+        [Fact]
+        public void AZoomWithinOneFovBucketDoesNotGatherAgain()
+        {
+            var tab = BuildTab();
+            // 1.1^k buckets: 60.0 -> 60.5 cannot cross one.
+            var keys = new List<object>
+            {
+                KeyFor(tab, 6.5, 40.0, 60.0),
+                KeyFor(tab, 6.5, 40.0, 60.2),
+                KeyFor(tab, 6.5, 40.0, 60.5),
+            };
+
+            GathersOver(keys).ShouldBe(1);
+        }
+
+        /// <summary>
+        /// A pan is the gesture the quantization was designed for and was always fine; asserted here so
+        /// a future change to the grid cannot fix the zoom by making the pan worse.
+        /// </summary>
+        [Fact]
+        public void APanCostsAGatherPerCellNotPerEvent()
+        {
+            var tab = BuildTab();
+            var keys = new List<object>();
+            for (var i = 0; i < 70; i++) // 1.4h of RA at a fixed 60 degree FOV
+            {
+                keys.Add(KeyFor(tab, centreRa: 6.5 + i * 0.02, centreDec: 40.0, fov: 60.0));
+            }
+
+            var gathers = GathersOver(keys);
+            output.WriteLine($"pan 1.4h of RA over {keys.Count} events at fov=60: {gathers} gathers");
+            gathers.ShouldBeLessThanOrEqualTo(6);
+        }
+
+        /// <summary>
+        /// Panning inside a single cell must not gather at all -- the case the whole cache exists for.
+        /// </summary>
+        [Fact]
+        public void APanWithinOneCellDoesNotGatherAgain()
+        {
+            var tab = BuildTab();
+            var keys = new List<object>
+            {
+                KeyFor(tab, 6.5000, 40.00, 60.0),
+                KeyFor(tab, 6.5005, 40.01, 60.0),
+                KeyFor(tab, 6.5010, 40.02, 60.0),
+            };
+
+            GathersOver(keys).ShouldBe(1);
+        }
+
+        /// <summary>
+        /// Past the wide-FOV threshold the gather sweeps the whole sphere, so the centre drops out of
+        /// the key entirely and a pan at that zoom must be free.
+        /// </summary>
+        [Fact]
+        public void AtAWideFovThePanDropsOutOfTheKey()
+        {
+            var tab = BuildTab();
+            var keys = new List<object>();
+            for (var i = 0; i < 24; i++)
+            {
+                keys.Add(KeyFor(tab, centreRa: i, centreDec: 0.0, fov: 120.0));
+            }
+
+            GathersOver(keys).ShouldBe(1);
+        }
+    }
+}

--- a/src/TianWen.UI.Abstractions/LibraryAttributes.cs
+++ b/src/TianWen.UI.Abstractions/LibraryAttributes.cs
@@ -1,3 +1,8 @@
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("TianWen.Lib.Tests")]
+// The web host reads the overlay gather counter for its E2E render-stats hook. The count is a
+// diagnostic, not API: a cache miss draws the identical frame, so nothing else can tell a key that
+// holds from one that misses per event, and the browser is the only place that runs the CPU overlay
+// path at all. Kept internal rather than made public so it stays a diagnostic.
+[assembly: InternalsVisibleTo("TianWen.UI.Web")]

--- a/src/TianWen.UI.Abstractions/SkyMapTab.ObjectOverlay.cs
+++ b/src/TianWen.UI.Abstractions/SkyMapTab.ObjectOverlay.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using DIR.Lib;
 using TianWen.Lib.Astrometry;
@@ -28,6 +28,24 @@ namespace TianWen.UI.Abstractions
         private readonly List<OverlayItem> _primOverlayItems = [];
         private bool _primOverlayHasKey;
         private PrimOverlayKey _primOverlayKey;
+
+        /// <summary>
+        /// How many times the candidate gather has actually run, the counterpart of
+        /// <see cref="SkyMapState.PlanetCacheRebuilds"/> and load-bearing for the same reason: the cost
+        /// of this cache is invisible from its output (a stale-keyed rebuild draws the identical frame,
+        /// just slower), so only a count can tell a cache that holds from one that misses every event.
+        /// Bumped by <see cref="BuildOverlayKeyForTest"/>'s production path, not by the test seam.
+        /// </summary>
+        internal int PrimOverlayGathers { get; private set; }
+
+        /// <summary>
+        /// The cache key for a given view, for tests that need to count key changes across a gesture
+        /// without driving a whole render (which needs a renderer, a font and a populated catalog).
+        /// Returns an opaque value -- only its equality across successive calls is meaningful.
+        /// </summary>
+        internal object BuildOverlayKeyForTest(
+            RectF32 contentRect, double fov, float cxView, float cyView, double ppr, PlannerState plannerState)
+            => BuildOverlayKey(contentRect, fov, cxView, cyView, ppr, showAllOverlays: true, showDark: false, plannerState);
 
         private readonly record struct PrimOverlayKey(
             double QuantRa, double QuantDec, double QuantFov,
@@ -74,6 +92,7 @@ namespace TianWen.UI.Abstractions
             var key = BuildOverlayKey(contentRect, fov, cxView, cyView, ppr, showAllOverlays, showDark, plannerState);
             if (!_primOverlayHasKey || !_primOverlayKey.Equals(key))
             {
+                PrimOverlayGathers++;
                 OverlayEngine.GatherSkyMapOverlayCandidates(
                     State.CurrentViewMatrix, fov, contentRect, dpiScale, db, pinned, _primOverlayCandidates);
 
@@ -239,7 +258,16 @@ namespace TianWen.UI.Abstractions
                     // Quantize the centre to FOV/8 cells (RA step widens by 1/cos(dec) so cells stay
                     // roughly square) -- matches the gather's scan margin so the cached set stays valid
                     // while the centre drifts inside a cell.
-                    var stepDeg = fov / 8.0;
+                    //
+                    // The step comes from the BUCKETED fov, never the raw one. Deriving it from the raw
+                    // value rescales the grid continuously, so during a zoom the rounded centre moves on
+                    // every event even when the centre is perfectly still -- the cache then misses per
+                    // tick and re-gathers the whole candidate set, which is the opposite of what the
+                    // quantFov bucketing above is for. Measured over a 60->30 degree pinch with a fixed
+                    // centre: 69 gathers from the raw fov against 8 from the bucketed one. It made a
+                    // pinch the most expensive gesture in the app (touchmove p95 91 ms, max 246 ms)
+                    // while a pan of 1.4h of RA cost 3 gathers.
+                    var stepDeg = quantFov / 8.0;
                     quantDec = Math.Round(centreDec / stepDeg) * stepDeg;
                     var cosDec = Math.Max(Math.Abs(Math.Cos(quantDec * Math.PI / 180.0)), 0.05);
                     var stepRaH = stepDeg / 15.0 / cosDec;

--- a/src/TianWen.UI.Gui/VkSkyMapTab.cs
+++ b/src/TianWen.UI.Gui/VkSkyMapTab.cs
@@ -319,7 +319,20 @@ public sealed unsafe class VkSkyMapTab(VkRenderer renderer) : SkyMapTab<VulkanCo
         // Quantize the centre to FOV/8 cells. The RA step widens by 1/cos(dec) (clamped) so
         // cells stay roughly square on the sky; near the pole RA quantization is meaningless
         // anyway -- the gather sweeps the full 24h there.
-        var quantStepDeg = fov / 8.0;
+        //
+        // The step comes from the BUCKETED fov above, never the raw one, for the same reason as in
+        // SkyMapTab.BuildOverlayKey (its hand-maintained CPU mirror, which had the identical bug):
+        // the raw value rescales the grid continuously, so a zoom moves the rounded centre on every
+        // tick even when the centre is perfectly still, and the FOV bucketing right above it buys
+        // nothing. Measured on the CPU path over a 60->30 degree pinch with a fixed centre: 69
+        // gathers from the raw fov against 8 from the bucketed one.
+        //
+        // It shows up differently here, which is why it survived longer on this path: the walk runs
+        // on a background task and the render thread keeps drawing the last-good list, so instead of
+        // stalling frames a zoom just re-gathered a 60-170ms catalog walk continuously without ever
+        // settling -- exactly the "slow gather -> the view had already moved -> cache miss -> slow
+        // gather" loop the async design above was introduced to escape.
+        var quantStepDeg = quantFov / 8.0;
         var quantDec = Math.Round(centreDec / quantStepDeg) * quantStepDeg;
         var cosDec = Math.Max(Math.Abs(Math.Cos(quantDec * Math.PI / 180.0)), 0.05);
         var quantStepRaHours = quantStepDeg / 15.0 / cosDec;

--- a/src/TianWen.UI.Web.E2E/CanvasGestures.cs
+++ b/src/TianWen.UI.Web.E2E/CanvasGestures.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using Microsoft.Playwright;
 
 namespace TianWen.UI.Web.E2E;
@@ -55,5 +56,70 @@ internal static class CanvasGestures
             ["type"] = "touchEnd",
             ["touchPoints"] = Array.Empty<object>(), // release all fingers
         });
+    }
+
+    /// <summary>
+    /// A TRACKPAD pinch, which is a different input path from <see cref="PinchAsync"/> and was the
+    /// densest gesture in a real browser trace: a browser reports it as a stream of <c>wheel</c> events
+    /// with <c>ctrlKey</c> set (there is no pinch event and no touch event), so it arrives through
+    /// Blazor's <c>@onwheel</c> binding rather than the canvas touch bridge.
+    ///
+    /// <para><paramref name="burst"/> selects WHICH property this exercises, and the two are mutually
+    /// exclusive by construction:</para>
+    /// <list type="bullet">
+    /// <item><b>true</b> - every event is dispatched inside ONE JS task, so the browser cannot paint
+    /// between them. This is the frame-coalescing case: a correct app paints once.</item>
+    /// <item><b>false</b> - one event per animation frame, so each one paints. This is the case that can
+    /// see per-repaint work such as the overlay candidate gather; a burst would collapse it to one
+    /// repaint and hide exactly what is being measured.</item>
+    /// </list>
+    ///
+    /// <para>Dispatched in-page rather than through <c>page.Mouse.WheelAsync</c> because that is a
+    /// round-trip per event, which inserts a paint opportunity between them and makes the burst case
+    /// timing-dependent instead of deterministic.</para>
+    /// </summary>
+    /// <param name="deltaPerEvent">Wheel deltaY per event; negative zooms IN. Small values keep the
+    /// total zoom (and so the number of FOV buckets crossed) low.</param>
+    public static async Task TrackpadPinchAsync(
+        IPage page, ILocator target, int events, double deltaPerEvent, bool burst)
+    {
+        var box = await target.BoundingBoxAsync()
+            ?? throw new InvalidOperationException("Pinch target has no bounding box (not visible).");
+        var cx = box.X + (box.Width / 2);
+        var cy = box.Y + (box.Height / 2);
+
+        // The event is dispatched ON the located element (ILocator.EvaluateAsync binds it as the first
+        // argument), so there is no elementFromPoint lookup to get wrong. Values are formatted into the
+        // script rather than passed as an argument object: Playwright's argument serialization did not
+        // bind an anonymous type's members here, which surfaced as clientX arriving non-finite.
+        static string Script(int n, double delta, double cx, double cy)
+        {
+            var ci = CultureInfo.InvariantCulture;
+            return $$"""
+                (el) => {
+                  for (let i = 0; i < {{n.ToString(ci)}}; i++) {
+                    el.dispatchEvent(new WheelEvent('wheel', {
+                      deltaY: {{delta.ToString("R", ci)}}, deltaMode: 0, ctrlKey: true,
+                      clientX: {{cx.ToString("R", ci)}}, clientY: {{cy.ToString("R", ci)}},
+                      bubbles: true, cancelable: true,
+                    }));
+                  }
+                }
+                """;
+        }
+
+        if (burst)
+        {
+            await target.EvaluateAsync(Script(events, deltaPerEvent, cx, cy));
+            return;
+        }
+
+        var one = Script(1, deltaPerEvent, cx, cy);
+        for (var i = 0; i < events; i++)
+        {
+            await target.EvaluateAsync(one);
+            // One animation frame between events, so each one is painted rather than coalesced away.
+            await page.EvaluateAsync("() => new Promise(r => requestAnimationFrame(() => r()))");
+        }
     }
 }

--- a/src/TianWen.UI.Web.E2E/CanvasRenderCostTests.cs
+++ b/src/TianWen.UI.Web.E2E/CanvasRenderCostTests.cs
@@ -1,0 +1,161 @@
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using Microsoft.Playwright;
+using Xunit;
+using static Microsoft.Playwright.Assertions;
+
+namespace TianWen.UI.Web.E2E;
+
+/// <summary>
+/// Browser E2E for the COST of a continuous gesture, as opposed to <see cref="CanvasGestureTests"/>
+/// which asserts its effect. Both fixes these pin were found by reading a Chrome trace of a real touch
+/// session by hand; the point of these tests is that the next regression does not need that.
+///
+/// <para>Two independent properties, asserted separately because each one hides the other:</para>
+/// <list type="number">
+/// <item><b>Repaints coalesce onto the frame clock.</b> The web host has no render loop, so every input
+/// event used to paint a full frame synchronously. In the traced session 1096 of 1535 move-driven
+/// repaints (71%) were superseded inside their own 16.67 ms window, 275 windows carrying four each.</item>
+/// <item><b>The object-overlay candidate cache survives a zoom.</b> Its key quantizes the centre into
+/// FOV/8 cells, but the step was taken from the RAW field of view, so a zoom rescaled the grid
+/// continuously and the rounded centre moved on every event even with the centre perfectly still - the
+/// cache missed per tick and re-walked the catalog. Measured over a 60->30 degree pinch: 69 gathers
+/// against 8. That is why a pinch was the app's most expensive gesture (touchmove p95 91 ms, max
+/// 246 ms) while a pan of 1.4h of RA cost 3 gathers.</item>
+/// </list>
+///
+/// <para>Read through the <c>?e2e=1</c> render-stats hook (<c>window.__tianwenTest.getRenderStats()</c>).
+/// A cache miss and a superseded repaint both produce the byte-identical picture, just later, so there is
+/// nothing in the output - pixels included - that could distinguish either from correct behaviour. Only a
+/// count can, which is the same reason <c>SkyMapState.PlanetCacheRebuilds</c> exists.</para>
+/// </summary>
+[Collection(TianWenWebCollection.Name)]
+public sealed class CanvasRenderCostTests(TianWenWebFixture fixture)
+{
+    private const float BootTimeout = 120_000;
+    private static readonly Regex ActiveClass = new(@"\bactive\b");
+
+    private readonly record struct RenderStats(int Frames, int Coalesced, int Gathers, bool Overlay);
+
+    private static async Task<RenderStats> GetStatsAsync(IPage page)
+    {
+        var json = await page.EvaluateAsync<string>("async () => await window.__tianwenTest.getRenderStats()");
+        using var doc = JsonDocument.Parse(json);
+        var r = doc.RootElement;
+        return new RenderStats(
+            r.GetProperty("frames").GetInt32(),
+            r.GetProperty("coalesced").GetInt32(),
+            r.GetProperty("gathers").GetInt32(),
+            r.GetProperty("overlay").GetBoolean());
+    }
+
+    /// <summary>
+    /// Turns the [O] catalog overlay ON, which is what makes the gather run at all -- it is off by
+    /// default (the sky map is already dense), and with it off <c>RenderObjectOverlayPrimitive</c>
+    /// early-outs before gathering. Presses until the state hook confirms it rather than pressing once,
+    /// so the test cannot silently measure nothing.
+    /// </summary>
+    private static Task EnsureObjectOverlayOnAsync(IPage page, ILocator canvas) => SetObjectOverlayAsync(page, canvas, on: true);
+
+    /// <summary>
+    /// Drives the [O] toggle to a known state. Restoring it afterwards matters because the warm page is
+    /// SHARED for the whole suite and the fixture's contract is that each warm test arranges its own
+    /// start state - leaving the overlay on would hand every later test a different (and heavier) app
+    /// than the one it expects.
+    /// </summary>
+    private static async Task SetObjectOverlayAsync(IPage page, ILocator canvas, bool on)
+    {
+        for (var attempt = 0; attempt < 4; attempt++)
+        {
+            if ((await GetStatsAsync(page)).Overlay == on) return;
+            await canvas.PressAsync("o");
+            await page.EvaluateAsync("() => new Promise(r => requestAnimationFrame(() => r()))");
+        }
+        Assert.Fail($"could not drive the [O] catalog overlay to {on}; the gather assertions would measure nothing");
+    }
+
+    private async Task<IPage> WarmSkyAtlasAsync()
+    {
+        var page = await fixture.WarmPageAsync();
+        await page.Locator("[data-view=sky]").ClickAsync();
+        await Expect(page.Locator("[data-view=sky]")).ToHaveClassAsync(ActiveClass, new() { Timeout = BootTimeout });
+        // Let any in-flight repaint land so the before-stats are a settled baseline.
+        await page.EvaluateAsync("() => new Promise(r => requestAnimationFrame(() => r()))");
+        return page;
+    }
+
+    /// <summary>
+    /// A dense gesture must not paint per event. The burst puts every wheel event in one JS task, so the
+    /// browser has no chance to paint between them: a coalescing app paints once for the whole run, and
+    /// one that does not paints 40 frames of which 39 are never seen.
+    /// </summary>
+    [Fact]
+    public async Task ADenseTrackpadPinchPaintsOncePerFrameNotOncePerEvent()
+    {
+        var page = await WarmSkyAtlasAsync();
+        var canvas = page.Locator("#planner");
+        const int events = 40;
+
+        var before = await GetStatsAsync(page);
+        await CanvasGestures.TrackpadPinchAsync(page, canvas, events, deltaPerEvent: -1.0, burst: true);
+        // Give the scheduled repaint its frame, then one more so a second would have landed too.
+        await page.EvaluateAsync("() => new Promise(r => requestAnimationFrame(() => requestAnimationFrame(() => r())))");
+        var after = await GetStatsAsync(page);
+
+        var painted = after.Frames - before.Frames;
+        var coalesced = after.Coalesced - before.Coalesced;
+
+        Assert.True(coalesced > 0,
+            $"a {events}-event burst in one task must coalesce; coalesced={coalesced}, painted={painted}");
+        Assert.True(painted < events,
+            $"painted {painted} frames for {events} events - repaints are not coalescing onto the frame clock");
+    }
+
+    /// <summary>
+    /// The overlay cache across a zoom, measured where a burst cannot help: one event per animation
+    /// frame, so every event genuinely paints. The gathers must then be bounded by the FOV buckets the
+    /// zoom crossed, NOT by the number of frames painted.
+    ///
+    /// <para>The delta is small on purpose (~1.4x total zoom, ~4 buckets of 10%), which is what makes the
+    /// assertion discriminating: before the fix this cost a gather on every one of the 30 events.</para>
+    /// </summary>
+    [Fact]
+    public async Task APacedZoomDoesNotReGatherTheOverlayOnEveryFrame()
+    {
+        var page = await WarmSkyAtlasAsync();
+        var canvas = page.Locator("#planner");
+        const int events = 30;
+        await EnsureObjectOverlayOnAsync(page, canvas);
+
+        RenderStats before, after;
+        try
+        {
+            before = await GetStatsAsync(page);
+            await CanvasGestures.TrackpadPinchAsync(page, canvas, events, deltaPerEvent: -1.5, burst: false);
+            await page.EvaluateAsync("() => new Promise(r => requestAnimationFrame(() => r()))");
+            after = await GetStatsAsync(page);
+        }
+        finally
+        {
+            // Hand the shared warm page back with the overlay off, however this test ends.
+            await SetObjectOverlayAsync(page, canvas, on: false);
+        }
+
+        var painted = after.Frames - before.Frames;
+        var gathers = after.Gathers - before.Gathers;
+
+        // The zoom really happened, so SOME repaints landed - otherwise the test proves nothing.
+        Assert.True(painted >= events / 2,
+            $"expected the paced gesture to paint per event; painted={painted} for {events} events");
+        // Non-zero, or the assertion below would pass on a gather that never ran. This is the guard the
+        // first version of this test lacked: the overlay is off by default, so it passed on gathers=0
+        // even with the fix reverted.
+        Assert.True(gathers > 0,
+            "the overlay never gathered, so the bound below would be vacuous");
+        // Bounded well under the painted count. Generous (the exact bucket count depends on the starting
+        // FOV the warm page happens to be at) but far below per-event, which is the regression.
+        Assert.True(gathers <= 12,
+            $"overlay re-gathered {gathers} times over {painted} painted frames - the cache key is "
+            + "missing per event, which is the raw-FOV grid-step regression");
+    }
+}

--- a/src/TianWen.UI.Web/Pages/Planner.razor
+++ b/src/TianWen.UI.Web/Pages/Planner.razor
@@ -7,7 +7,7 @@
    back/forward). *@
 @using System.Globalization
 @using Microsoft.AspNetCore.Components.Routing
-@implements IDisposable
+@implements IAsyncDisposable
 @using DIR.Lib
 @using TianWen.Lib.Astrometry.Catalogs
 @using TianWen.Lib.Astrometry.Comets
@@ -128,6 +128,21 @@
     // normal session (the hook is never registered).
     DotNetObjectReference<Planner>? _testRef;
 
+    // ── Frame-coalesced repaints (see wwwroot/raf-pump.js for the why) ────────
+    // A continuous gesture (drag-pan, pinch, wheel) delivers several events per vsync and each one
+    // used to paint a full frame that the next overwrote unseen. Those handlers now call
+    // RequestRenderCoalesced, which paints at most once per animation frame. One-shot events keep
+    // calling RenderFrame directly - deferring a click's repaint by a frame is latency for nothing.
+    IJSObjectReference? _rafModule;
+    DotNetObjectReference<Planner>? _rafRef;
+    // Owned by the UI thread only (WASM is single-threaded and every writer is an event handler or the
+    // rAF callback), so a plain bool needs no interlocking.
+    bool _rafPending;
+    // Counts repaints the coalescing actually skipped, so the win is measurable from the app rather
+    // than only from a browser trace. Read by the E2E hook.
+    int _rafCoalesced;
+    int _renderFrames;
+
     // Sensible default dark-ish mid-northern site; geolocation / manual entry override it.
     double _lat = 47.5;
     double _lon = 11.0;
@@ -211,6 +226,20 @@
         {
             _testRef = DotNetObjectReference.Create(this);
             await JS.InvokeVoidAsync("__tianwenTestInit", _testRef);
+        }
+
+        // Bring up the repaint pump. Imported here rather than earlier because everything before this
+        // point paints one-shot frames through RenderFrame anyway, and RequestRenderCoalesced falls
+        // back to a direct paint until this lands - so a slow import costs correctness nothing.
+        try
+        {
+            _rafRef = DotNetObjectReference.Create(this);
+            _rafModule = await JS.InvokeAsync<IJSObjectReference>("import", "./raf-pump.js");
+        }
+        catch (Exception ex)
+        {
+            // Every gesture then paints synchronously, exactly as it did before the pump existed.
+            Logger.LogWarning(ex, "raf-pump.js did not load; repaints will not be frame-coalesced");
         }
 
         await ComputeAsync();
@@ -917,9 +946,61 @@
         }
     }
 
+    // Marks the frame dirty and ensures exactly one repaint lands on the next animation frame. Used by
+    // the continuous-gesture handlers; see the field block and wwwroot/raf-pump.js.
+    //
+    // Falls back to painting synchronously when the pump is not up yet (the module import is async and
+    // the first frames are painted during init). A dropped frame here would be a visibly stuck canvas,
+    // so the fallback is "paint now", never "skip".
+    void RequestRenderCoalesced()
+    {
+        if (_rafModule is null || _rafRef is null)
+        {
+            RenderFrame();
+            return;
+        }
+        if (_rafPending)
+        {
+            _rafCoalesced++;
+            return; // already dirty: costs nothing, not even an interop crossing
+        }
+        _rafPending = true;
+        // Fire-and-forget by design: this is called from synchronous input handlers. A failure to
+        // schedule would latch _rafPending and freeze the canvas, so clear it on the failure path.
+        _ = ScheduleRepaintAsync();
+    }
+
+    async Task ScheduleRepaintAsync()
+    {
+        try
+        {
+            await _rafModule!.InvokeVoidAsync("schedule", _rafRef);
+        }
+        catch (Exception ex)
+        {
+            _rafPending = false;
+            Logger.LogDebug(ex, "rAF repaint schedule failed; falling back to a direct paint");
+            RenderFrame();
+        }
+    }
+
+    /// <summary>
+    /// The scheduled repaint. Public + [JSInvokable] so raf-pump.js can call it; not part of any
+    /// contract otherwise.
+    /// </summary>
+    [JSInvokable]
+    public void RenderFrameFromRaf()
+    {
+        // Cleared FIRST: if the paint below throws, the next gesture event must still be able to
+        // schedule a frame rather than finding the flag latched forever.
+        _rafPending = false;
+        RenderFrame();
+    }
+
     void RenderFrame()
     {
         if (_webGl is null || _tab is null) return;
+        _renderFrames++;
         // Web has no per-frame loop; every event ends in a RenderFrame, so this is the bus pump
         // (delivers the auto-posted SavePlannerSessionSignal after pin/slider mutations) and the
         // completion reaper for the tracked async saves.
@@ -1215,6 +1296,23 @@
     // to reach them. These return the arranged clickable rects (CSS px, relative to the canvas host) so a
     // Playwright test can click the canvas at the exact spot -- the "assert canvas state without pixels"
     // pattern GetSkyViewJson uses, applied to interaction targets. Read-only; wired only under ?e2e=1.
+    // Repaint accounting, so the two perf properties this app depends on are assertable from a browser
+    // test instead of only from a hand-read Chrome trace:
+    //   coalesced - repaints the frame pump skipped because the frame was already dirty. A continuous
+    //               gesture must produce some; zero means every event painted its own frame again.
+    //   gathers   - object-overlay candidate gathers. Bounded per FOV bucket / pan cell, so a gesture
+    //               must NOT produce one per event (see SkyMapOverlayCacheKeyTests).
+    //   overlay   - whether the [O] catalog overlay is on. Reported because it is OFF by default and
+    //               the gather is skipped entirely when it is off: without this a test asserting
+    //               "gathers stay bounded" passes on zero, i.e. passes while measuring nothing. The
+    //               first version of the E2E did exactly that and passed with the fix reverted.
+    [JSInvokable]
+    public string GetRenderStatsJson()
+        => "{\"frames\":" + _renderFrames.ToString(CultureInfo.InvariantCulture)
+            + ",\"coalesced\":" + _rafCoalesced.ToString(CultureInfo.InvariantCulture)
+            + ",\"gathers\":" + (_skyTab?.PrimOverlayGathers ?? 0).ToString(CultureInfo.InvariantCulture)
+            + ",\"overlay\":" + ((_skyTab?.State.ShowObjectOverlay ?? false) ? "true" : "false") + "}";
+
     [JSInvokable]
     public string GetPlannerSearchRectJson()
         => RegionRectCssJson(r => r.Result is HitResult.TextInputHit { Input: { } i } && ReferenceEquals(i, _state.SearchInput));
@@ -1246,10 +1344,29 @@
         return "null";
     }
 
-    public void Dispose()
+    public async ValueTask DisposeAsync()
     {
         Nav.LocationChanged -= OnLocationChanged;
         _testRef?.Dispose();
+        _rafRef?.Dispose();
+        if (_rafModule is not null)
+        {
+            // A JS module reference can only be released asynchronously, which is why this component is
+            // IAsyncDisposable. Teardown ordering is not guaranteed (the circuit may already be gone,
+            // and on a WASM page unload it always is), so a failure here is expected, not exceptional.
+            try
+            {
+                await _rafModule.DisposeAsync();
+            }
+            catch (JSDisconnectedException)
+            {
+                // Page going away; the module dies with it.
+            }
+            catch (Exception ex)
+            {
+                Logger.LogDebug(ex, "raf-pump.js module disposal failed during teardown");
+            }
+        }
     }
 
     // --- Input: routed through the tab's InputEvent handler, mirroring the desktop host ---------
@@ -1304,7 +1421,8 @@
         {
             tab.HandleInput(new InputEvent.MouseMove(e.X, e.Y));
         }
-        RenderFrame(); // mouse-follower / sky-map drag pan
+        // Coalesced: a drag delivers several moves per vsync and only the last is ever presented.
+        RequestRenderCoalesced(); // mouse-follower / sky-map drag pan
     }
 
     void OnPointerUp(CanvasPointerEventArgs e)
@@ -1352,14 +1470,16 @@
             var scale = Math.Exp(-pixels / PinchPixelsPerEFold);
             tab.HandleInput(new InputEvent.Pinch((float)scale, e.X, e.Y) { Source = PinchSource.Touchpad });
             tab.HandleInput(new InputEvent.PinchEnd());
-            RenderFrame();
+            // Coalesced: a trackpad pinch is the densest gesture the app sees - a continuous stream of
+            // ctrl+wheel events, several per vsync.
+            RequestRenderCoalesced();
             return;
         }
 
         // Browser deltaY > 0 = wheel down; the tab uses the SDL convention (positive = up).
         var scrollY = (float)(-pixels / 100.0);
         tab.HandleInput(new InputEvent.Scroll(scrollY, e.X, e.Y));
-        RenderFrame();
+        RequestRenderCoalesced(); // a wheel stream is continuous too
     }
 
     // Two-finger pinch (touchscreen): drive the shared sky-map zoom the same way the desktop SDL host
@@ -1371,7 +1491,7 @@
     {
         if (ActiveTab is not { } tab) return;
         tab.HandleInput(new InputEvent.Pinch((float)e.Scale, e.X, e.Y) { Source = PinchSource.Touchscreen });
-        RenderFrame();
+        RequestRenderCoalesced(); // touchscreen pinch: same density as the trackpad one
     }
 
     void OnPinchEnd()

--- a/src/TianWen.UI.Web/wwwroot/index.html
+++ b/src/TianWen.UI.Web/wwwroot/index.html
@@ -110,6 +110,10 @@
                 // the canvas at the exact target (there is no DOM for these). Return "null" when absent.
                 getPlannerSearchRect: function () { return ref.invokeMethodAsync('GetPlannerSearchRectJson'); },
                 getPlannerSuggestionRect: function (i) { return ref.invokeMethodAsync('GetPlannerSuggestionRectJson', i); },
+                // Repaint accounting -> {frames, coalesced, gathers}. Lets a test assert the two perf
+                // properties of a continuous gesture (frames coalesce onto vsync; the overlay cache does
+                // not re-gather per event) without reading a Chrome trace by hand.
+                getRenderStats: function () { return ref.invokeMethodAsync('GetRenderStatsJson'); },
             };
         };
     </script>

--- a/src/TianWen.UI.Web/wwwroot/raf-pump.js
+++ b/src/TianWen.UI.Web/wwwroot/raf-pump.js
@@ -1,0 +1,36 @@
+// Coalesces the app's canvas repaints onto the browser's frame clock.
+//
+// The web host has no render loop: every input event ends in a synchronous full repaint
+// (Planner.RenderFrame). For one-shot events (a click, a key, a chip switch) that is exactly right --
+// painting immediately is the lowest latency there is. For a CONTINUOUS gesture it is not: a drag or a
+// trackpad pinch delivers several events between two vsyncs, and each one paints a frame that the next
+// one overwrites before the compositor ever sees it. Measured in a browser trace of a touch session:
+// 1096 of 1535 move-driven repaints (71%) were superseded within their own 16.67 ms window, 275 windows
+// carrying four repaints each.
+//
+// So the continuous-gesture handlers mark the frame dirty instead, and this schedules ONE repaint per
+// animation frame. requestAnimationFrame is the right clock rather than a timer: it fires once per
+// compositor frame, is throttled with the tab, and is skipped entirely on a hidden tab -- so a
+// background tab holding a latched gesture stops burning CPU for free.
+//
+// The pending flag lives on the .NET side (Planner._rafPending) rather than here, so a gesture that is
+// already dirty costs NOTHING at all -- no interop crossing, no call into this module. That makes the
+// steady-state cost of a gesture exactly two crossings per PAINTED frame (this schedule, plus the
+// callback below), regardless of how many events arrive.
+//
+// This lives in the app, not in WebGl.Renderer, because WHEN to paint is the app's policy: the canvas
+// component owns input and the GL surface, but it has no view on whether a given repaint is worth a
+// frame. Worth upstreaming if a second consumer wants the same pump.
+
+/**
+ * Requests a single repaint on the next animation frame.
+ * @param {object} ref DotNetObjectReference to the component exposing RenderFrameFromRaf.
+ */
+export function schedule(ref) {
+  requestAnimationFrame(() => {
+    // Fire-and-forget: the callback clears the component's pending flag, so a throw here (teardown
+    // race - the component disposed between the schedule and the frame) must not reject unhandled.
+    // Swallowing also cannot wedge the pump, because the flag is cleared on the .NET side FIRST.
+    ref.invokeMethodAsync("RenderFrameFromRaf").catch(() => { /* component gone */ });
+  });
+}


### PR DESCRIPTION
Two independent gesture costs, both found by reading a Chrome trace of the deployed atlas, and both worst during a pinch zoom — the gesture the trace was taken for.

## 1. A quantized cache key derived its grid from a continuous input

The object-overlay candidate cache quantizes the view centre into `FOV/8` cells and separately buckets the FOV into ~10% steps — but took the cell step from the **raw** FOV. So a zoom rescaled the grid continuously and the rounded centre moved on **every event even with the centre held perfectly still**. The quantization quantized nothing; the bucketing beside it bought nothing.

| gesture | gathers |
|---|---|
| pinch 60 -> 30 deg, 69 events, centre fixed — raw FOV | **69** |
| same, bucketed FOV | **8** |
| pan 1.4h of RA, 70 events, fixed FOV | 3 |

The pan/zoom asymmetry is the tell: the cache was designed for pan, tested by panning, and a *zoom* is what broke it.

**Both hand-maintained mirrors had it, and they presented so differently that the desktop one was invisible.** The browser gathers inline, so it stalled frames — `touchmove` p95 91 ms, max 246 ms, 91% of main-thread busy time inside move handling. The desktop gathers on a background task and keeps drawing the last-good list, so it showed as *no jank at all*: just a 60-170 ms catalog walk re-running forever without settling. That is precisely the "slow gather -> the view had already moved -> cache miss -> slow gather" loop the async design was introduced to escape, so the async wrapper hid its own motivating bug.

## 2. The web host paints per event

There is no render loop in the browser build: every input handler ends in a synchronous full repaint. Right for a one-shot event, waste for a continuous one — several events land between two vsyncs and each paints a frame the next overwrites before the compositor sees it.

Measured: **1096 of 1535 move-driven repaints (71%) superseded inside their own 16.67 ms window**, 275 windows carrying four each.

`OnPointerMove` / `OnWheel` / `OnPinch` now mark the frame dirty and one repaint lands per animation frame (`wwwroot/raf-pump.js`). Everything else still paints directly — deferring a click by a frame is latency for nothing. The pending flag is held on the .NET side, so an already-dirty frame costs not even an interop crossing; steady state is two crossings per *painted* frame at any event rate. A trackpad pinch is `ctrl`+`wheel` through Blazor's own binding, a different path from the canvas touch bridge, so it needed this rather than anything done to the bridge.

## Context

The GPU was already fixed by the two-axis star cull in #156 (`CrGpuMain` 59% busy -> 3.6%). This is the bottleneck that remained afterwards, on the main thread.

## Verification

Both properties are asserted on **counts, never on output** — a stale-keyed rebuild and a superseded repaint each produce the byte-identical picture, so nothing observable, pixels included, separates them from correct behaviour.

Each fix was reverted and the matching test watched to fail:

- `overlay re-gathered 30 times over 30 painted frames` (cache key)
- `a 40-event burst in one task must coalesce; coalesced=0, painted=40` (repaints)

That step earned its keep immediately: the **first version of the E2E passed with the fix reverted**, because `ShowObjectOverlay` is off by default, so it turned nothing on and `gathers <= 12` was satisfied by `gathers == 0`. It now drives the `[O]` toggle on, asserts `gathers > 0` beside the bound, and restores the shared warm page's state afterwards.

The two E2E tests are deliberately opposite: the burst dispatches every event inside one JS task (so the browser cannot paint between them — the coalescing case), while the paced variant paints per event, which is the only way per-repaint work like the gather is measurable at all.

Suites, all on the package path (`UseLocalSiblings=false`, since DIR.Lib is on a feature branch):

- unit **4239** passed / 25 skipped
- functional **338** passed
- web E2E **14/14** (full suite, 7m21)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YYnrhjBmgaqrqrXn7tZaoP