### PR TITLE
feat(web): say when the atlas is still building, and stop replaying the input from that time

### DIFF
--- a/src/TianWen.UI.Web.E2E/AtlasLoadingOverlayTests.cs
+++ b/src/TianWen.UI.Web.E2E/AtlasLoadingOverlayTests.cs
@@ -1,0 +1,89 @@
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using Microsoft.Playwright;
+using Xunit;
+using static Microsoft.Playwright.Assertions;
+
+namespace TianWen.UI.Web.E2E;
+
+/// <summary>
+/// The atlas keeps assembling itself after the catalog chip clears -- the ~30 MB star catalog is
+/// fetched, decompressed and flattened, and each of those is a synchronous stall on the one WASM
+/// thread. These pin the two things that makes survivable.
+///
+/// <para><b>The overlay must always come down.</b> Its phases end in a <c>finally</c> for a reason:
+/// a dev server with no baked catalog answers 404, and an overlay left up by a failure is an app
+/// that cannot be navigated at all -- strictly worse than the freeze it exists to explain. The
+/// 404 path is the DEFAULT here (the dev server has no <c>tyc2.bin.lz</c>), so this suite exercises
+/// the failure case by construction rather than by simulating it.</para>
+/// </summary>
+[Collection(TianWenWebCollection.Name)]
+public sealed class AtlasLoadingOverlayTests(TianWenWebFixture fixture)
+{
+    private const float BootTimeout = 120_000;
+    private static readonly Regex ActiveClass = new(@"\bactive\b");
+
+    private async Task<IPage> SkyAtlasAsync()
+    {
+        var page = await fixture.WarmPageAsync();
+        await page.Locator("[data-view=sky]").ClickAsync();
+        await Expect(page.Locator("[data-view=sky]")).ToHaveClassAsync(ActiveClass, new() { Timeout = BootTimeout });
+        return page;
+    }
+
+    /// <summary>
+    /// However the catalog load ends -- landed, or 404 on a server that never baked it -- the overlay
+    /// comes down and the canvas takes input again. Asserted by DRIVING a zoom and reading the field
+    /// of view back: "the element is gone" would still pass if the input gate had been left latched,
+    /// and a latched gate is indistinguishable from a hung app.
+    /// </summary>
+    [Fact]
+    public async Task TheOverlayClearsAndInputResumesHoweverTheCatalogLoadEnds()
+    {
+        var page = await SkyAtlasAsync();
+
+        await Expect(page.Locator("[data-atlas-loading]")).ToHaveCountAsync(0, new() { Timeout = BootTimeout });
+
+        var canvas = page.Locator("#planner");
+        var before = await FovAsync(page);
+        await CanvasGestures.WheelZoomAsync(page, canvas, events: 4, deltaPerEvent: +120.0, burst: false);
+        var after = await FovAsync(page);
+
+        Assert.True(after > before,
+            $"the canvas ignored a zoom after loading finished (fov {before:F1} -> {after:F1}); "
+            + "the input gate is latched");
+    }
+
+    /// <summary>
+    /// The overlay never eats a click. It is drawn over the canvas, so a stray
+    /// <c>pointer-events</c> would break selection on the region it covers for the whole session --
+    /// and only while it is UP, which is the hardest kind of bug to reproduce later.
+    /// </summary>
+    [Fact]
+    public async Task TheOverlayIsNotHitTestable()
+    {
+        var page = await SkyAtlasAsync();
+
+        var pointerEvents = await page.EvaluateAsync<string>("""
+            () => {
+              // Force it visible for the check regardless of load timing: the property is what
+              // matters and it is static CSS, not state.
+              const el = document.createElement('div');
+              el.className = 'atlas-loading';
+              document.querySelector('.canvas-host').appendChild(el);
+              const v = getComputedStyle(el).pointerEvents;
+              el.remove();
+              return v;
+            }
+            """);
+
+        Assert.Equal("none", pointerEvents);
+    }
+
+    private static async Task<double> FovAsync(IPage page)
+    {
+        var json = await page.EvaluateAsync<string>("async () => await window.__tianwenTest.getSkyView()");
+        using var doc = JsonDocument.Parse(json);
+        return doc.RootElement.GetProperty("fovDeg").GetDouble();
+    }
+}

--- a/src/TianWen.UI.Web.E2E/TianWenWebFixture.cs
+++ b/src/TianWen.UI.Web.E2E/TianWenWebFixture.cs
@@ -10,6 +10,14 @@ namespace TianWen.UI.Web.E2E;
 /// launches one headless browser that every test opens a fresh, isolated context on. Mirrors
 /// chess's ChessWebFixture.
 ///
+/// <b>The auto-started server has served STALE content, twice.</b> Both times the build was green
+/// and the output timestamps were fresh, and it produced a false PASS (a measurement of code that
+/// predated the change) and later a false FAIL (a CSS rule that was in the file and in
+/// <c>bin/Release</c> but not in what the page loaded). When a result is surprising in either
+/// direction, start a dev server yourself, fetch the asset and confirm the change is IN it
+/// (<c>curl .../css/app.css</c>, or probe a <c>.wasm</c> for a new symbol), then point
+/// <c>TIANWEN_WEB_BASEURL</c> at that server. A verified server is the only trustworthy baseline.
+///
 /// Server: set <c>TIANWEN_WEB_BASEURL</c> to reuse a dev server you already have running (fast local
 /// iteration: the interpreted WASM cold-boot is slow, so reusing a warm server matters here);
 /// otherwise the fixture starts <c>dotnet run --project TianWen.UI.Web</c> itself and tears it down

--- a/src/TianWen.UI.Web/Pages/Planner.razor
+++ b/src/TianWen.UI.Web/Pages/Planner.razor
@@ -57,6 +57,14 @@
     </div>
 
     <div class="canvas-host">
+        @* The atlas keeps building AFTER the catalog chip clears: the star field is fetched,
+           decompressed and flattened in phases that are synchronous stalls on the single WASM
+           thread. Without this the app looks finished and then freezes, which reads as a hang
+           rather than as loading. pointer-events:none so it can never swallow a click. *@
+        @if (_atlasBusy)
+        {
+            <div class="atlas-loading" data-atlas-loading aria-live="polite">@_atlasBusyText</div>
+        }
         @* WebGlCanvas (1.2) owns the hi-dpi plumbing: backing-buffer sizing, resize/dpr watching,
            backing-space input mapping, pointer capture (drags survive leaving the canvas), and
            focus - the JS helpers this host used to carry. *@
@@ -104,6 +112,25 @@
     string _status = "Loading…";
     (float X, float Y) _mouse;
     bool _ready;
+
+    // The atlas is still assembling itself: shown as an overlay, and canvas navigation is dropped
+    // while it is set. Dropping matters more than it looks -- the heavy phases are synchronous on
+    // the one WASM thread, so the BROWSER queues every pointer/wheel event that arrives during a
+    // stall and delivers the whole burst the moment it ends. Handling them then applies a second's
+    // worth of accumulated pan and zoom in one frame, which is how a stall turns into a jump.
+    bool _atlasBusy;
+    string _atlasBusyText = "";
+
+    // Canvas navigation is ignored while the atlas builds. Deliberately NOT applied to the DOM
+    // toolbar: Lat/Lon/Recompute stay usable, and they do not touch the half-built star field.
+    bool CanvasInputBlocked => _atlasBusy;
+
+    void SetAtlasBusy(bool busy, string text = "")
+    {
+        _atlasBusy = busy;
+        _atlasBusyText = text;
+        StateHasChanged();
+    }
     bool _busy;
     // Which canvas text field has the keyboard. The same owner the desktop uses, so the two hosts differ
     // only in what they BIND to its transition: SDL Start/StopTextInput there, showing and hiding the
@@ -866,25 +893,32 @@
         {
             // This "background" task runs inline until its first await; yield so the HR atlas
             // paints before the heavy work below (mirrors LoadCometsInBackgroundAsync).
+            SetAtlasBusy(true, "Loading star catalog...");
             await Task.Delay(30);
 
             // Warm path: the raw decompressed catalog cached from a prior visit skips BOTH the
             // ~30 MB fetch and the lzip decompress. It feeds the SAME DB path as the cold decode
             // (records + spatial index), so click-to-identify works identically on a cached load.
             var cachedRaw = await TryReadTycho2CacheAsync();
-            if (cachedRaw is { Length: > 0 } && Db.TryLoadTycho2BulkFromDecoded(cachedRaw))
+            if (cachedRaw is { Length: > 0 })
             {
-                FlattenAndSubmitTycho2("IndexedDB cache");
-                return;
+                await AtlasPhaseAsync("Building star field...");
+                if (Db.TryLoadTycho2BulkFromDecoded(cachedRaw))
+                {
+                    FlattenAndSubmitTycho2("IndexedDB cache");
+                    return;
+                }
             }
 
             // Cold path: fetch the compressed catalog, decompress, wire the DB + spatial index,
             // flatten to the GPU, then cache the raw decompressed bytes for next time.
             var sw = System.Diagnostics.Stopwatch.StartNew();
+            await AtlasPhaseAsync("Downloading star catalog (30 MB)...");
             var lz = await Http.GetByteArrayAsync("tyc2.bin.lz");
             Console.WriteLine($"[tianwen-web] tyc2 fetch: {lz.Length / (1024 * 1024)} MB in {sw.ElapsedMilliseconds} ms");
 
             sw.Restart();
+            await AtlasPhaseAsync("Decompressing star catalog...");
             var raw = SharpAstro.Lzip.LzipDecoder.Decompress(lz);
             if (!Db.TryLoadTycho2BulkFromDecoded(raw))
             {
@@ -893,6 +927,7 @@
             }
             Console.WriteLine($"[tianwen-web] tyc2 decompress: {raw.Length / (1024 * 1024)} MB in {sw.ElapsedMilliseconds} ms");
 
+            await AtlasPhaseAsync("Building star field...");
             FlattenAndSubmitTycho2("decode");
             _ = SaveTycho2ToCacheAsync(raw); // persist the raw buffer (fire-and-forget; non-fatal)
         }
@@ -900,6 +935,23 @@
         {
             Console.WriteLine($"[tianwen-web] Tycho-2 catalog unavailable (HR-only atlas): {ex.Message}");
         }
+        finally
+        {
+            // In the finally so a 404 (a dev server with no baked catalog) cannot leave the app
+            // permanently overlaid and unnavigable.
+            SetAtlasBusy(false);
+            RenderFrame();
+        }
+    }
+
+    // Names the phase and gives the browser a frame to actually paint it before the next stall.
+    // The await is load-bearing, not cosmetic: every phase below runs synchronously on the one WASM
+    // thread, so a label set without yielding first is only ever rendered once the work it describes
+    // has already finished.
+    async Task AtlasPhaseAsync(string text)
+    {
+        SetAtlasBusy(true, text);
+        await Task.Delay(30);
     }
 
     // Flattens the loaded Tycho-2 records to 5-float star instances (shared desktop builder, dt=0)
@@ -1481,6 +1533,7 @@
 
     void OnPointerDown(CanvasPointerEventArgs e)
     {
+        if (CanvasInputBlocked) return;
         if (ActiveTab is not { } tab || e.Original.Button != 0) return;
         _pointerGestureActive = true; // a pause inside a drag is not the end of it (see ScheduleLabelSettle)
         var mods = ToModifiers(e.Original);
@@ -1525,6 +1578,7 @@
 
     void OnPointerMove(CanvasPointerEventArgs e)
     {
+        if (CanvasInputBlocked) return;
         if (ActiveTab is not { } tab) return;
         _mouse = (e.X, e.Y);
         // An active divider drag consumes the move (shared state machine with the desktop
@@ -1540,7 +1594,11 @@
 
     void OnPointerUp(CanvasPointerEventArgs e)
     {
+        // The release CLEARS the gesture flag before anything can return: a press that began before
+        // the atlas landed would otherwise end while input is blocked and leave the flag stuck on, so
+        // the labels would stay suppressed until the 700 ms backstop caught every later frame.
         _pointerGestureActive = false;
+        if (CanvasInputBlocked) return;
         if (ActiveTab is not { } tab) return;
         tab.HandleInput(new InputEvent.MouseUp(e.X, e.Y));
         if (_view == View.Planner)
@@ -1573,6 +1631,7 @@
 
     void OnWheel(CanvasWheelEventArgs e)
     {
+        if (CanvasInputBlocked) return;
         if (ActiveTab is not { } tab) return;
         var pixels = WheelPixels(e);
 
@@ -1603,6 +1662,7 @@
     // so the existing drag-pan handles it for free.
     void OnPinch(CanvasPinchEventArgs e)
     {
+        if (CanvasInputBlocked) return;
         if (ActiveTab is not { } tab) return;
         _pointerGestureActive = true; // fingers still down; the pinch END is what settles the labels
         tab.HandleInput(new InputEvent.Pinch((float)e.Scale, e.X, e.Y) { Source = PinchSource.Touchscreen });
@@ -1611,7 +1671,9 @@
 
     void OnPinchEnd()
     {
+        // Cleared before any early-out, for the same reason as OnPointerUp above.
         _pointerGestureActive = false;
+        if (CanvasInputBlocked) return;
         if (ActiveTab is not { } tab) return;
         tab.HandleInput(new InputEvent.PinchEnd());
         // Driving the map with two fingers is as clear a claim on it as a click, and touch cannot take

--- a/src/TianWen.UI.Web/SkyMap/WebGlSkyMapPipeline.cs
+++ b/src/TianWen.UI.Web/SkyMap/WebGlSkyMapPipeline.cs
@@ -538,6 +538,13 @@ namespace TianWen.UI.Web.SkyMap
                 return;
             }
 
+            // Timed because it is the FIRST atlas frame and it is entirely synchronous: the HR seed,
+            // the figures, the boundaries, every grid scale and the ecliptic are all built here, on
+            // the one WASM thread, inside a paint. If this turns out to be seconds rather than
+            // milliseconds it needs the same build-up overlay the Tycho-2 phases have, which is a
+            // different fix (the overlay would have to paint a frame BEFORE this one).
+            var geometrySw = System.Diagnostics.Stopwatch.StartNew();
+
             // Unit quad corners as two triangles (per-vertex stream of the instanced star draw).
             _cornerQuad = _renderer.CreateBuffer([-1f, -1f, 1f, -1f, 1f, 1f, -1f, -1f, 1f, 1f, -1f, 1f]);
 
@@ -574,6 +581,8 @@ namespace TianWen.UI.Web.SkyMap
                 $"[tianwen-web] sky geometry: {_starCount} HR stars, {_figureVertexCount / 2} figure segments, "
                 + $"{_boundaryVertexCount / 2} boundary segments, buffers star={_stars.Id} corner={_cornerQuad.Id}");
             _geometryBuilt = true;
+            Console.WriteLine($"[tianwen-web] sky geometry built in {geometrySw.ElapsedMilliseconds} ms "
+                + $"({_starCount} HR stars, {_figureVertexCount + _boundaryVertexCount} figure/boundary vertices)");
         }
 
         /// <summary>

--- a/src/TianWen.UI.Web/wwwroot/css/app.css
+++ b/src/TianWen.UI.Web/wwwroot/css/app.css
@@ -147,6 +147,28 @@ button.chip:disabled {
     animation: chip-pulse 1.6s ease-in-out infinite;
 }
 
+/* Atlas build-up overlay: sits over the canvas while the star catalog is fetched, decompressed
+   and flattened. Centred near the top rather than the middle so it never covers the object the
+   user is looking at, and pointer-events:none so it cannot swallow a click even though canvas
+   navigation is gated in the handlers while it is up. */
+.atlas-loading {
+    position: absolute;
+    top: 1.25rem;
+    left: 50%;
+    transform: translateX(-50%);
+    z-index: 5;
+    pointer-events: none;
+    padding: 0.45rem 0.9rem;
+    border-radius: 999px;
+    background: rgba(12, 16, 28, 0.82);
+    border: 1px solid rgba(255, 255, 255, 0.14);
+    color: var(--fg, #e6e9f0);
+    font-size: 0.85rem;
+    white-space: nowrap;
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.45);
+    animation: chip-pulse 1.6s ease-in-out infinite;
+}
+
 @keyframes chip-pulse {
     0%, 100% { opacity: 0.4; }
     50% { opacity: 0.9; }


### PR DESCRIPTION
Boot on the **deployed AOT build**, fresh browser context (measured, since nothing recorded this before — the E2E fixture waited on readiness and threw the duration away):

| | cold | warm |
|---|---|---|
| DOMContentLoaded | 3.5 s | 0.15–0.2 s |
| planner visible | 6.6 s | 2.7–3.1 s |
| **catalog ready** | **10.7 s** | 6.3–6.8 s |

23.2 MB transferred, 22.3 MB of it WASM across 59 files.

**But the catalog chip clearing is not the app being ready.** The star field is then fetched (~30 MB), decompressed and flattened, and on the single WASM thread each of those is a synchronous stall *inside a paint*. So the app looked finished and then froze — which reads as a hang, not as loading.

## Two halves, and the second is easy to miss

The overlay is the obvious half. The other one: **the browser queues every pointer and wheel event that arrives during a stall** and delivers the whole burst the moment it ends, so a second of accumulated pan and zoom was applied in one frame. The stall turned into a *jump*. Canvas navigation is now dropped while the atlas builds.

The DOM toolbar is deliberately **not** gated — Lat/Lon/Recompute stay usable and do not touch the half-built star field.

## Details that are load-bearing

- **The overlay names its phase** (downloading / decompressing / building) instead of spinning anonymously for ten seconds. That needs `AtlasPhaseAsync` to yield a frame before each stall: a label set without yielding first is only ever rendered once the work it describes has already finished.
- **The phases end in a `finally`.** A dev server with no baked catalog answers 404, and an overlay left up by a failure is an app that cannot be navigated at all — strictly worse than the freeze it exists to explain. That 404 is the *default* path locally, so `AtlasLoadingOverlayTests` exercises the failure case by construction rather than by simulating it.
- **Recovery is asserted by driving a zoom and reading the field of view back**, not by checking the element is gone. A latched input gate would pass the weaker check, and a latched gate is indistinguishable from a hung app.
- **`pointer-events: none`**, pinned by its own test: the overlay is drawn over the canvas, so a stray hit-test would break selection on the region it covers — and only while it is up, which is the hardest kind of bug to reproduce later.

## What this does NOT cover, deliberately

`EnsureGeometry` — the first atlas frame, which builds the HR seed, the figures, the boundaries, every grid scale and the ecliptic synchronously inside a paint — is **instrumented, not covered**. Whether it needs the same treatment is a question about its wall time, and covering it means painting a frame *before* it, which is a different change. The log answers the question on the next deploy instead of guessing now.

## A trap that cost two sessions today

The E2E fixture's **auto-started dev server has served stale content twice**: once producing a false PASS (a whole measurement session against code that predated the change, caught only because the "fixed" and "unfixed" runs agreed exactly, which they cannot) and once a false FAIL (a CSS rule present in the file *and* in `bin/Release`, but not in what the page loaded). Both times the build was green and the timestamps were fresh.

The fixture now says so, with the remedy: start a server yourself, fetch the asset and confirm the change is in it (`curl .../css/app.css`, or probe a `.wasm` for a new symbol), then point `TIANWEN_WEB_BASEURL` at that server.

## Testing

Both new E2E tests pass against a verified dev server. `dotnet build TianWen.UI.Web -c Release -p:UseLocalSiblings=false -p:Lightweight=true` is clean — worth stating explicitly because **no CI check compiles this project**: it is outside `TianWen.slnx` and `pages.yml` only runs on push to main.

Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YYnrhjBmgaqrqrXn7tZaoP
