### PR TITLE
The field-radius PSF profile splits by filter, and each section names its glass

### DIFF
--- a/src/TianWen.Lib.Tests/DatasetPsfNoiseReportTests.cs
+++ b/src/TianWen.Lib.Tests/DatasetPsfNoiseReportTests.cs
@@ -447,5 +447,67 @@ namespace TianWen.Lib.Tests
                 MasterNoiseRelative: 0.004,
                 BinsByChannel: [[new DatasetPsfNoiseReport.RadiusSamples([2.9f], [0.5f])]],
                 MasterProfiles: profiles);
+
+        /// <summary>The filter is the FOURTH field of the session id and nothing else: a target is
+        /// not a filter, and a filter with no OBJECT still occupies the fourth slot because
+        /// <see cref="ImagingSession.Id"/> always emits the OBJECT slot when a filter is present.</summary>
+        [Theory]
+        [InlineData("2025-06/session|ASI533", "")]
+        [InlineData("2025-06/session|ASI533|Vela SNR", "")]
+        [InlineData("2025-06/session|ASI533|Vela SNR|Optolong L-Ultimate 3nm", "Optolong L-Ultimate 3nm")]
+        [InlineData("2025-06/session|ASI533||Ha", "Ha")]
+        public void FilterFromSessionId_ReadsTheFourthFieldAndOnlyThat(string sessionId, string expected)
+            => DatasetPsfNoiseReport.FilterFromSessionId(sessionId).ShouldBe(expected);
+
+        /// <summary>
+        /// An RGB night and a narrowband night on the same scope are two different measurement
+        /// populations (autofocus optimises ~500-550 nm, so how badly red loses depends on the
+        /// passband), so one optical train splits into one section per filter -- while a record
+        /// whose id predates filters keeps the pre-filter behaviour: one unfiltered bucket.
+        /// </summary>
+        [Fact]
+        public void SessionsOfOneTrain_AreSplitByFilter_AndPreFilterIdsKeepOneBucket()
+        {
+            DatasetPsfNoiseReport.SessionPsf Session(string id) => new(
+                SessionId: id, OpticalTrain: "T", SubFwhm: [3f], SubHfd: [3f],
+                SubEllipticity: [0.5f], MasterNoiseRelative: 0.004, BinsByChannel: null);
+
+            var acc = new DatasetPsfNoiseReport.Accumulator(radiusBins: 1);
+            acc.Add(Session("d1|CAM|Obj|Optolong L-Ultimate 3nm"));
+            acc.Add(Session("d2|CAM|Obj|Optolong L-Quad Enhance"));
+            acc.Add(Session("d3|CAM|Obj"));
+            var report = acc.Build();
+
+            report.Trains.Length.ShouldBe(3);
+            // Ordered by label then filter, so the unfiltered bucket ("" sorts first) leads.
+            report.Trains.Select(t => t.Filter).ShouldBe(["", "Optolong L-Quad Enhance", "Optolong L-Ultimate 3nm"]);
+            report.Trains.ShouldAllBe(t => t.OpticalTrain == "T" && t.Sessions == 1);
+        }
+
+        /// <summary>The rendered section names its filter (in the heading AND beside the numbers)
+        /// and classifies the glass, so a reader can judge a corner trend without knowing the
+        /// hardware by name -- and so the first Newtonian to enter the archive announces itself.
+        /// "(no filter recorded)" is deliberate wording: an absent FILTER header is an absent fact,
+        /// not broadband.</summary>
+        [Fact]
+        public async Task TheRenderedSectionNamesTheFilterAndTheOpticalSystem()
+        {
+            var ct = TestContext.Current.CancellationToken;
+            DatasetPsfNoiseReport.SessionPsf Session(string id, string train) => new(
+                SessionId: id, OpticalTrain: train, SubFwhm: [3f], SubHfd: [3f],
+                SubEllipticity: [0.5f], MasterNoiseRelative: 0.004, BinsByChannel: null);
+
+            var acc = new DatasetPsfNoiseReport.Accumulator(radiusBins: 1);
+            acc.Add(Session("d1|SV605|Orion|Optolong L-Ultimate 3nm", "SVBONY SV605CC / SH61 EDPH @ 270mm"));
+            acc.Add(Session("d2|ASI585|Widefield", "ZWO ASI585MC Pro @ 24mm"));
+            var mdPath = Path.Combine(_dir, "filter-sections.md");
+            await DatasetPsfNoiseReport.WriteMarkdownAsync(acc.Build(), mdPath, ct);
+            var md = await File.ReadAllTextAsync(mdPath, ct);
+
+            md.ShouldContain("### SVBONY SV605CC / SH61 EDPH @ 270mm [Optolong L-Ultimate 3nm]");
+            md.ShouldContain("- Filter: Optolong L-Ultimate 3nm | Optical system: refractor");
+            md.ShouldContain("### ZWO ASI585MC Pro @ 24mm");
+            md.ShouldContain("- Filter: (no filter recorded) | Optical system: camera lens");
+        }
     }
 }

--- a/src/TianWen.Lib.Tests/OpticalSystemsTests.cs
+++ b/src/TianWen.Lib.Tests/OpticalSystemsTests.cs
@@ -13,30 +13,38 @@ namespace TianWen.Lib.Tests
     public class OpticalSystemsTests
     {
         [Theory]
-        [InlineData("SH61 EDPH", OpticalSystems.Refractor)]
-        [InlineData("WO ZS61", OpticalSystems.Refractor)]
-        [InlineData("WO RC51", OpticalSystems.Refractor)]
-        [InlineData("Samyang 135 f/2 ED", OpticalSystems.CameraLens)]
+        [InlineData("SH61 EDPH", OpticalSystem.Refractor)]
+        [InlineData("WO ZS61", OpticalSystem.Refractor)]
+        [InlineData("WO RC51", OpticalSystem.Refractor)]
+        [InlineData("Samyang 135 f/2 ED", OpticalSystem.CameraLens)]
         // The raw header spelling classifies via TelescopeAliases, so a classification never has to
         // be entered twice for one physical lens.
-        [InlineData("SAMYANG 135mm", OpticalSystems.CameraLens)]
+        [InlineData("SAMYANG 135mm", OpticalSystem.CameraLens)]
         // No TELESCOP = a camera behind a bare photographic lens; that IS the classification.
-        [InlineData("", OpticalSystems.CameraLens)]
-        [InlineData("   ", OpticalSystems.CameraLens)]
+        [InlineData("", OpticalSystem.CameraLens)]
+        [InlineData("   ", OpticalSystem.CameraLens)]
         // Not in the archive (checked across every store 2026-08-17); stays unclassified until a
         // bake actually surfaces it and someone adds the reviewed table entry.
-        [InlineData("SW8", OpticalSystems.Unclassified)]
-        public void Classify_KnowsTheArchiveAndRefusesToGuess(string telescope, string expected)
+        [InlineData("SW8", OpticalSystem.Unclassified)]
+        public void Classify_KnowsTheArchiveAndRefusesToGuess(string telescope, OpticalSystem expected)
             => OpticalSystems.Classify(telescope).ShouldBe(expected);
 
         [Theory]
-        [InlineData("ZWO ASI533MC Pro / Samyang 135 f/2 ED @ 130mm", OpticalSystems.CameraLens)]
-        [InlineData("SVBONY SV605CC / SH61 EDPH @ 270mm", OpticalSystems.Refractor)]
+        [InlineData("ZWO ASI533MC Pro / Samyang 135 f/2 ED @ 130mm", OpticalSystem.CameraLens)]
+        [InlineData("SVBONY SV605CC / SH61 EDPH @ 270mm", OpticalSystem.Refractor)]
         // A bare-lens label has no telescope slot at all, which parses to an empty telescope.
-        [InlineData("ZWO ASI585MC Pro @ 24mm", OpticalSystems.CameraLens)]
+        [InlineData("ZWO ASI585MC Pro @ 24mm", OpticalSystem.CameraLens)]
         // An unparseable label is NOT a camera-lens claim: we could not read the telescope slot.
-        [InlineData("", OpticalSystems.Unclassified)]
-        public void ClassifyLabel_ReadsTheTelescopeSlotOfATrainLabel(string label, string expected)
+        [InlineData("", OpticalSystem.Unclassified)]
+        public void ClassifyLabel_ReadsTheTelescopeSlotOfATrainLabel(string label, OpticalSystem expected)
             => OpticalSystems.ClassifyLabel(label).ShouldBe(expected);
+
+        [Theory]
+        [InlineData(OpticalSystem.Refractor, "refractor")]
+        [InlineData(OpticalSystem.CameraLens, "camera lens")]
+        [InlineData(OpticalSystem.Newtonian, "Newtonian")]
+        [InlineData(OpticalSystem.Unclassified, "(unclassified)")]
+        public void Label_IsTheWordsTheReportPrints(OpticalSystem kind, string expected)
+            => kind.Label.ShouldBe(expected);
     }
 }

--- a/src/TianWen.Lib.Tests/OpticalSystemsTests.cs
+++ b/src/TianWen.Lib.Tests/OpticalSystemsTests.cs
@@ -1,0 +1,42 @@
+using Shouldly;
+using TianWen.Lib.Imaging.Dataset;
+using Xunit;
+
+namespace TianWen.Lib.Tests
+{
+    /// <summary>
+    /// Coverage for <see cref="OpticalSystems"/>: the coarse refractor-vs-Newtonian-vs-camera-lens
+    /// classification the PSF report annotates each (train, filter) section with. The interesting
+    /// edges are the two absences: no TELESCOP at all is a bare-lens rig by construction, while an
+    /// unknown NAME must stay unclassified rather than be guessed at.
+    /// </summary>
+    public class OpticalSystemsTests
+    {
+        [Theory]
+        [InlineData("SH61 EDPH", OpticalSystems.Refractor)]
+        [InlineData("WO ZS61", OpticalSystems.Refractor)]
+        [InlineData("WO RC51", OpticalSystems.Refractor)]
+        [InlineData("Samyang 135 f/2 ED", OpticalSystems.CameraLens)]
+        // The raw header spelling classifies via TelescopeAliases, so a classification never has to
+        // be entered twice for one physical lens.
+        [InlineData("SAMYANG 135mm", OpticalSystems.CameraLens)]
+        // No TELESCOP = a camera behind a bare photographic lens; that IS the classification.
+        [InlineData("", OpticalSystems.CameraLens)]
+        [InlineData("   ", OpticalSystems.CameraLens)]
+        // Not in the archive (checked across every store 2026-08-17); stays unclassified until a
+        // bake actually surfaces it and someone adds the reviewed table entry.
+        [InlineData("SW8", OpticalSystems.Unclassified)]
+        public void Classify_KnowsTheArchiveAndRefusesToGuess(string telescope, string expected)
+            => OpticalSystems.Classify(telescope).ShouldBe(expected);
+
+        [Theory]
+        [InlineData("ZWO ASI533MC Pro / Samyang 135 f/2 ED @ 130mm", OpticalSystems.CameraLens)]
+        [InlineData("SVBONY SV605CC / SH61 EDPH @ 270mm", OpticalSystems.Refractor)]
+        // A bare-lens label has no telescope slot at all, which parses to an empty telescope.
+        [InlineData("ZWO ASI585MC Pro @ 24mm", OpticalSystems.CameraLens)]
+        // An unparseable label is NOT a camera-lens claim: we could not read the telescope slot.
+        [InlineData("", OpticalSystems.Unclassified)]
+        public void ClassifyLabel_ReadsTheTelescopeSlotOfATrainLabel(string label, string expected)
+            => OpticalSystems.ClassifyLabel(label).ShouldBe(expected);
+    }
+}

--- a/src/TianWen.Lib/Imaging/Dataset/DatasetPsfNoiseReport.cs
+++ b/src/TianWen.Lib/Imaging/Dataset/DatasetPsfNoiseReport.cs
@@ -152,11 +152,43 @@ public static class DatasetPsfNoiseReport
         string? MasterStrategy = null,
         string? RadiusSampling = null);
 
-    /// <summary>Per-optical-train sub-report. The field-radius PSF profile lives HERE, never
-    /// aggregated across trains: a Newtonian's coma grows with field radius while a refractor's does
-    /// not, so a merged profile would smear the position-varying degradation the deconvolver sweep
-    /// must reproduce. Keyed by <see cref="CalibrationResolver.CalTrain.OpticalTrain"/> (camera +
-    /// telescope + focal length -- i.e. one profile per OTA/camera combination).</summary>
+    /// <summary>
+    /// The filter encoded in a <see cref="SessionPsf.SessionId"/>, or empty when the session had
+    /// none recorded. <see cref="ImagingSession.Id"/> emits <c>dir|CAMERA[|OBJECT[|FILTER]]</c>
+    /// and always emits the OBJECT slot (possibly empty) when a filter is present, so a fourth
+    /// field IS the filter, unambiguously. Deriving it here rather than storing it again is
+    /// deliberate: the id already carries it for every record written since filters entered the
+    /// session key (the whole organized-root store), a second copy would be one more thing able to
+    /// disagree with the join key, and records that predate filtered ids (three fields or fewer)
+    /// degrade to one unfiltered bucket per train with no migration. Note that empty does NOT mean
+    /// broadband -- per the filter-inference work, an absent FILTER header is an absent fact -- so
+    /// the report renders it as "(no filter recorded)", never as a filter.
+    /// </summary>
+    public static string FilterFromSessionId(string sessionId)
+    {
+        var first = sessionId.IndexOf('|');
+        if (first < 0) return "";
+        var second = sessionId.IndexOf('|', first + 1);
+        if (second < 0) return "";
+        var third = sessionId.IndexOf('|', second + 1);
+        return third < 0 ? "" : sessionId[(third + 1)..];
+    }
+
+    /// <summary>Per-(optical train, filter) sub-report. The field-radius PSF profile lives HERE,
+    /// never aggregated across trains OR filters. Across trains because a Newtonian's coma grows
+    /// with field radius while a refractor's does not, so a merged profile would smear the
+    /// position-varying degradation the deconvolver sweep must reproduce. Across filters because
+    /// autofocus never optimises red (it minimises star size where the flux is, ~500-550 nm), and
+    /// how badly red loses depends on the passband: measured red/green centre width is 1.381
+    /// broadband but 1.642 under narrowband on the same rigs, with the field-radius trend flipping
+    /// sign between them -- so an RGB night and an Ha-OIII night on the same scope are two
+    /// different measurement populations, and pooling them was the same grouping error the
+    /// per-<see cref="SessionPsf.MasterStrategy"/> split already fixed for integrators. Keyed by
+    /// <see cref="CalibrationResolver.CalTrain"/>'s label (camera + telescope + focal length) plus
+    /// <see cref="Filter"/>.</summary>
+    /// <param name="Filter">The filter this section's sessions were shot through
+    /// (<see cref="FilterFromSessionId"/>), empty when none was recorded -- which the rendering
+    /// states as "(no filter recorded)" rather than treating as broadband.</param>
     /// <param name="RecordedAs">The distinct header labels that folded into this train, sorted; a
     /// single entry equal to <paramref name="OpticalTrain"/> in the ordinary case. More than one
     /// means <see cref="TelescopeAliases"/> merged differently-spelled headers, and the report says
@@ -172,6 +204,7 @@ public static class DatasetPsfNoiseReport
     /// <c>--force-psf</c>.</param>
     public sealed record TrainReport(
         string OpticalTrain,
+        string Filter,
         int Sessions,
         int Subs,
         long StarsSampled,
@@ -612,13 +645,17 @@ public static class DatasetPsfNoiseReport
         private readonly int _radiusBins;
         private readonly float _snrMin;
         private readonly int _maxStars;
-        // One accumulator per optical train (OTA/camera). The field-radius profile is optics-specific
-        // -- it must not merge a coma-heavy Newtonian with a flat-field refractor -- so everything is
-        // bucketed by train and the overall population summary is derived by concatenation. Keyed by
-        // the train's DESCRIBED label rather than the CalTrain value, because a record read back from
-        // the store carries only the label (its frames were never re-read) and must bucket with a
-        // freshly measured session of the same train.
-        private readonly Dictionary<string, TrainAcc> _byTrain = new(StringComparer.Ordinal);
+        // One accumulator per (optical train, filter). Per train because the field-radius profile is
+        // optics-specific -- it must not merge a coma-heavy Newtonian with a flat-field refractor --
+        // and per filter because the chromatic behaviour it measures is passband-specific: an RGB
+        // night and a narrowband night on the same scope are two different populations (see
+        // TrainReport's remarks for the measured sizes). The overall population summary is derived
+        // by concatenation. Keyed by the train's DESCRIBED label rather than the CalTrain value,
+        // because a record read back from the store carries only the label (its frames were never
+        // re-read) and must bucket with a freshly measured session of the same train; the filter
+        // half of the key comes out of the session id (FilterFromSessionId), which has carried it
+        // since filters entered the session key.
+        private readonly Dictionary<(string Label, string Filter), TrainAcc> _byTrain = new();
 
         public Accumulator(int radiusBins = 5, float snrMin = 5f, int maxStars = 3000)
         {
@@ -651,11 +688,15 @@ public static class DatasetPsfNoiseReport
             // Keyed by the STORED label, so a resumed session (whose frames were never re-read) lands
             // in the same train bucket as a freshly measured one -- but canonicalised first, so one
             // lens recorded under two TELESCOP spellings is one train here even though the store
-            // faithfully kept both names. Display-time merge: see TelescopeAliases.
+            // faithfully kept both names. Display-time merge: see TelescopeAliases. The filter joins
+            // the key from the session id, so an RGB night and a narrowband night on the same scope
+            // stop pooling into one profile; a record whose id predates filters lands in the train's
+            // single "(no filter recorded)" bucket, which is exactly the pre-filter behaviour.
             var label = TelescopeAliases.CanonicalizeLabel(record.OpticalTrain);
-            if (!_byTrain.TryGetValue(label, out var acc))
+            var filter = FilterFromSessionId(record.SessionId);
+            if (!_byTrain.TryGetValue((label, filter), out var acc))
             {
-                _byTrain[label] = acc = new TrainAcc(label, _radiusBins);
+                _byTrain[(label, filter)] = acc = new TrainAcc(label, filter, _radiusBins);
             }
             acc.RecordedAs.Add(record.OpticalTrain);
 
@@ -807,7 +848,9 @@ public static class DatasetPsfNoiseReport
             var totalSubs = 0;
             long totalStars = 0;
 
-            foreach (var acc in _byTrain.Values.OrderBy(a => a.Label, StringComparer.Ordinal))
+            foreach (var acc in _byTrain.Values
+                .OrderBy(a => a.Label, StringComparer.Ordinal)
+                .ThenBy(a => a.Filter, StringComparer.Ordinal))
             {
                 var radialProfiles = ImmutableArray.CreateBuilder<ChannelRadiusProfile>(acc.ChannelBinFwhm.Count);
                 for (var c = 0; c < acc.ChannelBinFwhm.Count; c++)
@@ -836,6 +879,7 @@ public static class DatasetPsfNoiseReport
 
                 trains.Add(new TrainReport(
                     OpticalTrain: acc.Label,
+                    Filter: acc.Filter,
                     RecordedAs: [.. acc.RecordedAs],
                     Sessions: acc.Sessions,
                     Subs: acc.Subs,
@@ -874,11 +918,15 @@ public static class DatasetPsfNoiseReport
                 Trains: trains.MoveToImmutable());
         }
 
-        /// <summary>Per-train accumulator: the same small metric lists + radius bins the whole report
-        /// used to keep once, now held one instance per optical train.</summary>
+        /// <summary>Per-(train, filter) accumulator: the same small metric lists + radius bins the
+        /// whole report used to keep once, now held one instance per optical train per filter.</summary>
         private sealed class TrainAcc
         {
             public string Label { get; }
+            /// <summary>The session-id-derived filter this bucket aggregates, empty for sessions
+            /// with none recorded (including every record written before filters entered the
+            /// session key).</summary>
+            public string Filter { get; }
             /// <summary>Distinct header labels folded into this train (usually just one). A
             /// SortedSet so the rendered note is deterministic across runs, like everything else in
             /// this report.</summary>
@@ -911,9 +959,10 @@ public static class DatasetPsfNoiseReport
             /// so, because a mixed table is the one thing this measurement must not do silently.</summary>
             public int BandedSessions;
 
-            public TrainAcc(string label, int radiusBins)
+            public TrainAcc(string label, string filter, int radiusBins)
             {
                 Label = label;
+                Filter = filter;
             }
         }
     }
@@ -929,7 +978,7 @@ public static class DatasetPsfNoiseReport
         sb.AppendLine(string.Create(ci, $"- Sessions: {report.Sessions}"));
         sb.AppendLine(string.Create(ci, $"- Subs (registered): {report.Subs}"));
         sb.AppendLine(string.Create(ci, $"- Stars sampled (field-radius profile): {report.StarsSampled}"));
-        sb.AppendLine(string.Create(ci, $"- Optical trains (OTA/camera): {report.Trains.Length}"));
+        sb.AppendLine(string.Create(ci, $"- Field-radius sections (optical train x filter): {report.Trains.Length}"));
         sb.AppendLine();
         sb.AppendLine("## Per-sub PSF distribution (median-of-frame metrics, all trains)");
         sb.AppendLine();
@@ -945,18 +994,30 @@ public static class DatasetPsfNoiseReport
         sb.AppendLine("|--------|----|-----|-----|-----|-----|");
         AppendPct(sb, ci, "MAD / max", report.MasterNoiseRelative);
         sb.AppendLine();
-        sb.AppendLine("## Field-radius PSF profile (per optical train, centre -> corner)");
+        sb.AppendLine("## Field-radius PSF profile (per optical train PER FILTER, centre -> corner)");
         sb.AppendLine();
         sb.AppendLine("Drives the deconvolver's position-varying synthetic-PSF sweep: sample FWHM per");
         sb.AppendLine("field-radius bin so corner degradation matches the optics. Reported PER OPTICAL");
         sb.AppendLine("TRAIN -- a Newtonian's coma grows toward the corner while a refractor's field");
-        sb.AppendLine("stays flat, so a single merged profile would smear both. Sweep each train against");
-        sb.AppendLine("its own row set.");
+        sb.AppendLine("stays flat, so a single merged profile would smear both -- and PER FILTER,");
+        sb.AppendLine("because autofocus optimises where the flux is (~500-550 nm) and how badly red");
+        sb.AppendLine("loses depends on the passband: red/green centre width measures 1.381 broadband");
+        sb.AppendLine("but 1.642 narrowband on the same rigs, with the radial trend flipping sign.");
+        sb.AppendLine("\"(no filter recorded)\" means exactly that -- an absent FILTER header is an");
+        sb.AppendLine("absent fact, not broadband. Sweep each section against its own row set.");
         sb.AppendLine();
         foreach (var train in report.Trains)
         {
-            sb.AppendLine(string.Create(ci, $"### {train.OpticalTrain}"));
+            sb.AppendLine(train.Filter.Length > 0
+                ? string.Create(ci, $"### {train.OpticalTrain} [{train.Filter}]")
+                : string.Create(ci, $"### {train.OpticalTrain}"));
             sb.AppendLine();
+            // Which glass this is, coarsely, so the reader does not need to know the hardware by
+            // name to judge whether a corner trend is plausible -- and so the first Newtonian to
+            // enter the archive announces itself. Filter stated on its own line as well as in the
+            // heading, because "(no filter recorded)" must be legible where the numbers are read.
+            sb.AppendLine(string.Create(ci,
+                $"- Filter: {(train.Filter.Length > 0 ? train.Filter : "(no filter recorded)")} | Optical system: {OpticalSystems.ClassifyLabel(train.OpticalTrain)}"));
             // Only when an alias actually merged something: on the ordinary single-spelling train
             // this line would be noise repeating the heading.
             if (train.RecordedAs.Length > 1)

--- a/src/TianWen.Lib/Imaging/Dataset/DatasetPsfNoiseReport.cs
+++ b/src/TianWen.Lib/Imaging/Dataset/DatasetPsfNoiseReport.cs
@@ -1017,7 +1017,7 @@ public static class DatasetPsfNoiseReport
             // enter the archive announces itself. Filter stated on its own line as well as in the
             // heading, because "(no filter recorded)" must be legible where the numbers are read.
             sb.AppendLine(string.Create(ci,
-                $"- Filter: {(train.Filter.Length > 0 ? train.Filter : "(no filter recorded)")} | Optical system: {OpticalSystems.ClassifyLabel(train.OpticalTrain)}"));
+                $"- Filter: {(train.Filter.Length > 0 ? train.Filter : "(no filter recorded)")} | Optical system: {OpticalSystems.ClassifyLabel(train.OpticalTrain).Label}"));
             // Only when an alias actually merged something: on the ordinary single-spelling train
             // this line would be noise repeating the heading.
             if (train.RecordedAs.Length > 1)

--- a/src/TianWen.Lib/Imaging/Dataset/OpticalSystems.cs
+++ b/src/TianWen.Lib/Imaging/Dataset/OpticalSystems.cs
@@ -5,69 +5,97 @@ using System.Collections.Generic;
 namespace TianWen.Lib.Imaging.Dataset
 {
     /// <summary>
-    /// Coarse optical-system classification for the archive's telescopes. The field-radius PSF
-    /// profile exists because a Newtonian's coma grows with field radius while a refractor's field
-    /// stays comparatively flat, so the report should SAY which kind each train is instead of
-    /// leaving the reader to know the hardware by name.
+    /// Coarse optical-system kinds for the archive's telescopes. The field-radius PSF profile
+    /// exists because a Newtonian's coma grows with field radius while a refractor's field stays
+    /// comparatively flat, so the report should SAY which kind each train is instead of leaving
+    /// the reader to know the hardware by name. Deliberately coarse, because kind is the axis the
+    /// field-radius profile cares about; doublet-vs-triplet would be asserting element counts
+    /// nobody has verified against the physical hardware.
+    /// </summary>
+    public enum OpticalSystem
+    {
+        /// <summary>
+        /// The name did not classify (unknown telescope, or an unparseable train label). The safe
+        /// default, and deliberately the zero value.
+        /// </summary>
+        Unclassified = 0,
+
+        /// <summary>A camera behind a bare photographic lens, telephoto primes included.</summary>
+        CameraLens,
+
+        /// <summary>Any refracting telescope; petzvals count as refractors at this grain.</summary>
+        Refractor,
+
+        /// <summary>A reflector whose coma grows with field radius. None in the archive yet.</summary>
+        Newtonian,
+    }
+
+    /// <summary>
+    /// Classifies the archive's telescopes into <see cref="OpticalSystem"/> kinds.
     ///
     /// <para><b>The archive holds no Newtonian yet.</b> Checked 2026-08-17 across every
     /// <c>psf-sessions.jsonl</c> store (six bake roots, 50-134 records each): the trains are the
     /// Samyang 135 telephoto, the SH61 EDPH / WO ZS61 / WO RC51 refractors, and bare camera-lens
-    /// rigs -- the SW8 never appears. When older archive years bake one in (task #11), add it here;
-    /// the per-(train, filter) field-radius sections exist largely for that case.</para>
+    /// rigs; the SW8 never appears. When older archive years bake one in (task #11), add it here.
+    /// The per-(train, filter) field-radius sections exist largely for that case.</para>
     ///
     /// <para>Kept in the repo for the same reason as <see cref="TelescopeAliases"/>: a
     /// classification is a factual claim about hardware, worth reviewing in a diff, and the set is
-    /// small and slow-moving. Deliberately coarse (refractor vs Newtonian vs camera lens), because
-    /// that is the axis the field-radius profile cares about; doublet-vs-triplet would be asserting
-    /// element counts nobody has verified against the physical hardware.</para>
+    /// small and slow-moving.</para>
     /// </summary>
     public static class OpticalSystems
     {
-        public const string Refractor = "refractor";
-        public const string CameraLens = "camera lens";
-        public const string Newtonian = "Newtonian";
-        public const string Unclassified = "(unclassified)";
+        extension(OpticalSystem kind)
+        {
+            /// <summary>The words the report prints for this kind.</summary>
+            public string Label => kind switch
+            {
+                OpticalSystem.Refractor => "refractor",
+                OpticalSystem.CameraLens => "camera lens",
+                OpticalSystem.Newtonian => "Newtonian",
+                _ => "(unclassified)",
+            };
+        }
 
         /// <summary>Canonical telescope name (post-<see cref="TelescopeAliases"/>) to kind.</summary>
-        private static readonly FrozenDictionary<string, string> ByTelescope =
-            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        private static readonly FrozenDictionary<string, OpticalSystem> ByTelescope =
+            new Dictionary<string, OpticalSystem>(StringComparer.OrdinalIgnoreCase)
             {
-                ["Samyang 135 f/2 ED"] = CameraLens,
-                ["SH61 EDPH"] = Refractor,
-                ["WO ZS61"] = Refractor,
+                ["Samyang 135 f/2 ED"] = OpticalSystem.CameraLens,
+                ["SH61 EDPH"] = OpticalSystem.Refractor,
+                ["WO ZS61"] = OpticalSystem.Refractor,
                 // The RedCat 51 is a petzval, which is still a refractor at this table's grain.
-                ["WO RC51"] = Refractor,
+                ["WO RC51"] = OpticalSystem.Refractor,
             }.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
 
         /// <summary>
-        /// Classifies one telescope name. Empty means the train carries no TELESCOP at all -- a
-        /// camera behind a bare photographic lens, identified only by focal length -- which is a
+        /// Classifies one telescope name. Empty means the train carries no TELESCOP at all (a
+        /// camera behind a bare photographic lens, identified only by focal length), which is a
         /// camera-lens rig by construction, not an unknown. An unknown NAME stays
-        /// <see cref="Unclassified"/> rather than being guessed at: the safe direction, mirroring
-        /// <see cref="TelescopeAliases.Canonical"/>.
+        /// <see cref="OpticalSystem.Unclassified"/> rather than being guessed at: the safe
+        /// direction, mirroring <see cref="TelescopeAliases.Canonical"/>.
         /// </summary>
-        public static string Classify(string telescope)
+        public static OpticalSystem Classify(string telescope)
         {
             if (string.IsNullOrWhiteSpace(telescope))
             {
-                return CameraLens;
+                return OpticalSystem.CameraLens;
             }
             var canonical = TelescopeAliases.Canonical(telescope.Trim());
-            return ByTelescope.TryGetValue(canonical, out var kind) ? kind : Unclassified;
+            return ByTelescope.TryGetValue(canonical, out var kind) ? kind : OpticalSystem.Unclassified;
         }
 
         /// <summary>
         /// Classifies a whole train label ("ZWO ASI533MC Pro / Samyang 135 f/2 ED @ 130mm"), the
         /// only form a report holds for a stored session. A label that does not parse is
-        /// <see cref="Unclassified"/> rather than <see cref="CameraLens"/>: an unreadable telescope
-        /// slot is not evidence there is no telescope.
+        /// <see cref="OpticalSystem.Unclassified"/> rather than <see cref="OpticalSystem.CameraLens"/>:
+        /// an unreadable telescope slot is not evidence there is no telescope.
         /// </summary>
-        public static string ClassifyLabel(string label)
+        public static OpticalSystem ClassifyLabel(string label)
         {
             return CalibrationResolver.CalTrain.TryParseDescription(label, out var train)
                 ? Classify(train.Telescope)
-                : Unclassified;
+                : OpticalSystem.Unclassified;
         }
     }
 }

--- a/src/TianWen.Lib/Imaging/Dataset/OpticalSystems.cs
+++ b/src/TianWen.Lib/Imaging/Dataset/OpticalSystems.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Collections.Frozen;
+using System.Collections.Generic;
+
+namespace TianWen.Lib.Imaging.Dataset
+{
+    /// <summary>
+    /// Coarse optical-system classification for the archive's telescopes. The field-radius PSF
+    /// profile exists because a Newtonian's coma grows with field radius while a refractor's field
+    /// stays comparatively flat, so the report should SAY which kind each train is instead of
+    /// leaving the reader to know the hardware by name.
+    ///
+    /// <para><b>The archive holds no Newtonian yet.</b> Checked 2026-08-17 across every
+    /// <c>psf-sessions.jsonl</c> store (six bake roots, 50-134 records each): the trains are the
+    /// Samyang 135 telephoto, the SH61 EDPH / WO ZS61 / WO RC51 refractors, and bare camera-lens
+    /// rigs -- the SW8 never appears. When older archive years bake one in (task #11), add it here;
+    /// the per-(train, filter) field-radius sections exist largely for that case.</para>
+    ///
+    /// <para>Kept in the repo for the same reason as <see cref="TelescopeAliases"/>: a
+    /// classification is a factual claim about hardware, worth reviewing in a diff, and the set is
+    /// small and slow-moving. Deliberately coarse (refractor vs Newtonian vs camera lens), because
+    /// that is the axis the field-radius profile cares about; doublet-vs-triplet would be asserting
+    /// element counts nobody has verified against the physical hardware.</para>
+    /// </summary>
+    public static class OpticalSystems
+    {
+        public const string Refractor = "refractor";
+        public const string CameraLens = "camera lens";
+        public const string Newtonian = "Newtonian";
+        public const string Unclassified = "(unclassified)";
+
+        /// <summary>Canonical telescope name (post-<see cref="TelescopeAliases"/>) to kind.</summary>
+        private static readonly FrozenDictionary<string, string> ByTelescope =
+            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["Samyang 135 f/2 ED"] = CameraLens,
+                ["SH61 EDPH"] = Refractor,
+                ["WO ZS61"] = Refractor,
+                // The RedCat 51 is a petzval, which is still a refractor at this table's grain.
+                ["WO RC51"] = Refractor,
+            }.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
+
+        /// <summary>
+        /// Classifies one telescope name. Empty means the train carries no TELESCOP at all -- a
+        /// camera behind a bare photographic lens, identified only by focal length -- which is a
+        /// camera-lens rig by construction, not an unknown. An unknown NAME stays
+        /// <see cref="Unclassified"/> rather than being guessed at: the safe direction, mirroring
+        /// <see cref="TelescopeAliases.Canonical"/>.
+        /// </summary>
+        public static string Classify(string telescope)
+        {
+            if (string.IsNullOrWhiteSpace(telescope))
+            {
+                return CameraLens;
+            }
+            var canonical = TelescopeAliases.Canonical(telescope.Trim());
+            return ByTelescope.TryGetValue(canonical, out var kind) ? kind : Unclassified;
+        }
+
+        /// <summary>
+        /// Classifies a whole train label ("ZWO ASI533MC Pro / Samyang 135 f/2 ED @ 130mm"), the
+        /// only form a report holds for a stored session. A label that does not parse is
+        /// <see cref="Unclassified"/> rather than <see cref="CameraLens"/>: an unreadable telescope
+        /// slot is not evidence there is no telescope.
+        /// </summary>
+        public static string ClassifyLabel(string label)
+        {
+            return CalibrationResolver.CalTrain.TryParseDescription(label, out var train)
+                ? Classify(train.Telescope)
+                : Unclassified;
+        }
+    }
+}


### PR DESCRIPTION
Task #19: the field-radius PSF profile was keyed by optical train alone, so an RGB night and a narrowband night on the same scope pooled into one section and averaged two different chromatic behaviours (red/green centre width 1.381 broadband vs 1.642 narrowband on the same rigs, radial trend flipping sign). The filter now joins the bucket key, derived from the session id's fourth field - no store migration; pre-filter ids degrade to one '(no filter recorded)' bucket per train, byte-identical to the old behaviour.

Each section is also annotated with its optical system via a reviewed-in-repo OpticalSystems table (refractor / camera lens / Newtonian, coarse on purpose). Fact established on the way: the archive holds NO Newtonian - the SW8 never appears in any psf-sessions.jsonl store - so it can only enter via the older-years bake (task #11), and when it does, its sections will announce themselves.

Rendered against the real organized store: the SH61's pooled 14 sessions split into 10 quad-band + 4 narrowband sections, the Samyang into 36 + 1, alias merge composing. 73 dataset tests green, including new pins for the id parse, the split, the pre-filter degradation, the render wording, and the classification's two absence edges.

Note: test-unit will show the standing LFS-budget red; the change itself is dataset tooling only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AbXdVLeiJALjm946tEyarD
