### PR TITLE
The LFS budget was spent by non-CI pulls, so the workflow comments say so

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -61,8 +61,10 @@ jobs:
         key: ${{ steps.lfs-key.outputs.key }}
         # A changed key (any LFS pointer added or updated) restores the newest previous
         # object set so `git lfs pull` fetches only the delta. Without this, adding one
-        # 3 MB file forced a full re-pull of every object in the glob per leg, which is
-        # how the account's LFS budget got exhausted on 2026-08-17.
+        # 3 MB file meant a full cold re-pull of every object in the glob per leg --
+        # which is what turned the 2026-08-17 LFS-budget refusal into a hard CI failure.
+        # (The budget itself was spent by non-CI pulls; every sampled run that month rode
+        # a cache hit and transferred nothing.)
         restore-keys: |
           lfs-build-
     - name: Fetch required LFS objects
@@ -201,10 +203,12 @@ jobs:
         key: ${{ steps.lfs-key.outputs.key }}
         # A changed key (any LFS pointer added or updated) restores the newest previous
         # object set so `git lfs pull` fetches only the delta. Without this, adding one
-        # 3 MB file forced a full ~205 MB re-pull per leg, which is how the account's
-        # LFS budget got exhausted on 2026-08-17. The prefix is shared with the other
-        # test job on purpose: their globs overlap almost entirely, so either job's
-        # saved set is a near-complete starting point for the other.
+        # 3 MB file meant a full ~205 MB cold re-pull per leg -- which is what turned the
+        # 2026-08-17 LFS-budget refusal into a hard CI failure. (The budget itself was
+        # spent by non-CI pulls; every sampled run that month rode a cache hit.) The
+        # prefix is shared with the other test job on purpose: their globs overlap almost
+        # entirely, so either job's saved set is a near-complete starting point for the
+        # other.
         restore-keys: |
           lfs-tests-
     - name: Fetch required LFS objects
@@ -340,10 +344,12 @@ jobs:
         key: ${{ steps.lfs-key.outputs.key }}
         # A changed key (any LFS pointer added or updated) restores the newest previous
         # object set so `git lfs pull` fetches only the delta. Without this, adding one
-        # 3 MB file forced a full ~205 MB re-pull per leg, which is how the account's
-        # LFS budget got exhausted on 2026-08-17. The prefix is shared with the other
-        # test job on purpose: their globs overlap almost entirely, so either job's
-        # saved set is a near-complete starting point for the other.
+        # 3 MB file meant a full ~205 MB cold re-pull per leg -- which is what turned the
+        # 2026-08-17 LFS-budget refusal into a hard CI failure. (The budget itself was
+        # spent by non-CI pulls; every sampled run that month rode a cache hit.) The
+        # prefix is shared with the other test job on purpose: their globs overlap almost
+        # entirely, so either job's saved set is a near-complete starting point for the
+        # other.
         restore-keys: |
           lfs-tests-
     - name: Fetch required LFS objects
@@ -427,8 +433,10 @@ jobs:
         key: ${{ steps.lfs-key.outputs.key }}
         # A changed key (any LFS pointer added or updated) restores the newest previous
         # object set so `git lfs pull` fetches only the delta. Without this, adding one
-        # 3 MB file forced a full re-pull of every object in the glob per leg, which is
-        # how the account's LFS budget got exhausted on 2026-08-17.
+        # 3 MB file meant a full cold re-pull of every object in the glob per leg --
+        # which is what turned the 2026-08-17 LFS-budget refusal into a hard CI failure.
+        # (The budget itself was spent by non-CI pulls; every sampled run that month rode
+        # a cache hit and transferred nothing.)
         restore-keys: |
           lfs-build-
     - name: Fetch required LFS objects


### PR DESCRIPTION
One commit that missed the merge window: PR #172 was merged (deliberately red) while this correction was being pushed, so the branch auto-delete orphaned it. Cherry-picked onto main.

The restore-keys comments in dotnet.yml claimed the full re-pull is how the LFS budget got exhausted. Measured, that is wrong: no LFS-tracked file changed on main since Aug 1, sampled runs across the month all rode cache hits, and the billing API shows 4.6-15.2 GB/month of tianwen LFS bandwidth since April (all non-CI pulls, discounted to USD 0 until enforcement started). The key change only exposed the wall; the comments now say what the re-pull actually cost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AbXdVLeiJALjm946tEyarD
