### PR TITLE
perf(skymap): the browser overlay drew one polyline per marker, and re-gathered per zoom step

### DIFF
--- a/src/TianWen.Lib.Tests/OverlayEllipseInstanceTests.cs
+++ b/src/TianWen.Lib.Tests/OverlayEllipseInstanceTests.cs
@@ -1,0 +1,220 @@
+using System;
+using System.Collections.Generic;
+using System.Numerics;
+using DIR.Lib;
+using Shouldly;
+using TianWen.Lib.Astrometry.Catalogs;
+using TianWen.Lib.Astrometry.SOFA;
+using TianWen.UI.Abstractions.Overlays;
+using Xunit;
+
+namespace TianWen.Lib.Tests
+{
+    /// <summary>
+    /// <see cref="OverlayEllipseInstances"/> is the one description of what the instanced overlay
+    /// pipelines draw -- desktop Vulkan and browser WebGL both fill their buffer from it, and both
+    /// shaders read the layout it writes.
+    ///
+    /// <para><b>Nothing downstream can catch a mistake here.</b> The consumer is a vertex shader on
+    /// two backends: a size in the wrong unit, a swapped semi-axis or a stride that disagrees with
+    /// the attribute declaration renders something plausible-looking rather than failing, and the
+    /// only surface that could show it is a GPU. So the arithmetic is pinned at the boundary where
+    /// it is still ordinary CPU code.</para>
+    /// </summary>
+    public class OverlayEllipseInstanceTests(ITestOutputHelper output)
+    {
+        // 900 px tall viewport at 60 degrees -- an ordinary sky-map frame.
+        private static readonly float ArcminToPx =
+            (float)(TianWen.UI.Abstractions.SkyMapProjection.PixelsPerRadian(900f, 60.0) * Math.PI / (180.0 * 60.0));
+
+        private static OverlayCandidate Candidate(
+            OverlayCandidateMarker marker, bool pinned = false, double ra = 5.5, double dec = 10.0)
+            => new()
+            {
+                CatalogIndex = default,  // nothing on this path reads it
+                ObjectType = ObjectType.Galaxy,
+                RA = ra,
+                Dec = dec,
+                UnitVec = Vector3.Normalize(new Vector3(0.3f, 0.5f, 0.81f)),
+                Color = (0.5f, 0.6f, 0.7f),
+                Marker = marker,
+                LabelLines = ["x"],
+                IsPinned = pinned,
+                LabelPriority = 1f,
+                LabelSlotHint = 0,
+                ScreenSizeFilterArcmin = float.NaN,
+            };
+
+        private static List<float> Build(
+            IReadOnlyList<OverlayCandidate> candidates, float fovAlpha = 1f,
+            bool dimBelowHorizon = false, SiteContext site = default)
+        {
+            var instances = new List<float>();
+            OverlayEllipseInstances.Build(
+                candidates, instances, ArcminToPx, dpiScale: 1f, fovAlpha,
+                dimBelowHorizon, site,
+                OverlayEngine.PinnedMarkerColor, OverlayEngine.PinnedHaloColor);
+            return instances;
+        }
+
+        private static (float MajArcmin, float MinArcmin, float PaRad, float Thickness, float A) At(
+            List<float> instances, int index)
+        {
+            var o = index * OverlayEllipseInstances.FloatsPerInstance;
+            return (instances[o + 3], instances[o + 4], instances[o + 5], instances[o + 6], instances[o + 10]);
+        }
+
+        /// <summary>
+        /// The buffer is a whole number of instances of the declared width. Both pipelines derive the
+        /// instance COUNT by dividing the float count by this, so a stride that drifted from the
+        /// attribute declaration would not fail -- it would silently shear every marker's geometry
+        /// into the next one's.
+        /// </summary>
+        [Fact]
+        public void TheStrideMatchesTheDeclaredInstanceWidth()
+        {
+            var instances = Build([
+                Candidate(new OverlayCandidateMarker.Ellipse(10f, 4f, (Half)30f)),
+                Candidate(new OverlayCandidateMarker.Circle(8f)),
+            ]);
+
+            OverlayEllipseInstances.FloatsPerInstance.ShouldBe(11);
+            instances.Count.ShouldBe(2 * OverlayEllipseInstances.FloatsPerInstance);
+        }
+
+        /// <summary>
+        /// A cross has no angular extent, so it is not an instance -- the caller draws it with line
+        /// primitives. Emitting one would draw a ring where a star's cross belongs.
+        /// </summary>
+        [Fact]
+        public void ACrossIsNotAnInstance()
+        {
+            var instances = Build([
+                Candidate(new OverlayCandidateMarker.Cross(6f)),
+                Candidate(new OverlayCandidateMarker.Ellipse(10f, 4f, (Half)0f)),
+                Candidate(new OverlayCandidateMarker.Cross(6f)),
+            ]);
+
+            instances.Count.ShouldBe(OverlayEllipseInstances.FloatsPerInstance);
+        }
+
+        /// <summary>
+        /// A pinned target emits its halo BEFORE its marker, because the two overlap and the painter
+        /// order is the buffer order -- a halo emitted second draws over the ring it is meant to sit
+        /// behind. The halo is identified by its own stroke width.
+        /// </summary>
+        [Fact]
+        public void ThePinnedHaloPrecedesItsMarker()
+        {
+            var instances = Build([Candidate(new OverlayCandidateMarker.Ellipse(10f, 4f, (Half)0f), pinned: true)]);
+
+            instances.Count.ShouldBe(2 * OverlayEllipseInstances.FloatsPerInstance);
+            At(instances, 0).Thickness.ShouldBe(OverlayEngine.PinnedHaloStrokePx);
+            At(instances, 1).Thickness.ShouldBe(OverlayEllipseInstances.MarkerStrokePx);
+        }
+
+        /// <summary>
+        /// The halo scales BOTH semi-axes by one factor and keeps the marker's position angle, so a
+        /// pinned edge-on galaxy wears an elongated halo rather than a wide circle. This is the exact
+        /// defect that was fixed on the two rasterisation paths separately, one of them long after the
+        /// other -- which is the argument for the geometry living in one place.
+        /// </summary>
+        [Fact]
+        public void ThePinnedHaloKeepsTheObjectsAxisRatioAndAngle()
+        {
+            const float maj = 12f, min = 3f;
+            var instances = Build([Candidate(new OverlayCandidateMarker.Ellipse(maj, min, (Half)45f), pinned: true)]);
+
+            var halo = At(instances, 0);
+            var marker = At(instances, 1);
+
+            (halo.MajArcmin / halo.MinArcmin).ShouldBe(maj / min, 1e-4f);
+            halo.MajArcmin.ShouldBeGreaterThan(marker.MajArcmin);
+            halo.PaRad.ShouldBe(marker.PaRad, 1e-6f);
+            output.WriteLine($"marker {marker.MajArcmin:0.##}x{marker.MinArcmin:0.##}', halo {halo.MajArcmin:0.##}x{halo.MinArcmin:0.##}'");
+        }
+
+        /// <summary>
+        /// A circle's radius is authored in SCREEN PIXELS but the shader only speaks arcminutes, so
+        /// the builder divides by the current scale. It has to come back out at the pixel size it
+        /// went in as, or every default marker changes size with the zoom instead of staying put.
+        /// </summary>
+        [Theory]
+        [InlineData(180.0)]
+        [InlineData(60.0)]
+        [InlineData(5.0)]
+        public void ACircleRoundTripsThroughArcminutesAtItsPixelSize(double fovDeg)
+        {
+            const float radiusPx = 8f;
+            var arcminToPx = (float)(
+                TianWen.UI.Abstractions.SkyMapProjection.PixelsPerRadian(900f, fovDeg) * Math.PI / (180.0 * 60.0));
+
+            var instances = new List<float>();
+            OverlayEllipseInstances.Build(
+                [Candidate(new OverlayCandidateMarker.Circle(radiusPx))], instances,
+                arcminToPx, dpiScale: 1f, fovAlpha: 1f, dimBelowHorizon: false, site: default,
+                OverlayEngine.PinnedMarkerColor, OverlayEngine.PinnedHaloColor);
+
+            var c = At(instances, 0);
+            (c.MajArcmin * arcminToPx).ShouldBe(radiusPx, 1e-3f);
+            c.MajArcmin.ShouldBe(c.MinArcmin);
+        }
+
+        /// <summary>
+        /// The wide-FOV fade dims ordinary markers and leaves pinned ones alone -- that exemption is
+        /// what makes a planner target a landmark at any zoom.
+        /// </summary>
+        [Fact]
+        public void TheWideFovFadeSparesAPinnedTarget()
+        {
+            const float fovAlpha = 0.55f;
+            var plain = Build([Candidate(new OverlayCandidateMarker.Ellipse(10f, 4f, (Half)0f))], fovAlpha);
+            var pinned = Build([Candidate(new OverlayCandidateMarker.Ellipse(10f, 4f, (Half)0f), pinned: true)], fovAlpha);
+
+            At(plain, 0).A.ShouldBe(fovAlpha, 1e-6f);
+            At(pinned, 1).A.ShouldBe(1f, 1e-6f);
+        }
+
+        /// <summary>
+        /// An unknown catalog position angle draws unrotated. NaN would propagate through the
+        /// shader's rotation into a degenerate quad -- the marker would vanish, not tilt.
+        /// </summary>
+        [Fact]
+        public void AnUnknownPositionAngleDrawsUnrotated()
+        {
+            var instances = Build([Candidate(new OverlayCandidateMarker.Ellipse(10f, 4f, Half.NaN))]);
+
+            At(instances, 0).PaRad.ShouldBe(0f);
+        }
+
+        /// <summary>
+        /// A shape with a zero minor axis still gets a sub-pixel floor on both axes, so it traces a
+        /// thin ring instead of collapsing to a line the ellipse SDF cannot stroke.
+        /// </summary>
+        [Fact]
+        public void ADegenerateShapeStillHasBothAxes()
+        {
+            var instances = Build([Candidate(new OverlayCandidateMarker.Ellipse(0f, 0f, (Half)0f))]);
+
+            var m = At(instances, 0);
+            (m.MajArcmin * ArcminToPx).ShouldBe(1f, 1e-3f);
+            (m.MinArcmin * ArcminToPx).ShouldBe(0.5f, 1e-3f);
+        }
+
+        /// <summary>Rebuilding clears first: the buffer is reused across frames.</summary>
+        [Fact]
+        public void ARebuildReplacesRatherThanAppends()
+        {
+            var instances = new List<float>();
+            var candidates = new[] { Candidate(new OverlayCandidateMarker.Ellipse(10f, 4f, (Half)0f)) };
+            for (var i = 0; i < 3; i++)
+            {
+                OverlayEllipseInstances.Build(
+                    candidates, instances, ArcminToPx, 1f, 1f, false, default,
+                    OverlayEngine.PinnedMarkerColor, OverlayEngine.PinnedHaloColor);
+            }
+
+            instances.Count.ShouldBe(OverlayEllipseInstances.FloatsPerInstance);
+        }
+    }
+}

--- a/src/TianWen.Lib.Tests/OverlayLabelOrderTests.cs
+++ b/src/TianWen.Lib.Tests/OverlayLabelOrderTests.cs
@@ -1,0 +1,140 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Shouldly;
+using TianWen.UI.Abstractions.Overlays;
+using Xunit;
+
+namespace TianWen.Lib.Tests
+{
+    /// <summary>
+    /// Label placement consumes items in priority order but usually stops after
+    /// <see cref="OverlayEngine.MaxOverlayLabels"/> of them (80). It used to copy the whole item list
+    /// and sort it completely to find those 80 -- at a full-sky zoom, ~7,800 items copied and sorted
+    /// on every repaint, measured at 1.84 ms per frame. It now pops from a heap built in O(n).
+    ///
+    /// <para><b>What has to be pinned is the ORDER, not the speed.</b> Placement is deliberately
+    /// deterministic frame to frame: the slot is a pure function of the catalog index and the
+    /// priority is a pure function of the object, so labels do not reshuffle while panning. A pop
+    /// order that differed from the sorted one even for equal-priority items would reintroduce
+    /// exactly the flicker the StableSortKey tiebreak was added to kill -- and it would look like a
+    /// rendering glitch, not like a comparison bug.</para>
+    /// </summary>
+    public class OverlayLabelOrderTests(ITestOutputHelper output)
+    {
+        private static OverlayItem Item(float priority, ulong key) => new()
+        {
+            ScreenX = 100f,
+            ScreenY = 100f,
+            Marker = OverlayMarker.Circle(4f),
+            LabelLines = ["L" + key],
+            LabelPriority = priority,
+            StableSortKey = key,
+        };
+
+        /// <summary>The order the old copy-and-sort produced, kept here as the oracle.</summary>
+        private static List<OverlayItem> SortedTheOldWay(IReadOnlyList<OverlayItem> items)
+        {
+            var sorted = new List<OverlayItem>(items);
+            sorted.Sort((a, b) =>
+            {
+                var c = b.LabelPriority.CompareTo(a.LabelPriority);
+                if (c != 0) return c;
+                return a.StableSortKey.CompareTo(b.StableSortKey);
+            });
+            return sorted;
+        }
+
+        private static List<ulong> DrawOrder(IReadOnlyList<OverlayItem> items, int maxLabels)
+        {
+            var seen = new List<ulong>();
+            OverlayEngine.PlaceLabelsBestEffort(
+                items, labelSize: 10f, labelPad: 4f,
+                measureText: (t, s) => t.Length * s * 0.5f,
+                drawLabelLines: (item, _, _) => seen.Add(item.StableSortKey),
+                maxLabels: maxLabels);
+            return seen;
+        }
+
+        /// <summary>
+        /// Element for element, including ties. Deliberately seeds MANY equal priorities: that is the
+        /// case the tiebreak exists for, and a heap that only agreed on distinct priorities would pass
+        /// a test built from unique values.
+        /// </summary>
+        [Fact]
+        public void ThePopOrderMatchesTheSortedOrderExactly()
+        {
+            var rng = new Random(42);
+            var items = new List<OverlayItem>();
+            for (var i = 0; i < 2000; i++)
+            {
+                // Only 20 distinct priorities over 2000 items, so ties are the common case.
+                items.Add(Item(rng.Next(0, 20), (ulong)rng.Next(0, int.MaxValue)));
+            }
+
+            var expected = SortedTheOldWay(items).Select(i => i.StableSortKey).ToList();
+            var actual = DrawOrder(items, maxLabels: items.Count);
+
+            actual.Count.ShouldBe(expected.Count);
+            actual.SequenceEqual(expected).ShouldBeTrue("the heap order must equal the sorted order");
+            output.WriteLine($"{items.Count} items, {expected.Distinct().Count()} distinct keys: order identical");
+        }
+
+        /// <summary>
+        /// The cap still applies, and the items drawn are the TOP ones -- the whole point of ordering
+        /// before capping. A heap that popped in arbitrary order would still draw exactly 80 labels,
+        /// so a count assertion alone cannot see this.
+        /// </summary>
+        [Fact]
+        public void TheCapKeepsTheHighestPriorityItems()
+        {
+            var items = new List<OverlayItem>();
+            for (var i = 0; i < 500; i++)
+            {
+                items.Add(Item(priority: i, key: (ulong)i));
+            }
+
+            var drawn = DrawOrder(items, maxLabels: OverlayEngine.MaxOverlayLabels);
+
+            drawn.Count.ShouldBe(OverlayEngine.MaxOverlayLabels);
+            var expected = SortedTheOldWay(items)
+                .Take(OverlayEngine.MaxOverlayLabels).Select(i => i.StableSortKey).ToList();
+            drawn.SequenceEqual(expected).ShouldBeTrue();
+            drawn[0].ShouldBe(499ul, "the highest priority must come first");
+        }
+
+        /// <summary>
+        /// Why the order is popped LAZILY rather than selected as a bounded top-80. The collision
+        /// variant drops a label that cannot find a free slot and lets the next one through, so it can
+        /// walk well past the cap; truncating its input to 80 would silently change which labels
+        /// appear. Every item here is stacked on one point, so all four slots collide immediately and
+        /// placement has to keep reaching further down the order to fill the cap.
+        /// </summary>
+        [Fact]
+        public void TheCollisionVariantWalksPastTheCap()
+        {
+            var items = new List<OverlayItem>();
+            for (var i = 0; i < 400; i++)
+            {
+                items.Add(Item(priority: i, key: (ulong)i));
+            }
+
+            var examined = 0;
+            var placed = 0;
+            OverlayEngine.PlaceLabels(
+                items, labelSize: 10f, labelPad: 4f,
+                measureText: (t, s) => { examined++; return 400f; },
+                drawLabelLines: (_, _, _) => placed++,
+                maxLabels: 10);
+
+            output.WriteLine($"placed {placed} labels after measuring {examined} items");
+            examined.ShouldBeGreaterThan(placed,
+                "collisions must let placement reach past the items it actually drew");
+        }
+
+        /// <summary>An empty input must not pop, allocate, or throw.</summary>
+        [Fact]
+        public void AnEmptyItemListDrawsNothing()
+            => DrawOrder([], maxLabels: OverlayEngine.MaxOverlayLabels).ShouldBeEmpty();
+    }
+}

--- a/src/TianWen.Lib.Tests/SkyMapDarkNebulaScreenFilterTests.cs
+++ b/src/TianWen.Lib.Tests/SkyMapDarkNebulaScreenFilterTests.cs
@@ -1,0 +1,162 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using DIR.Lib;
+using Shouldly;
+using TianWen.Lib.Astrometry.Catalogs;
+using TianWen.UI.Abstractions;
+using TianWen.UI.Abstractions.Overlays;
+using Xunit;
+
+namespace TianWen.Lib.Tests
+{
+    /// <summary>
+    /// The dark-nebula on-screen-size rule is split across the two overlay phases: the gather admits a
+    /// SUPERSET (permissive at the widest field of view its cache key can be reused across) and
+    /// <see cref="OverlayEngine.ProjectSkyMapCandidatesInto"/> applies the exact test per frame.
+    ///
+    /// <para><b>Why the split exists.</b> The test is view-dependent, and it was the last view-dependent
+    /// thing left inside the CACHED phase -- which meant a wide zoom with [D] on re-ran the full-sky walk
+    /// for every 10% FOV bucket it crossed. Measured against the deployed build: 30 gathers over a
+    /// zoom-out with dark nebulae on, against 3 with them off.</para>
+    ///
+    /// <para><b>Why the gather does not simply drop the filter.</b> That was the first attempt and it is
+    /// far too expensive: only 190 of 4,827 shaped dark nebulae survive at 180 degrees, so removing it
+    /// would inflate the cached set -- and its label building -- by ~4,600 entries. Clamping the
+    /// pre-filter to the threshold FOV admits 1,655 instead, which is the union over the whole wide
+    /// range and therefore exact rather than merely cheaper.</para>
+    ///
+    /// <para>These pin both halves: nothing illegible is ever drawn, the visible set still shrinks as the
+    /// view widens, and the gathered set is genuinely FOV-independent above the threshold (which is what
+    /// entitles the cache key to drop the FOV).</para>
+    /// </summary>
+    [Collection("Astrometry")]
+    public class SkyMapDarkNebulaScreenFilterTests(ITestOutputHelper output)
+    {
+        private const float Width = 1600f;
+        private const float Height = 1000f;
+        private static readonly RectF32 Rect = new(0f, 0f, Width, Height);
+
+        /// <summary>
+        /// Waits for the bulk load, which these tests genuinely need rather than merely prefer. The
+        /// gather's cross-catalog dedupe suppresses an object when a cross-index of it has already been
+        /// seen, so a DB that is still filling in cross-references answers a LATER gather with FEWER
+        /// candidates than an earlier one -- which reads exactly like a field-of-view dependence and is
+        /// not one. It cost a false failure here (312 objects, all "missing" from the last gather in the
+        /// sequence) before the cause was found.
+        /// </summary>
+        private static async Task<CelestialObjectDB> LoadAsync()
+        {
+            var db = new CelestialObjectDB();
+            await db.InitDBAsync(waitForTycho2BulkLoad: true);
+            return db;
+        }
+
+        private static List<OverlayCandidate> GatherAt(CelestialObjectDB db, double fov)
+        {
+            var state = new SkyMapState { CenterRA = 18.0, CenterDec = -25.0, FieldOfViewDeg = fov };
+            var candidates = new List<OverlayCandidate>(16384);
+            OverlayEngine.GatherSkyMapOverlayCandidates(
+                state.ComputeViewMatrix(), fov, Rect, 1f, db, null, candidates);
+            return candidates;
+        }
+
+        private static List<OverlayItem> ProjectAt(IReadOnlyList<OverlayCandidate> candidates, double fov)
+        {
+            var state = new SkyMapState { CenterRA = 18.0, CenterDec = -25.0, FieldOfViewDeg = fov };
+            state.CurrentViewMatrix = state.ComputeViewMatrix();
+            var items = new List<OverlayItem>(16384);
+            OverlayEngine.ProjectSkyMapCandidatesInto(candidates, state, Rect, 1f, items);
+            return items;
+        }
+
+        /// <summary>
+        /// The exact rule, enforced where it now lives. Every dark nebula that survives projection must
+        /// clear the legibility threshold AT THE PROJECTED FIELD OF VIEW -- not at the wider one the
+        /// cached candidate list was gathered for. A superset that is never narrowed is the failure mode
+        /// this whole split could have introduced, and it would look like clutter rather than a crash.
+        /// </summary>
+        [Theory]
+        [InlineData(90.0)]
+        [InlineData(120.0)]
+        [InlineData(150.0)]
+        [InlineData(180.0)]
+        public async Task NoIllegibleDarkNebulaSurvivesProjection(double fov)
+        {
+            var db = await LoadAsync();
+            var candidates = GatherAt(db, OverlayEngine.WideFovDeg);
+            var byKey = candidates.ToDictionary(c => (ulong)c.CatalogIndex, c => c);
+
+            var items = ProjectAt(candidates, fov);
+            var arcminToPixels = OverlayEngine.GetArcminToPixels(Height, fov);
+
+            var drawn = 0;
+            foreach (var item in items)
+            {
+                if (!byKey.TryGetValue(item.StableSortKey, out var cand)) continue;
+                if (float.IsNaN(cand.ScreenSizeFilterArcmin) || cand.IsPinned) continue;
+                drawn++;
+                (cand.ScreenSizeFilterArcmin * arcminToPixels)
+                    .ShouldBeGreaterThanOrEqualTo(OverlayEngine.DarkNebulaMinOnScreenPx,
+                        $"a dark nebula {cand.ScreenSizeFilterArcmin:F1} arcmin across was drawn at fov {fov}");
+            }
+
+            output.WriteLine($"fov {fov,5:F0}: {items.Count,6} items projected, {drawn,5} size-filtered dark nebulae drawn");
+            drawn.ShouldBeGreaterThan(0, "the sample view should contain SOME legible dark nebulae");
+        }
+
+        /// <summary>
+        /// The half a one-directional check cannot see: the visible set must still SHRINK as the view
+        /// widens, exactly as it did when the filter ran inside the gather. A projection that quietly
+        /// stopped filtering would satisfy "nothing illegible survives" only by drawing nothing, and a
+        /// projection that never narrowed the superset would show a flat count here.
+        /// </summary>
+        [Fact]
+        public async Task TheVisibleDarkNebulaCountFallsAsTheViewWidens()
+        {
+            var db = await LoadAsync();
+            var candidates = GatherAt(db, OverlayEngine.WideFovDeg);
+            var byKey = candidates.ToDictionary(c => (ulong)c.CatalogIndex, c => c);
+
+            var counts = new List<(double Fov, int Drawn)>();
+            foreach (var fov in new[] { 90.0, 120.0, 150.0, 180.0 })
+            {
+                var drawn = ProjectAt(candidates, fov)
+                    .Count(i => byKey.TryGetValue(i.StableSortKey, out var c)
+                        && !float.IsNaN(c.ScreenSizeFilterArcmin));
+                counts.Add((fov, drawn));
+                output.WriteLine($"  fov {fov,5:F0}: {drawn,5} dark nebulae drawn");
+            }
+
+            for (var i = 1; i < counts.Count; i++)
+            {
+                counts[i].Drawn.ShouldBeLessThan(counts[i - 1].Drawn,
+                    $"widening from {counts[i - 1].Fov} to {counts[i].Fov} must hide more dark nebulae");
+            }
+        }
+
+        /// <summary>
+        /// What entitles the cache key to drop the field of view above the threshold: the gathered set is
+        /// the SAME at every wide FOV. Assert on the candidate identities rather than the count, since two
+        /// different sets of equal size would pass a count check.
+        /// </summary>
+        [Fact]
+        public async Task TheGatheredSetIsIdenticalAcrossTheWholeWideRange()
+        {
+            var db = await LoadAsync();
+            var baseline = GatherAt(db, OverlayEngine.WideFovDeg)
+                .Select(c => (ulong)c.CatalogIndex).ToHashSet();
+
+            foreach (var fov in new[] { 120.0, 150.0, 180.0 })
+            {
+                var here = GatherAt(db, fov).Select(c => (ulong)c.CatalogIndex).ToHashSet();
+                here.SetEquals(baseline).ShouldBeTrue(
+                    $"the gather at fov {fov} differs from the one at {OverlayEngine.WideFovDeg} by "
+                    + $"{here.Except(baseline).Count()} added / {baseline.Except(here).Count()} missing");
+            }
+
+            output.WriteLine($"wide-range gathered set: {baseline.Count} candidates, identical at 90/120/150/180");
+        }
+    }
+}

--- a/src/TianWen.Lib.Tests/SkyMapDarkNebulaScreenFilterTests.cs
+++ b/src/TianWen.Lib.Tests/SkyMapDarkNebulaScreenFilterTests.cs
@@ -18,8 +18,9 @@ namespace TianWen.Lib.Tests
     ///
     /// <para><b>Why the split exists.</b> The test is view-dependent, and it was the last view-dependent
     /// thing left inside the CACHED phase -- which meant a wide zoom with [D] on re-ran the full-sky walk
-    /// for every 10% FOV bucket it crossed. Measured against the deployed build: 30 gathers over a
-    /// zoom-out with dark nebulae on, against 3 with them off.</para>
+    /// for every 10% FOV bucket it crossed. Measured against the deployed build over a 60-to-180
+    /// degree zoom-out: 6 gathers with dark nebulae on and 632 ms spent gathering, against 3 and
+    /// 193 ms with them off; the fixed build costs 3 either way.</para>
     ///
     /// <para><b>Why the gather does not simply drop the filter.</b> That was the first attempt and it is
     /// far too expensive: only 190 of 4,827 shaped dark nebulae survive at 180 degrees, so removing it

--- a/src/TianWen.Lib.Tests/SkyMapOverlayCacheKeyTests.cs
+++ b/src/TianWen.Lib.Tests/SkyMapOverlayCacheKeyTests.cs
@@ -33,7 +33,8 @@ namespace TianWen.Lib.Tests
             => new SkyMapTab<RgbaImage>(new RgbaImageRenderer((int)Width, (int)Height)) { Bus = new SignalBus() };
 
         /// <summary>Keys the tab's overlay cache for the current view, as a render would.</summary>
-        private static object KeyFor(SkyMapTab<RgbaImage> tab, double centreRa, double centreDec, double fov)
+        private static object KeyFor(
+            SkyMapTab<RgbaImage> tab, double centreRa, double centreDec, double fov, bool showDark = false)
         {
             tab.State.CenterRA = centreRa;
             tab.State.CenterDec = centreDec;
@@ -44,7 +45,7 @@ namespace TianWen.Lib.Tests
             var cx = rect.X + rect.Width * 0.5f;
             var cy = rect.Y + rect.Height * 0.5f;
             var ppr = SkyMapProjection.PixelsPerRadian(rect.Height, fov);
-            return tab.BuildOverlayKeyForTest(rect, fov, cx, cy, ppr, new PlannerState());
+            return tab.BuildOverlayKeyForTest(rect, fov, cx, cy, ppr, new PlannerState(), showDark);
         }
 
         /// <summary>Gathers a gesture would cost: one per key change, plus the first.</summary>
@@ -145,24 +146,34 @@ namespace TianWen.Lib.Tests
         /// <summary>
         /// Past the wide-FOV threshold the gather cannot depend on the field of view either, so
         /// ZOOMING there must not re-gather. The scan already sweeps the whole sphere, and both
-        /// magnitude cutoffs are flat above 5 degrees (8.0 extended, 1.0 stellar), so the only FOV
-        /// dependence left is the dark-nebula on-screen-size filter, which is off here.
+        /// magnitude cutoffs are flat above 5 degrees (8.0 extended, 1.0 stellar).
         ///
         /// <para>This is the expensive gather: a full-sky sweep measured at 121 ms in the browser, and
         /// a 90-to-180-degree zoom-out crossed about eleven of the 10% FOV buckets before this.</para>
+        ///
+        /// <para><b>Both toggle states, and the [D]-on one is the regression.</b> The dark-nebula
+        /// on-screen-size test was the last FOV-dependent thing in the gather, so the first version of
+        /// this optimisation had to give up whenever [D] was on -- measured against the deployed build,
+        /// a zoom-out then cost a gather on EVERY step (30 against 3), which handed the worst case to
+        /// the users who had asked for the most overlay. The gather now admits a superset valid across
+        /// the whole wide range and the projection applies the exact test per frame, so the answer no
+        /// longer depends on the toggle.</para>
         /// </summary>
-        [Fact]
-        public void AWideFovZoomDoesNotReGatherWhenDarkNebulaeAreOff()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void AWideFovZoomDoesNotReGather(bool showDark)
         {
             var tab = BuildTab();
             var keys = new List<object>();
             for (var fov = 90.0; fov <= 180.0; fov += 5.0)
             {
-                keys.Add(KeyFor(tab, centreRa: 6.5, centreDec: 20.0, fov));
+                keys.Add(KeyFor(tab, centreRa: 6.5, centreDec: 20.0, fov, showDark));
             }
 
             var gathers = GathersOver(keys);
-            output.WriteLine($"zoom 90->180 deg over {keys.Count} steps, dark nebulae off: {gathers} gathers");
+            output.WriteLine($"zoom 90->180 deg over {keys.Count} steps, dark nebulae "
+                + (showDark ? "ON" : "off") + $": {gathers} gathers");
             gathers.ShouldBe(1);
         }
 

--- a/src/TianWen.Lib.Tests/SkyMapOverlayCacheKeyTests.cs
+++ b/src/TianWen.Lib.Tests/SkyMapOverlayCacheKeyTests.cs
@@ -154,7 +154,8 @@ namespace TianWen.Lib.Tests
         /// <para><b>Both toggle states, and the [D]-on one is the regression.</b> The dark-nebula
         /// on-screen-size test was the last FOV-dependent thing in the gather, so the first version of
         /// this optimisation had to give up whenever [D] was on -- measured against the deployed build,
-        /// a zoom-out then cost a gather on EVERY step (30 against 3), which handed the worst case to
+        /// a zoom-out then cost a gather per FOV bucket ABOVE the threshold too (6 against 3 over a
+        /// 60-to-180 degree sweep, and 632 ms of gathering against 193), which handed the worst case to
         /// the users who had asked for the most overlay. The gather now admits a superset valid across
         /// the whole wide range and the projection applies the exact test per frame, so the answer no
         /// longer depends on the toggle.</para>

--- a/src/TianWen.UI.Abstractions/Overlays/OverlayCandidate.cs
+++ b/src/TianWen.UI.Abstractions/Overlays/OverlayCandidate.cs
@@ -50,6 +50,20 @@ public readonly record struct OverlayCandidate
     public required float LabelPriority { get; init; }
 
     public required int LabelSlotHint { get; init; }
+
+    /// <summary>
+    /// Angular major axis in arcminutes for an object whose visibility depends on how big it
+    /// lands on screen (dark nebulae), or <see cref="float.NaN"/> when no such test applies.
+    ///
+    /// <para>It is here because the test is VIEW-dependent while this record is deliberately
+    /// view-independent: the gather admits a superset using the widest FOV its cache key can be
+    /// reused across, and <see cref="OverlayEngine.ProjectSkyMapCandidatesInto"/> applies the
+    /// exact test for the current frame. That split is what lets the FOV drop out of the cache
+    /// key above <see cref="OverlayEngine.WideFovDeg"/> even with dark nebulae switched on --
+    /// before it, a wide zoom re-ran the full-sky walk for every 10% FOV bucket it crossed
+    /// (measured: 30 gathers over a zoom-out against 3 with them switched off).</para>
+    /// </summary>
+    public required float ScreenSizeFilterArcmin { get; init; }
 }
 
 /// <summary>Marker payload that still requires the current view matrix (for screen PA)

--- a/src/TianWen.UI.Abstractions/Overlays/OverlayCandidate.cs
+++ b/src/TianWen.UI.Abstractions/Overlays/OverlayCandidate.cs
@@ -61,7 +61,8 @@ public readonly record struct OverlayCandidate
     /// exact test for the current frame. That split is what lets the FOV drop out of the cache
     /// key above <see cref="OverlayEngine.WideFovDeg"/> even with dark nebulae switched on --
     /// before it, a wide zoom re-ran the full-sky walk for every 10% FOV bucket it crossed
-    /// (measured: 30 gathers over a zoom-out against 3 with them switched off).</para>
+    /// (measured on the deployed build over a 60-to-180 degree zoom-out: 6 gathers and 632 ms of
+    /// gathering, against 3 and 193 ms with them switched off).</para>
     /// </summary>
     public required float ScreenSizeFilterArcmin { get; init; }
 }

--- a/src/TianWen.UI.Abstractions/Overlays/OverlayEllipseInstances.cs
+++ b/src/TianWen.UI.Abstractions/Overlays/OverlayEllipseInstances.cs
@@ -1,0 +1,176 @@
+using System;
+using System.Collections.Generic;
+using System.Numerics;
+using DIR.Lib;
+using TianWen.Lib.Astrometry.SOFA;
+
+namespace TianWen.UI.Abstractions.Overlays;
+
+/// <summary>
+/// Builds the per-instance vertex stream for the instanced overlay-ellipse pipeline -- the one
+/// draw that replaces a per-marker CPU trace. Shared by the Vulkan pipeline
+/// (<c>VkSkyMapPipeline.DrawOverlayEllipses</c>) and the WebGL one
+/// (<c>WebGlSkyMapPipeline.DrawOverlay</c>), which run byte-identical shaders modulo GL's flipped
+/// NDC Y.
+///
+/// <para>Nothing here projects: the vertex shader stereographic-projects each unit vector and
+/// recovers the screen-space position angle by finite-differencing a point one arcmin north, so
+/// this pass is pure geometry selection -- which markers exist, how big in ARCMINUTES, what
+/// colour. That is also why it is worth sharing rather than mirroring: the halo sizing alone has
+/// four rules (uniform scale, legibility floor, axis-ratio preservation, per-marker-kind
+/// fallback) and both surfaces had to agree on all of them.</para>
+///
+/// <para><b>Cross markers are deliberately absent.</b> A cross is two straight strokes with no
+/// angular extent, so it has nothing to gain from a projection the shader would do for it, and
+/// giving the instance a kind discriminant would put a branch in front of every ellipse. Callers
+/// draw crosses with line primitives from the projected items. At a full-sky zoom that is 772
+/// markers against 7,072 here.</para>
+/// </summary>
+public static class OverlayEllipseInstances
+{
+    /// <summary>
+    /// Floats per instance: <c>vec3 unitVec, vec2 sizeArcmin, float paFromNorth, float thickness,
+    /// vec4 color</c>. Matches the attribute layout both pipelines declare.
+    /// </summary>
+    public const int FloatsPerInstance = 11;
+
+    /// <summary>Stroke width of an ordinary (non-halo) marker ring, in pixels.</summary>
+    public const float MarkerStrokePx = 1.5f;
+
+    /// <summary>
+    /// Appends one instance per ellipse / circle marker in <paramref name="candidates"/> (plus a
+    /// halo instance ahead of each pinned one, so the halo draws underneath) to
+    /// <paramref name="instances"/>, which is cleared first.
+    /// </summary>
+    /// <param name="candidates">The cached, view-independent candidate list.</param>
+    /// <param name="instances">Destination float buffer; <see cref="FloatsPerInstance"/> per instance.</param>
+    /// <param name="arcminToPx">Current arcminutes-to-pixels scale. Markers whose size is defined in
+    /// SCREEN pixels (circles, the halo floor) are converted back to arcminutes with its reciprocal,
+    /// because the shader only speaks arcminutes; the round trip is exact since both sides derive the
+    /// scale from the same pixels-per-radian.</param>
+    /// <param name="dpiScale">Surface DPI scale, applied to the pixel-defined sizes.</param>
+    /// <param name="fovAlpha">Wide-FOV fade already resolved by the caller. Applied to non-pinned
+    /// markers only.</param>
+    /// <param name="dimBelowHorizon">Whether to dim objects currently below the horizon.</param>
+    /// <param name="site">Site context for that horizon test.</param>
+    /// <param name="pinnedMarkerColor">Colour of a pinned target's own marker, alpha ignored.</param>
+    /// <param name="pinnedHaloColor">Colour of the halo behind it, alpha included -- the caller has
+    /// already folded <paramref name="fovAlpha"/> into it.</param>
+    public static void Build(
+        IReadOnlyList<OverlayCandidate> candidates,
+        List<float> instances,
+        float arcminToPx,
+        float dpiScale,
+        float fovAlpha,
+        bool dimBelowHorizon,
+        SiteContext site,
+        RGBAColor32 pinnedMarkerColor,
+        RGBAColor32 pinnedHaloColor)
+    {
+        instances.Clear();
+        if (candidates.Count == 0)
+        {
+            return;
+        }
+
+        var pxToArcmin = 1f / arcminToPx;
+        var haloFloorPx = OverlayEngine.PinnedHaloMinSemiMajorPx * dpiScale;
+        var haloR = pinnedHaloColor.RedF;
+        var haloG = pinnedHaloColor.GreenF;
+        var haloB = pinnedHaloColor.BlueF;
+        var haloA = pinnedHaloColor.AlphaF;
+
+        for (var i = 0; i < candidates.Count; i++)
+        {
+            var cand = candidates[i];
+            if (cand.Marker is OverlayCandidateMarker.Cross)
+            {
+                continue;
+            }
+
+            var alpha = OverlayEngine.MarkerAlpha(
+                cand.IsPinned, cand.RA, cand.Dec, dimBelowHorizon, site, fovAlpha);
+
+            // Halo first so it lands behind the marker. An ELLIPSE marker gets an ELLIPSE halo --
+            // one uniform scale on both semi-axes plus the marker's own position angle, so the halo
+            // keeps the object's shape. Sizing a circle from the major axis alone (which both paths
+            // used to do) puts a wide round halo around an edge-on galaxy.
+            if (cand.IsPinned)
+            {
+                if (cand.Marker is OverlayCandidateMarker.Ellipse he)
+                {
+                    var haloScale = OverlayEngine.EllipseLegibilityScale(
+                        he.SemiMajArcmin * arcminToPx, haloFloorPx, OverlayEngine.PinnedHaloScale);
+                    // Same 1 px / 0.5 px floors as the marker below, so a catalog shape with a zero
+                    // minor axis still traces a visible ring rather than a degenerate line.
+                    Append(instances, cand.UnitVec,
+                        MathF.Max(he.SemiMajArcmin * haloScale, pxToArcmin),
+                        MathF.Max(he.SemiMinArcmin * haloScale, 0.5f * pxToArcmin),
+                        PositionAngleRad(he),
+                        OverlayEngine.PinnedHaloStrokePx,
+                        haloR, haloG, haloB, haloA);
+                }
+                else
+                {
+                    var haloPx = cand.Marker is OverlayCandidateMarker.Circle hc
+                        ? MathF.Max(hc.RadiusPxAtDpi1 * dpiScale * OverlayEngine.PinnedHaloScale, haloFloorPx)
+                        : haloFloorPx;
+                    var haloArcmin = haloPx * pxToArcmin;
+                    Append(instances, cand.UnitVec, haloArcmin, haloArcmin, 0f,
+                        OverlayEngine.PinnedHaloStrokePx, haloR, haloG, haloB, haloA);
+                }
+            }
+
+            float r, g, b;
+            if (cand.IsPinned)
+            {
+                r = pinnedMarkerColor.RedF;
+                g = pinnedMarkerColor.GreenF;
+                b = pinnedMarkerColor.BlueF;
+            }
+            else
+            {
+                (r, g, b) = cand.Color;
+            }
+
+            switch (cand.Marker)
+            {
+                case OverlayCandidateMarker.Ellipse e:
+                    // 1 px / 0.5 px floors keep tiny galaxies legible at wide FOV.
+                    Append(instances, cand.UnitVec,
+                        MathF.Max(e.SemiMajArcmin, pxToArcmin),
+                        MathF.Max(e.SemiMinArcmin, 0.5f * pxToArcmin),
+                        PositionAngleRad(e),
+                        MarkerStrokePx, r, g, b, alpha);
+                    break;
+                case OverlayCandidateMarker.Circle c:
+                    var circleArcmin = c.RadiusPxAtDpi1 * dpiScale * pxToArcmin;
+                    Append(instances, cand.UnitVec, circleArcmin, circleArcmin, 0f,
+                        MarkerStrokePx, r, g, b, alpha);
+                    break;
+            }
+        }
+    }
+
+    /// <summary>An unknown catalog position angle draws unrotated rather than not at all.</summary>
+    private static float PositionAngleRad(OverlayCandidateMarker.Ellipse e)
+        => Half.IsNaN(e.PositionAngle) ? 0f : (float)((double)e.PositionAngle * Math.PI / 180.0);
+
+    private static void Append(
+        List<float> instances, Vector3 unitVec,
+        float semiMajArcmin, float semiMinArcmin, float paFromNorthRad, float thickness,
+        float r, float g, float b, float a)
+    {
+        instances.Add(unitVec.X);
+        instances.Add(unitVec.Y);
+        instances.Add(unitVec.Z);
+        instances.Add(semiMajArcmin);
+        instances.Add(semiMinArcmin);
+        instances.Add(paFromNorthRad);
+        instances.Add(thickness);
+        instances.Add(r);
+        instances.Add(g);
+        instances.Add(b);
+        instances.Add(a);
+    }
+}

--- a/src/TianWen.UI.Abstractions/Overlays/OverlayEngine.cs
+++ b/src/TianWen.UI.Abstractions/Overlays/OverlayEngine.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Buffers;
 using System.Collections.Generic;
 using System.Numerics;
 using DIR.Lib;
@@ -1108,8 +1109,10 @@ public static class OverlayEngine
         var cyView = contentRect.Y + contentRect.Height * 0.5f;
         var arcminToPixels = (float)(ppr * Math.PI / (180.0 * 60.0));
 
-        foreach (var cand in candidates)
+        for (var candIndex = 0; candIndex < candidates.Count; candIndex++)
         {
+            var cand = candidates[candIndex];
+
             // The exact half of the dark-nebula on-screen-size rule. The gather admits a superset
             // (see OverlayCandidate.ScreenSizeFilterArcmin), so the decision for THIS field of
             // view is made here, per frame, where the real ppr is known. Pinned targets bypass it,
@@ -1178,7 +1181,119 @@ public static class OverlayEngine
                 LabelPriority = cand.LabelPriority,
                 LabelSlotHint = cand.LabelSlotHint,
                 StableSortKey = (ulong)cand.CatalogIndex,
+                CandidateIndex = candIndex,
             });
+        }
+    }
+
+    /// <summary>
+    /// Label order: higher <see cref="OverlayItem.LabelPriority"/> first, ties broken on the raw
+    /// catalog-index bits. Negative means <paramref name="a"/> labels first.
+    ///
+    /// <para>The tiebreak is load-bearing rather than tidy: priority is a function of the object
+    /// alone, so without it two equal-priority stars fought over the same slot and one flickered
+    /// away each frame.</para>
+    /// </summary>
+    private static int CompareLabelOrder(OverlayItem a, OverlayItem b)
+    {
+        var c = b.LabelPriority.CompareTo(a.LabelPriority);
+        return c != 0 ? c : a.StableSortKey.CompareTo(b.StableSortKey);
+    }
+
+    /// <summary>
+    /// Yields overlay items in label order while doing only the work the caller actually consumes.
+    ///
+    /// <para><b>Why not just sort.</b> Both placement routines stop once <c>maxLabels</c> labels are
+    /// down -- 80 by default -- but they used to copy the whole item list and sort it completely to
+    /// find those 80. At a full-sky zoom that is ~7,800 items copied and sorted every frame to pick
+    /// 80 of them, measured at 1.84 ms per frame on desktop .NET and paid again on every repaint
+    /// (the browser has no render loop, so a gesture repaints per event). Heapify is O(n) and each
+    /// pop is O(log n), so the same 80 cost O(n + 80 log n).</para>
+    ///
+    /// <para>It is LAZY rather than a bounded top-80 select, because the collision variant may walk
+    /// well past 80 items: a label that cannot find a free slot is dropped and the next one gets a
+    /// chance. Truncating the input would silently change which labels appear. Popping preserves
+    /// the previous order exactly, element for element.</para>
+    ///
+    /// <para>Backed by <see cref="ArrayPool{T}"/>, so the steady state allocates nothing at all;
+    /// the old form allocated a fresh <see cref="List{T}"/> of every item per frame. Callers must
+    /// <see cref="Dispose"/> it -- via <c>try/finally</c>, since the draw callbacks can throw.</para>
+    /// </summary>
+    private struct LabelOrder
+    {
+        private OverlayItem[]? _heap;
+        private int _count;
+
+        public static LabelOrder Build(IReadOnlyList<OverlayItem> items)
+        {
+            var n = items.Count;
+            var heap = ArrayPool<OverlayItem>.Shared.Rent(Math.Max(n, 1));
+            for (var i = 0; i < n; i++)
+            {
+                heap[i] = items[i];
+            }
+            // Floyd's construction: sift down every internal node, bottom up. O(n), not O(n log n).
+            for (var i = (n >> 1) - 1; i >= 0; i--)
+            {
+                SiftDown(heap, n, i);
+            }
+            return new LabelOrder { _heap = heap, _count = n };
+        }
+
+        public bool TryPop(out OverlayItem item)
+        {
+            var heap = _heap;
+            if (heap is null || _count == 0)
+            {
+                item = null!;
+                return false;
+            }
+
+            item = heap[0];
+            _count--;
+            if (_count > 0)
+            {
+                heap[0] = heap[_count];
+                SiftDown(heap, _count, 0);
+            }
+            return true;
+        }
+
+        public void Dispose()
+        {
+            if (_heap is { } heap)
+            {
+                _heap = null;
+                // Cleared on return: OverlayItem is a class holding label strings, so a pooled
+                // array would otherwise keep a frame's worth of them reachable indefinitely.
+                ArrayPool<OverlayItem>.Shared.Return(heap, clearArray: true);
+            }
+        }
+
+        private static void SiftDown(OverlayItem[] heap, int count, int index)
+        {
+            while (true)
+            {
+                var left = 2 * index + 1;
+                if (left >= count)
+                {
+                    return;
+                }
+
+                var best = left;
+                var right = left + 1;
+                if (right < count && CompareLabelOrder(heap[right], heap[left]) < 0)
+                {
+                    best = right;
+                }
+                if (CompareLabelOrder(heap[best], heap[index]) >= 0)
+                {
+                    return;
+                }
+
+                (heap[index], heap[best]) = (heap[best], heap[index]);
+                index = best;
+            }
         }
     }
 
@@ -1212,18 +1327,9 @@ public static class OverlayEngine
         // silently when they collide. This produces stable placement under
         // panning -- priority is a function of the object alone, not of
         // neighbours, so the relative order never flips frame-to-frame.
-        // Tiebreaker on StableSortKey (raw catalog-index bits) keeps equal-priority
-        // items in a deterministic order under List<T>.Sort (QuickSort is unstable).
-        // Without this, bright stars with matching priorities fought over the same
-        // label slot and one would flicker away each frame.
-        var sorted = new List<OverlayItem>(items);
-        sorted.Sort((a, b) =>
-        {
-            var c = b.LabelPriority.CompareTo(a.LabelPriority);
-            if (c != 0) return c;
-            return a.StableSortKey.CompareTo(b.StableSortKey);
-        });
-
+        // The order (and its StableSortKey tiebreak) lives in LabelOrder, which yields it
+        // lazily: this loop usually consumes ~80 of several thousand items, so the copy +
+        // full sort this replaced was doing work for items it would never look at.
         // Seed the occupied set with any externally-owned boxes (the mount reticle label)
         // so the first catalog label that would land there is forced to another slot.
         var placedLabels = new List<(float X, float Y, float W, float H)>();
@@ -1233,64 +1339,75 @@ public static class OverlayEngine
         }
         var labelCount = 0;
 
-        foreach (var item in sorted)
+        var order = LabelOrder.Build(items);
+        try
         {
-            if (labelCount >= maxLabels || item.LabelLines.Count == 0)
+            while (order.TryPop(out var item))
             {
-                continue;
-            }
-
-            var cx = item.ScreenX;
-            var cy = item.ScreenY;
-
-            var maxLineW = 0f;
-            foreach (var line in item.LabelLines)
-            {
-                var w = measureText(line, labelSize);
-                if (w > maxLineW) maxLineW = w;
-            }
-            var lineH = labelSize * 1.2f;
-            var totalH = lineH * item.LabelLines.Count;
-
-            (float X, float Y)[] positions =
-            [
-                (cx + labelPad + 6f, cy - totalH / 2f),                 // 0 = right
-                (cx - maxLineW - labelPad - 6f, cy - totalH / 2f),      // 1 = left
-                (cx - maxLineW / 2f, cy - totalH - labelPad - 6f),      // 2 = above
-                (cx - maxLineW / 2f, cy + labelPad + 6f),               // 3 = below
-            ];
-
-            // Start from the item's stable preferred slot so the same object keeps
-            // the same label side across frames: otherwise panning causes labels to
-            // fight for position 0 and reshuffle every frame.
-            var startSlot = item.LabelSlotHint & 3;
-
-            for (var p = 0; p < 4; p++)
-            {
-                var posIdx = (startSlot + p) & 3;
-                var (lx, ly) = positions[posIdx];
-                var overlaps = false;
-                foreach (var (px, py, pw, ph) in placedLabels)
+                if (labelCount >= maxLabels || item.LabelLines.Count == 0)
                 {
-                    if (lx < px + pw && lx + maxLineW > px && ly < py + ph && ly + totalH > py)
+                    continue;
+                }
+
+                var cx = item.ScreenX;
+                var cy = item.ScreenY;
+
+                var maxLineW = 0f;
+                foreach (var line in item.LabelLines)
+                {
+                    var w = measureText(line, labelSize);
+                    if (w > maxLineW) maxLineW = w;
+                }
+                var lineH = labelSize * 1.2f;
+                var totalH = lineH * item.LabelLines.Count;
+
+                (float X, float Y)[] positions =
+                [
+                    (cx + labelPad + 6f, cy - totalH / 2f),                 // 0 = right
+                    (cx - maxLineW - labelPad - 6f, cy - totalH / 2f),      // 1 = left
+                    (cx - maxLineW / 2f, cy - totalH - labelPad - 6f),      // 2 = above
+                    (cx - maxLineW / 2f, cy + labelPad + 6f),               // 3 = below
+                ];
+
+                // Start from the item's stable preferred slot so the same object keeps
+                // the same label side across frames: otherwise panning causes labels to
+                // fight for position 0 and reshuffle every frame.
+                var startSlot = item.LabelSlotHint & 3;
+
+                for (var p = 0; p < 4; p++)
+                {
+                    var posIdx = (startSlot + p) & 3;
+                    var (lx, ly) = positions[posIdx];
+                    var overlaps = false;
+                    foreach (var (px, py, pw, ph) in placedLabels)
                     {
-                        overlaps = true;
+                        if (lx < px + pw && lx + maxLineW > px && ly < py + ph && ly + totalH > py)
+                        {
+                            overlaps = true;
+                            break;
+                        }
+                    }
+
+                    if (!overlaps)
+                    {
+                        drawLabelLines(item, lx, ly);
+                        placedLabels.Add((lx, ly, maxLineW, totalH));
+                        labelCount++;
                         break;
                     }
                 }
 
-                if (!overlaps)
-                {
-                    drawLabelLines(item, lx, ly);
-                    placedLabels.Add((lx, ly, maxLineW, totalH));
-                    labelCount++;
-                    break;
-                }
+                // If all 4 rotations collided, the label is dropped (no force fallback).
+                // Because the pop order is priority-ordered, the dropped labels are always
+                // the least important ones in a dense region: stable and principled. It is
+                // also why the order has to stay LAZY rather than a bounded top-N select --
+                // a drop here lets the next item through, so this loop can walk well past
+                // maxLabels before it is done.
             }
-
-            // If all 4 rotations collided, the label is dropped (no force fallback).
-            // Because sorted is priority-ordered, the dropped labels are always the
-            // least important ones in a dense region: stable and principled.
+        }
+        finally
+        {
+            order.Dispose();
         }
     }
 
@@ -1317,78 +1434,78 @@ public static class OverlayEngine
         int maxLabels = MaxOverlayLabels,
         IReadOnlyList<(float X, float Y, float W, float H)>? reservedRegions = null)
     {
-        var sorted = new List<OverlayItem>(items);
-        sorted.Sort((a, b) =>
-        {
-            var c = b.LabelPriority.CompareTo(a.LabelPriority);
-            if (c != 0) return c;
-            return a.StableSortKey.CompareTo(b.StableSortKey);
-        });
-
         var labelCount = 0;
-        foreach (var item in sorted)
+        var order = LabelOrder.Build(items);
+        try
         {
-            if (labelCount >= maxLabels || item.LabelLines.Count == 0)
+            while (order.TryPop(out var item))
             {
-                break;
-            }
-
-            var maxLineW = 0f;
-            foreach (var line in item.LabelLines)
-            {
-                var w = measureText(line, labelSize);
-                if (w > maxLineW) maxLineW = w;
-            }
-            var lineH = labelSize * 1.2f;
-            var totalH = lineH * item.LabelLines.Count;
-
-            // Slot is a pure function of the catalog index (see OverlayItem.LabelSlotHint),
-            // so a given object always labels on the same side across frames.
-            var slot = item.LabelSlotHint & 3;
-            float lx, ly;
-            switch (slot)
-            {
-                case 1: // left
-                    lx = item.ScreenX - maxLineW - labelPad - 6f;
-                    ly = item.ScreenY - totalH / 2f;
-                    break;
-                case 2: // above
-                    lx = item.ScreenX - maxLineW / 2f;
-                    ly = item.ScreenY - totalH - labelPad - 6f;
-                    break;
-                case 3: // below
-                    lx = item.ScreenX - maxLineW / 2f;
-                    ly = item.ScreenY + labelPad + 6f;
-                    break;
-                default: // 0 = right
-                    lx = item.ScreenX + labelPad + 6f;
-                    ly = item.ScreenY - totalH / 2f;
-                    break;
-            }
-
-            // Best-effort placement has no inter-label collision check (overlapping labels
-            // are accepted, Stellarium-style), but a reserved box belongs to something more
-            // important than a catalog name (the mount reticle label); drop the few labels
-            // that would land on it rather than letting them bury it.
-            if (reservedRegions is { Count: > 0 })
-            {
-                var blocked = false;
-                foreach (var (px, py, pw, ph) in reservedRegions)
+                if (labelCount >= maxLabels || item.LabelLines.Count == 0)
                 {
-                    if (lx < px + pw && lx + maxLineW > px && ly < py + ph && ly + totalH > py)
-                    {
-                        blocked = true;
+                    break;
+                }
+
+                var maxLineW = 0f;
+                foreach (var line in item.LabelLines)
+                {
+                    var w = measureText(line, labelSize);
+                    if (w > maxLineW) maxLineW = w;
+                }
+                var lineH = labelSize * 1.2f;
+                var totalH = lineH * item.LabelLines.Count;
+
+                // Slot is a pure function of the catalog index (see OverlayItem.LabelSlotHint),
+                // so a given object always labels on the same side across frames.
+                var slot = item.LabelSlotHint & 3;
+                float lx, ly;
+                switch (slot)
+                {
+                    case 1: // left
+                        lx = item.ScreenX - maxLineW - labelPad - 6f;
+                        ly = item.ScreenY - totalH / 2f;
                         break;
+                    case 2: // above
+                        lx = item.ScreenX - maxLineW / 2f;
+                        ly = item.ScreenY - totalH - labelPad - 6f;
+                        break;
+                    case 3: // below
+                        lx = item.ScreenX - maxLineW / 2f;
+                        ly = item.ScreenY + labelPad + 6f;
+                        break;
+                    default: // 0 = right
+                        lx = item.ScreenX + labelPad + 6f;
+                        ly = item.ScreenY - totalH / 2f;
+                        break;
+                }
+
+                // Best-effort placement has no inter-label collision check (overlapping labels
+                // are accepted, Stellarium-style), but a reserved box belongs to something more
+                // important than a catalog name (the mount reticle label); drop the few labels
+                // that would land on it rather than letting them bury it.
+                if (reservedRegions is { Count: > 0 })
+                {
+                    var blocked = false;
+                    foreach (var (px, py, pw, ph) in reservedRegions)
+                    {
+                        if (lx < px + pw && lx + maxLineW > px && ly < py + ph && ly + totalH > py)
+                        {
+                            blocked = true;
+                            break;
+                        }
+                    }
+                    if (blocked)
+                    {
+                        continue;
                     }
                 }
-                if (blocked)
-                {
-                    continue;
-                }
-            }
 
-            drawLabelLines(item, lx, ly);
-            labelCount++;
+                drawLabelLines(item, lx, ly);
+                labelCount++;
+            }
+        }
+        finally
+        {
+            order.Dispose();
         }
     }
 }

--- a/src/TianWen.UI.Abstractions/Overlays/OverlayEngine.cs
+++ b/src/TianWen.UI.Abstractions/Overlays/OverlayEngine.cs
@@ -645,6 +645,25 @@ public static class OverlayEngine
     }
 
     /// <summary>
+    /// Field of view at or above which the candidate walk sweeps the WHOLE sphere, so the
+    /// gathered set stops depending on where the view is pointed.
+    ///
+    /// <para>One constant rather than the three literal 90s it replaced, because the cache keys
+    /// that drop the centre (and now the FOV) above this threshold are only correct if they use
+    /// the same number the scan switches on. Two of the three lived in hand-maintained mirrors of
+    /// each other, which is exactly the pair that silently drifts.</para>
+    /// </summary>
+    public const double WideFovDeg = 90.0;
+
+    /// <summary>
+    /// Minimum on-screen size, in pixels, for a dark nebula's label and outline to be worth
+    /// drawing. Below this it is illegible clutter. Continuous in pixel space rather than the
+    /// old binary FOV cut, so appearance fades smoothly with zoom instead of flickering a pile
+    /// of labels in and out as a touch zoom crosses a boundary.
+    /// </summary>
+    public const float DarkNebulaMinOnScreenPx = 6f;
+
+    /// <summary>
     /// Phase A: walk the spatial grid, filter, dedupe, and build label lines. Produces
     /// a view-matrix-independent list of <see cref="OverlayCandidate"/>s.
     /// </summary>
@@ -758,7 +777,30 @@ public static class OverlayEngine
         // the 1 deg floor keeps the old near-edge behaviour at narrow FOVs.
         var marginDeg = Math.Max(1.0, fieldOfViewDeg * 0.15);
 
-        if (poleInView)
+        if (fieldOfViewDeg >= WideFovDeg)
+        {
+            // Whole sphere, and this branch is tested FIRST -- ahead of the pole case below --
+            // because above the threshold the gathered set MUST NOT depend on the field of view.
+            // That is what entitles the consumers' cache keys to drop the FOV (SkyMapTab.
+            // BuildOverlayKey and its VkSkyMapTab mirror), and it is not a free-standing claim:
+            // the magnitude cutoffs are already flat past 5 degrees and the dark-nebula pre-filter
+            // is clamped to the threshold, so the scan bounds were the last FOV-dependent input.
+            //
+            // Ordered the other way round it silently was not. A pole in view took the branch
+            // below, whose Dec bounds come from the corner sample and so move with the FOV -- and
+            // at these fields of view a wide-angle projection folds those corners into a narrower
+            // strip rather than a wider one. Measured on a real catalog at centre 18h -25 deg, the
+            // gathered set differed by 959 objects between 90 and 120 degrees, ALL of them present
+            // at 90 and missing at 120. Pinned by
+            // SkyMapDarkNebulaScreenFilterTests.TheGatheredSetIsIdenticalAcrossTheWholeWideRange,
+            // which is what caught it.
+            minRA = 0.0;
+            maxRA = 24.0;
+            minDec = -90.0;
+            maxDec = 90.0;
+            raWrapped = false;
+        }
+        else if (poleInView)
         {
             // Every RA projects through the pole, so the corner sample's RA bounds
             // are meaningless: sweep the full 24 h. But the Dec bounds from the
@@ -771,14 +813,6 @@ public static class OverlayEngine
             raWrapped = false;
             minDec = Math.Max(-90.0, minDec - Math.Max(2.0, marginDeg));
             maxDec = Math.Min(90.0, maxDec + Math.Max(2.0, marginDeg));
-        }
-        else if (fieldOfViewDeg >= 90.0)
-        {
-            minRA = 0.0;
-            maxRA = 24.0;
-            minDec = -90.0;
-            maxDec = 90.0;
-            raWrapped = false;
         }
         else
         {
@@ -797,17 +831,25 @@ public static class OverlayEngine
         var grid = db.DeepSkyCoordinateGrid;
         var seen = new HashSet<CatalogIndex>();
 
-        // Arcmin -> pixels (used for the dark-nebula on-screen-size filter). Pure
-        // function of ppr, so safe to compute in Phase A (view-matrix independent).
-        var arcminToPixels = (float)(ppr * Math.PI / (180.0 * 60.0));
-
-        // Dark nebulae: once the companion *.shapes.json.lz files are loaded,
-        // Dobashi / Barnard / LDN / Ced all carry natural angular sizes. Filter
-        // them by on-screen pixel size instead of the old binary FOV>10 deg cut,
-        // which flickered a pile of labels in and out as touch zoom crossed the
-        // boundary. The threshold here is in continuous pixel space, so label
-        // appearance fades smoothly with zoom.
-        const float DarkNebulaMinOnScreenPx = 6f;
+        // Arcmin -> pixels for the dark-nebula on-screen-size PRE-filter, deliberately computed
+        // at the most permissive field of view this gather's cache key can be reused across --
+        // NOT at the caller's actual FOV.
+        //
+        // Above WideFovDeg the scan already sweeps the whole sphere and both magnitude cutoffs
+        // are flat, so the consumer's cache key drops the FOV and one gathered set has to serve
+        // every FOV in [WideFovDeg, 180]. Admittance grows as the FOV narrows, so the union over
+        // that range is exactly the set admitted AT the threshold. Clamping here is what makes
+        // "the FOV is not in the key" true rather than nearly true.
+        //
+        // It stays a pre-filter, not the filter: this admits a superset, and
+        // ProjectSkyMapCandidatesInto applies the exact test for the CURRENT view every frame.
+        // Deleting the pre-filter outright would also be correct and is what a first attempt
+        // reached for, but it costs far too much: only 190 of 4,827 shaped dark nebulae survive
+        // at 180 degrees, so dropping it would inflate the cached set (and its label building) by
+        // ~4,600 entries. Clamping to the threshold admits 1,655 instead.
+        var filterPpr = SkyMapProjection.PixelsPerRadian(
+            contentRect.Height, Math.Min(fieldOfViewDeg, WideFovDeg));
+        var darkNebFilterArcminToPixels = (float)(filterPpr * Math.PI / (180.0 * 60.0));
 
         var decStep = 1.0;
         var raStep = 1.0 / 15.0;
@@ -907,17 +949,20 @@ public static class OverlayEngine
                         continue;
                     }
 
-                    // Screen-size filter for DarkNeb: hide when on-screen size drops below ~6 px
-                    // (illegible anyway). Pinned planner targets bypass this too. Entries without
-                    // shape data (e.g. Simbad NAME-only, no VizieR match) are hidden entirely --
-                    // they'd otherwise clutter wide views with placeholder circles.
+                    // Screen-size PRE-filter for DarkNeb, at the clamped FOV (see above): admit
+                    // anything that could be legible anywhere in this cache key's FOV range, and
+                    // let the projection decide per frame. Pinned planner targets bypass it, as
+                    // they bypass every other filter here. Entries without shape data (e.g. Simbad
+                    // NAME-only, no VizieR match) are hidden entirely -- they'd otherwise clutter
+                    // wide views with placeholder circles -- and THAT half is a property of the
+                    // catalog rather than of the view, so it stays in the gather.
                     if (obj.ObjectType == ObjectType.DarkNeb && !isPinnedEarly)
                     {
                         if (!db.TryGetShape(catIdx, out var dnShape) || Half.IsNaN(dnShape.MajorAxis))
                         {
                             continue;
                         }
-                        var dnScreenPx = (float)((double)dnShape.MajorAxis * arcminToPixels);
+                        var dnScreenPx = (float)((double)dnShape.MajorAxis * darkNebFilterArcminToPixels);
                         if (dnScreenPx < DarkNebulaMinOnScreenPx)
                         {
                             continue;
@@ -981,8 +1026,19 @@ public static class OverlayEngine
         foreach (var (catIdx, obj, isPinned) in scratch)
         {
             OverlayCandidateMarker marker;
-            var hasShape = db.TryGetShape(catIdx, out var shape)
+            var shapeKnown = db.TryGetShape(catIdx, out var shape);
+            var hasShape = shapeKnown
                 && !Half.IsNaN(shape.MajorAxis) && !Half.IsNaN(shape.MinorAxis);
+
+            // Carried so the projection can re-apply the on-screen-size test at the actual FOV.
+            // Read from the shape rather than off the marker: a dark nebula with a major axis but
+            // no minor axis draws as a Circle, which has no angular size at all, and that is
+            // precisely the entry a marker-derived size would silently stop filtering.
+            var sizeFilterArcmin = obj.ObjectType == ObjectType.DarkNeb
+                && shapeKnown && !Half.IsNaN(shape.MajorAxis)
+                    ? (float)shape.MajorAxis
+                    : float.NaN;
+
             switch (ChooseMarkerKind(obj.ObjectType, hasShape))
             {
                 case OverlayMarkerKind.Ellipse:
@@ -1022,6 +1078,7 @@ public static class OverlayEngine
                 IsPinned = isPinned,
                 LabelPriority = priority,
                 LabelSlotHint = (int)((ulong)catIdx & 3),
+                ScreenSizeFilterArcmin = sizeFilterArcmin,
             });
         }
     }
@@ -1053,6 +1110,16 @@ public static class OverlayEngine
 
         foreach (var cand in candidates)
         {
+            // The exact half of the dark-nebula on-screen-size rule. The gather admits a superset
+            // (see OverlayCandidate.ScreenSizeFilterArcmin), so the decision for THIS field of
+            // view is made here, per frame, where the real ppr is known. Pinned targets bypass it,
+            // matching every other filter in the gather. NaN means the object has no size test.
+            if (!float.IsNaN(cand.ScreenSizeFilterArcmin) && !cand.IsPinned
+                && cand.ScreenSizeFilterArcmin * arcminToPixels < DarkNebulaMinOnScreenPx)
+            {
+                continue;
+            }
+
             if (!SkyMapProjection.ProjectWithMatrix(cand.RA, cand.Dec, viewMatrix, ppr,
                     cxView, cyView, out var screenX, out var screenY))
             {

--- a/src/TianWen.UI.Abstractions/Overlays/OverlayEngine.cs
+++ b/src/TianWen.UI.Abstractions/Overlays/OverlayEngine.cs
@@ -5,6 +5,7 @@ using System.Numerics;
 using DIR.Lib;
 using TianWen.Lib.Astrometry;
 using TianWen.Lib.Astrometry.Catalogs;
+using TianWen.Lib.Astrometry.SOFA;
 using TianWen.Lib.Imaging;
 
 namespace TianWen.UI.Abstractions.Overlays;
@@ -271,6 +272,31 @@ public static class OverlayEngine
     /// <see cref="RGBAColor32.Alpha"/> for the wide-FOV fade rather than restating the RGB.
     /// </summary>
     public static readonly RGBAColor32 PinnedHaloColor = new(0xFF, 0x60, 0x20, 0x50);
+
+    /// <summary>
+    /// A pinned target's own marker colour (the ring inside <see cref="PinnedHaloColor"/>). Alpha is
+    /// a placeholder: every caller substitutes the horizon / wide-FOV fade it resolved. Here for the
+    /// same reason the halo colour is -- it was written out as three literals on the CPU path and
+    /// again as three float divisions on the GPU one.
+    /// </summary>
+    public static readonly RGBAColor32 PinnedMarkerColor = new(0xFF, 0x70, 0x30, 0xFF);
+
+    /// <summary>
+    /// The alpha an overlay marker or label draws at: 0.35 when it is below the horizon and the
+    /// caller dims those, times <paramref name="fovAlpha"/> unless it is pinned.
+    /// </summary>
+    /// <remarks>
+    /// A pinned target is exempt from the wide-FOV fade but NOT from horizon dimming, which is the
+    /// half that kept getting restated slightly differently: the rule appears once per marker kind
+    /// per surface (ellipse instances, crosses, labels; desktop and browser), and a landmark that
+    /// fades with zoom on one of them stops being a landmark.
+    /// </remarks>
+    public static float MarkerAlpha(
+        bool isPinned, double ra, double dec, bool dimBelowHorizon, SiteContext site, float fovAlpha)
+    {
+        var alpha = dimBelowHorizon && !site.IsAboveHorizon(ra, dec) ? 0.35f : 1f;
+        return isPinned ? alpha : alpha * fovAlpha;
+    }
 
     /// <summary>
     /// Uniform scale factor that grows a projected ellipse to a legibility floor on its

--- a/src/TianWen.UI.Abstractions/Overlays/OverlayItem.cs
+++ b/src/TianWen.UI.Abstractions/Overlays/OverlayItem.cs
@@ -66,4 +66,17 @@ public sealed class OverlayItem
     /// labels as the user pans.
     /// </summary>
     public ulong StableSortKey { get; init; }
+
+    /// <summary>
+    /// Index of the <see cref="OverlayCandidate"/> this was projected from, or -1 when the item did
+    /// not come from a candidate list (the FITS viewer builds items directly).
+    ///
+    /// <para>It exists so a marker pass can be driven FROM the projected items instead of projecting
+    /// every candidate a second time. The sky map used to do exactly that: one pass projected every
+    /// candidate to place markers, then <see cref="OverlayEngine.ProjectSkyMapCandidatesInto"/>
+    /// projected the identical set again to place labels. Markers still have to read the candidate
+    /// (the projected item drops the arcmin extent and position angle, which the GPU path reads off
+    /// the candidate instead), so the link back is what removes the duplication.</para>
+    /// </summary>
+    public int CandidateIndex { get; init; } = -1;
 }

--- a/src/TianWen.UI.Abstractions/SkyMapTab.ObjectOverlay.cs
+++ b/src/TianWen.UI.Abstractions/SkyMapTab.ObjectOverlay.cs
@@ -13,10 +13,10 @@ namespace TianWen.UI.Abstractions
     /// always-on pinned planner-target landmarks) for renderers WITHOUT a GPU instanced-ellipse
     /// pipeline -- i.e. the browser sky map. It shares the candidate gather / projection / label
     /// placement with the desktop GPU path (all in <see cref="Overlays.OverlayEngine"/>); only the
-    /// final rasterisation differs -- ellipses/crosses/circles are traced with the surface-agnostic
-    /// <c>DrawLine</c>/<c>DrawCircle</c>/<c>DrawText</c> primitives here, versus the instanced GPU
-    /// draw in <c>VkSkyMapTab.RenderObjectOverlay</c>. The two are hand-maintained mirrors, exactly
-    /// like <see cref="TryDrawShapeMarker"/> mirrors the GPU selection ellipse.
+    /// final rasterisation differs, and it is a virtual seam (<see cref="DrawOverlayMarkers"/>)
+    /// rather than a parallel method -- ellipses/crosses/circles trace with the surface-agnostic
+    /// <c>DrawLine</c>/<c>DrawCircle</c> primitives by default, while a surface with an instanced
+    /// overlay pipeline overrides it and submits one draw.
     /// </summary>
     public partial class SkyMapTab<TSurface>
     {
@@ -150,27 +150,93 @@ namespace TianWen.UI.Abstractions
                 return;
             }
 
-            // Pass 1: markers.
-            foreach (var item in _primOverlayItems)
+            DrawOverlayMarkers(_primOverlayCandidates, _primOverlayItems, PrimOverlayGathers,
+                arcminToPixels, ppr, cxView, cyView, dpiScale, fovAlpha, dimBelowHorizon, site);
+
+            // Pass 2: labels via the shared best-effort placement (stable slots) + DrawText, over the
+            // items projected once above.
+            var labelSize = baseFontSize * dpiScale * 0.85f;
+            var lineH = labelSize * 1.2f;
+            var measureText = (string text, float size) => Renderer.MeasureText(text.AsSpan(), fontPath, size).Width;
+            OverlayEngine.PlaceLabelsBestEffort(_primOverlayItems, labelSize, 4f, measureText,
+                (item, lx, ly) =>
+                {
+                    var a = OverlayEngine.MarkerAlpha(
+                        item.IsPinned, item.RA, item.Dec, dimBelowHorizon, site, fovAlpha);
+                    var (r, g, b) = item.Color;
+                    var col = item.IsPinned
+                        ? new RGBAColor32(0xFF, 0x90, 0x50, (byte)(a * 255f))
+                        : RGBAColor32.FromFloat(r, g, b, a);
+                    var maxLineW = 0f;
+                    for (var i = 0; i < item.LabelLines.Count; i++)
+                    {
+                        DrawText(item.LabelLines[i].AsSpan(), fontPath,
+                            lx, ly + i * lineH, 220f, lineH,
+                            labelSize, col, TextAlign.Near, TextAlign.Near);
+                        var w = measureText(item.LabelLines[i], labelSize);
+                        if (w > maxLineW) { maxLineW = w; }
+                    }
+
+                    // Make the LABEL itself clickable -> selects the same object its marker would (desktop
+                    // parity: VkSkyMapTab.RenderObjectOverlay registers the identical bridge on the GPU path;
+                    // the shared base already does it for planet/comet labels). Object selection is a
+                    // GEOMETRIC nearest-object search at the click point, and the label is drawn OFFSET from
+                    // the marker, so without a bridge a label click lands too far from the marker's screen
+                    // position to hit -- "clicking the label doesn't select" (web-only, since only the CPU
+                    // primitive path lacked it). Re-synthesize the click at the object's own screen position
+                    // so the existing resolver (SkyMapClickSelectSignal -> SelectObjectByClick) runs
+                    // unchanged. Skip nearly-faded labels so there are no phantom hit targets.
+                    if (a > 0.15f && maxLineW > 0f && item.LabelLines.Count > 0)
+                    {
+                        var labelH = item.LabelLines.Count * lineH;
+                        var objX = item.ScreenX;
+                        var objY = item.ScreenY;
+                        RegisterClickable(lx, ly, maxLineW, labelH,
+                            new HitResult.ButtonHit($"SkyMapObjectLabel:{item.LabelLines[0]}"),
+                            _ => PostSignal(new SkyMapClickSelectSignal(objX, objY, InputModifier.None)));
+                    }
+                });
+        }
+
+        /// <summary>
+        /// Rasterises the overlay markers for one frame. The default traces each one with the
+        /// surface-agnostic line primitives; a surface with an instanced overlay pipeline overrides
+        /// this and submits a single draw instead. Everything around it -- the cached gather, the one
+        /// projection, label placement -- is shared either way, which is the point of putting the seam
+        /// here rather than at <see cref="RenderObjectOverlayPrimitive"/>: only the rasterisation ever
+        /// differed between the two, and having them as whole parallel methods is what let the pinned
+        /// halo drift into an ellipse on one and a circle on the other.
+        /// </summary>
+        /// <param name="candidates">The cached, view-independent candidate list.</param>
+        /// <param name="items">The same candidates projected for this frame; a marker reads its
+        /// screen position here and its geometry from <paramref name="candidates"/> via
+        /// <see cref="OverlayItem.CandidateIndex"/>.</param>
+        /// <param name="candidateVersion">Bumped whenever <paramref name="candidates"/> was
+        /// re-gathered. An override that caches a GPU buffer needs it: the candidate COUNT is not a
+        /// version, so a re-gather that happens to return the same number of objects would otherwise
+        /// keep drawing the previous set.</param>
+        protected virtual void DrawOverlayMarkers(
+            IReadOnlyList<OverlayCandidate> candidates, IReadOnlyList<OverlayItem> items,
+            int candidateVersion,
+            float arcminToPixels, double ppr, float cxView, float cyView,
+            float dpiScale, float fovAlpha, bool dimBelowHorizon, SiteContext site)
+        {
+            foreach (var item in items)
             {
-                if ((uint)item.CandidateIndex >= (uint)_primOverlayCandidates.Count)
+                if ((uint)item.CandidateIndex >= (uint)candidates.Count)
                 {
                     continue;
                 }
-                var cand = _primOverlayCandidates[item.CandidateIndex];
+                var cand = candidates[item.CandidateIndex];
                 var sx = item.ScreenX;
                 var sy = item.ScreenY;
 
-                var below = dimBelowHorizon && !site.IsAboveHorizon(cand.RA, cand.Dec);
-                var alpha = below ? 0.35f : 1f;
-                if (!cand.IsPinned)
-                {
-                    alpha *= fovAlpha;
-                }
+                var alpha = OverlayEngine.MarkerAlpha(
+                    cand.IsPinned, cand.RA, cand.Dec, dimBelowHorizon, site, fovAlpha);
 
                 var (cr, cg, cb) = cand.Color;
                 var color = cand.IsPinned
-                    ? new RGBAColor32(0xFF, 0x70, 0x30, (byte)(alpha * 255f))
+                    ? OverlayEngine.PinnedMarkerColor with { Alpha = (byte)(alpha * 255f) }
                     : RGBAColor32.FromFloat(cr, cg, cb, alpha);
 
                 // Pinned halo behind the marker (geometry shared with the GPU path via
@@ -212,54 +278,6 @@ namespace TianWen.UI.Abstractions
                         break;
                 }
             }
-
-            // Pass 2: labels via the shared best-effort placement (stable slots) + DrawText, over the
-            // items projected once above.
-            var labelSize = baseFontSize * dpiScale * 0.85f;
-            var lineH = labelSize * 1.2f;
-            var measureText = (string text, float size) => Renderer.MeasureText(text.AsSpan(), fontPath, size).Width;
-            OverlayEngine.PlaceLabelsBestEffort(_primOverlayItems, labelSize, 4f, measureText,
-                (item, lx, ly) =>
-                {
-                    var below = dimBelowHorizon && !site.IsAboveHorizon(item.RA, item.Dec);
-                    var a = below ? 0.35f : 1f;
-                    if (!item.IsPinned)
-                    {
-                        a *= fovAlpha;
-                    }
-                    var (r, g, b) = item.Color;
-                    var col = item.IsPinned
-                        ? new RGBAColor32(0xFF, 0x90, 0x50, (byte)(a * 255f))
-                        : RGBAColor32.FromFloat(r, g, b, a);
-                    var maxLineW = 0f;
-                    for (var i = 0; i < item.LabelLines.Count; i++)
-                    {
-                        DrawText(item.LabelLines[i].AsSpan(), fontPath,
-                            lx, ly + i * lineH, 220f, lineH,
-                            labelSize, col, TextAlign.Near, TextAlign.Near);
-                        var w = measureText(item.LabelLines[i], labelSize);
-                        if (w > maxLineW) { maxLineW = w; }
-                    }
-
-                    // Make the LABEL itself clickable -> selects the same object its marker would (desktop
-                    // parity: VkSkyMapTab.RenderObjectOverlay registers the identical bridge on the GPU path;
-                    // the shared base already does it for planet/comet labels). Object selection is a
-                    // GEOMETRIC nearest-object search at the click point, and the label is drawn OFFSET from
-                    // the marker, so without a bridge a label click lands too far from the marker's screen
-                    // position to hit -- "clicking the label doesn't select" (web-only, since only the CPU
-                    // primitive path lacked it). Re-synthesize the click at the object's own screen position
-                    // so the existing resolver (SkyMapClickSelectSignal -> SelectObjectByClick) runs
-                    // unchanged. Skip nearly-faded labels so there are no phantom hit targets.
-                    if (a > 0.15f && maxLineW > 0f && item.LabelLines.Count > 0)
-                    {
-                        var labelH = item.LabelLines.Count * lineH;
-                        var objX = item.ScreenX;
-                        var objY = item.ScreenY;
-                        RegisterClickable(lx, ly, maxLineW, labelH,
-                            new HitResult.ButtonHit($"SkyMapObjectLabel:{item.LabelLines[0]}"),
-                            _ => PostSignal(new SkyMapClickSelectSignal(objX, objY, InputModifier.None)));
-                    }
-                });
         }
 
         private PrimOverlayKey BuildOverlayKey(
@@ -282,8 +300,15 @@ namespace TianWen.UI.Abstractions
             //
             // Worth it because the wide gather is the expensive one: a full-sky sweep measured at 121 ms
             // in the browser, and zooming out from 90 to 180 degrees crosses ~7 of the 10% buckets. With
-            // dark nebulae ON that gate cost a gather on EVERY step of a zoom-out (30 against 3), which
-            // is to say the users who most wanted the overlay were the ones getting none of the fix.
+            // dark nebulae ON that gate kept costing a gather per bucket above the threshold: measured on
+            // the deployed build over a 60-to-180 degree zoom-out, 6 gathers and 632 ms of gathering
+            // against 3 and 193 ms with them off -- so the users who most wanted the overlay were the
+            // ones getting none of the fix. The fixed build costs 3 either way.
+            //
+            // Measure this from a FRESH page. The attribution probe runs three sweeps in sequence and the
+            // third inherits wherever the second left the zoom (0.5 degrees), so nearly all of its steps
+            // are legitimately below the threshold; read that way it reports 30 gathers and attributes
+            // them here, which is how this was first written down as "30 against 3".
             if (wideFov)
             {
                 quantFov = double.PositiveInfinity;

--- a/src/TianWen.UI.Abstractions/SkyMapTab.ObjectOverlay.cs
+++ b/src/TianWen.UI.Abstractions/SkyMapTab.ObjectOverlay.cs
@@ -130,22 +130,36 @@ namespace TianWen.UI.Abstractions
             // Overlay fade at wide FOV (matches VkSkyMapTab): non-pinned markers dim toward a 0.55 floor
             // between 120 and 180 deg so a zoomed-out view stays readable; pinned targets stay full.
             var fovAlpha = MathF.Max(MathF.Min(120f / (float)fov, 1f), 0.55f);
-            var margin = 100f + arcminToPixels; // generous cull slop for large shapes
 
-            // Pass 1: markers, drawn from the CANDIDATES (they carry arcmin + position angle; the
-            // projected OverlayItem drops the PA since the GPU reads it off the candidate instead).
-            foreach (var cand in _primOverlayCandidates)
+            // ONE projection per frame, feeding BOTH passes. Markers still read their geometry off
+            // the CANDIDATE (it carries arcmin extent + position angle, which the projected item
+            // drops because the GPU path reads them off the candidate instead), so the item's
+            // CandidateIndex is the link back. This pass used to project every candidate itself and
+            // then ProjectSkyMapCandidatesInto projected the identical set again a few lines below:
+            // pure duplication, measured at ~2.1 ms per frame each at a full-sky zoom, and paid on
+            // every repaint since the browser has no render loop.
+            //
+            // Using the projection's own cull also fixes a discrepancy rather than inheriting one:
+            // the margin here was 100 + arcminToPixels, which adds a SCALE FACTOR to a pixel margin
+            // and so is ~100 px whatever the shape's size, while the projection extends its margin
+            // by the shape's actual on-screen semi-major axis. A large nebula centred just off the
+            // viewport got a label but no marker.
+            OverlayEngine.ProjectSkyMapCandidatesInto(_primOverlayCandidates, State, contentRect, dpiScale, _primOverlayItems);
+            if (_primOverlayItems.Count == 0)
             {
-                if (!SkyMapProjection.ProjectWithMatrix(cand.RA, cand.Dec, State.CurrentViewMatrix,
-                        ppr, cxView, cyView, out var sx, out var sy))
+                return;
+            }
+
+            // Pass 1: markers.
+            foreach (var item in _primOverlayItems)
+            {
+                if ((uint)item.CandidateIndex >= (uint)_primOverlayCandidates.Count)
                 {
                     continue;
                 }
-                if (sx < contentRect.X - margin || sx > contentRect.X + contentRect.Width + margin
-                    || sy < contentRect.Y - margin || sy > contentRect.Y + contentRect.Height + margin)
-                {
-                    continue;
-                }
+                var cand = _primOverlayCandidates[item.CandidateIndex];
+                var sx = item.ScreenX;
+                var sy = item.ScreenY;
 
                 var below = dimBelowHorizon && !site.IsAboveHorizon(cand.RA, cand.Dec);
                 var alpha = below ? 0.35f : 1f;
@@ -199,13 +213,8 @@ namespace TianWen.UI.Abstractions
                 }
             }
 
-            // Pass 2: labels via the shared best-effort placement (O(N), stable slots) + DrawText.
-            OverlayEngine.ProjectSkyMapCandidatesInto(_primOverlayCandidates, State, contentRect, dpiScale, _primOverlayItems);
-            if (_primOverlayItems.Count == 0)
-            {
-                return;
-            }
-
+            // Pass 2: labels via the shared best-effort placement (stable slots) + DrawText, over the
+            // items projected once above.
             var labelSize = baseFontSize * dpiScale * 0.85f;
             var lineH = labelSize * 1.2f;
             var measureText = (string text, float size) => Renderer.MeasureText(text.AsSpan(), fontPath, size).Width;

--- a/src/TianWen.UI.Abstractions/SkyMapTab.ObjectOverlay.cs
+++ b/src/TianWen.UI.Abstractions/SkyMapTab.ObjectOverlay.cs
@@ -52,15 +52,18 @@ namespace TianWen.UI.Abstractions
         /// Returns an opaque value -- only its equality across successive calls is meaningful.
         /// </summary>
         internal object BuildOverlayKeyForTest(
-            RectF32 contentRect, double fov, float cxView, float cyView, double ppr, PlannerState plannerState)
-            => BuildOverlayKey(contentRect, fov, cxView, cyView, ppr, showAllOverlays: true, showDark: false, plannerState);
+            RectF32 contentRect, double fov, float cxView, float cyView, double ppr, PlannerState plannerState,
+            bool showDark = false)
+            => BuildOverlayKey(contentRect, fov, cxView, cyView, ppr, showAllOverlays: true, showDark, plannerState);
 
         private readonly record struct PrimOverlayKey(
             double QuantRa, double QuantDec, double QuantFov,
             int RectW, int RectH, bool ShowAll, bool ShowDark, int PinHash);
 
-        // Wide FOV: the gather sweeps the whole sphere, so the view centre drops out of the cache key.
-        private const double PrimOverlayWideFovDeg = 90.0;
+        // Wide FOV: the gather sweeps the whole sphere, so the view centre (and now the FOV) drops
+        // out of the cache key. Forwards to the engine's constant so this and VkSkyMapTab's copy
+        // cannot drift from the branch they both have to agree with.
+        private const double PrimOverlayWideFovDeg = OverlayEngine.WideFovDeg;
 
         /// <summary>
         /// Draws the object overlay using CPU primitives. A subclass whose renderer has no instanced
@@ -263,14 +266,16 @@ namespace TianWen.UI.Abstractions
             // drops out of the key exactly as the centre already has. Three facts make that exact rather
             // than approximate: the scan sweeps the whole sphere past 90 degrees, and BOTH magnitude
             // cutoffs are already flat by then (GetExtendedMagCutoff and GetStarMagCutoff both switch
-            // for the last time at 5 degrees, to 8.0 and 1.0). The one remaining FOV dependence is the
-            // dark-nebula on-screen-size filter, which only exists when [D] is on, so this is gated on
-            // it rather than approximated.
+            // for the last time at 5 degrees, to 8.0 and 1.0). The last FOV dependence was the
+            // dark-nebula on-screen-size filter; the gather now admits a superset valid across the
+            // whole wide range and the projection applies the exact test per frame, so [D] no longer
+            // has to hold the FOV in the key.
             //
             // Worth it because the wide gather is the expensive one: a full-sky sweep measured at 121 ms
-            // in the browser, and zooming out from 90 to 180 degrees crosses ~7 of the 10% buckets, so
-            // it used to run about eleven times for one gesture.
-            if (wideFov && !showDark)
+            // in the browser, and zooming out from 90 to 180 degrees crosses ~7 of the 10% buckets. With
+            // dark nebulae ON that gate cost a gather on EVERY step of a zoom-out (30 against 3), which
+            // is to say the users who most wanted the overlay were the ones getting none of the fix.
+            if (wideFov)
             {
                 quantFov = double.PositiveInfinity;
             }

--- a/src/TianWen.UI.Gui/VkSkyMapTab.cs
+++ b/src/TianWen.UI.Gui/VkSkyMapTab.cs
@@ -98,13 +98,9 @@ public sealed unsafe class VkSkyMapTab(VkRenderer renderer) : SkyMapTab<VulkanCo
     private readonly List<OverlayItem> _overlayItems = [];
     private readonly List<(OverlayItem Item, float X, float Y)> _overlayPlacedLabels = [];
 
-    // Per-frame instance buffer for the overlay ellipse pipeline -- 11 floats per
-    // instance (see OverlayEllipseVertexSource for layout: vec3 unit vector, vec2
-    // arcmin size, float PA-from-north, float thickness, vec4 rgba). Reused across
-    // frames to stay allocation-free during active pan. Only Ellipse / Circle
-    // markers go in here; Cross markers (stars, low count at wide FOV) still use
-    // the per-call DrawCross path.
-    private const int OverlayEllipseFloatsPerInstance = 11;
+    // Per-frame instance buffer for the overlay ellipse pipeline, filled by the shared
+    // OverlayEllipseInstances.Build (the browser pipeline fills its own buffer from the same
+    // builder). Reused across frames to stay allocation-free during active pan.
     private readonly List<float> _overlayEllipseInstances = new(1024);
 
     /// <summary>FOV threshold at which the scan bounds become view-matrix independent
@@ -434,94 +430,18 @@ public sealed unsafe class VkSkyMapTab(VkRenderer renderer) : SkyMapTab<VulkanCo
         // computes screen-space PA via a finite-difference, so we don't do any CPU
         // projection or atan2 screen-angle math here. Cross markers are drawn on the
         // per-item CPU path below (rectangle primitive, few stars at wide FOV).
-        _overlayEllipseInstances.Clear();
-        var pinnedHaloR = pinnedHaloColor.RedF;
-        var pinnedHaloG = pinnedHaloColor.GreenF;
-        var pinnedHaloB = pinnedHaloColor.BlueF;
-        var pinnedHaloA = pinnedHaloColor.AlphaF;
-
-        // The shader scales arcmin -> px using the UBO's pixelsPerRadian, so any
-        // marker whose size was defined in screen pixels (circles, pinned halos) has
-        // to be converted to arcmin here using the current ppr. The round-trip is
-        // exact since CPU and GPU share the same derivation.
+        //
+        // The geometry lives in OverlayEllipseInstances so the browser's WebGL pipeline fills its
+        // buffer from the same rules; it used to be written out here and nowhere else, which made
+        // the port a transcription. The halo COLOUR stays a caller argument because the two
+        // surfaces genuinely differ: the desktop tints it with the active theme's accent, while the
+        // browser has no theme switcher and uses the engine's fixed landmark colour.
         var ppr = SkyMapProjection.PixelsPerRadian(contentRect.Height, fov);
         var arcminToPx = (float)(ppr * Math.PI / (180.0 * 60.0));
-        var pxToArcmin = 1f / arcminToPx;
-
-        foreach (var cand in _overlayCandidates)
-        {
-            var (r, g, b) = cand.Color;
-            var alpha = dimBelowHorizon && !site.IsAboveHorizon(cand.RA, cand.Dec) ? 0.35f : 1.0f;
-            if (!cand.IsPinned) alpha *= fovAlpha;
-
-            // Pinned halo (emitted first so it's behind the marker), sized from the shared
-            // OverlayEngine.PinnedHalo* geometry the CPU overlay path also uses. An ELLIPSE marker
-            // gets an ellipse halo: one uniform scale on both semi-axes plus the marker's own PA, so
-            // the halo keeps the object's shape. Emitting equal axes (which this did, from the major
-            // axis alone) puts a wide circular halo around an edge-on galaxy.
-            if (cand.IsPinned)
-            {
-                var haloFloorPx = OverlayEngine.PinnedHaloMinSemiMajorPx * dpiScale;
-                if (cand.Marker is OverlayCandidateMarker.Ellipse he)
-                {
-                    var haloScale = OverlayEngine.EllipseLegibilityScale(
-                        he.SemiMajArcmin * arcminToPx, haloFloorPx, OverlayEngine.PinnedHaloScale);
-                    // Same 1 px / 0.5 px floors as the marker below, so a catalog shape with a zero
-                    // minor axis still traces a visible ring rather than a degenerate line.
-                    var haloMajArcmin = MathF.Max(he.SemiMajArcmin * haloScale, pxToArcmin);
-                    var haloMinArcmin = MathF.Max(he.SemiMinArcmin * haloScale, 0.5f * pxToArcmin);
-                    var haloPaRad = Half.IsNaN(he.PositionAngle)
-                        ? 0f
-                        : (float)((double)he.PositionAngle * Math.PI / 180.0);
-                    AppendEllipseInstance(cand.UnitVec,
-                        haloMajArcmin, haloMinArcmin, haloPaRad, OverlayEngine.PinnedHaloStrokePx,
-                        pinnedHaloR, pinnedHaloG, pinnedHaloB, pinnedHaloA);
-                }
-                else
-                {
-                    var haloPx = cand.Marker is OverlayCandidateMarker.Circle hc
-                        ? MathF.Max(hc.RadiusPxAtDpi1 * dpiScale * OverlayEngine.PinnedHaloScale, haloFloorPx)
-                        : haloFloorPx;
-                    var haloArcmin = haloPx * pxToArcmin;
-                    AppendEllipseInstance(cand.UnitVec,
-                        haloArcmin, haloArcmin, 0f, OverlayEngine.PinnedHaloStrokePx,
-                        pinnedHaloR, pinnedHaloG, pinnedHaloB, pinnedHaloA);
-                }
-            }
-
-            float mainR, mainG, mainB, mainA;
-            if (cand.IsPinned)
-            {
-                mainR = 1f; mainG = 0x70 / 255f; mainB = 0x30 / 255f; mainA = alpha;
-            }
-            else
-            {
-                mainR = r; mainG = g; mainB = b; mainA = alpha;
-            }
-
-            switch (cand.Marker)
-            {
-                case OverlayCandidateMarker.Ellipse e:
-                    // 1 px / 0.5 px floors keep tiny galaxies legible at wide FOV.
-                    var semiMajArcmin = MathF.Max(e.SemiMajArcmin, pxToArcmin);
-                    var semiMinArcmin = MathF.Max(e.SemiMinArcmin, 0.5f * pxToArcmin);
-                    var paFromNorthRad = Half.IsNaN(e.PositionAngle)
-                        ? 0f
-                        : (float)((double)e.PositionAngle * Math.PI / 180.0);
-                    AppendEllipseInstance(cand.UnitVec,
-                        semiMajArcmin, semiMinArcmin, paFromNorthRad, 1.5f,
-                        mainR, mainG, mainB, mainA);
-                    break;
-                case OverlayCandidateMarker.Circle c:
-                    var circleArcmin = c.RadiusPxAtDpi1 * dpiScale * pxToArcmin;
-                    AppendEllipseInstance(cand.UnitVec,
-                        circleArcmin, circleArcmin, 0f, 1.5f,
-                        mainR, mainG, mainB, mainA);
-                    break;
-                    // Cross: handled below via the _overlayItems loop, where we have the
-                    // CPU-projected screen coords needed by DrawCross.
-            }
-        }
+        OverlayEllipseInstances.Build(
+            _overlayCandidates, _overlayEllipseInstances,
+            arcminToPx, dpiScale, fovAlpha, dimBelowHorizon, site,
+            OverlayEngine.PinnedMarkerColor, pinnedHaloColor);
 
         // Crosses (stars): per-item CPU path. Uses _overlayItems (only candidates that
         // passed CPU projection + off-screen cull), so off-screen stars don't draw.
@@ -530,8 +450,8 @@ public sealed unsafe class VkSkyMapTab(VkRenderer renderer) : SkyMapTab<VulkanCo
             if (item.Marker.Kind != OverlayMarkerKind.Cross) continue;
 
             var (r, g, b) = item.Color;
-            var alpha = dimBelowHorizon && !site.IsAboveHorizon(item.RA, item.Dec) ? 0.35f : 1.0f;
-            if (!item.IsPinned) alpha *= fovAlpha;
+            var alpha = OverlayEngine.MarkerAlpha(
+                item.IsPinned, item.RA, item.Dec, dimBelowHorizon, site, fovAlpha);
 
             var crossColor = item.IsPinned
                 ? TianWen.UI.Abstractions.GuiTheme.Palette.Accent.WithAlpha((byte)(alpha * 255))
@@ -549,7 +469,7 @@ public sealed unsafe class VkSkyMapTab(VkRenderer renderer) : SkyMapTab<VulkanCo
             var instByteOffset = ctx.WriteVertices(span);
             if (instByteOffset != uint.MaxValue)
             {
-                var instanceCount = (uint)(_overlayEllipseInstances.Count / OverlayEllipseFloatsPerInstance);
+                var instanceCount = (uint)(_overlayEllipseInstances.Count / OverlayEllipseInstances.FloatsPerInstance);
                 pipeline.DrawOverlayEllipses(
                     renderer.CurrentCommandBuffer,
                     contentRect.X, contentRect.Y, contentRect.Width, contentRect.Height,
@@ -578,8 +498,8 @@ public sealed unsafe class VkSkyMapTab(VkRenderer renderer) : SkyMapTab<VulkanCo
         foreach (var (item, lx, ly) in _overlayPlacedLabels)
         {
             var (r, g, b) = item.IsPinned ? (1f, 0.44f, 0.19f) : item.Color;
-            var labelAlpha = dimBelowHorizon && !site.IsAboveHorizon(item.RA, item.Dec) ? 0.35f : 1.0f;
-            if (!item.IsPinned) labelAlpha *= fovAlpha;
+            var labelAlpha = OverlayEngine.MarkerAlpha(
+                item.IsPinned, item.RA, item.Dec, dimBelowHorizon, site, fovAlpha);
             var maxLineW = 0f;
             for (var li = 0; li < item.LabelLines.Count; li++)
             {
@@ -1224,29 +1144,6 @@ public sealed unsafe class VkSkyMapTab(VkRenderer renderer) : SkyMapTab<VulkanCo
             floats.Add(corners[i].X); floats.Add(corners[i].Y); floats.Add(corners[i].Z);
             floats.Add(corners[next].X); floats.Add(corners[next].Y); floats.Add(corners[next].Z);
         }
-    }
-
-    /// <summary>
-    /// Appends one DSO overlay ellipse instance to <see cref="_overlayEllipseInstances"/>.
-    /// Layout must match <c>OverlayEllipseVertexSource</c>'s vertex input (11 floats,
-    /// stride 44 bytes: unit vector, size arcmin, PA from north, thickness, rgba).
-    /// </summary>
-    private void AppendEllipseInstance(
-        Vector3 unitVec,
-        float semiMajArcmin, float semiMinArcmin, float paFromNorthRad, float thickness,
-        float r, float g, float b, float a)
-    {
-        _overlayEllipseInstances.Add(unitVec.X);
-        _overlayEllipseInstances.Add(unitVec.Y);
-        _overlayEllipseInstances.Add(unitVec.Z);
-        _overlayEllipseInstances.Add(semiMajArcmin);
-        _overlayEllipseInstances.Add(semiMinArcmin);
-        _overlayEllipseInstances.Add(paFromNorthRad);
-        _overlayEllipseInstances.Add(thickness);
-        _overlayEllipseInstances.Add(r);
-        _overlayEllipseInstances.Add(g);
-        _overlayEllipseInstances.Add(b);
-        _overlayEllipseInstances.Add(a);
     }
 
     private static (Vortice.Vulkan.VkBuffer Buffer, uint ByteOffset, uint VertexCount) WriteToRingBuffer(

--- a/src/TianWen.UI.Gui/VkSkyMapTab.cs
+++ b/src/TianWen.UI.Gui/VkSkyMapTab.cs
@@ -108,8 +108,11 @@ public sealed unsafe class VkSkyMapTab(VkRenderer renderer) : SkyMapTab<VulkanCo
     private readonly List<float> _overlayEllipseInstances = new(1024);
 
     /// <summary>FOV threshold at which the scan bounds become view-matrix independent
-    /// (full-sky sweep). Keep in sync with the branch in <c>GatherSkyMapOverlayCandidates</c>.</summary>
-    private const double WideFovThresholdDeg = 90.0;
+    /// (full-sky sweep). Forwards to the engine's own constant rather than restating it: this
+    /// and the CPU tab's copy were both literal 90s that had to agree with the branch inside
+    /// GatherSkyMapOverlayCandidates, which is the arrangement a "keep in sync" comment asks
+    /// for and cannot enforce.</summary>
+    private const double WideFovThresholdDeg = OverlayEngine.WideFovDeg;
 
     // Sticky "collision vs best-effort" label placement mode. The two modes
     // disagree about dropped labels and slot overrides, so flipping between
@@ -310,6 +313,15 @@ public sealed unsafe class VkSkyMapTab(VkRenderer renderer) : SkyMapTab<VulkanCo
         // instead of once per wheel tick. The magnitude cutoffs the gather derives from FOV
         // drift by at most ~10% before a re-gather picks them up -- visually indistinguishable.
         var quantFov = Math.Pow(1.1, Math.Round(Math.Log(Math.Max(fov, 0.1)) / Math.Log(1.1)));
+
+        // Past the wide threshold the FOV drops out of the key as well as the centre, because the
+        // gathered set genuinely cannot depend on it: the scan is already the whole sphere, both
+        // magnitude cutoffs are flat above 5 degrees, and the dark-nebula on-screen-size test now
+        // lives in the per-frame projection rather than the gather. Mirrors SkyMapTab.BuildOverlayKey.
+        if (wideFov)
+        {
+            quantFov = double.PositiveInfinity;
+        }
 
         var centreX = contentRect.X + contentRect.Width * 0.5f;
         var centreY = contentRect.Y + contentRect.Height * 0.5f;

--- a/src/TianWen.UI.Web.E2E/CanvasGestures.cs
+++ b/src/TianWen.UI.Web.E2E/CanvasGestures.cs
@@ -82,9 +82,24 @@ internal static class CanvasGestures
     /// total zoom (and so the number of FOV buckets crossed) low.</param>
     public static async Task TrackpadPinchAsync(
         IPage page, ILocator target, int events, double deltaPerEvent, bool burst)
+        => await WheelAsync(page, target, events, deltaPerEvent, burst, ctrlKey: true);
+
+    /// <summary>
+    /// A PLAIN wheel, which is what a mouse wheel and a two-finger trackpad scroll deliver, and what
+    /// zooms the sky map. Distinct from <see cref="TrackpadPinchAsync"/> (ctrl+wheel) because the two
+    /// reach the app by different routes and only one of them is a pinch; a real session's trace shows
+    /// plain wheels, so a measurement driven by ctrl+wheel would be measuring the other gesture.
+    /// </summary>
+    /// <param name="deltaPerEvent">Wheel deltaY per event; positive zooms OUT on the sky map.</param>
+    public static async Task WheelZoomAsync(
+        IPage page, ILocator target, int events, double deltaPerEvent, bool burst)
+        => await WheelAsync(page, target, events, deltaPerEvent, burst, ctrlKey: false);
+
+    private static async Task WheelAsync(
+        IPage page, ILocator target, int events, double deltaPerEvent, bool burst, bool ctrlKey)
     {
         var box = await target.BoundingBoxAsync()
-            ?? throw new InvalidOperationException("Pinch target has no bounding box (not visible).");
+            ?? throw new InvalidOperationException("Wheel target has no bounding box (not visible).");
         var cx = box.X + (box.Width / 2);
         var cy = box.Y + (box.Height / 2);
 
@@ -92,14 +107,14 @@ internal static class CanvasGestures
         // argument), so there is no elementFromPoint lookup to get wrong. Values are formatted into the
         // script rather than passed as an argument object: Playwright's argument serialization did not
         // bind an anonymous type's members here, which surfaced as clientX arriving non-finite.
-        static string Script(int n, double delta, double cx, double cy)
+        static string Script(int n, double delta, double cx, double cy, bool ctrlKey)
         {
             var ci = CultureInfo.InvariantCulture;
             return $$"""
                 (el) => {
                   for (let i = 0; i < {{n.ToString(ci)}}; i++) {
                     el.dispatchEvent(new WheelEvent('wheel', {
-                      deltaY: {{delta.ToString("R", ci)}}, deltaMode: 0, ctrlKey: true,
+                      deltaY: {{delta.ToString("R", ci)}}, deltaMode: 0, ctrlKey: {{(ctrlKey ? "true" : "false")}},
                       clientX: {{cx.ToString("R", ci)}}, clientY: {{cy.ToString("R", ci)}},
                       bubbles: true, cancelable: true,
                     }));
@@ -110,11 +125,11 @@ internal static class CanvasGestures
 
         if (burst)
         {
-            await target.EvaluateAsync(Script(events, deltaPerEvent, cx, cy));
+            await target.EvaluateAsync(Script(events, deltaPerEvent, cx, cy, ctrlKey));
             return;
         }
 
-        var one = Script(1, deltaPerEvent, cx, cy);
+        var one = Script(1, deltaPerEvent, cx, cy, ctrlKey);
         for (var i = 0; i < events; i++)
         {
             await target.EvaluateAsync(one);

--- a/src/TianWen.UI.Web.E2E/CanvasRenderCostTests.cs
+++ b/src/TianWen.UI.Web.E2E/CanvasRenderCostTests.cs
@@ -35,7 +35,7 @@ public sealed class CanvasRenderCostTests(TianWenWebFixture fixture)
     private const float BootTimeout = 120_000;
     private static readonly Regex ActiveClass = new(@"\bactive\b");
 
-    private readonly record struct RenderStats(int Frames, int Coalesced, int Gathers, bool Overlay);
+    private readonly record struct RenderStats(int Frames, int Coalesced, int Gathers, bool Overlay, int Uploads);
 
     private static async Task<RenderStats> GetStatsAsync(IPage page)
     {
@@ -46,7 +46,8 @@ public sealed class CanvasRenderCostTests(TianWenWebFixture fixture)
             r.GetProperty("frames").GetInt32(),
             r.GetProperty("coalesced").GetInt32(),
             r.GetProperty("gathers").GetInt32(),
-            r.GetProperty("overlay").GetBoolean());
+            r.GetProperty("overlay").GetBoolean(),
+            r.GetProperty("uploads").GetInt32());
     }
 
     /// <summary>
@@ -201,5 +202,68 @@ public sealed class CanvasRenderCostTests(TianWenWebFixture fixture)
         Assert.True(gathers <= 12,
             $"overlay re-gathered {gathers} times over {painted} painted frames - the cache key is "
             + "missing per event, which is the raw-FOV grid-step regression");
+    }
+
+    /// <summary>
+    /// The overlay's GPU instance buffer across a PAN. The candidate gather is already cached across a
+    /// pan; the instances additionally depend on the arcmin-to-pixel scale and the wide-FOV fade, which
+    /// a pan does not move either -- so a drag must upload nothing, and the buffer is ~311 KB at a wide
+    /// zoom.
+    ///
+    /// <para>Stated as "no more uploads than gathers" rather than "zero", because a re-gather is a
+    /// legitimate reason to re-upload: the assertion is that the pan itself is not one. That also keeps
+    /// it valid at any field of view, where a flat zero would only hold above the wide threshold.</para>
+    ///
+    /// <para>Like the gather counter beside it, this cannot be observed from the output: a stale-keyed
+    /// re-upload draws the byte-identical frame, just after a needless megabyte of interop.</para>
+    /// </summary>
+    [Fact]
+    public async Task APanDoesNotReUploadTheOverlayInstanceBuffer()
+    {
+        var page = await WarmSkyAtlasAsync();
+        var canvas = page.Locator("#planner");
+        await EnsureObjectOverlayOnAsync(page, canvas);
+
+        RenderStats before, afterPan, afterZoom;
+        try
+        {
+            // One upload has to have happened before the pan, or "it did not upload" is vacuous.
+            await CanvasGestures.WheelZoomAsync(page, canvas, events: 2, deltaPerEvent: 1.5, burst: false);
+            await page.EvaluateAsync("() => new Promise(r => requestAnimationFrame(() => r()))");
+            before = await GetStatsAsync(page);
+            Assert.True(before.Uploads > 0,
+                "no instance buffer was ever uploaded; the pan assertion below would measure nothing");
+
+            var box = await canvas.BoundingBoxAsync() ?? throw new InvalidOperationException("no canvas box");
+            var y = box.Y + (box.Height / 2);
+            await page.Mouse.MoveAsync(box.X + (box.Width * 0.6f), y);
+            await page.Mouse.DownAsync();
+            for (var i = 1; i <= 20; i++)
+            {
+                await page.Mouse.MoveAsync(box.X + (box.Width * 0.6f) - (i * 6), y);
+                await page.EvaluateAsync("() => new Promise(r => requestAnimationFrame(() => r()))");
+            }
+            await page.Mouse.UpAsync();
+            await page.EvaluateAsync("() => new Promise(r => requestAnimationFrame(() => r()))");
+            afterPan = await GetStatsAsync(page);
+
+            // A zoom, by contrast, MUST re-upload: it changes the scale every marker is sized by. Without
+            // this half the test would also pass on a buffer that is never uploaded again at all.
+            await CanvasGestures.WheelZoomAsync(page, canvas, events: 6, deltaPerEvent: 1.5, burst: false);
+            await page.EvaluateAsync("() => new Promise(r => requestAnimationFrame(() => r()))");
+            afterZoom = await GetStatsAsync(page);
+        }
+        finally
+        {
+            await SetObjectOverlayAsync(page, canvas, on: false);
+        }
+
+        var painted = afterPan.Frames - before.Frames;
+        Assert.True(painted > 0, "the pan painted nothing, so it measured nothing");
+        Assert.True(afterPan.Uploads - before.Uploads <= afterPan.Gathers - before.Gathers,
+            $"a pan re-uploaded the instance buffer without re-gathering; uploads +{afterPan.Uploads - before.Uploads}, "
+            + $"gathers +{afterPan.Gathers - before.Gathers} over {painted} painted frames");
+        Assert.True(afterZoom.Uploads > afterPan.Uploads,
+            "a zoom must re-upload the instance buffer; it changes the scale every marker is sized by");
     }
 }

--- a/src/TianWen.UI.Web.E2E/GatherAttributionProbe.cs
+++ b/src/TianWen.UI.Web.E2E/GatherAttributionProbe.cs
@@ -48,6 +48,32 @@ public sealed class GatherAttributionProbe(TianWenWebFixture fixture, ITestOutpu
         return doc.RootElement.GetProperty("fovDeg").GetDouble();
     }
 
+    /// <summary>
+    /// Zooms back to <paramref name="targetFov"/> before a sweep starts.
+    ///
+    /// <para><b>Sweeps do not start where the previous one started.</b> Each leaves the zoom wherever
+    /// it ended -- the second sweep here bottoms out around 0.5 degrees -- so a following zoom-out
+    /// spends nearly all its steps BELOW the 90 degree wide threshold, where a gather per 10% FOV
+    /// bucket is correct behaviour. Read without this, the third sweep reported 30 gathers and they
+    /// were attributed to its [D] toggle; measured from a common start the real figure is 6 against 3.
+    /// A leg that silently measures a different field of view than the one it is compared against is
+    /// worse than no measurement, because it looks like one.</para>
+    /// </summary>
+    private static async Task ResetFovAsync(IPage page, ILocator canvas, double targetFov)
+    {
+        for (var i = 0; i < 60; i++)
+        {
+            var fov = await FovAsync(page);
+            if (Math.Abs(fov - targetFov) / targetFov < 0.08)
+            {
+                return;
+            }
+            await CanvasGestures.WheelZoomAsync(page, canvas, events: 1,
+                deltaPerEvent: fov < targetFov ? +120.0 : -120.0, burst: false);
+        }
+        Assert.Fail($"could not return the sky map to {targetFov} deg; the sweeps would not be comparable");
+    }
+
     /// <summary>Presses a sky-map toggle key and lets the resulting repaint land.</summary>
     private static async Task ToggleAsync(IPage page, ILocator canvas, string key)
     {
@@ -98,6 +124,9 @@ public sealed class GatherAttributionProbe(TianWenWebFixture fixture, ITestOutpu
         // past 90 degrees; if it is the per-frame draw, they do not.
         async Task SweepAsync(string label, int steps, double deltaPerEvent)
         {
+            // Every sweep starts from the app's default field of view, so their gather counts are
+            // comparable with each other (see ResetFovAsync).
+            await ResetFovAsync(page, canvas, targetFov: 60.0);
             output.WriteLine($"=== {label} ===");
             output.WriteLine($"{"step",4} {"fov",8} {"frames",7} {"gathers",8} {"renderMs",9} {"gatherMs",9}");
             var rows = new List<(double Fov, Stats S)>(steps);

--- a/src/TianWen.UI.Web.E2E/GatherAttributionProbe.cs
+++ b/src/TianWen.UI.Web.E2E/GatherAttributionProbe.cs
@@ -40,6 +40,104 @@ public sealed class GatherAttributionProbe(TianWenWebFixture fixture, ITestOutpu
             r.GetProperty("gatherMs").GetDouble());
     }
 
+    /// <summary>Current sky-map field of view, so a per-step cost can be placed on the zoom axis.</summary>
+    private static async Task<double> FovAsync(IPage page)
+    {
+        var json = await page.EvaluateAsync<string>("async () => await window.__tianwenTest.getSkyView()");
+        using var doc = JsonDocument.Parse(json);
+        return doc.RootElement.GetProperty("fovDeg").GetDouble();
+    }
+
+    /// <summary>Presses a sky-map toggle key and lets the resulting repaint land.</summary>
+    private static async Task ToggleAsync(IPage page, ILocator canvas, string key)
+    {
+        await canvas.PressAsync(key);
+        await page.EvaluateAsync("() => new Promise(r => requestAnimationFrame(() => r()))");
+    }
+
+    /// <summary>
+    /// The follow-up measurement, and the one aimed at what is LEFT. A trace of the deployed build
+    /// after the gather fixes split cleanly by gesture: 805 pan frames averaged 2.22 ms (the
+    /// centre-quantized cache holding), while 57 frames following a wheel averaged 17.93 ms and carried
+    /// 36.4% of all animation-frame time, p95 124 ms and worst 161 ms. Twenty wheel events cost more
+    /// than eight hundred pointermoves, so the remaining cost is on the ZOOM axis specifically.
+    ///
+    /// <para>This drives plain wheel zooms and reports, per step, the field of view, whether a gather
+    /// ran, and the render/gather split -- which separates the two candidate explanations that a trace
+    /// cannot: a gather still re-running per 10% FOV bucket below the wide threshold, or a per-frame
+    /// cost that scales with zoom and was never cached at all (the overlay DRAW, which re-projects and
+    /// re-strokes every candidate each frame).</para>
+    ///
+    /// <para>Run it against the DEPLOYED artifact to reproduce a real trace, by pointing
+    /// <c>TIANWEN_WEB_BASEURL</c> at the published site. Interpreted WASM does not preserve ratios
+    /// between code paths (measured 29x inflation on primitive drawing against 8x on the catalog walk),
+    /// so a dev-server run can attribute this to the wrong half.</para>
+    /// </summary>
+    [Fact]
+    public async Task AttributeWheelZoomFrameCost()
+    {
+        Assert.SkipUnless(Enabled, "set TIANWEN_WEB_PROBE=1 to run this measurement");
+
+        var page = await fixture.WarmPageAsync();
+        await page.Locator("[data-view=sky]").ClickAsync();
+        await Expect(page.Locator("[data-view=sky]")).ToHaveClassAsync(ActiveClass, new() { Timeout = BootTimeout });
+        var canvas = page.Locator("#planner");
+
+        // The gather only runs with the [O] catalog overlay on, and it is off by default.
+        var stats = await page.EvaluateAsync<string>("async () => await window.__tianwenTest.getRenderStats()");
+        using (var doc = JsonDocument.Parse(stats))
+        {
+            if (!doc.RootElement.GetProperty("overlay").GetBoolean())
+            {
+                await ToggleAsync(page, canvas, "o");
+            }
+        }
+
+        // [D] is the one thing that keeps the field of view in the wide cache key, so the same sweep is
+        // run with dark nebulae off and on. If the residual cost is the gather, the two differ sharply
+        // past 90 degrees; if it is the per-frame draw, they do not.
+        async Task SweepAsync(string label, int steps, double deltaPerEvent)
+        {
+            output.WriteLine($"=== {label} ===");
+            output.WriteLine($"{"step",4} {"fov",8} {"frames",7} {"gathers",8} {"renderMs",9} {"gatherMs",9}");
+            var rows = new List<(double Fov, Stats S)>(steps);
+            var p0 = await ReadAsync(page);
+            for (var i = 0; i < steps; i++)
+            {
+                await CanvasGestures.WheelZoomAsync(page, canvas, events: 1, deltaPerEvent, burst: false);
+                var c = await ReadAsync(page);
+                var d = new Stats(c.Frames - p0.Frames, c.Gathers - p0.Gathers,
+                    c.RenderMs - p0.RenderMs, c.GatherMs - p0.GatherMs);
+                p0 = c;
+                var fov = await FovAsync(page);
+                rows.Add((fov, d));
+                output.WriteLine($"{i,4} {fov,8:F1} {d.Frames,7} {d.Gathers,8} {d.RenderMs,9:F1} {d.GatherMs,9:F1}");
+            }
+
+            var render = rows.Sum(r => r.S.RenderMs);
+            var gather = rows.Sum(r => r.S.GatherMs);
+            var gathers = rows.Sum(r => r.S.Gathers);
+            output.WriteLine($"  totals: {gathers} gathers, {render:F1} ms rendering, {gather:F1} ms gathering "
+                + $"({(render > 0 ? 100.0 * gather / render : 0):F0}% of render time)");
+            var withG = rows.Where(r => r.S.Gathers > 0).ToList();
+            var noG = rows.Where(r => r.S.Gathers == 0).ToList();
+            foreach (var (name, set) in new[] { ("WITH a gather", withG), ("WITHOUT a gather", noG) })
+            {
+                if (set.Count == 0) continue;
+                output.WriteLine($"  steps {name,-17}: {set.Count,3} steps, "
+                    + $"{set.Sum(r => r.S.RenderMs) / set.Count:8.1f} ms mean render, "
+                    + $"worst {set.Max(r => r.S.RenderMs):.1f} ms");
+            }
+            output.WriteLine("");
+        }
+
+        await SweepAsync("zoom OUT, dark nebulae OFF", steps: 30, deltaPerEvent: +120.0);
+        await SweepAsync("zoom IN, dark nebulae OFF", steps: 30, deltaPerEvent: -120.0);
+        await ToggleAsync(page, canvas, "d");
+        await SweepAsync("zoom OUT, dark nebulae ON", steps: 30, deltaPerEvent: +120.0);
+        await ToggleAsync(page, canvas, "d");
+    }
+
     [Fact]
     public async Task AttributeZoomFrameCostToTheOverlayGather()
     {

--- a/src/TianWen.UI.Web/Pages/Planner.razor
+++ b/src/TianWen.UI.Web/Pages/Planner.razor
@@ -1314,6 +1314,10 @@
     //               gesture must produce some; zero means every event painted its own frame again.
     //   gathers   - object-overlay candidate gathers. Bounded per FOV bucket / pan cell, so a gesture
     //               must NOT produce one per event (see SkyMapOverlayCacheKeyTests).
+    //   uploads   - overlay instance-buffer re-uploads. Bounded by the same reasoning as gathers but
+    //               on a DIFFERENT axis: the gather is cached across a pan AND a wide zoom, while the
+    //               instances additionally depend on the arcmin-to-pixel scale, so a zoom is expected
+    //               to re-upload and a pan is expected not to.
     //   overlay   - whether the [O] catalog overlay is on. Reported because it is OFF by default and
     //               the gather is skipped entirely when it is off: without this a test asserting
     //               "gathers stay bounded" passes on zero, i.e. passes while measuring nothing. The
@@ -1325,7 +1329,8 @@
             + ",\"gathers\":" + (_skyTab?.PrimOverlayGathers ?? 0).ToString(CultureInfo.InvariantCulture)
             + ",\"overlay\":" + ((_skyTab?.State.ShowObjectOverlay ?? false) ? "true" : "false")
             + ",\"renderMs\":" + _renderMs.ToString("F1", CultureInfo.InvariantCulture)
-            + ",\"gatherMs\":" + (_skyTab?.PrimOverlayGatherMs ?? 0).ToString("F1", CultureInfo.InvariantCulture) + "}";
+            + ",\"gatherMs\":" + (_skyTab?.PrimOverlayGatherMs ?? 0).ToString("F1", CultureInfo.InvariantCulture)
+            + ",\"uploads\":" + (_skyTab?.OverlayInstanceUploads ?? 0).ToString(CultureInfo.InvariantCulture) + "}";
 
     [JSInvokable]
     public string GetPlannerSearchRectJson()

--- a/src/TianWen.UI.Web/SkyMap/WebGlSkyMapPipeline.cs
+++ b/src/TianWen.UI.Web/SkyMap/WebGlSkyMapPipeline.cs
@@ -4,6 +4,7 @@ using DIR.Lib;
 using TianWen.Lib.Astrometry.Catalogs;
 using TianWen.Lib.Astrometry.SOFA;
 using TianWen.UI.Abstractions;
+using TianWen.UI.Abstractions.Overlays;
 using WebGl.Renderer;
 
 namespace TianWen.UI.Web.SkyMap
@@ -213,6 +214,122 @@ namespace TianWen.UI.Web.SkyMap
             }
             """;
 
+        // Overlay ellipse: instanced quads for the [O]/[D] DSO markers, transcribed from
+        // Shaders/skymap_overlay.vert|frag. The instance stream is the shared
+        // OverlayEllipseInstances layout, so the browser and the desktop feed identical bytes to
+        // identical arithmetic; the only delta is the flipped NDC Y that every shader here carries.
+        //
+        // What it replaces on this surface is not one draw call per marker but one POLYLINE per
+        // marker: the CPU path tessellated each ellipse into 8-32 stroke segments and pushed 36
+        // floats per segment. At a full-sky zoom that measured 7,072 ellipse + circle markers,
+        // 46,986 segments and about 6.8 MB of vertex data built and marshalled EVERY repaint --
+        // and the browser has no render loop, so every repaint is an input event.
+        private static readonly string OverlayVertexSource = $$"""
+            #version 300 es
+            precision highp float;
+            precision highp int;
+
+            layout(location = 0) in vec2  aCorner;       // per-vertex unit quad, [-1, 1]
+            layout(location = 1) in vec3  aUnitVec;      // per-instance J2000 unit vec
+            layout(location = 2) in vec2  aSizeArcmin;   // per-instance semi-axes (arcmin)
+            layout(location = 3) in float aPaFromNorth;  // per-instance PA from north (rad)
+            layout(location = 4) in float aThickness;    // per-instance stroke (px)
+            layout(location = 5) in vec4  aColor;        // per-instance color
+
+            {{UboGlsl}}
+
+            out vec2  vLocal;
+            out vec2  vSize;
+            out float vThickness;
+            out vec4  vColor;
+
+            {{ProjectionGlsl}}
+
+            void main() {
+                vec3 camPos = (viewMatrix * vec4(aUnitVec, 1.0)).xyz;
+                vec3 proj = stereoProject(camPos);
+                if (proj.z <= -0.99) {
+                    // Anti-hemisphere: emit a degenerate vertex so the whole instance is culled.
+                    gl_Position = vec4(0.0, 0.0, 0.0, 0.0);
+                    vLocal = vec2(0.0);
+                    vSize = vec2(1.0);
+                    vThickness = 0.0;
+                    vColor = vec4(0.0);
+                    return;
+                }
+                vec2 center = proj.xy;
+
+                // Local north tangent from the unit vector alone. The clamped cosDec avoids the
+                // pole singularity where cosDec -> 0 would blow up the division.
+                float cosDec = sqrt(max(1e-6, 1.0 - aUnitVec.z * aUnitVec.z));
+                vec3 nTangent = vec3(-aUnitVec.z * aUnitVec.x / cosDec,
+                                     -aUnitVec.z * aUnitVec.y / cosDec,
+                                      cosDec);
+
+                // Project a tip one arcmin north and measure the screen-space angle to it.
+                float stepRad = 2.908882e-4; // 1 arcmin in radians
+                vec3 tipUnit = normalize(aUnitVec + nTangent * stepRad);
+                vec3 tipProj = stereoProject((viewMatrix * vec4(tipUnit, 1.0)).xyz);
+                vec2 north2d = tipProj.xy - center;
+                // Measured in SCREEN space (Y down), exactly as the Vulkan source does -- the GL
+                // NDC flip belongs at the gl_Position write and nowhere else. Flipping earlier
+                // would mirror every position angle.
+                float screenNorthAngle = atan(north2d.y, north2d.x);
+                float totalAngle = screenNorthAngle - aPaFromNorth;
+
+                float arcminToPx = pixelsPerRadian * 0.00029088820866;  // pi / (180 * 60)
+                vec2 sizePx = aSizeArcmin * arcminToPx;
+
+                // Pad the quad for the ring SDF antialias, then rotate + expand.
+                float pad = max(aThickness * 0.75 + 1.0, 1.5);
+                vec2 local = aCorner * (sizePx + vec2(pad));
+                float cs = cos(totalAngle);
+                float sn = sin(totalAngle);
+                vec2 rotated = vec2(local.x * cs - local.y * sn,
+                                    local.x * sn + local.y * cs);
+                vec2 screenPos = center + rotated;
+
+                gl_Position = vec4(
+                    (screenPos.x - viewportCenter.x) / (viewportSize.x * 0.5),
+                    -(screenPos.y - viewportCenter.y) / (viewportSize.y * 0.5),
+                    0.0, 1.0);
+
+                vLocal = local;
+                vSize = sizePx;
+                vThickness = aThickness;
+                vColor = aColor;
+            }
+            """;
+
+        private const string OverlayFragmentSource = """
+            #version 300 es
+            precision highp float;
+            precision highp int;
+
+            in vec2  vLocal;
+            in vec2  vSize;
+            in float vThickness;
+            in vec4  vColor;
+
+            out vec4 FragColor;
+
+            void main() {
+                // Axis-aligned ellipse SDF: (x/a)^2 + (y/b)^2 = 1 on the boundary, scaled by the
+                // mean semi-axis to approximate a pixel distance from the ring.
+                vec2 s = max(vSize, vec2(0.5));
+                vec2 n = vLocal / s;
+                float normDist = sqrt(dot(n, n));
+                float avgR = (s.x + s.y) * 0.5;
+                float pixelDist = abs(normDist - 1.0) * avgR;
+
+                float halfT = max(vThickness * 0.5, 0.5);
+                float alpha = 1.0 - smoothstep(halfT, halfT + 1.0, pixelDist);
+                if (alpha < 0.01) discard;
+
+                FragColor = vec4(vColor.rgb * alpha, vColor.a * alpha);
+            }
+            """;
+
         // Horizon ground shading: an attributeless full-screen pass (gl_VertexID generates the
         // quad; no vertex data consumed) whose FS inverse-stereographic-projects each pixel and
         // tints below-horizon directions with depth-scaled alpha - the port of the Vulkan
@@ -318,6 +435,13 @@ namespace TianWen.UI.Web.SkyMap
         private readonly PipelineHandle _starPipeline;
         private readonly PipelineHandle _linePipeline;
         private readonly PipelineHandle _horizonFillPipeline;
+        private readonly PipelineHandle _overlayPipeline;
+
+        // The overlay instance buffer, re-uploaded only when the overlay's own inputs move (see
+        // SubmitOverlayInstances). A pan changes none of them, so a drag uploads nothing.
+        private GpuBufferHandle _overlayInstances;
+        private bool _overlayBufferCreated;
+        private int _overlayInstanceCount;
 
         private bool _geometryBuilt;
         private GpuBufferHandle _cornerQuad;
@@ -382,6 +506,24 @@ namespace TianWen.UI.Web.SkyMap
             _horizonFillPipeline = renderer.RegisterPipeline(new CustomPipelineDescriptor(
                 HorizonFillVertexSource, HorizonFillFragmentSource,
                 Attribs: [],
+                UniformBlockName: "SkyMapUBO"));
+            // Per-instance widths 3+2+1+1+4 = OverlayEllipseInstances.FloatsPerInstance, in
+            // declaration order -- the descriptor interleaves same-divisor attributes into one
+            // buffer, which is exactly how the shared builder writes them. AlphaOver matches the
+            // Vulkan pipeline's non-additive state (SrcAlpha/OneMinusSrcAlpha colour,
+            // One/OneMinusSrcAlpha alpha), so a marker composites the same on both surfaces.
+            _overlayPipeline = renderer.RegisterPipeline(new CustomPipelineDescriptor(
+                OverlayVertexSource, OverlayFragmentSource,
+                Attribs:
+                [
+                    new VertexAttrib(0, 2),
+                    new VertexAttrib(1, 3, PerInstance: true),
+                    new VertexAttrib(2, 2, PerInstance: true),
+                    new VertexAttrib(3, 1, PerInstance: true),
+                    new VertexAttrib(4, 1, PerInstance: true),
+                    new VertexAttrib(5, 4, PerInstance: true),
+                ],
+                Blend: PipelineBlend.AlphaOver,
                 UniformBlockName: "SkyMapUBO"));
         }
 
@@ -498,6 +640,7 @@ namespace TianWen.UI.Web.SkyMap
             _renderer.SetUniformBlock(_starPipeline, block);
             _renderer.SetUniformBlock(_linePipeline, block);
             _renderer.SetUniformBlock(_horizonFillPipeline, block);
+            _renderer.SetUniformBlock(_overlayPipeline, block);
 
             // Horizon + meridian + Alt/Az geometry depends on (LST, latitude). LST moves ~15
             // arcsec/s of RA; a 30-second bucket keeps the lines visually glued to real time
@@ -674,6 +817,50 @@ namespace TianWen.UI.Web.SkyMap
                     _renderer.DrawInstanced(_cornerQuad, 6, buffer, visible, (int)chunk.Offset);
                 }
             }
+        }
+
+        /// <summary>
+        /// Replaces the overlay instance buffer. The caller decides WHEN, because it owns the inputs
+        /// the instances are a function of (the cached candidate list, the arcmin-to-pixel scale, the
+        /// wide-FOV fade and the horizon dimming) and none of them move during a pan. That matters
+        /// because <c>UpdateBuffer</c> is a full <c>bufferData</c> reallocation: at a full-sky zoom
+        /// this stream is ~7,000 instances, about 311 KB. It is still an order of magnitude less than
+        /// the ~6.8 MB of stroke vertices the CPU path rebuilt per repaint, which is why uploading it
+        /// on every FOV change is a good trade and uploading it on every pan event would not be.
+        /// </summary>
+        public void SubmitOverlayInstances(ReadOnlySpan<float> instances)
+        {
+            _overlayInstanceCount = instances.Length / OverlayEllipseInstances.FloatsPerInstance;
+            if (_overlayInstanceCount == 0)
+            {
+                return;
+            }
+
+            if (_overlayBufferCreated)
+            {
+                _renderer.UpdateBuffer(_overlayInstances, instances);
+            }
+            else
+            {
+                _overlayInstances = _renderer.CreateBuffer(instances);
+                _overlayBufferCreated = true;
+            }
+        }
+
+        /// <summary>
+        /// One instanced draw for every ellipse + circle overlay marker last submitted. Records after
+        /// the star field so markers sit on top of it; the caller draws crosses and labels afterwards
+        /// with the ordinary primitives, and the renderer rebinds its fixed pipeline for those.
+        /// </summary>
+        public void DrawOverlay()
+        {
+            if (!_geometryBuilt || !_overlayBufferCreated || _overlayInstanceCount == 0)
+            {
+                return;
+            }
+
+            _renderer.UsePipeline(_overlayPipeline);
+            _renderer.DrawInstanced(_cornerQuad, 6, _overlayInstances, _overlayInstanceCount);
         }
     }
 }

--- a/src/TianWen.UI.Web/SkyMap/WebSkyMapTab.cs
+++ b/src/TianWen.UI.Web/SkyMap/WebSkyMapTab.cs
@@ -1,6 +1,10 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
 using TianWen.Lib.Astrometry.Catalogs;
 using TianWen.Lib.Astrometry.SOFA;
 using TianWen.UI.Abstractions;
+using TianWen.UI.Abstractions.Overlays;
 using DIR.Lib;
 using WebGl.Renderer;
 
@@ -10,10 +14,10 @@ namespace TianWen.UI.Web.SkyMap
     /// The browser sky map: <see cref="SkyMapTab{TSurface}"/> (all labels, search, info panel,
     /// input, planet/comet markers - drawn via the generic renderer primitives) over
     /// <see cref="WebGlSkyMapPipeline"/> for the GPU star field + line work, mirroring
-    /// VkSkyMapTab's split on desktop. The [O]/[D] object overlay is drawn via the shared
-    /// CPU-primitive path (<see cref="SkyMapTab{TSurface}.RenderObjectOverlayPrimitive"/>) since
-    /// WebGL has no instanced overlay-ellipse pipeline; mount / schedule-marker hooks stay at their
-    /// no-op base until needed.
+    /// VkSkyMapTab's split on desktop. The [O]/[D] object overlay runs the shared
+    /// <see cref="SkyMapTab{TSurface}.RenderObjectOverlayPrimitive"/> (gather, projection, labels)
+    /// with its markers rasterised by an instanced GPU draw, as on desktop; mount / schedule-marker
+    /// hooks stay at their no-op base until needed.
     /// </summary>
     internal sealed class WebSkyMapTab(WebGlRenderer renderer) : SkyMapTab<WebGlContext>(renderer)
     {
@@ -38,14 +42,91 @@ namespace TianWen.UI.Web.SkyMap
             _pipeline.Draw(State, site);
         }
 
-        /// <summary>Draws the [O] catalog overlay + [D] dark nebulae + pinned-target landmarks via the
-        /// shared CPU-primitive path (WebGL has no instanced overlay pipeline). Same candidate gather /
-        /// projection / label placement as desktop; only the rasterisation is CPU DrawLine/DrawCircle.</summary>
+        /// <summary>Draws the [O] catalog overlay + [D] dark nebulae + pinned-target landmarks through
+        /// the shared path: same candidate gather, projection and label placement as desktop, with the
+        /// markers rasterised by <see cref="DrawOverlayMarkers"/> below.</summary>
         protected override void RenderObjectOverlay(
             ICelestialObjectDB db, RectF32 contentRect,
             float baseFontSize, SiteContext site, bool dimBelowHorizon, PlannerState plannerState,
             bool showAllOverlays)
             => RenderObjectOverlayPrimitive(db, contentRect, baseFontSize,
                 site, dimBelowHorizon, plannerState, showAllOverlays);
+
+        // Inputs the instance stream is a function of. A pan moves NONE of them, which is what makes
+        // the buffer worth keying: the gather is already cached across a pan, so re-uploading its
+        // projection-independent instances every pointermove would put back a per-event cost the
+        // cache exists to remove. The horizon term is the site's own hour angle bucketed to 30 s, the
+        // same bucket UpdateFrame uses for the horizon and meridian line sets and for the same reason
+        // -- dimming crosses the horizon at real-clock speed, not at input speed.
+        private readonly record struct OverlayInstanceKey(
+            int CandidateVersion, int CandidateCount, float ArcminToPixels,
+            float DpiScale, float FovAlpha, bool DimBelowHorizon, double LstBucket);
+
+        private OverlayInstanceKey _overlayInstanceKey;
+        private bool _hasOverlayInstanceKey;
+        private readonly List<float> _overlayInstances = new(1024);
+
+        /// <summary>
+        /// How many times the instance stream was rebuilt and submitted, the sibling of
+        /// <see cref="SkyMapTab{TSurface}.PrimOverlayGathers"/> and load-bearing for the same reason: a
+        /// stale-keyed re-upload draws the byte-identical frame, so nothing observable -- pixels
+        /// included -- separates a key that holds across a pan from one that misses on every event.
+        /// Only a count can.
+        /// </summary>
+        internal int OverlayInstanceUploads { get; private set; }
+
+        /// <summary>
+        /// One instanced GPU draw for every ellipse + circle marker, replacing a tessellated polyline
+        /// per marker. Crosses stay on the primitive path: they have no angular extent for the shader
+        /// to project, and at a full-sky zoom they are 772 markers against 7,072 here.
+        /// </summary>
+        protected override void DrawOverlayMarkers(
+            IReadOnlyList<OverlayCandidate> candidates,
+            IReadOnlyList<OverlayItem> items,
+            int candidateVersion,
+            float arcminToPixels, double ppr, float cxView, float cyView,
+            float dpiScale, float fovAlpha, bool dimBelowHorizon, SiteContext site)
+        {
+            var key = new OverlayInstanceKey(
+                candidateVersion, candidates.Count, arcminToPixels, dpiScale, fovAlpha,
+                dimBelowHorizon,
+                dimBelowHorizon && site.IsValid ? Math.Round(site.LST * 120.0) / 120.0 : 0.0);
+            if (!_hasOverlayInstanceKey || !_overlayInstanceKey.Equals(key))
+            {
+                // The browser has no theme switcher, so the halo takes the engine's fixed landmark
+                // colour rather than the desktop's themed accent.
+                OverlayEllipseInstances.Build(
+                    candidates, _overlayInstances,
+                    arcminToPixels, dpiScale, fovAlpha, dimBelowHorizon, site,
+                    OverlayEngine.PinnedMarkerColor,
+                    OverlayEngine.PinnedHaloColor with { Alpha = (byte)(OverlayEngine.PinnedHaloColor.Alpha * fovAlpha) });
+                _pipeline.SubmitOverlayInstances(CollectionsMarshal.AsSpan(_overlayInstances));
+                _overlayInstanceKey = key;
+                _hasOverlayInstanceKey = true;
+                OverlayInstanceUploads++;
+            }
+
+            _pipeline.DrawOverlay();
+
+            // Crosses (stars) from the projected items, so an off-screen star draws nothing.
+            foreach (var item in items)
+            {
+                if (item.Marker.Kind != OverlayMarkerKind.Cross)
+                {
+                    continue;
+                }
+
+                var alpha = OverlayEngine.MarkerAlpha(
+                    item.IsPinned, item.RA, item.Dec, dimBelowHorizon, site, fovAlpha);
+
+                var (r, g, b) = item.Color;
+                var color = item.IsPinned
+                    ? OverlayEngine.PinnedMarkerColor with { Alpha = (byte)(alpha * 255f) }
+                    : RGBAColor32.FromFloat(r, g, b, alpha);
+                var armPx = item.Marker.ArmPx;
+                DrawLine(item.ScreenX - armPx, item.ScreenY, item.ScreenX + armPx, item.ScreenY, color);
+                DrawLine(item.ScreenX, item.ScreenY - armPx, item.ScreenX, item.ScreenY + armPx, color);
+            }
+        }
     }
 }


### PR DESCRIPTION
A trace of the deployed build, after the gather fixes in #159, splits cleanly by gesture:

| | frames | mean | p50 | p95 | max |
|---|---|---|---|---|---|
| **pan** (no wheel) | 805 | **2.22 ms** | 0.70 | 9.31 | 128.7 |
| **zoom** (after a wheel) | 57 | **17.93 ms** | 0.79 | 124.4 | **160.9** |

Twenty wheel events cost more than eight hundred pointermoves. Zoom frames are 6.6% of the trace carrying **36.4% of all animation-frame time**, so what remains is on the FOV axis. Three independent causes, one per commit.

---

# 1. Dark nebulae were holding the FOV in the cache key

The wide-FOV key invariance was gated on `[D]` being off, so with dark nebulae on a zoom-out kept paying a full-sky gather per 10% FOV bucket **above** the 90° threshold, where the gathered set cannot depend on the field of view at all.

Measured on the **deployed artifact**, one paced wheel zoom-out per run from a fresh page (so both start at the default 60°), 60° → 180°:

| | gathers | time gathering |
|---|---|---|
| `[D]` **off** | 3 | 193 ms |
| `[D]` **on** | **6** | **632 ms** |

The same sweep on this branch costs **3 either way**.

> ### Correction: this said "30 against 3" until the last push
>
> That figure came from the shared attribution probe, which runs three sweeps in sequence — and **each sweep starts wherever the previous one left the zoom**. The second bottoms out at 0.5°, so the third (the `[D]`-on one) spent nearly all thirty steps *below* the wide threshold, where a gather per bucket is correct behaviour. It reports 30 gathers with the fix applied too.
>
> The bug is real and the fix works, but it was a doubling, not a tenfold. `GatherAttributionProbe` now resets to 60° before every sweep, and the four places that quoted the number are corrected. A leg that silently measures a different field of view than the one it is compared against is worse than no measurement, because it looks like one.

## The fix: split the rule across the two phases

The dark-nebula on-screen-size test was the last view-dependent thing inside the *cached* phase. The gather now admits a **superset** computed at the widest FOV its cache key can be reused across, and `ProjectSkyMapCandidatesInto` applies the **exact** test per frame where the real pixel scale is known.

**Deleting the filter from the gather was the first attempt, and the measurement killed it:** only 190 of 4,827 shaped dark nebulae survive at 180°, so removing it would inflate the cached set — and its label building — by ~4,600 entries. Clamping the pre-filter to the threshold FOV admits 1,655, which is exactly the union over the wide range.

## The new test caught a bug in #159

`TheGatheredSetIsIdenticalAcrossTheWholeWideRange` failed on its first run: **959 objects differed between 90° and 120°**.

Above the threshold the scan was *not* FOV-independent when a pole was in view. That branch was tested **first**, and it derives its Dec bounds from FOV-dependent corner sampling — and at these fields of view a wide-angle projection folds those corners into a *narrower* strip. So the claim that the FOV drops out of the cache key, which #159 rests on, was quietly false whenever a pole was on screen.

The wide branch is now tested ahead of the pole branch; the gathered set is identical at 90/120/150/180 (11,466 candidates). One threshold constant (`OverlayEngine.WideFovDeg`) replaces the three literal `90.0`s, two of which were hand-maintained mirrors carrying a "keep in sync" comment that nothing enforced — and had just drifted. The desktop tab gains the FOV invariance it never had.

*One false alarm, recorded because it mimics the bug:* a residual 312-object difference was `InitDBAsync(waitForTycho2BulkLoad: false)`. As cross-references load the dedupe suppresses more objects, so a **later** gather returns **fewer** candidates — indistinguishable from an FOV dependence until you look.

---

# 2. The draw path projected everything twice, and sorted 7,800 items to draw 80

With the gather cached, what is left runs **every frame**. Measured on desktop .NET at 180° (11,466 candidates → 7,786 items):

| | before | after |
|---|---|---|
| label placement | 1.84 ms | **0.37 ms** |
| allocation per label pass | full copy + sort | **3,264 bytes** |
| projection passes per frame | **2** | **1** |
| | | **≈ 4.3 ms/frame** |

**Label placement** stopped after `MaxOverlayLabels` (80) but copied and fully sorted the list to find them; it now pops from a heap built in O(n) over a pooled buffer. It is popped **lazily** rather than selected as a bounded top-80 because the collision variant drops a label that cannot find a free slot and lets the next through — `TheCollisionVariantWalksPastTheCap` measures 400 items examined to place 4.

**The marker pass** projected every candidate, then `ProjectSkyMapCandidatesInto` projected the identical set again for the labels. Markers still have to read the candidate (the projected item drops the arcmin extent and position angle), so `OverlayItem.CandidateIndex` is the link back. That also closes a discrepancy rather than preserving it: the marker pass culled on a margin of `100f + arcminToPixels` — adding a *scale factor* to a pixel margin — while the projection extends its margin by the shape's actual on-screen semi-major axis. A large nebula centred just off-viewport got a label and no marker.

`OverlayLabelOrderTests` pins the **order**, not the speed: a pop order differing from the sorted one even for equal priorities would reintroduce the label flicker `StableSortKey` exists to kill, and would read as a rendering glitch rather than a comparison bug. Seen to fail with the tiebreak removed.

---

# 3. The browser drew one polyline per marker

The web pipeline had star and line programs but **no overlay program at all**, so markers were traced with CPU primitives while the desktop instanced them. Each ellipse tessellated to 8–32 stroke segments of 36 floats and became its own `gl.drawArrays`.

At a full-sky zoom (7,844 items):

| | CPU primitives | instanced |
|---|---|---|
| draw calls | **8,616** | **1,545** (crosses only) |
| vertex floats/frame | **1.69 M** (~6.8 MB) | **78 K** (~311 KB) |

Measured as a clean A/B on **one** dev-server binary, differing only by whether the override is in place, over a 60° → 180° paced wheel zoom-out:

| | CPU polylines | instanced GPU |
|---|---|---|
| mean wide-FOV frame | **842 ms** | **246 ms** |
| 30-step sweep total | 27.1 s | 9.4 s |

That is **interpreted** WASM, which inflates CPU primitive work far more than the interop the GPU path spends instead, so 3.4× is an upper bound until the deployed AOT build is traced. The draw-call and vertex-byte counts above are exact and platform-independent.

Crosses stay on the primitive path: a cross has no angular extent for the shader to project, and giving the instance a kind discriminant would put a branch in front of every ellipse.

## The geometry is now shared rather than transcribed

It lived only in `VkSkyMapTab`, and it is not incidental detail — the pinned halo alone has four rules (uniform scale, legibility floor, axis-ratio preservation, per-marker-kind fallback) that both surfaces must agree on, and the halo-as-a-circle defect was fixed on the two rasterisation paths **separately, months apart**. `OverlayEllipseInstances.Build` is the one description. The halo *colour* stays a caller argument because the surfaces genuinely differ there: the desktop tints it with the active theme accent, the browser has no theme switcher.

The marker pass is a **virtual seam** instead of two parallel methods: `RenderObjectOverlayPrimitive` keeps the cached gather, the single projection and label placement, and `DrawOverlayMarkers` is the only part a surface overrides. The wide-FOV fade rule was written out five times across the two surfaces and is now `OverlayEngine.MarkerAlpha` — a pinned target is exempt from the zoom fade but **not** from horizon dimming, and a landmark that fades on one surface is not a landmark.

## Uploads are keyed, and counted

The buffer is keyed on what the instances are a function of (candidate version, scale, dpi, fade, horizon bucket), so a **pan re-uploads nothing**; a 30-step zoom uploads 7 times. `OverlayInstanceUploads` is exposed through the e2e render-stats hook for the same reason `PrimOverlayGathers` is — a stale-keyed re-upload draws the byte-identical frame, so only a count can see it — and `APanDoesNotReUploadTheOverlayInstanceBuffer` asserts it, with `uploads > 0` beforehand so it cannot pass on a buffer that was never uploaded.

## Verified three ways, because a GLSL transcription error compiles

1. **Mechanically diffed against the Vulkan sources** — identical statement for statement (40 in the vertex shader, 11 in the fragment) after dropping the `ubo.` prefix, comments, and the one intended NDC Y flip.
2. **No shader compile or link error** in the browser (the bridge throws with the info log on either).
3. **Same F3-searched view on the deployed CPU build and this one** — NGC 891 / NGC 4565 / M 31, identical centres to 6 decimal places — shows the same markers in the same places with the same colours.

`OverlayEllipseInstanceTests` pins the builder's arithmetic at the last point it is still ordinary CPU code: nothing downstream can catch a mistake, since the consumer is a vertex shader on two backends and a wrong unit or a drifted stride renders something plausible rather than failing. Seen to fail with the halo's minor axis swapped for its major.

## Testing

4262 unit (up 11) and 338 functional, zero failures.

Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YYnrhjBmgaqrqrXn7tZaoP
