### PR TITLE
perf(skymap): the browser spent half of every gesture frame on labels nobody can read

### DIFF
--- a/src/TianWen.Lib.Tests/SkyMapObjectOverlayRenderTests.cs
+++ b/src/TianWen.Lib.Tests/SkyMapObjectOverlayRenderTests.cs
@@ -109,4 +109,68 @@ public sealed class SkyMapObjectOverlayRenderTests
         labelRegions.ShouldBeGreaterThan(0,
             "the [O] overlay should register clickable label regions so label clicks select the object");
     }
+
+    /// <summary>
+    /// Labels are skipped on a frame where the VIEW MOVED, and drawn again once it holds still.
+    ///
+    /// <para>Measured in the browser over a 40-frame dense zoom, placement plus text was 3,275 ms
+    /// against 1,253 for the candidate gather, 605 for the markers and 306 for the projection --
+    /// about half of every frame, spent on text sliding past too fast to read. Markers are NOT
+    /// skipped, so the sky itself never goes blank.</para>
+    ///
+    /// <para><b>The first frame must count as still.</b> The previous-view seeds are NaN and NaN
+    /// compares unequal to everything, so deriving "moved" from them alone made the very first render
+    /// suppress its own labels -- which a host that debounces a repaint hides, and a host that never
+    /// repaints by itself (this renderer) makes permanent. That is the regression this pins; it was
+    /// caught by the test above going red, not by review.</para>
+    /// </summary>
+    [Fact]
+    public async Task Labels_AreSkippedWhileTheViewMoves_AndComeBackWhenItStops()
+    {
+        var db = await SharedCatalogDB.InitAsync(TestContext.Current.CancellationToken);
+
+        const int w = 900, h = 900;
+        using var renderer = new RgbaImageRenderer(w, h);
+        var tab = new OverlayTestSkyMapTab(renderer) { FontPath = FontResolver.ResolveSystemFont() };
+        var state = new PlannerState
+        {
+            ObjectDb = db,
+            SiteLatitude = 48.0,
+            SiteLongitude = 11.0,
+            SiteTimeZone = TimeSpan.FromHours(1),
+            PlanningDate = new DateTimeOffset(2026, 6, 21, 0, 0, 0, TimeSpan.FromHours(1)),
+        };
+        var time = new FakeTimeProviderWrapper(state.PlanningDate.Value);
+        var content = new RectF32(0, 0, w, h);
+
+        int LabelRegions() => tab.GetRegisteredRegions()
+            .Count(r => r.Result is HitResult.ButtonHit { Action: { } act } && act.StartsWith("SkyMapObjectLabel:"));
+
+        tab.State.ShowObjectOverlay = true;
+        tab.State.CenterRA = 18.0;
+        tab.State.CenterDec = -24.0;
+        tab.State.FieldOfViewDeg = 30.0;
+
+        // First frame: no previous view, so nothing moved.
+        tab.Render(state, content, time);
+        tab.OverlayLabelsPending.ShouldBeFalse("the first frame has no previous view and so no motion");
+        LabelRegions().ShouldBeGreaterThan(0, "the first frame must draw labels");
+
+        // A zoom: this frame moved.
+        tab.State.FieldOfViewDeg = 24.0;
+        tab.Render(state, content, time);
+        tab.OverlayLabelsPending.ShouldBeTrue("a moving frame owes the host a settle repaint");
+        LabelRegions().ShouldBe(0, "labels must be skipped while the view is moving");
+
+        // Held still: the settle frame draws them again.
+        tab.Render(state, content, time);
+        tab.OverlayLabelsPending.ShouldBeFalse();
+        LabelRegions().ShouldBeGreaterThan(0, "labels must come back once the view stops");
+
+        // A PAN moves the view too, by centre rather than by field of view.
+        tab.State.CenterRA = 18.5;
+        tab.Render(state, content, time);
+        tab.OverlayLabelsPending.ShouldBeTrue("a pan is motion just as much as a zoom is");
+        LabelRegions().ShouldBe(0);
+    }
 }

--- a/src/TianWen.UI.Abstractions/SkyMapTab.ObjectOverlay.cs
+++ b/src/TianWen.UI.Abstractions/SkyMapTab.ObjectOverlay.cs
@@ -29,6 +29,32 @@ namespace TianWen.UI.Abstractions
         private bool _primOverlayHasKey;
         private PrimOverlayKey _primOverlayKey;
 
+        // Whether the view is still moving, compared on the RAW field of view and centre. Not on the
+        // quantized cache key: a smooth zoom crosses a 10% FOV bucket only every ~9 frames, so a
+        // key-based test reads a gesture as a series of unrelated discrete changes and fires on
+        // almost none of its frames.
+        private double _primLastFov = double.NaN;
+        private double _primLastCentreRa = double.NaN;
+        private double _primLastCentreDec = double.NaN;
+
+        /// <summary>
+        /// True when labels were suppressed because the view moved on this frame, so the host owes a
+        /// repaint once the motion stops.
+        ///
+        /// <para><b>Labels are the overlay's dominant cost and the one part a moving view cannot
+        /// use.</b> Measured over a 40-frame dense zoom in the browser: placement plus text was
+        /// 3,275 ms against 1,253 for the gather, 605 for the markers and 306 for the projection --
+        /// about half of every frame, spent on text sliding past too fast to read. Markers keep
+        /// drawing throughout, so the sky itself never goes blank.</para>
+        ///
+        /// <para>The host must DEBOUNCE this, not answer it with an immediate frame. The browser has
+        /// no render loop, so a repaint requested straight away simply runs the suppression again and
+        /// asks once more; measured that way a 40-event gesture painted 159 frames instead of 40 and
+        /// spent more total time than it saved, even though each frame was 2.5x cheaper. One repaint
+        /// after the motion stops is the whole requirement.</para>
+        /// </summary>
+        internal bool OverlayLabelsPending { get; private set; }
+
         /// <summary>
         /// How many times the candidate gather has actually run, the counterpart of
         /// <see cref="SkyMapState.PlanetCacheRebuilds"/> and load-bearing for the same reason: the cost
@@ -45,6 +71,24 @@ namespace TianWen.UI.Abstractions
         /// callback, so a slow frame and a slow gather are the same sample until they are timed apart.
         /// </summary>
         internal double PrimOverlayGatherMs { get; private set; }
+
+        /// <summary>
+        /// Cumulative wall time in the per-frame overlay phases: projecting the cached candidates,
+        /// rasterising their markers, and placing plus drawing the labels.
+        ///
+        /// <para>Split out because the totals are misleading in the direction that costs work. The
+        /// gather is the eye-catching number -- 14 to 55 ms whenever it runs -- but on a dense zoom it
+        /// runs about four times while these three are paid on all forty frames, so a fix aimed at the
+        /// gather can be measured, correct, and worth almost nothing. That is exactly the wrong turn
+        /// these were added to prevent.</para>
+        /// </summary>
+        internal double PrimOverlayProjectMs { get; private set; }
+
+        /// <inheritdoc cref="PrimOverlayProjectMs"/>
+        internal double PrimOverlayMarkerMs { get; private set; }
+
+        /// <inheritdoc cref="PrimOverlayProjectMs"/>
+        internal double PrimOverlayLabelMs { get; private set; }
 
         /// <summary>
         /// The cache key for a given view, for tests that need to count key changes across a gesture
@@ -81,6 +125,7 @@ namespace TianWen.UI.Abstractions
             var fontPath = FontPath;
             if (contentRect.Width <= 0 || contentRect.Height <= 0)
             {
+                OverlayLabelsPending = false;
                 return;
             }
 
@@ -92,6 +137,7 @@ namespace TianWen.UI.Abstractions
             {
                 _primOverlayCandidates.Clear();
                 _primOverlayHasKey = false;
+                OverlayLabelsPending = false;
                 return;
             }
 
@@ -100,6 +146,18 @@ namespace TianWen.UI.Abstractions
             var cyView = contentRect.Y + contentRect.Height * 0.5f;
             var ppr = SkyMapProjection.PixelsPerRadian(contentRect.Height, fov);
 
+            // The FIRST frame has no previous sample and therefore no motion. Deriving that from the
+            // NaN seeds instead (NaN != anything) made the first render report "moved" and suppress
+            // its labels -- invisible on a host that debounces a repaint, permanent on one that does
+            // not paint again by itself, which is how the offline renderer sees it.
+            var hasPreviousView = !double.IsNaN(_primLastFov);
+            var viewMoved = hasPreviousView
+                && (fov != _primLastFov
+                    || State.CenterRA != _primLastCentreRa
+                    || State.CenterDec != _primLastCentreDec);
+            _primLastFov = fov;
+            _primLastCentreRa = State.CenterRA;
+            _primLastCentreDec = State.CenterDec;
             var key = BuildOverlayKey(contentRect, fov, cxView, cyView, ppr, showAllOverlays, showDark, plannerState);
             if (!_primOverlayHasKey || !_primOverlayKey.Equals(key))
             {
@@ -123,6 +181,7 @@ namespace TianWen.UI.Abstractions
 
             if (_primOverlayCandidates.Count == 0)
             {
+                OverlayLabelsPending = false;
                 return;
             }
 
@@ -144,20 +203,33 @@ namespace TianWen.UI.Abstractions
             // and so is ~100 px whatever the shape's size, while the projection extends its margin
             // by the shape's actual on-screen semi-major axis. A large nebula centred just off the
             // viewport got a label but no marker.
+            var projectStart = System.Diagnostics.Stopwatch.GetTimestamp();
             OverlayEngine.ProjectSkyMapCandidatesInto(_primOverlayCandidates, State, contentRect, dpiScale, _primOverlayItems);
+            PrimOverlayProjectMs += System.Diagnostics.Stopwatch.GetElapsedTime(projectStart).TotalMilliseconds;
             if (_primOverlayItems.Count == 0)
+            {
+                OverlayLabelsPending = false;
+                return;
+            }
+
+            var markerStart = System.Diagnostics.Stopwatch.GetTimestamp();
+            DrawOverlayMarkers(_primOverlayCandidates, _primOverlayItems, PrimOverlayGathers,
+                arcminToPixels, ppr, cxView, cyView, dpiScale, fovAlpha, dimBelowHorizon, site);
+            PrimOverlayMarkerMs += System.Diagnostics.Stopwatch.GetElapsedTime(markerStart).TotalMilliseconds;
+
+            // Pass 2: labels via the shared best-effort placement (stable slots) + DrawText, over the
+            // items projected once above -- skipped entirely while the view is moving, which is where
+            // roughly half of a gesture's frame time was going.
+            OverlayLabelsPending = viewMoved;
+            if (OverlayLabelsPending)
             {
                 return;
             }
 
-            DrawOverlayMarkers(_primOverlayCandidates, _primOverlayItems, PrimOverlayGathers,
-                arcminToPixels, ppr, cxView, cyView, dpiScale, fovAlpha, dimBelowHorizon, site);
-
-            // Pass 2: labels via the shared best-effort placement (stable slots) + DrawText, over the
-            // items projected once above.
             var labelSize = baseFontSize * dpiScale * 0.85f;
             var lineH = labelSize * 1.2f;
             var measureText = (string text, float size) => Renderer.MeasureText(text.AsSpan(), fontPath, size).Width;
+            var labelStart = System.Diagnostics.Stopwatch.GetTimestamp();
             OverlayEngine.PlaceLabelsBestEffort(_primOverlayItems, labelSize, 4f, measureText,
                 (item, lx, ly) =>
                 {
@@ -196,6 +268,7 @@ namespace TianWen.UI.Abstractions
                             _ => PostSignal(new SkyMapClickSelectSignal(objX, objY, InputModifier.None)));
                     }
                 });
+            PrimOverlayLabelMs += System.Diagnostics.Stopwatch.GetElapsedTime(labelStart).TotalMilliseconds;
         }
 
         /// <summary>

--- a/src/TianWen.UI.Web.E2E/GatherAttributionProbe.cs
+++ b/src/TianWen.UI.Web.E2E/GatherAttributionProbe.cs
@@ -27,7 +27,8 @@ public sealed class GatherAttributionProbe(TianWenWebFixture fixture, ITestOutpu
     private static bool Enabled => Environment.GetEnvironmentVariable("TIANWEN_WEB_PROBE") == "1";
 
     private readonly record struct Stats(
-        int Frames, int Gathers, double RenderMs, double GatherMs, int Uploads);
+        int Frames, int Gathers, double RenderMs, double GatherMs, int Uploads,
+        double ProjectMs, double MarkerMs, double LabelMs);
 
     private static async Task<Stats> ReadAsync(IPage page)
     {
@@ -41,7 +42,19 @@ public sealed class GatherAttributionProbe(TianWenWebFixture fixture, ITestOutpu
             r.GetProperty("gatherMs").GetDouble(),
             // Absent on any build predating the instanced overlay; -1 is the "old artifact" signal
             // RequireInstancedOverlayAsync turns into a failure.
-            r.TryGetProperty("uploads", out var u) ? u.GetInt32() : -1);
+            r.TryGetProperty("uploads", out var u) ? u.GetInt32() : -1,
+            Phase(r, "projectMs"), Phase(r, "markerMs"), Phase(r, "labelMs"));
+    }
+
+    /// <summary>A per-phase timer, or 0 on a build that predates it (so an old artifact still reads).</summary>
+    private static double Phase(JsonElement r, string name)
+        => r.TryGetProperty(name, out var v) ? v.GetDouble() : 0.0;
+
+    private static Stats Sub(Stats a, Stats b)
+    {
+        return new Stats(a.Frames - b.Frames, a.Gathers - b.Gathers, a.RenderMs - b.RenderMs,
+            a.GatherMs - b.GatherMs, a.Uploads - b.Uploads,
+            a.ProjectMs - b.ProjectMs, a.MarkerMs - b.MarkerMs, a.LabelMs - b.LabelMs);
     }
 
     /// <summary>
@@ -160,8 +173,7 @@ public sealed class GatherAttributionProbe(TianWenWebFixture fixture, ITestOutpu
             {
                 await CanvasGestures.WheelZoomAsync(page, canvas, events: 1, deltaPerEvent, burst: false);
                 var c = await ReadAsync(page);
-                var d = new Stats(c.Frames - p0.Frames, c.Gathers - p0.Gathers,
-                    c.RenderMs - p0.RenderMs, c.GatherMs - p0.GatherMs, c.Uploads - p0.Uploads);
+                var d = Sub(c, p0);
                 p0 = c;
                 var fov = await FovAsync(page);
                 rows.Add((fov, d));
@@ -227,7 +239,8 @@ public sealed class GatherAttributionProbe(TianWenWebFixture fixture, ITestOutpu
                 await CanvasGestures.TrackpadPinchAsync(page, canvas, events: 1, deltaPerEvent: -1.5, burst: false);
                 var c = await ReadAsync(page);
                 acc.Add(new Stats(c.Frames - p0.Frames, c.Gathers - p0.Gathers,
-                    c.RenderMs - p0.RenderMs, c.GatherMs - p0.GatherMs, c.Uploads - p0.Uploads));
+                    c.RenderMs - p0.RenderMs, c.GatherMs - p0.GatherMs, c.Uploads - p0.Uploads,
+                    c.ProjectMs - p0.ProjectMs, c.MarkerMs - p0.MarkerMs, c.LabelMs - p0.LabelMs));
                 p0 = c;
             }
             return acc;
@@ -246,7 +259,8 @@ public sealed class GatherAttributionProbe(TianWenWebFixture fixture, ITestOutpu
                 await CanvasGestures.TrackpadPinchAsync(page, canvas, events: 1, deltaPerEvent: +1.5, burst: false);
                 var c = await ReadAsync(page);
                 offRows.Add(new Stats(c.Frames - p0.Frames, c.Gathers - p0.Gathers,
-                    c.RenderMs - p0.RenderMs, c.GatherMs - p0.GatherMs, c.Uploads - p0.Uploads));
+                    c.RenderMs - p0.RenderMs, c.GatherMs - p0.GatherMs, c.Uploads - p0.Uploads,
+                    c.ProjectMs - p0.ProjectMs, c.MarkerMs - p0.MarkerMs, c.LabelMs - p0.LabelMs));
                 p0 = c;
             }
         }
@@ -269,7 +283,8 @@ public sealed class GatherAttributionProbe(TianWenWebFixture fixture, ITestOutpu
                 await CanvasGestures.TrackpadPinchAsync(page, canvas, events: 1, deltaPerEvent: +8.0, burst: false);
                 var c = await ReadAsync(page);
                 wide.Add(new Stats(c.Frames - p0.Frames, c.Gathers - p0.Gathers,
-                    c.RenderMs - p0.RenderMs, c.GatherMs - p0.GatherMs, c.Uploads - p0.Uploads));
+                    c.RenderMs - p0.RenderMs, c.GatherMs - p0.GatherMs, c.Uploads - p0.Uploads,
+                    c.ProjectMs - p0.ProjectMs, c.MarkerMs - p0.MarkerMs, c.LabelMs - p0.LabelMs));
                 p0 = c;
             }
         }
@@ -369,8 +384,7 @@ public sealed class GatherAttributionProbe(TianWenWebFixture fixture, ITestOutpu
             var fovBefore = await FovAsync(page);
             await CanvasGestures.WheelZoomAsync(page, canvas, events: 1, deltaPerEvent: +120.0, burst: false);
             var cur = await ReadAsync(page);
-            var d = new Stats(cur.Frames - prev.Frames, cur.Gathers - prev.Gathers,
-                cur.RenderMs - prev.RenderMs, cur.GatherMs - prev.GatherMs, cur.Uploads - prev.Uploads);
+            var d = Sub(cur, prev);
             prev = cur;
             rows.Add((fovBefore, d));
             output.WriteLine($"{i,4} {fovBefore,8:F1} {d.Gathers,8} {d.Uploads,8} {d.RenderMs,9:F1} {d.GatherMs,9:F1}");
@@ -393,5 +407,69 @@ public sealed class GatherAttributionProbe(TianWenWebFixture fixture, ITestOutpu
                     ? $"  |  {noGather.Count} without a gather: {noGather.Average(r => r.S.RenderMs):F1} ms mean"
                     : ""));
         }
+    }
+
+    /// <summary>
+    /// The cost of a DENSE zoom, which is the gesture the coarse sweep above cannot measure: with a
+    /// large per-event delta the field of view clamps at 180 within a few steps, so 24 of 30 steps
+    /// move nothing and cross no FOV bucket. A real wheel or trackpad delivers ~1.5 units per event,
+    /// crossing a bucket every few frames -- and a gather is 14-55 ms in the browser, so that is a
+    /// dropped frame per bucket for the length of the gesture.
+    ///
+    /// <para>Both routes are driven because they are different code paths: a trackpad two-finger
+    /// pinch arrives as ctrl+wheel through the Blazor wheel binding, a mouse wheel as a plain one.
+    /// The overlay is also driven ON and off, because the difference between them IS the overlay's
+    /// share -- the base frame (star field, lines, chrome) is over half the 60 fps budget on its own,
+    /// so a total with no baseline beside it cannot say what the overlay costs.</para>
+    /// </summary>
+    [Theory]
+    [InlineData(true, true)]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    [InlineData(false, false)]
+    public async Task DenseZoomCost(bool ctrlPinch, bool overlayOn)
+    {
+        Assert.SkipUnless(Enabled, "set TIANWEN_WEB_PROBE=1 to run this measurement");
+
+        var page = await fixture.NewPageAsync();
+        await page.GotoAsync(fixture.BaseUrl + "?e2e=1", new PageGotoOptions { WaitUntil = WaitUntilState.DOMContentLoaded });
+        await Expect(page.Locator("[data-view=planner]")).ToBeVisibleAsync(new() { Timeout = BootTimeout });
+        await Expect(page.Locator(".catalog-loading")).ToHaveCountAsync(0, new() { Timeout = BootTimeout });
+        await page.Locator("[data-view=sky]").ClickAsync();
+        await Expect(page.Locator("[data-view=sky]")).ToHaveClassAsync(ActiveClass, new() { Timeout = BootTimeout });
+
+        var canvas = page.Locator("#planner");
+        await canvas.ClickAsync();
+        if (overlayOn)
+        {
+            await ToggleAsync(page, canvas, "o");
+        }
+
+        const int events = 40;
+        const double delta = -1.5;
+        var before = await ReadAsync(page);
+        var fov0 = await FovAsync(page);
+        if (ctrlPinch)
+        {
+            await CanvasGestures.TrackpadPinchAsync(page, canvas, events, delta, burst: false);
+        }
+        else
+        {
+            await CanvasGestures.WheelZoomAsync(page, canvas, events, delta, burst: false);
+        }
+        await page.EvaluateAsync("() => new Promise(r => requestAnimationFrame(() => r()))");
+        var after = await ReadAsync(page);
+        var fov1 = await FovAsync(page);
+
+        var frames = after.Frames - before.Frames;
+        var render = after.RenderMs - before.RenderMs;
+        output.WriteLine($"=== {(ctrlPinch ? "trackpad pinch (ctrl+wheel)" : "plain wheel")}, "
+            + $"[O] {(overlayOn ? "ON" : "off")}: {events} events, fov {fov0:F1} -> {fov1:F1} ===");
+        var d = Sub(after, before);
+        output.WriteLine($"  {d.Gathers} gathers, {d.Uploads} uploads, {frames} frames, "
+            + $"{render:F0} ms render ({render / Math.Max(1, frames):F1} ms/frame)");
+        output.WriteLine($"  phases: gather {d.GatherMs:F0} | project {d.ProjectMs:F0} | markers {d.MarkerMs:F0} "
+            + $"| labels {d.LabelMs:F0} ms  (overlay {d.GatherMs + d.ProjectMs + d.MarkerMs + d.LabelMs:F0} of "
+            + $"{render:F0} ms = {100 * (d.GatherMs + d.ProjectMs + d.MarkerMs + d.LabelMs) / Math.Max(1, render):F0}%)");
     }
 }

--- a/src/TianWen.UI.Web/Pages/Planner.razor
+++ b/src/TianWen.UI.Web/Pages/Planner.razor
@@ -953,6 +953,33 @@
     // Falls back to painting synchronously when the pump is not up yet (the module import is async and
     // the first frames are painted during init). A dropped frame here would be a visibly stuck canvas,
     // so the fallback is "paint now", never "skip".
+    // Debounced repaint that draws the overlay labels back once the view stops moving. Every frame
+    // of a gesture bumps the generation, so only the LAST request survives its delay and exactly one
+    // extra frame is painted per gesture.
+    //
+    // Answering immediately instead (an rAF) is the version that does not work: the repaint runs the
+    // same suppression, asks again, and a 40-event gesture painted 159 frames -- each 2.5x cheaper
+    // and more total work than doing nothing.
+    int _labelSettleGeneration;
+
+    void ScheduleLabelSettle()
+    {
+        var generation = ++_labelSettleGeneration;
+        _ = SettleLabelsAsync(generation);
+    }
+
+    async Task SettleLabelsAsync(int generation)
+    {
+        // Longer than a frame, shorter than a deliberate pause: a gesture's own events arrive far
+        // faster than this, so mid-gesture requests all supersede each other.
+        await Task.Delay(120);
+        if (generation != _labelSettleGeneration || _skyTab is null)
+        {
+            return; // superseded by a later frame of the same gesture
+        }
+        RenderFrame();
+    }
+
     void RequestRenderCoalesced()
     {
         if (_rafModule is null || _rafRef is null)
@@ -1029,6 +1056,16 @@
                 _skyTab.DpiScale = (float)_metrics.DevicePixelRatio;
                 _skyTab.FontPath = _fontPath;
                 _skyTab.Render(_state, content, Time);
+
+                // The overlay skips its labels while the view is moving -- about half of a gesture's
+                // frame time, spent on text sliding past too fast to read. There is no render loop
+                // here to notice the motion has stopped, so the repaint that draws them back is
+                // DEBOUNCED: every moving frame supersedes the last request, so one repaint lands at
+                // the end of the gesture instead of one per event.
+                if (_skyTab.OverlayLabelsPending)
+                {
+                    ScheduleLabelSettle();
+                }
             }
             else
             {
@@ -1330,7 +1367,10 @@
             + ",\"overlay\":" + ((_skyTab?.State.ShowObjectOverlay ?? false) ? "true" : "false")
             + ",\"renderMs\":" + _renderMs.ToString("F1", CultureInfo.InvariantCulture)
             + ",\"gatherMs\":" + (_skyTab?.PrimOverlayGatherMs ?? 0).ToString("F1", CultureInfo.InvariantCulture)
-            + ",\"uploads\":" + (_skyTab?.OverlayInstanceUploads ?? 0).ToString(CultureInfo.InvariantCulture) + "}";
+            + ",\"uploads\":" + (_skyTab?.OverlayInstanceUploads ?? 0).ToString(CultureInfo.InvariantCulture)
+            + ",\"projectMs\":" + (_skyTab?.PrimOverlayProjectMs ?? 0).ToString("F1", CultureInfo.InvariantCulture)
+            + ",\"markerMs\":" + (_skyTab?.PrimOverlayMarkerMs ?? 0).ToString("F1", CultureInfo.InvariantCulture)
+            + ",\"labelMs\":" + (_skyTab?.PrimOverlayLabelMs ?? 0).ToString("F1", CultureInfo.InvariantCulture) + "}";
 
     [JSInvokable]
     public string GetPlannerSearchRectJson()


### PR DESCRIPTION
Per-phase timers over a 40-frame dense zoom in the browser — which is what I should have measured before any of the previous attempts:

| phase | pinch | wheel |
|---|---|---|
| gather | 1,253 ms | 364 ms |
| project | 306 ms | 399 ms |
| markers | 605 ms | 758 ms |
| **labels** | **3,275 ms** | **2,670 ms** |

**Labels are ~60% of the overlay and about half the entire frame** — and they are the one part a moving view cannot use, because the text slides past too fast to read. They are now skipped on any frame where the field of view or the centre moved, and drawn once the motion stops. Markers keep drawing throughout, so the sky never goes blank.

Interactive frame, same binary, dense pinch: **~172 ms → ~90 ms** of non-label work, about **1.9×**.

> Absolute numbers are an interpreted dev server; the deployed build is mono AOT. This needs confirming against the live artifact — there is now a baseline to confirm it against, and the probe refuses to measure an artifact that predates the change.

## Three things that are load-bearing, each found by a measurement contradicting me

**The repaint must be DEBOUNCED, not immediate.** There is no render loop in the browser, so a repaint requested straight away re-runs the suppression and asks again. Measured that way, a 40-event gesture painted **159 frames instead of 40 and spent more total time than doing nothing at all** — even though every frame was 2.5× cheaper. One repaint 120 ms after the last movement is the whole requirement; every moving frame supersedes the previous request through a generation counter.

**Motion is compared on the RAW field of view and centre, not the quantized overlay cache key.** A smooth zoom crosses a 10% FOV bucket only every ~9 frames, so a key-based test reads a gesture as a series of unrelated *discrete* changes and fires on almost none of its frames. That was the first attempt, and it deferred nothing at all — 4 gathers over a 40-event pinch, identical to no deferral.

**The first frame counts as still.** The previous-view seeds are `NaN`, and NaN compares unequal to everything, so deriving motion from them alone made the very first render suppress its own labels — invisible on a host that debounces a repaint, *permanent* on one that never repaints by itself. The existing offline render test went red; that is how it was caught, not review.

## Also here

- **The per-phase timers** (`projectMs` / `markerMs` / `labelMs`, beside the existing `gatherMs`), exposed through the e2e render-stats hook.
- **A `DenseZoomCost` probe** driving both zoom routes (a trackpad pinch is ctrl+wheel, a different code path from a plain wheel) with realistic 1.5-unit deltas, and both overlay states — because the difference between them *is* the overlay's share, and the base frame is already over half the 60 fps budget on its own. The coarse sweep already in the probe cannot see any of this: with a large per-event delta the field of view clamps at 180 within a few steps, so 24 of 30 steps move nothing and cross no bucket.

## What this replaced

Two earlier attempts at the same slowness, both abandoned on measurement rather than shipped:

1. **Deferring the candidate gather.** The gather is 14–55 ms per FOV bucket, which reads like the bottleneck — but it runs ~4 times in a gesture while the per-frame work is paid on all 40 frames. The deferral made total time *worse*.
2. **Stopping the instance buffer re-uploading every zoom event** (40 uploads for 40 events). Real waste, but freezing the buffer on the same binary put it at 3–12% of the frame — not worth moving three view-dependent quantities into the shaders on both backends, which is where that was heading.

The common error: a large *per-occurrence* cost with no occurrence count beside it. Cost is magnitude × frequency, and the frequencies came from different parts of the system, so nothing put them in the same units until the timers did.

## Testing

4263 unit (up 1) and 338 functional, zero failures. The new `Labels_AreSkippedWhileTheViewMoves_AndComeBackWhenItStops` and the pre-existing render test were both seen to fail with the first-frame rule inverted.

Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YYnrhjBmgaqrqrXn7tZaoP
