### PR TITLE
ci(web): compile the browser build on the PR loop, the quick way

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -109,6 +109,34 @@ jobs:
         name: nuget-packages
         path: '**/*.nupkg'
         retention-days: 5
+    # TianWen.UI.Web and its E2E harness live OUTSIDE TianWen.slnx, so nothing on the PR path
+    # compiled them: an API change in TianWen.UI.Abstractions, or a sibling pin bump that moves
+    # WebGl.Renderer, could only be found by pages.yml -- AFTER merge, as a broken deploy of main.
+    # This is the QUICK build: interpreted, no AOT and no native relink, so it needs no wasm-tools
+    # workload, and it compiles against the libraries this job has already built. That is what makes
+    # it affordable on every push and PR (~1 min) rather than the deploy's full AOT publish.
+    #
+    # Placed after the uploads so a web-only break still leaves the catalog + package artifacts
+    # behind, and three details are deliberate, each because the alternative costs a FULL rebuild of
+    # TianWen.Lib (catalog resources and all) instead of reusing the Build step above:
+    #  - The version properties are repeated verbatim from Build. A different -p:Version regenerates
+    #    AssemblyInfo for every project in the graph -- and TianWen.Lib sets GeneratePackageOnBuild,
+    #    so a rebuild here at a DIFFERENT version would also drop a second, stray .nupkg beside the
+    #    real one (the org-wide trap in ../.github/CLAUDE.md, which --skip-duplicate then hides).
+    #  - No -p:Lightweight=true, even though the deploy passes it. It only REMOVES an EmbeddedResource
+    #    from TianWen.Lib, so it changes no C# and no razor -- there is nothing extra to cover -- but
+    #    it does change Lib's inputs.
+    #  - No --no-restore: the solution restore never saw these two projects, so they restore here.
+    #
+    # What this CANNOT catch, and pages.yml still owns: the AOT leg (the mono cross-compiler
+    # fail-fasts on the vendor SDK assemblies TianWen.UI.Web works around), trimming, and anything at
+    # runtime. The E2E suite is COMPILED here but not RUN -- it needs a browser and a served app.
+    - name: Build TianWen.UI.Web + E2E (interpreted, no AOT)
+      run: |
+        for p in TianWen.UI.Web TianWen.UI.Web.E2E; do
+          dotnet build "$p/$p.csproj" -c $BUILD_CONF -p:UseLocalSiblings=false -p:Version=${VERSION_PREFIX}${VERSION_REV}${VERSION_HASH} -p:FileVersion=${VERSION_PREFIX}.${VERSION_REV} -p:ContinuousIntegrationBuild=true
+        done
+      working-directory: src
 
   test-unit:
     needs: build

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -3,9 +3,12 @@ name: pages
 # Deploy the TianWen.UI.Web in-browser planner to GitHub Pages.
 #
 # TianWen.UI.Web is a standalone Blazor WebAssembly app hosting PlannerTab<WebGlContext>
-# (WebGl.Renderer) - a fully static site, no server. It lives OUTSIDE TianWen.slnx, so the PR
-# `dotnet.yml` loop never builds it; this workflow is its sole CI and publishes
-# to https://sharpastro.github.io/tianwen/. Design + findings: docs/plans/web-showcase.md.
+# (WebGl.Renderer) - a fully static site, no server. It publishes to
+# https://sharpastro.github.io/tianwen/. Design + findings: docs/plans/web-showcase.md.
+# It lives OUTSIDE TianWen.slnx, so `dotnet build` on the solution never touches it; dotnet.yml's
+# build job compiles it explicitly on every push and PR, but only the QUICK interpreted way. This
+# workflow is still the only thing that AOTs it, trims it, bakes its assets or deploys it, so an AOT
+# or trimming regression is visible here and nowhere else.
 # It IS under the repo's Central Package Management, despite the above: CPM resolves by walking
 # directories, so solution membership never had any bearing on it. While the project opted out,
 # its inline WebGl.Renderer pin was invisible to a sibling-family sweep and fell two minors behind.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,10 +145,20 @@ WebGl.Renderer was gated on the switch but absent from the list, so a box with e
 cloned resolved it to `true` and aimed a `ProjectReference` at a path that was not there.
 
 **Both web projects stay out of `TianWen.slnx`, which is a separate and legitimate decision.**
-`TianWen.UI.Web` is a Blazor WASM app whose sole CI is `pages.yml` (a mono AOT publish, far too heavy for
-the per-push `dotnet.yml` loop), and `TianWen.UI.Web.E2E` needs a browser plus a running dev server, so a
-solution-wide `dotnet test` must not sweep it up. Run them explicitly:
+`TianWen.UI.Web` is a Blazor WASM app whose *deploy* CI is `pages.yml` (a mono AOT publish, far too heavy
+for the per-push `dotnet.yml` loop), and `TianWen.UI.Web.E2E` needs a browser plus a running dev server, so
+a solution-wide `dotnet test` must not sweep it up. Run them explicitly:
 `dotnet build TianWen.UI.Web`, `dotnet test TianWen.UI.Web.E2E`.
+
+**Being outside the solution is not a reason to be outside CI, and for a while it was treated as one.**
+`dotnet.yml`'s `build` job now compiles both projects explicitly, after its artifact uploads, the QUICK
+way: interpreted, no AOT, no relink (so no `wasm-tools` workload), reusing the libraries the job just
+built, and passing the same `-p:Version` so nothing rebuilds. That closes the hole where a change to
+`TianWen.UI.Abstractions` -- or a sibling pin bump moving `WebGl.Renderer` -- broke the web host and no PR
+check could say so; it surfaced only in `pages.yml`, after merge, as a broken deploy of main. It does NOT
+cover the AOT leg, trimming, or anything at runtime, and it compiles `TianWen.UI.Web.E2E` without running
+it. Keep the version properties in that step identical to the `Build` step above: a different `-p:Version`
+regenerates AssemblyInfo and turns a ~1 min incremental compile into a full rebuild of the graph.
 
 **`open-vs.ps1` generates `TianWen.local.slnx`** at the repo root (gitignored) by re-rooting
 `src/TianWen.slnx` and appending a `/Siblings/` folder, so Go To Definition lands in sibling *source*.

--- a/src/TianWen.UI.Web.E2E/CanvasRenderCostTests.cs
+++ b/src/TianWen.UI.Web.E2E/CanvasRenderCostTests.cs
@@ -312,12 +312,12 @@ public sealed class CanvasRenderCostTests(TianWenWebFixture fixture)
 
             // Hold still, fingers/button still DOWN, well past the 120 ms settle. A human pausing to
             // look at where they have dragged to is the everyday version of this.
-            await Task.Delay(500);
+            await Task.Delay(500, TestContext.Current.CancellationToken);
             var paused = await GetStatsAsync(page);
 
             await page.Mouse.UpAsync();
             await page.EvaluateAsync("() => new Promise(r => requestAnimationFrame(() => r()))");
-            await Task.Delay(300);
+            await Task.Delay(300, TestContext.Current.CancellationToken);
             var released = await GetStatsAsync(page);
 
             Assert.True(paused.LabelMs - moving.LabelMs < 0.01,
@@ -359,9 +359,9 @@ public sealed class CanvasRenderCostTests(TianWenWebFixture fixture)
             await CanvasGestures.WheelZoomAsync(page, canvas, events: 6, deltaPerEvent: -1.5, burst: false);
 
             // Well past the 120 ms settle: anything after this point is unrequested.
-            await Task.Delay(800);
+            await Task.Delay(800, TestContext.Current.CancellationToken);
             var settled = await GetStatsAsync(page);
-            await Task.Delay(2000);
+            await Task.Delay(2000, TestContext.Current.CancellationToken);
             var idle = await GetStatsAsync(page);
 
             var painted = idle.Frames - settled.Frames;

--- a/src/TianWen.UI.Web.E2E/OverlayVisibilityProbe.cs
+++ b/src/TianWen.UI.Web.E2E/OverlayVisibilityProbe.cs
@@ -62,7 +62,7 @@ public sealed class OverlayVisibilityProbe(TianWenWebFixture fixture, ITestOutpu
                     break;
                 }
             }
-            await Task.Delay(500);
+            await Task.Delay(500, TestContext.Current.CancellationToken);
         }
         lock (console)
         {


### PR DESCRIPTION
`TianWen.UI.Web` and `TianWen.UI.Web.E2E` live outside `TianWen.slnx`, so nothing on the push/PR path compiled them. An API change in `TianWen.UI.Abstractions`, or a sibling pin bump moving `WebGl.Renderer`, could only be found by `pages.yml` -- after merge, as a broken deploy of main.

The `build` job now compiles both, after its artifact uploads, the quick way: interpreted, no AOT, no native relink (so no `wasm-tools` workload), against the libraries it has already built. The exact command line measured ~35 s locally on the package path (`-p:UseLocalSiblings=false`, WebGl.Renderer from NuGet), 0 warnings.

Three details keep it that cheap, each because the alternative rebuilds `TianWen.Lib` with its catalog resources:

- the version properties are repeated verbatim from the `Build` step. A different `-p:Version` regenerates AssemblyInfo for the whole graph -- and `TianWen.Lib` sets `GeneratePackageOnBuild`, so it would also drop a stray `.nupkg` beside the real one, the org-wide trap `--skip-duplicate` then hides
- no `-p:Lightweight=true`, though the deploy passes it. It only removes an `EmbeddedResource`, so there is no extra C# or razor to cover
- no `--no-restore`: the solution restore never saw these two projects

## What it does not cover

The AOT leg (the mono cross-compiler fail-fasts on the vendor SDK assemblies the csproj works around), trimming, and anything at runtime. The E2E suite is **compiled but not run** -- it needs a browser and a served app. `pages.yml` still owns all of that, and its header comment now says so instead of claiming to be the sole CI.

## One thing this PR itself has to prove

The local box has the `wasm-tools` workload installed, so a green local build cannot show whether the runner needs it. A plain non-AOT Blazor build should not, but the check on this PR is the evidence -- if the step fails on a missing workload, the fix is one `dotnet workload install wasm-tools` step.

Also fixes the five xUnit1051 warnings in the E2E project, which this step would otherwise start printing on every run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YYnrhjBmgaqrqrXn7tZaoP
