### PR TITLE
fix(web): the sky map went deaf to the keyboard, and touch could never give it back

### DIFF
--- a/src/TianWen.UI.Web.E2E/CanvasKeyboardFocusTests.cs
+++ b/src/TianWen.UI.Web.E2E/CanvasKeyboardFocusTests.cs
@@ -1,0 +1,126 @@
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using Microsoft.Playwright;
+using Xunit;
+using static Microsoft.Playwright.Assertions;
+
+namespace TianWen.UI.Web.E2E;
+
+/// <summary>
+/// The sky map's whole keyboard layer hangs off DOM focus sitting on the canvas, and nothing puts it
+/// back once it leaves. The canvas is <c>TabIndex="0" AutoFocus="true"</c>, so it takes focus once at
+/// startup; clicking any chrome button, dismissing an overlay, or coming back to a backgrounded tab
+/// moves focus elsewhere and every shortcut ([O], [D], arrows, F3) goes silently dead while the map
+/// still pans and zooms perfectly, because pointer events do not need focus.
+///
+/// <para><b>No existing test could see this.</b> They all press through
+/// <c>canvas.PressAsync(...)</c>, and Playwright FOCUSES an element before pressing a key into it, so
+/// every one of them silently repaired the exact state under test. These press through
+/// <c>page.Keyboard</c>, which types at whatever the document has focused -- what a user's keyboard
+/// does.</para>
+/// </summary>
+[Collection(TianWenWebCollection.Name)]
+public sealed class CanvasKeyboardFocusTests(TianWenWebFixture fixture)
+{
+    private const float BootTimeout = 120_000;
+    private static readonly Regex ActiveClass = new(@"\bactive\b");
+
+    private static async Task<bool> OverlayOnAsync(IPage page)
+    {
+        var json = await page.EvaluateAsync<string>("async () => await window.__tianwenTest.getRenderStats()");
+        using var doc = JsonDocument.Parse(json);
+        return doc.RootElement.GetProperty("overlay").GetBoolean();
+    }
+
+    private async Task<(IPage Page, ILocator Canvas)> SkyMapAsync()
+    {
+        var page = await fixture.WarmPageAsync();
+        await page.Locator("[data-view=sky]").ClickAsync();
+        await Expect(page.Locator("[data-view=sky]")).ToHaveClassAsync(ActiveClass, new() { Timeout = BootTimeout });
+        return (page, page.Locator("#planner"));
+    }
+
+    /// <summary>Polls the focused element's id until it matches, and returns whatever it settled on so a
+    /// failure names the element that actually holds the keyboard.</summary>
+    private static async Task<string> ActiveElementIdAsync(IPage page, string expected)
+    {
+        var id = "";
+        for (var i = 0; i < 40; i++) // ~2 s
+        {
+            id = await page.EvaluateAsync<string>("() => document.activeElement?.id ?? ''");
+            if (id == expected) return id;
+            await Task.Delay(50);
+        }
+        return id;
+    }
+
+    /// <summary>Presses at the DOCUMENT, the way a real keyboard does -- never at the canvas, which
+    /// would focus it first and hide the defect.</summary>
+    private static async Task PressAtDocumentAsync(IPage page, string key)
+    {
+        await page.Keyboard.PressAsync(key);
+        await page.EvaluateAsync("() => new Promise(r => requestAnimationFrame(() => r()))");
+        await Task.Delay(150);
+    }
+
+    [Fact]
+    public async Task AChromeButtonClickDoesNotSwallowTheKeyboard()
+    {
+        var (page, canvas) = await SkyMapAsync();
+
+        // Start from a known state, pressing at the canvas (which focuses it) so the toggle is
+        // definitely reachable before the interesting part.
+        if (await OverlayOnAsync(page))
+        {
+            await canvas.PressAsync("o");
+        }
+
+        // The everyday way focus leaves: clicking a chrome button. The chip of the view already active
+        // is used deliberately -- it is the path with an early-out, so it is the one that would be
+        // missed by restoring focus only where the view actually changes.
+        await page.Locator("[data-view=sky]").ClickAsync();
+        // The restore crosses into JS through the page's task tracker, so it lands a beat after the
+        // click rather than inside it -- poll rather than sampling the instant the click returns.
+        Assert.Equal("planner", await ActiveElementIdAsync(page, expected: "planner"));
+
+        await PressAtDocumentAsync(page, "o");
+        var on = await OverlayOnAsync(page);
+        await RestoreOverlayOffAsync(page, canvas);
+        Assert.True(on, "[O] did nothing after a chrome button click: the button kept the keyboard");
+    }
+
+    /// <summary>The warm page is shared for the whole suite, so a test that turns the overlay on owes
+    /// putting it back -- otherwise every later test gets a heavier app than it arranged for.</summary>
+    private static async Task RestoreOverlayOffAsync(IPage page, ILocator canvas)
+    {
+        for (var i = 0; i < 4 && await OverlayOnAsync(page); i++)
+        {
+            await canvas.PressAsync("o");
+            await page.EvaluateAsync("() => new Promise(r => requestAnimationFrame(() => r()))");
+        }
+    }
+
+    [Fact]
+    public async Task DrivingTheMapWithAGestureGivesTheKeyboardBack()
+    {
+        var (page, canvas) = await SkyMapAsync();
+        if (await OverlayOnAsync(page))
+        {
+            await canvas.PressAsync("o");
+        }
+
+        await page.EvaluateAsync("() => document.activeElement instanceof HTMLElement && document.activeElement.blur()");
+
+        // A two-finger pinch -- the gesture the reported session was driven with (910 touchmoves against
+        // 127 mousemoves in its trace). It proves the pointer half of the app is alive, which is exactly
+        // why a dead keyboard reads as "[O] is broken" rather than "the page is ignoring me". A MOUSE
+        // press would not do as the repro: the browser focuses a tabindex element on mousedown, so a
+        // mouse drag repairs the state on its own, and touch does not.
+        await CanvasGestures.PinchAsync(page, canvas, startGap: 200, endGap: 260, steps: 6);
+
+        await PressAtDocumentAsync(page, "o");
+        var on = await OverlayOnAsync(page);
+        await RestoreOverlayOffAsync(page, canvas);
+        Assert.True(on, "[O] did nothing after a touch pinch: driving the map does not restore keyboard focus");
+    }
+}

--- a/src/TianWen.UI.Web.E2E/CanvasRenderCostTests.cs
+++ b/src/TianWen.UI.Web.E2E/CanvasRenderCostTests.cs
@@ -35,7 +35,8 @@ public sealed class CanvasRenderCostTests(TianWenWebFixture fixture)
     private const float BootTimeout = 120_000;
     private static readonly Regex ActiveClass = new(@"\bactive\b");
 
-    private readonly record struct RenderStats(int Frames, int Coalesced, int Gathers, bool Overlay, int Uploads);
+    private readonly record struct RenderStats(
+        int Frames, int Coalesced, int Gathers, bool Overlay, int Uploads, double LabelMs);
 
     private static async Task<RenderStats> GetStatsAsync(IPage page)
     {
@@ -47,7 +48,11 @@ public sealed class CanvasRenderCostTests(TianWenWebFixture fixture)
             r.GetProperty("coalesced").GetInt32(),
             r.GetProperty("gathers").GetInt32(),
             r.GetProperty("overlay").GetBoolean(),
-            r.GetProperty("uploads").GetInt32());
+            r.GetProperty("uploads").GetInt32(),
+            // Only ever advances on a frame that actually DREW labels, which is what makes it the
+            // observable for "did the labels come back" -- the pixels cannot say, since a frame with
+            // labels and a frame without are both correct renders of their own moment.
+            r.GetProperty("labelMs").GetDouble());
     }
 
     /// <summary>
@@ -265,5 +270,103 @@ public sealed class CanvasRenderCostTests(TianWenWebFixture fixture)
             + $"gathers +{afterPan.Gathers - before.Gathers} over {painted} painted frames");
         Assert.True(afterZoom.Uploads > afterPan.Uploads,
             "a zoom must re-upload the instance buffer; it changes the scale every marker is sized by");
+    }
+
+    /// <summary>
+    /// Labels must not blink back mid-drag. They are hidden while the view moves (about half a gesture's
+    /// frame time, spent on text sliding past too fast to read) and drawn again once it stops -- and a
+    /// pure DELAY cannot tell a pause from an end. Measured over a real touch session: 3.7% of the gaps
+    /// between moves WITHIN one gesture were longer than the 120 ms debounce (33 of them), so the labels
+    /// came back mid-drag and the next move hid them again. That is the reported flicker, and shortening
+    /// the delay makes it worse (5.5% of gaps clear 60 ms).
+    ///
+    /// <para>So a pointer gesture states when it is over rather than being timed: the press holds the
+    /// settle off, and the RELEASE brings the labels back by itself -- the release frame paints a view
+    /// that has not moved since the last one, so nothing is suppressed.</para>
+    /// </summary>
+    [Fact]
+    public async Task APauseInTheMiddleOfADragDoesNotFlashTheLabelsBack()
+    {
+        var page = await WarmSkyAtlasAsync();
+        var canvas = page.Locator("#planner");
+        var box = await canvas.BoundingBoxAsync() ?? throw new InvalidOperationException("canvas not visible");
+        var cx = box.X + (box.Width / 2);
+        var cy = box.Y + (box.Height / 2);
+
+        await EnsureObjectOverlayOnAsync(page, canvas);
+        try
+        {
+            await page.Mouse.MoveAsync((float)cx, (float)cy);
+            await page.Mouse.DownAsync();
+            for (var i = 1; i <= 6; i++)
+            {
+                await page.Mouse.MoveAsync((float)(cx + (i * 12)), (float)cy);
+            }
+            await page.EvaluateAsync("() => new Promise(r => requestAnimationFrame(() => r()))");
+            var moving = await GetStatsAsync(page);
+
+            // Hold still, fingers/button still DOWN, well past the 120 ms settle. A human pausing to
+            // look at where they have dragged to is the everyday version of this.
+            await Task.Delay(500);
+            var paused = await GetStatsAsync(page);
+
+            await page.Mouse.UpAsync();
+            await page.EvaluateAsync("() => new Promise(r => requestAnimationFrame(() => r()))");
+            await Task.Delay(300);
+            var released = await GetStatsAsync(page);
+
+            Assert.True(paused.LabelMs - moving.LabelMs < 0.01,
+                $"the labels were redrawn during a 500 ms pause inside a drag (+{paused.LabelMs - moving.LabelMs:F1} ms "
+                + "of label work): the next move hides them again, which is the flicker");
+            Assert.True(released.LabelMs - paused.LabelMs > 0,
+                "the labels never came back after the drag ended, so the suppression is permanent");
+        }
+        finally
+        {
+            await SetObjectOverlayAsync(page, canvas, on: false);
+        }
+    }
+
+    /// <summary>
+    /// An idle map must paint NOTHING. There is no render loop here, so a frame while nobody is touching
+    /// it can only come from the app asking for one -- and the label-settle repaint is exactly such a
+    /// request, scheduled by any frame that suppressed its labels for a moving view.
+    ///
+    /// <para><b>The failure mode is a self-feeding loop, not a wasted frame.</b> Motion is decided by
+    /// comparing the view centre against the previous frame's, and in ALT-AZ mode the equatorial centre
+    /// drifts with the live clock -- so a settle repaint arriving 120 ms later legitimately sees a moved
+    /// view, suppresses its labels again, and schedules another. The map then repaints for ever at ~8 fps
+    /// with the labels never landing, which is what a "flicker after the movement stops" looks like.</para>
+    ///
+    /// <para>Asserted over a window many times the settle delay, so one late repaint passes and a
+    /// standing loop cannot.</para>
+    /// </summary>
+    [Fact]
+    public async Task AnIdleMapPaintsNothingOnceTheLabelsHaveSettled()
+    {
+        var page = await WarmSkyAtlasAsync();
+        var canvas = page.Locator("#planner");
+
+        await EnsureObjectOverlayOnAsync(page, canvas);
+        try
+        {
+            // Move the view, so the labels are suppressed and a settle repaint is genuinely owed.
+            await CanvasGestures.WheelZoomAsync(page, canvas, events: 6, deltaPerEvent: -1.5, burst: false);
+
+            // Well past the 120 ms settle: anything after this point is unrequested.
+            await Task.Delay(800);
+            var settled = await GetStatsAsync(page);
+            await Task.Delay(2000);
+            var idle = await GetStatsAsync(page);
+
+            var painted = idle.Frames - settled.Frames;
+            Assert.True(painted <= 1,
+                $"the map painted {painted} frames over 2 s while nobody touched it: the label-settle "
+                + "repaint is re-arming itself, so the labels never land and the map never goes quiet");
+        }
+        finally
+        {
+            await SetObjectOverlayAsync(page, canvas, on: false);
+        }
     }
 }

--- a/src/TianWen.UI.Web.E2E/OverlayVisibilityProbe.cs
+++ b/src/TianWen.UI.Web.E2E/OverlayVisibilityProbe.cs
@@ -1,0 +1,117 @@
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using Microsoft.Playwright;
+using Xunit;
+using static Microsoft.Playwright.Assertions;
+
+namespace TianWen.UI.Web.E2E;
+
+/// <summary>
+/// Dumps what the sky map actually PAINTS with the [O] overlay off, on, and off again, so the
+/// markers can be looked at rather than inferred from timers.
+///
+/// <para>Every existing overlay measurement reads <c>getRenderStats</c> -- gathers, uploads, per-phase
+/// milliseconds. All of those stay identical whether the draw lands on the screen or is discarded by
+/// the GPU, so none of them can see a marker that is submitted and never composited.</para>
+///
+/// <para>The third capture is the control: the sky map advances with real time, so two shots are never
+/// byte-identical and a raw off-vs-on difference proves nothing on its own.</para>
+/// </summary>
+[Collection(TianWenWebCollection.Name)]
+public sealed class OverlayVisibilityProbe(TianWenWebFixture fixture, ITestOutputHelper output)
+{
+    private const float BootTimeout = 120_000;
+    private static readonly Regex ActiveClass = new(@"\bactive\b");
+
+    private static bool Enabled => Environment.GetEnvironmentVariable("TIANWEN_WEB_PROBE") == "1";
+
+    private static async Task<JsonElement> StatsAsync(IPage page)
+    {
+        var json = await page.EvaluateAsync<string>("async () => await window.__tianwenTest.getRenderStats()");
+        return JsonDocument.Parse(json).RootElement.Clone();
+    }
+
+    [Fact]
+    public async Task DumpOverlayFrames()
+    {
+        Assert.SkipUnless(Enabled, "set TIANWEN_WEB_PROBE=1 to run this measurement");
+
+        var dir = Environment.GetEnvironmentVariable("TIANWEN_WEB_SHOTS")
+            ?? Path.Combine(Path.GetTempPath(), "tianwen-overlay-shots");
+        Directory.CreateDirectory(dir);
+
+        var page = await fixture.WarmPageAsync();
+        var console = new List<string>();
+        page.Console += (_, m) => { lock (console) { console.Add($"[{m.Type}] {m.Text}"); } };
+        page.PageError += (_, e) => { lock (console) { console.Add($"[pageerror] {e}"); } };
+
+        await page.Locator("[data-view=sky]").ClickAsync();
+        await Expect(page.Locator("[data-view=sky]")).ToHaveClassAsync(ActiveClass, new() { Timeout = BootTimeout });
+        var canvas = page.Locator("#planner");
+
+        // Wait for the full Tycho-2 atlas to land. The user's session has it (the trace fetches
+        // tyc2-cache.js); a probe that screenshots 8 seconds in has only the HR bright-star seed, so
+        // it is measuring a DIFFERENT star pipeline state than the one being reported broken.
+        var atlasDeadline = DateTime.UtcNow.AddSeconds(120);
+        while (DateTime.UtcNow < atlasDeadline)
+        {
+            lock (console)
+            {
+                if (console.Any(c => c.Contains("tyc2 flatten") || c.Contains("HR-only atlas")))
+                {
+                    break;
+                }
+            }
+            await Task.Delay(500);
+        }
+        lock (console)
+        {
+            output.WriteLine($"atlas: {(console.FirstOrDefault(c => c.Contains("tyc2 flatten")) ?? "NOT LOADED (HR seed only)")}");
+        }
+
+        async Task SettleAsync()
+        {
+            // Long enough for the debounced label repaint (120 ms) to have landed, so a capture shows
+            // the settled frame rather than a mid-gesture one.
+            await page.EvaluateAsync("() => new Promise(r => requestAnimationFrame(() => r()))");
+            await Task.Delay(400);
+        }
+
+        async Task<bool> OverlayOnAsync() => (await StatsAsync(page)).GetProperty("overlay").GetBoolean();
+
+        async Task ShootAsync(string name)
+        {
+            await SettleAsync();
+            var s = await StatsAsync(page);
+            var path = Path.Combine(dir, name + ".png");
+            await canvas.ScreenshotAsync(new LocatorScreenshotOptions { Path = path });
+            var bytes = new FileInfo(path).Length;
+            var uploads = s.TryGetProperty("uploads", out var u) ? u.GetInt32() : -1;
+            output.WriteLine($"{name,-12} overlay={s.GetProperty("overlay").GetBoolean(),-5} "
+                + $"gathers={s.GetProperty("gathers").GetInt32(),-4} uploads={uploads,-4} "
+                + $"markerMs={(s.TryGetProperty("markerMs", out var m) ? m.GetDouble() : 0),8:F1} "
+                + $"{bytes,9} bytes  {path}");
+        }
+
+        if (await OverlayOnAsync())
+        {
+            await canvas.PressAsync("o");
+        }
+
+        await ShootAsync("1-overlay-off");
+        await canvas.PressAsync("o");
+        Assert.True(await OverlayOnAsync(), "[O] did not turn the overlay on");
+        await ShootAsync("2-overlay-on");
+        await canvas.PressAsync("o");
+        await ShootAsync("3-overlay-off-again");
+
+        lock (console)
+        {
+            output.WriteLine($"--- {console.Count} console messages ---");
+            foreach (var m in console)
+            {
+                output.WriteLine("  " + m);
+            }
+        }
+    }
+}

--- a/src/TianWen.UI.Web.E2E/TianWenWebFixture.cs
+++ b/src/TianWen.UI.Web.E2E/TianWenWebFixture.cs
@@ -48,7 +48,12 @@ public sealed class TianWenWebFixture : IAsyncLifetime
         _playwright = await Playwright.CreateAsync();
         Browser = await _playwright.Chromium.LaunchAsync(new BrowserTypeLaunchOptions
         {
-            Headless = true,
+            // TIANWEN_E2E_HEADED=1 drives a VISIBLE browser, which is the only way to exercise the
+            // real GPU: headless Chromium falls back to SwiftShader, so a WebGL defect that depends
+            // on the actual driver (this box is win-arm64 / Adreno via ANGLE) renders perfectly
+            // headless and is invisible to every headless assertion. Off by default -- a visible
+            // window steals focus and cannot run unattended.
+            Headless = Environment.GetEnvironmentVariable("TIANWEN_E2E_HEADED") != "1",
             Channel = string.IsNullOrWhiteSpace(channel) ? null : channel,
         });
     }

--- a/src/TianWen.UI.Web/Pages/Planner.razor
+++ b/src/TianWen.UI.Web/Pages/Planner.razor
@@ -325,6 +325,7 @@
     // Toolbar 📍: re-fetch the current position on demand (prompting if needed) and recompute.
     async Task RelocateAsync()
     {
+        RestoreCanvasFocus(); // the button click took the keyboard; give it straight back
         if (_busy) return;
         if (await TryGeolocateAsync(waitForPrompt: true))
         {
@@ -533,6 +534,31 @@
     }
 
     void DeactivateTextInput() => _focus.Blur();
+
+    // Hands the keyboard back to the canvas. The canvas IS the app -- [O], [D], F3, the arrows and every
+    // other shortcut are canvas keys -- but they ride DOM focus, and the canvas takes focus exactly ONCE
+    // (AutoFocus, at startup) with nothing anywhere to give it back. So the shortcuts die silently the
+    // first time focus leaves, while the map goes on panning and zooming perfectly, because pointer
+    // events need no focus: it reads as "[O] is broken", not as "the page cannot hear me".
+    //
+    // Both ways out are ordinary. Any chrome button (a view chip, Locate, Recompute) takes focus on
+    // click and keeps it. And TOUCH can never restore it, even by driving the map: the touch bridge
+    // calls preventDefault() on touchstart -- which is what stops the page scrolling under the fingers
+    // -- and that suppresses the browser's own focus-on-press along with it. A finger-driven session
+    // therefore has no way back at all, which is how this was reported.
+    //
+    // Deliberately a no-op while a canvas text field is focused: the floating <input> legitimately owns
+    // the keyboard then, and stealing it back would break typing and the IME with it. The lat/lon number
+    // fields are real DOM inputs and are never touched here for the same reason -- they are not buttons,
+    // so nothing calls this after clicking into them.
+    void RestoreCanvasFocus()
+    {
+        if (_focus.Current is not null || _canvas is null)
+        {
+            return;
+        }
+        _tracker.Run(() => _canvas.FocusAsync().AsTask(), "Focus canvas");
+    }
 
     // The active view's widget as the concrete pixel-widget base, for the region-rect scan
     // (GetRegisteredRegions is not on the IPixelWidget interface).
@@ -934,6 +960,7 @@
 
     async Task RecomputeAsync()
     {
+        RestoreCanvasFocus(); // the button click took the keyboard; give it straight back
         if (_busy || _webGl is null) return;
         _busy = true;
         try
@@ -962,17 +989,31 @@
     // and more total work than doing nothing.
     int _labelSettleGeneration;
 
+    // True between a press and its release (mouse, one-finger touch pan, or a pinch). A DELAY cannot
+    // tell a pause from an end, which is what made the labels flicker: measured over a real touch
+    // session, 3.7% of the gaps BETWEEN moves of a single gesture were longer than the 120 ms debounce
+    // -- 33 of them -- so the labels blinked back on mid-drag and were hidden again by the next move.
+    // Shortening the delay makes that worse (5.5% of gaps clear 60 ms) and lengthening it makes the
+    // real settle late. A pointer gesture knows when it is over, so it says so instead of being timed.
+    bool _pointerGestureActive;
+
     void ScheduleLabelSettle()
     {
         var generation = ++_labelSettleGeneration;
-        _ = SettleLabelsAsync(generation);
+        // Mid-gesture this is only a BACKSTOP, not the settle: the release repaints with labels itself
+        // (the view has not moved since the last frame, so nothing is suppressed). It exists because a
+        // gesture can end without a release reaching us -- a pointercancel the app never sees -- and
+        // without it the labels would then stay hidden until the next gesture ended. Set well past the
+        // longest observed within-gesture pause (397 ms) so a genuine pause never trips it.
+        var delayMs = _pointerGestureActive ? 700 : 120;
+        _ = SettleLabelsAsync(generation, delayMs);
     }
 
-    async Task SettleLabelsAsync(int generation)
+    async Task SettleLabelsAsync(int generation, int delayMs)
     {
         // Longer than a frame, shorter than a deliberate pause: a gesture's own events arrive far
-        // faster than this, so mid-gesture requests all supersede each other.
-        await Task.Delay(120);
+        // faster than this (median 8.3 ms, p90 26.5 ms), so mid-gesture requests supersede each other.
+        await Task.Delay(delayMs);
         if (generation != _labelSettleGeneration || _skyTab is null)
         {
             return; // superseded by a later frame of the same gesture
@@ -1125,6 +1166,9 @@
     async Task ToggleFullscreenAsync()
     {
         if (_canvas is { } c) await c.ToggleFullscreenAsync();
+        // After the transition, not before: entering fullscreen moves focus to the fullscreen element
+        // itself, so a restore beforehand would be undone by the very call it precedes.
+        RestoreCanvasFocus();
     }
 
     // Active view's widget for generic input routing (both are PixelWidgetBase<WebGlContext>).
@@ -1304,6 +1348,10 @@
 
     void SwitchView(View view)
     {
+        // The chip click just moved DOM focus onto that button, so hand it back (see
+        // RestoreCanvasFocus) -- BEFORE the early-out, so re-clicking the chip of the view you are
+        // already on is not the one path that leaves the map deaf to the keyboard.
+        RestoreCanvasFocus();
         if (_view == view) return;
         // Build the target from the app ROOT (Nav.BaseUri), NEVER from the current URI, and always
         // stamp an EXPLICIT "?view=" - "?view=planner" as well as "?view=sky" (symmetric + shareable).
@@ -1434,6 +1482,7 @@
     void OnPointerDown(CanvasPointerEventArgs e)
     {
         if (ActiveTab is not { } tab || e.Original.Button != 0) return;
+        _pointerGestureActive = true; // a pause inside a drag is not the end of it (see ScheduleLabelSettle)
         var mods = ToModifiers(e.Original);
         // Desktop order (GuiEventHandlerBase): hit-test the registered clickable regions FIRST
         // (planet/comet labels, reticles, planner rows), then feed the result to the shared
@@ -1462,6 +1511,11 @@
         // desktop order - a slider grab keeps the focused input).
         DeactivateTextInput();
 
+        // A press on the map claims the keyboard for it. This also covers a ONE-FINGER touch pan, which
+        // the JS bridge routes through these same pointer callbacks (see RestoreCanvasFocus for why
+        // touch cannot do it for itself).
+        RestoreCanvasFocus();
+
         if (hit is null)
         {
             tab.HandleInput(new InputEvent.MouseDown(e.X, e.Y, Modifiers: mods, ClickCount: (int)e.Original.Detail));
@@ -1486,6 +1540,7 @@
 
     void OnPointerUp(CanvasPointerEventArgs e)
     {
+        _pointerGestureActive = false;
         if (ActiveTab is not { } tab) return;
         tab.HandleInput(new InputEvent.MouseUp(e.X, e.Y));
         if (_view == View.Planner)
@@ -1549,14 +1604,20 @@
     void OnPinch(CanvasPinchEventArgs e)
     {
         if (ActiveTab is not { } tab) return;
+        _pointerGestureActive = true; // fingers still down; the pinch END is what settles the labels
         tab.HandleInput(new InputEvent.Pinch((float)e.Scale, e.X, e.Y) { Source = PinchSource.Touchscreen });
         RequestRenderCoalesced(); // touchscreen pinch: same density as the trackpad one
     }
 
     void OnPinchEnd()
     {
+        _pointerGestureActive = false;
         if (ActiveTab is not { } tab) return;
         tab.HandleInput(new InputEvent.PinchEnd());
+        // Driving the map with two fingers is as clear a claim on it as a click, and touch cannot take
+        // focus by itself (RestoreCanvasFocus explains why). Done on END, not on every pinch step: a
+        // pinch delivers a move per touchmove and a focus call per frame would be pure interop traffic.
+        RestoreCanvasFocus();
         RenderFrame();
     }
 


### PR DESCRIPTION
[O] and [D] stopped doing anything while the map still panned and zoomed perfectly. That combination is why it reads as "the overlay is broken" rather than "the page cannot hear me".

**Neither key was ever delivered.** In the reported session's trace, all 19 keydown tasks cost 0.10-0.23 ms, and `OnKeyDown` repaints synchronously on *both* of its branches -- so no repaint can hide in 0.15 ms. The app never saw them.

The canvas is `TabIndex="0" AutoFocus="true"`: it takes DOM focus exactly once, at startup, and nothing anywhere hands it back. Two ordinary things take it away, and one of them has no way back at all:

- **Any chrome button click** (a view chip, Locate, Recompute) takes focus and keeps it.
- **Touch can never restore it, even by driving the map.** The touch bridge calls `preventDefault()` on `touchstart` -- which is what stops the page scrolling under the fingers -- and that suppresses the browser's own focus-on-press along with it. The reported session was driven by fingers: **910 touchmoves against 127 mousemoves**.

A press on the map, a pinch, and every chrome BUTTON now hand focus back. The lat/lon fields are deliberately left alone (real DOM inputs that want the keyboard), as is any focused canvas text field, whose floating `<input>` legitimately owns it.

## Why no test caught it, in one line

They all press through `canvas.PressAsync`, and **Playwright focuses an element before pressing a key into it** -- so every existing test silently repaired the exact state under test. The new ones press at the `document`, the way a keyboard does. Both were seen to FAIL against the deployed build and pass locally.

## Also here: the labels flicker back mid-drag

Same trace, reported separately. The label suppression settles on a 120 ms debounce, and **a delay cannot tell a pause from an end**. Measured over that session, **3.7% of the gaps between moves of a single gesture are longer than 120 ms** -- 33 of them -- so the labels blink on mid-drag and the next move hides them again. Shortening the delay makes it worse (5.5% of gaps clear 60 ms); lengthening it makes the real settle late.

So a pointer gesture states when it is over instead of being timed: the press holds the settle off, and the RELEASE brings the labels back by itself, because the release frame paints a view that has not moved since the last one. The timer stays as a **700 ms backstop** for a gesture that ends without a release reaching us (a `pointercancel`), set past the longest pause observed (397 ms). The wheel keeps the 120 ms debounce -- it has no end event, so the delay IS its detector.

Pinned by a mid-drag pause asserting on `labelMs`, which only advances on a frame that actually drew labels -- pixels cannot tell, since a frame with labels and one without are both correct renders of their own moment. Seen failing on the deployed build (+1.1 ms of label work during the pause).

An idle-map test comes with it: the settle repaint could re-arm itself for ever in ALT-AZ mode, where the equatorial centre drifts with the live clock, giving a map that repaints at ~8 fps with the labels never landing. It does not, but nothing was watching for it.

## Two diagnosis tools kept, because both gaps were real

- **`TIANWEN_E2E_HEADED=1`** drives a VISIBLE browser and therefore the real GPU. Headless Chromium falls back to SwiftShader, so a WebGL defect that depends on the actual driver (this box is win-arm64 / Adreno through ANGLE) renders perfectly headless and is invisible to every headless assertion.
- **A probe that dumps what the overlay actually PAINTS** with [O] off / on / off, the third capture being the control for a sky that advances with real time. Every existing overlay measurement reads timers -- gathers, uploads, per-phase milliseconds -- and all of those stay identical whether the draw lands on screen or is discarded by the GPU. That is what ruled the GPU out here, on the deployed build, at full atlas, on real hardware, before the trace pointed at the keyboard.

## Testing

20 web e2e passing against a locally served build (9 env-gated probes skipped), including the pre-existing search and view-switch tests that the focus change could have broken. The served artifact was probed for the new symbols first -- a stale dev server has already cost this workstream one entire measurement session.

Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YYnrhjBmgaqrqrXn7tZaoP
