### PR TITLE
The renderers declared an older DIR.Lib than the one they ran on

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -77,9 +77,9 @@
 
     <PackageVersion Include="Console.Lib" Version="4.26.*" />
 
-    <PackageVersion Include="SdlVulkan.Renderer" Version="7.20.*" />
+    <PackageVersion Include="SdlVulkan.Renderer" Version="7.21.*" />
 
-    <PackageVersion Include="WebGl.Renderer" Version="1.25.*" />
+    <PackageVersion Include="WebGl.Renderer" Version="1.26.*" />
     <PackageVersion Include="SDL3-CS" Version="3.5.0-preview.20260213-150035" />
     <PackageVersion Include="SDL3-CS.Native" Version="3.5.0-preview.20260205-174353" />
 


### PR DESCRIPTION
Two pins, closing the gap the release chain opened.

## What was wrong

| declares DIR.Lib | before | after |
|---|---|---|
| SdlVulkan.Renderer | **7.29.2321** (7.20) | 8.3.2491 (7.21) |
| WebGl.Renderer | **8.0.2451** (1.25) | 8.3.2491 (1.26) |
| Console.Lib | 8.3.2491 | 8.3.2491 |
| this repo | 8.3.* | 8.3.* |

The graph unified DIR.Lib at 8.3 by **highest-version-wins**, so the renderers' shipped
binaries -- compiled against a pre-8.0 DIR.Lib -- were loaded against a post-8.0 one.
7.29 to 8.0 is a MAJOR bump, breaking by the org convention, so that was resolution
*against* intent rather than agreement with it.

## Why it stayed invisible

It never bit: nothing the renderers actually call moved across the break, which is why
every build and every CI leg was green. That is the part worth naming -- a compile cannot
catch this class at all. The next 8.x break would have arrived as a runtime
`MissingMethodException`, inside a renderer, on whichever machine restored first.

## Verification

On the **package** path specifically, since `UseLocalSiblings` self-enables when the
siblings are cloned and then compiles their source, never exercising a pin:

- `dotnet restore -p:UseLocalSiblings=false` pulls SdlVulkan.Renderer 7.21.2481 and
  (via an explicit restore) WebGl.Renderer 1.26.361
- Release build of the solution **plus** `TianWen.UI.Web` and `TianWen.UI.Web.E2E`,
  which sit outside `TianWen.slnx` and are the only consumers of the WebGl pin -- a
  solution-wide restore never touches them. Zero warnings, zero errors.
- `TianWen.Lib.Tests`: 4327 passed, 0 failed, 26 skipped.

## Not in scope

`Directory.Build.props` still carries prose comments; unlike the pin list its comments
cover version-derivation logic, so it is a separate judgement call.

Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nk84WCAuh28ZsWhWCV2XXk