### PR TITLE
test(web-e2e): a gesture driven during the atlas load measures nothing

### DIFF
--- a/src/TianWen.UI.Web.E2E/CanvasKeyboardFocusTests.cs
+++ b/src/TianWen.UI.Web.E2E/CanvasKeyboardFocusTests.cs
@@ -37,6 +37,9 @@ public sealed class CanvasKeyboardFocusTests(TianWenWebFixture fixture)
         var page = await fixture.WarmPageAsync();
         await page.Locator("[data-view=sky]").ClickAsync();
         await Expect(page.Locator("[data-view=sky]")).ToHaveClassAsync(ActiveClass, new() { Timeout = BootTimeout });
+        // The Tycho-2 atlas load deliberately ignores canvas input while it runs, so a gesture driven
+        // during it is dropped and proves nothing about focus.
+        await Expect(page.Locator("[data-atlas-loading]")).ToHaveCountAsync(0, new() { Timeout = BootTimeout });
         return (page, page.Locator("#planner"));
     }
 

--- a/src/TianWen.UI.Web.E2E/CanvasRenderCostTests.cs
+++ b/src/TianWen.UI.Web.E2E/CanvasRenderCostTests.cs
@@ -85,6 +85,11 @@ public sealed class CanvasRenderCostTests(TianWenWebFixture fixture)
         var page = await fixture.WarmPageAsync();
         await page.Locator("[data-view=sky]").ClickAsync();
         await Expect(page.Locator("[data-view=sky]")).ToHaveClassAsync(ActiveClass, new() { Timeout = BootTimeout });
+        // Wait out the Tycho-2 atlas load, which DELIBERATELY ignores canvas input while it runs. A test
+        // that drives a gesture during it measures nothing: the moves are dropped, the view never moves,
+        // and nothing repaints. Invisible on a Lightweight dev build (no atlas, so no busy phase) and
+        // certain against the deployed site, where the 28 MB fetch outlasts the boot wait above.
+        await Expect(page.Locator("[data-atlas-loading]")).ToHaveCountAsync(0, new() { Timeout = BootTimeout });
         // Let any in-flight repaint land so the before-stats are a settled baseline.
         await page.EvaluateAsync("() => new Promise(r => requestAnimationFrame(() => r()))");
         return page;


### PR DESCRIPTION
The canvas input tests drive a gesture as soon as the sky view goes active, but the Tycho-2 atlas load **deliberately ignores canvas input** while it runs (the loading overlay, merged one commit ago). Drive a drag during it and the moves are dropped, the view never moves, and nothing repaints -- so the test asserts against a map that was never touched.

**Invisible locally, certain against the deployed site.** A dev server built with `-p:Lightweight=true` carries no Tycho-2 at all, so there is no busy phase to race; the deployed build spends ~6 s on a 28 MB fetch plus decompress, which outlasts the boot wait these tests already had.

That is exactly how it surfaced: the mid-drag flicker test passed locally and then failed against the deployed site claiming the labels never came back. They never went away -- the drag never happened.

Both sky-map helpers now wait for `[data-atlas-loading]` to clear, the same gate the loading-overlay tests already use.

## Testing

10 web e2e passing against the DEPLOYED site (was 9 of 10), covering the keyboard-focus, render-cost and loading-overlay suites.

Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YYnrhjBmgaqrqrXn7tZaoP