### PR TITLE
perf(skymap): the wide-field overlay gather, 5.5x cheaper over a zoom-out

### DIFF
--- a/src/TianWen.Lib.Tests/SkyMapOverlayCacheKeyTests.cs
+++ b/src/TianWen.Lib.Tests/SkyMapOverlayCacheKeyTests.cs
@@ -143,6 +143,30 @@ namespace TianWen.Lib.Tests
         }
 
         /// <summary>
+        /// Past the wide-FOV threshold the gather cannot depend on the field of view either, so
+        /// ZOOMING there must not re-gather. The scan already sweeps the whole sphere, and both
+        /// magnitude cutoffs are flat above 5 degrees (8.0 extended, 1.0 stellar), so the only FOV
+        /// dependence left is the dark-nebula on-screen-size filter, which is off here.
+        ///
+        /// <para>This is the expensive gather: a full-sky sweep measured at 121 ms in the browser, and
+        /// a 90-to-180-degree zoom-out crossed about eleven of the 10% FOV buckets before this.</para>
+        /// </summary>
+        [Fact]
+        public void AWideFovZoomDoesNotReGatherWhenDarkNebulaeAreOff()
+        {
+            var tab = BuildTab();
+            var keys = new List<object>();
+            for (var fov = 90.0; fov <= 180.0; fov += 5.0)
+            {
+                keys.Add(KeyFor(tab, centreRa: 6.5, centreDec: 20.0, fov));
+            }
+
+            var gathers = GathersOver(keys);
+            output.WriteLine($"zoom 90->180 deg over {keys.Count} steps, dark nebulae off: {gathers} gathers");
+            gathers.ShouldBe(1);
+        }
+
+        /// <summary>
         /// Past the wide-FOV threshold the gather sweeps the whole sphere, so the centre drops out of
         /// the key entirely and a pan at that zoom must be free.
         /// </summary>

--- a/src/TianWen.UI.Abstractions/Overlays/OverlayEngine.cs
+++ b/src/TianWen.UI.Abstractions/Overlays/OverlayEngine.cs
@@ -854,6 +854,29 @@ public static class OverlayEngine
                     // target of a type the overlay doesn't normally draw (e.g. a Star Forming Region /
                     // molecular cloud, which is not an "extended" type) would be dropped here and
                     // never render, even though the user explicitly pinned it.
+                    // CHEAP GATES FIRST. Everything below this point is only reachable by an object
+                    // that will actually be kept, or that might be pinned. The two questions here cost
+                    // a field read and a comparison; the cross-index closure below is, by this file's
+                    // own account, the single most expensive question asked per candidate, and it used
+                    // to be asked of EVERY object in every scanned cell with the magnitude test coming
+                    // last. That is backwards precisely where it hurts most: past 90 degrees the walk
+                    // sweeps the whole sphere (65,160 cells, the entire DSO catalog) while the cutoff
+                    // is at its tightest -- GetExtendedMagCutoff returns 8.0, "Messier-class only" --
+                    // so nearly every object paid for a cross-index lookup and was then dropped on
+                    // magnitude.
+                    var effectiveMagCutoffEarly = isStar ? starMagCutoff : magCutoff;
+                    var magPasses = Half.IsNaN(obj.V_Mag) || (double)obj.V_Mag <= effectiveMagCutoffEarly;
+                    var typePasses = isExtended || isStar;
+
+                    // A pinned target bypasses both gates, so it can only be skipped here when there
+                    // are no pins at all. With pins present the object still has to go the long way,
+                    // because recognising one needs the cross-refs; the pinned set is tiny, so this
+                    // costs nothing on the common path and stays exactly as correct on the rare one.
+                    if (!(magPasses && typePasses) && pinnedCatalogIndices is null)
+                    {
+                        continue;
+                    }
+
                     // ONE cross-index closure per object. The pinned check and the duplicate check
                     // below both need it, and it is the single most expensive question asked per
                     // candidate, so asking it twice doubled the cost of the whole walk.
@@ -926,13 +949,9 @@ public static class OverlayEngine
                     // survives the filters AND renders as the orange landmark.
                     var isPinned = isPinnedEarly;
 
-                    if (!isPinned)
+                    if (!isPinned && !magPasses)
                     {
-                        var effectiveMagCutoff = isStar ? starMagCutoff : magCutoff;
-                        if (!Half.IsNaN(obj.V_Mag) && (double)obj.V_Mag > effectiveMagCutoff)
-                        {
-                            continue;
-                        }
+                        continue;
                     }
 
                     // Note: no per-candidate projection / off-screen cull here anymore.

--- a/src/TianWen.UI.Abstractions/SkyMapTab.ObjectOverlay.cs
+++ b/src/TianWen.UI.Abstractions/SkyMapTab.ObjectOverlay.cs
@@ -39,6 +39,14 @@ namespace TianWen.UI.Abstractions
         internal int PrimOverlayGathers { get; private set; }
 
         /// <summary>
+        /// Cumulative wall time inside the candidate gather. Paired with
+        /// <see cref="PrimOverlayGathers"/> it separates "how often" from "how expensive", which a
+        /// frame-duration trace cannot: the browser runs the gather INSIDE the animation-frame
+        /// callback, so a slow frame and a slow gather are the same sample until they are timed apart.
+        /// </summary>
+        internal double PrimOverlayGatherMs { get; private set; }
+
+        /// <summary>
         /// The cache key for a given view, for tests that need to count key changes across a gesture
         /// without driving a whole render (which needs a renderer, a font and a populated catalog).
         /// Returns an opaque value -- only its equality across successive calls is meaningful.
@@ -93,8 +101,10 @@ namespace TianWen.UI.Abstractions
             if (!_primOverlayHasKey || !_primOverlayKey.Equals(key))
             {
                 PrimOverlayGathers++;
+                var gatherStart = System.Diagnostics.Stopwatch.GetTimestamp();
                 OverlayEngine.GatherSkyMapOverlayCandidates(
                     State.CurrentViewMatrix, fov, contentRect, dpiScale, db, pinned, _primOverlayCandidates);
+                PrimOverlayGatherMs += System.Diagnostics.Stopwatch.GetElapsedTime(gatherStart).TotalMilliseconds;
 
                 // Per-layer visibility (same rule as VkSkyMapTab): dark nebulae follow [D], every other
                 // catalog object follows [O]; pinned targets bypass both so they stay visible.
@@ -248,6 +258,23 @@ namespace TianWen.UI.Abstractions
             var quantFov = Math.Pow(1.1, Math.Round(Math.Log(Math.Max(fov, 0.1)) / Math.Log(1.1)));
 
             var wideFov = fov >= PrimOverlayWideFovDeg;
+
+            // Above the wide threshold the gather cannot depend on the field of view AT ALL, so the FOV
+            // drops out of the key exactly as the centre already has. Three facts make that exact rather
+            // than approximate: the scan sweeps the whole sphere past 90 degrees, and BOTH magnitude
+            // cutoffs are already flat by then (GetExtendedMagCutoff and GetStarMagCutoff both switch
+            // for the last time at 5 degrees, to 8.0 and 1.0). The one remaining FOV dependence is the
+            // dark-nebula on-screen-size filter, which only exists when [D] is on, so this is gated on
+            // it rather than approximated.
+            //
+            // Worth it because the wide gather is the expensive one: a full-sky sweep measured at 121 ms
+            // in the browser, and zooming out from 90 to 180 degrees crosses ~7 of the 10% buckets, so
+            // it used to run about eleven times for one gesture.
+            if (wideFov && !showDark)
+            {
+                quantFov = double.PositiveInfinity;
+            }
+
             double quantRa = 0.0, quantDec = 0.0;
             if (!wideFov)
             {

--- a/src/TianWen.UI.Web.E2E/GatherAttributionProbe.cs
+++ b/src/TianWen.UI.Web.E2E/GatherAttributionProbe.cs
@@ -1,0 +1,161 @@
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using Microsoft.Playwright;
+using Xunit;
+using static Microsoft.Playwright.Assertions;
+
+namespace TianWen.UI.Web.E2E;
+
+/// <summary>
+/// On-demand measurement, not an assertion: attributes the browser's per-frame render cost during a
+/// zoom to the object-overlay candidate gather. Gated on <c>TIANWEN_WEB_PROBE=1</c> so a normal
+/// <c>dotnet test</c> skips it, mirroring the env-gated probes elsewhere in this repo
+/// (<c>PhotometricRepeatabilityProbe</c>, <c>VelaMosaicStarListExport</c>).
+///
+/// <para><b>Why this cannot be read off a Chrome trace.</b> The browser runs the whole paint inside
+/// the animation-frame callback, so a trace samples "the frame was slow" and "the gather inside it was
+/// slow" as the same event. A trace of the deployed build showed 62 of 1899 rAF callbacks (3.3%)
+/// carrying 54% of all render time, 61 of them during a gesture, which says WHEN but not WHAT. The
+/// app-side timers (<c>renderMs</c> / <c>gatherMs</c>) separate them.</para>
+/// </summary>
+[Collection(TianWenWebCollection.Name)]
+public sealed class GatherAttributionProbe(TianWenWebFixture fixture, ITestOutputHelper output)
+{
+    private const float BootTimeout = 120_000;
+    private static readonly Regex ActiveClass = new(@"\bactive\b");
+
+    private static bool Enabled => Environment.GetEnvironmentVariable("TIANWEN_WEB_PROBE") == "1";
+
+    private readonly record struct Stats(int Frames, int Gathers, double RenderMs, double GatherMs);
+
+    private static async Task<Stats> ReadAsync(IPage page)
+    {
+        var json = await page.EvaluateAsync<string>("async () => await window.__tianwenTest.getRenderStats()");
+        using var doc = JsonDocument.Parse(json);
+        var r = doc.RootElement;
+        return new Stats(
+            r.GetProperty("frames").GetInt32(),
+            r.GetProperty("gathers").GetInt32(),
+            r.GetProperty("renderMs").GetDouble(),
+            r.GetProperty("gatherMs").GetDouble());
+    }
+
+    [Fact]
+    public async Task AttributeZoomFrameCostToTheOverlayGather()
+    {
+        Assert.SkipUnless(Enabled, "set TIANWEN_WEB_PROBE=1 to run this measurement");
+
+        var page = await fixture.WarmPageAsync();
+        await page.Locator("[data-view=sky]").ClickAsync();
+        await Expect(page.Locator("[data-view=sky]")).ToHaveClassAsync(ActiveClass, new() { Timeout = BootTimeout });
+        var canvas = page.Locator("#planner");
+
+        // The gather only runs with the [O] catalog overlay on, and it is off by default.
+        for (var i = 0; i < 4 && !(await ReadAsync(page)).Gathers.Equals(int.MinValue); i++)
+        {
+            var json = await page.EvaluateAsync<string>("async () => await window.__tianwenTest.getRenderStats()");
+            using var doc = JsonDocument.Parse(json);
+            if (doc.RootElement.GetProperty("overlay").GetBoolean()) break;
+            await canvas.PressAsync("o");
+            await page.EvaluateAsync("() => new Promise(r => requestAnimationFrame(() => r()))");
+        }
+
+        const int steps = 26;
+
+        // Run the SAME zoom twice, with the [O] overlay on and off. The difference isolates the
+        // overlay's own per-frame cost (drawing every candidate as traced ellipses + labels with CPU
+        // primitives, which is what the desktop does with an instanced GPU pipeline instead) from
+        // everything else the frame does.
+        async Task<List<Stats>> SweepAsync()
+        {
+            var acc = new List<Stats>(steps);
+            var p0 = await ReadAsync(page);
+            for (var i = 0; i < steps; i++)
+            {
+                await CanvasGestures.TrackpadPinchAsync(page, canvas, events: 1, deltaPerEvent: -1.5, burst: false);
+                var c = await ReadAsync(page);
+                acc.Add(new Stats(c.Frames - p0.Frames, c.Gathers - p0.Gathers,
+                    c.RenderMs - p0.RenderMs, c.GatherMs - p0.GatherMs));
+                p0 = c;
+            }
+            return acc;
+        }
+
+        var rows = await SweepAsync();
+
+        // Overlay OFF, zooming back out over the same range.
+        await canvas.PressAsync("o");
+        await page.EvaluateAsync("() => new Promise(r => requestAnimationFrame(() => r()))");
+        var offRows = new List<Stats>(steps);
+        {
+            var p0 = await ReadAsync(page);
+            for (var i = 0; i < steps; i++)
+            {
+                await CanvasGestures.TrackpadPinchAsync(page, canvas, events: 1, deltaPerEvent: +1.5, burst: false);
+                var c = await ReadAsync(page);
+                offRows.Add(new Stats(c.Frames - p0.Frames, c.Gathers - p0.Gathers,
+                    c.RenderMs - p0.RenderMs, c.GatherMs - p0.GatherMs));
+                p0 = c;
+            }
+        }
+        var offFrames = Math.Max(offRows.Sum(r => r.Frames), 1);
+        output.WriteLine($"OVERLAY OFF: {offRows.Sum(r => r.RenderMs):F1} ms over {offFrames} frames "
+            + $"({offRows.Sum(r => r.RenderMs) / offFrames:F1} ms/frame), {offRows.Sum(r => r.Gathers)} gathers");
+
+        // Overlay back ON, and zoom OUT past the wide-FOV threshold. Beyond 90 degrees the gather
+        // abandons the sampled bounds and sweeps the FULL sphere (minRA 0, maxRA 24, dec -90..90),
+        // which is 65,160 grid cells against a few thousand for a narrow field. This is the case that
+        // matches the 231 ms animation-frame callbacks seen in a real session, and the narrow-field
+        // sweep above does not reach it.
+        await canvas.PressAsync("o");
+        await page.EvaluateAsync("() => new Promise(r => requestAnimationFrame(() => r()))");
+        var wide = new List<Stats>(40);
+        {
+            var p0 = await ReadAsync(page);
+            for (var i = 0; i < 40; i++)
+            {
+                await CanvasGestures.TrackpadPinchAsync(page, canvas, events: 1, deltaPerEvent: +8.0, burst: false);
+                var c = await ReadAsync(page);
+                wide.Add(new Stats(c.Frames - p0.Frames, c.Gathers - p0.Gathers,
+                    c.RenderMs - p0.RenderMs, c.GatherMs - p0.GatherMs));
+                p0 = c;
+            }
+        }
+        var wg = wide.Sum(r => r.Gathers);
+        var fovJson = await page.EvaluateAsync<string>("async () => await window.__tianwenTest.getSkyView()");
+        using (var fd = JsonDocument.Parse(fovJson))
+        {
+            output.WriteLine($"ZOOM OUT to fov={fd.RootElement.GetProperty("fovDeg").GetDouble():F1} deg, overlay ON: "
+                + $"{wg} gathers, {wide.Sum(r => r.GatherMs):F1} ms gathering "
+                + $"({(wg > 0 ? wide.Sum(r => r.GatherMs) / wg : 0):F1} ms per gather), "
+                + $"worst single step {wide.Max(r => r.RenderMs):F1} ms");
+        }
+        output.WriteLine("");
+
+        output.WriteLine($"{"step",4} {"frames",7} {"gathers",8} {"renderMs",9} {"gatherMs",9}");
+        for (var i = 0; i < rows.Count; i++)
+        {
+            var r = rows[i];
+            output.WriteLine($"{i,4} {r.Frames,7} {r.Gathers,8} {r.RenderMs,9:F1} {r.GatherMs,9:F1}");
+        }
+
+        var totalRender = rows.Sum(r => r.RenderMs);
+        var totalGather = rows.Sum(r => r.GatherMs);
+        var totalFrames = rows.Sum(r => r.Frames);
+        var totalGathers = rows.Sum(r => r.Gathers);
+        output.WriteLine("");
+        output.WriteLine($"totals: {totalFrames} frames, {totalGathers} gathers, "
+            + $"{totalRender:F1} ms rendering, {totalGather:F1} ms gathering");
+        output.WriteLine($"the gather is {(totalRender > 0 ? 100.0 * totalGather / totalRender : 0):F0}% of render time");
+
+        var withG = rows.Where(r => r.Gathers > 0).ToList();
+        var without = rows.Where(r => r.Gathers == 0).ToList();
+        foreach (var (name, set) in new[] { ("WITH a gather", withG), ("WITHOUT a gather", without) })
+        {
+            if (set.Count == 0) continue;
+            var f = Math.Max(set.Sum(r => r.Frames), 1);
+            output.WriteLine($"steps {name,-17}: {set.Count,3} steps, {set.Sum(r => r.RenderMs),8:F1} ms "
+                + $"over {f} frames ({set.Sum(r => r.RenderMs) / f:F1} ms/frame)");
+        }
+    }
+}

--- a/src/TianWen.UI.Web/Pages/Planner.razor
+++ b/src/TianWen.UI.Web/Pages/Planner.razor
@@ -142,6 +142,7 @@
     // than only from a browser trace. Read by the E2E hook.
     int _rafCoalesced;
     int _renderFrames;
+    double _renderMs;
 
     // Sensible default dark-ish mid-northern site; geolocation / manual entry override it.
     double _lat = 47.5;
@@ -1001,40 +1002,51 @@
     {
         if (_webGl is null || _tab is null) return;
         _renderFrames++;
-        // Web has no per-frame loop; every event ends in a RenderFrame, so this is the bus pump
-        // (delivers the auto-posted SavePlannerSessionSignal after pin/slider mutations) and the
-        // completion reaper for the tracked async saves.
-        _bus.ProcessPending(_tracker);
-        _tracker.ProcessCompletions(Logger);
-        _webGl.Clear(Background);
-        var content = new RectF32(0f, 0f, _metrics.BackingWidth, _metrics.BackingHeight);
-        if (_view == View.SkyMap && _skyTab is not null)
+        var frameStart = System.Diagnostics.Stopwatch.GetTimestamp();
+        try
         {
-            // First atlas paint: kick the lazy Tycho-2 fetch (once). Triggering here - rather than
-            // in ApplyViewFromLocation - guarantees the pipeline exists (a deep-link resolves the
-            // view before the renderer/tabs are created), and it naturally covers chip switches +
-            // browser back/forward too.
-            if (!_tycho2Requested)
+            // Web has no per-frame loop; every event ends in a RenderFrame, so this is the bus pump
+            // (delivers the auto-posted SavePlannerSessionSignal after pin/slider mutations) and the
+            // completion reaper for the tracked async saves.
+            _bus.ProcessPending(_tracker);
+            _tracker.ProcessCompletions(Logger);
+            _webGl.Clear(Background);
+            var content = new RectF32(0f, 0f, _metrics.BackingWidth, _metrics.BackingHeight);
+            if (_view == View.SkyMap && _skyTab is not null)
             {
-                _tycho2Requested = true;
-                _ = EnsureTycho2AtlasAsync();
+                // First atlas paint: kick the lazy Tycho-2 fetch (once). Triggering here - rather than
+                // in ApplyViewFromLocation - guarantees the pipeline exists (a deep-link resolves the
+                // view before the renderer/tabs are created), and it naturally covers chip switches +
+                // browser back/forward too.
+                if (!_tycho2Requested)
+                {
+                    _tycho2Requested = true;
+                    _ = EnsureTycho2AtlasAsync();
+                }
+                // DPI + font each have one owner: the widget's DpiScale / FontPath properties (the browser's
+                // devicePixelRatio + resolved font, re-set per frame since the JS resize observer updates
+                // _metrics / _fontPath out of band). The web host has no emoji font.
+                _skyTab.DpiScale = (float)_metrics.DevicePixelRatio;
+                _skyTab.FontPath = _fontPath;
+                _skyTab.Render(_state, content, Time);
             }
-            // DPI + font each have one owner: the widget's DpiScale / FontPath properties (the browser's
-            // devicePixelRatio + resolved font, re-set per frame since the JS resize observer updates
-            // _metrics / _fontPath out of band). The web host has no emoji font.
-            _skyTab.DpiScale = (float)_metrics.DevicePixelRatio;
-            _skyTab.FontPath = _fontPath;
-            _skyTab.Render(_state, content, Time);
+            else
+            {
+                _tab.DpiScale = (float)_metrics.DevicePixelRatio;
+                _tab.FontPath = _fontPath;
+                _tab.Render(_state, content, Time, _mouse);
+            }
+            _webGl.Present();
+            SyncOverlayRect(); // regions were re-registered by the Render above
+            SyncSelectableTextLayer();
         }
-        else
+        finally
         {
-            _tab.DpiScale = (float)_metrics.DevicePixelRatio;
-            _tab.FontPath = _fontPath;
-            _tab.Render(_state, content, Time, _mouse);
+            // Measured here rather than read off a trace: the browser runs the whole paint inside the
+            // animation-frame callback, so a trace cannot separate "the frame was slow" from "the
+            // candidate gather inside it was slow". Paired with the tab's own gather timer it can.
+            _renderMs += System.Diagnostics.Stopwatch.GetElapsedTime(frameStart).TotalMilliseconds;
         }
-        _webGl.Present();
-        SyncOverlayRect(); // regions were re-registered by the Render above
-        SyncSelectableTextLayer();
     }
 
     // ── Selectable-text DOM layer ─────────────────────────────────────────────
@@ -1311,7 +1323,9 @@
         => "{\"frames\":" + _renderFrames.ToString(CultureInfo.InvariantCulture)
             + ",\"coalesced\":" + _rafCoalesced.ToString(CultureInfo.InvariantCulture)
             + ",\"gathers\":" + (_skyTab?.PrimOverlayGathers ?? 0).ToString(CultureInfo.InvariantCulture)
-            + ",\"overlay\":" + ((_skyTab?.State.ShowObjectOverlay ?? false) ? "true" : "false") + "}";
+            + ",\"overlay\":" + ((_skyTab?.State.ShowObjectOverlay ?? false) ? "true" : "false")
+            + ",\"renderMs\":" + _renderMs.ToString("F1", CultureInfo.InvariantCulture)
+            + ",\"gatherMs\":" + (_skyTab?.PrimOverlayGatherMs ?? 0).ToString("F1", CultureInfo.InvariantCulture) + "}";
 
     [JSInvokable]
     public string GetPlannerSearchRectJson()


### PR DESCRIPTION
A browser trace of a real session showed **62 of 1899 animation-frame callbacks (3.3%) carrying 54% of all render time**, worst 231 ms, 61 of them during a gesture. That says *when* but not *what*, so the first thing here is the instrumentation that can answer it, and then two measured fixes.

## Attributing it needed app-side timers, not the trace

The browser runs the whole paint inside the rAF callback, so "the frame was slow" and "the gather inside it was slow" are the same trace sample until they are timed apart. `renderMs` (Planner) + `PrimOverlayGatherMs` (the tab) separate them; `GatherAttributionProbe` (env-gated on `TIANWEN_WEB_PROBE=1`, like the other probes in this repo) drives the gesture and reads them back.

**And it has to be measured on the AOT artifact.** A `dotnet run` dev-server measurement is not merely noisier, it is *wrong in direction*: interpreted WASM inflates the primitive drawing 29x and the catalog walk 8x, so it does not preserve ratios **between** code paths. It initially falsified the gather hypothesis; the AOT measurement inverted that.

## 1. Cheap gates before the expensive one

The magnitude test was the **last** gate, after the cross-index closure that this file itself calls "the single most expensive question asked per candidate". That is backwards exactly where it hurts most: past 90 degrees the walk sweeps the whole sphere (65,160 grid cells, the entire DSO catalog) while the cutoff is at its **tightest** (`GetExtendedMagCutoff` returns 8.0, Messier-class only), so nearly every object paid for a cross-index lookup and was then dropped on magnitude.

Semantics are unchanged, pinned targets included: with pins present an object still takes the long way, because recognising a pin genuinely needs the cross-refs. `seen` membership is untouched, so the cross-catalog dedupe behaves identically.

Desktop benchmark (`SkyMapOverlayGatherBenchmarks`):

| case | before | after |
|---|---|---|
| fov 20 | 1.01 ms | **0.61 ms** |
| fov 60 | 12.10 ms | **4.83 ms** |
| fov 94 | 51.81 ms | **23.94 ms** |
| pole | 11.62 ms | **4.86 ms** |

## 2. The FOV drops out of the wide-field cache key

Above the wide threshold the gather **cannot depend on the field of view at all**: the scan already sweeps the whole sphere, and both magnitude cutoffs are flat above 5 degrees (8.0 extended, 1.0 stellar). The only remaining FOV dependence is the dark-nebula on-screen-size filter, so this is gated on `[D]` being off rather than approximated. That makes it exact, which is why it is a key change and not a cache.

A 90-to-180-degree zoom-out used to cross about eleven of the 10% FOV buckets, each paying for a full-sky sweep.

## End to end, AOT artifact

| | before | after |
|---|---|---|
| gathers on a wide zoom-out | 11 | **5** |
| per gather | 121.0 ms | **48.8 ms** |
| total gathering | 1331 ms | **244 ms** |
| worst single frame | 223.7 ms | **91.1 ms** |
| narrow-field gather frames | 43.3 ms | **35.6 ms** |

## One alternative tried and dropped

Reusing the gather's scratch collections: 3% at narrow field and **slightly worse** at wide (110.2 to 121.0 ms per gather). Allocation is not the cost here, the per-object work is. Reverted rather than kept as a plausible-sounding no-op.

## Still on the table

Sorting each `RaDecIndex` cell brightest-first, so faint objects are never *visited*. After change 1 the residual per-object cost is `seen.Add` plus `TryLookupByIndex`, which a magnitude-sorted prefix would skip entirely. Biggest remaining lever and the most invasive: entry storage changes, and it interacts with the cross-catalog dedupe (a faint object currently suppresses a bright cross-linked one via `seen`, which arguably wants fixing on its own merits).

## Testing

`gathers.ShouldBe(1)` over a 90-to-180-degree sweep, in `SkyMapOverlayCacheKeyTests`. The counter is why this is testable at all: a stale-keyed rebuild draws the byte-identical frame, so nothing observable, pixels included, separates a key that holds from one that misses on every event.

`TianWen.Lib.Tests` 4240 passed / 0 failed, `TianWen.Lib.Tests.Functional` 338 passed / 0 failed.

Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YYnrhjBmgaqrqrXn7tZaoP
