### PR TITLE
CI: hand the publish matrix its LFS files as an artifact, so Windows stops needing a live fetch

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -58,10 +58,11 @@ jobs:
     # (*.fits.gz) saves ~120 MB per pull -- they're only needed by the test
     # jobs, not for compilation or the .nupkg artifact.
     #
-    # The .onnx is 3 MB and this job does not itself ship anything, so it is
-    # here to keep this glob IDENTICAL to publish-apps' -- the two share the
-    # lfs-build- cache, and a set that differs between them means the publish
-    # matrix takes a cache miss on the one object it cannot ship without.
+    # The .onnx in this glob is a leftover and a no-op: the weights are a plain git
+    # blob now, so checkout already carries them and `git lfs pull` has nothing to do
+    # for them. It is kept only so the glob still matches the cache key computed above.
+    # (It used to be here to keep this glob identical to publish-apps', which shared the
+    # lfs-build- cache; that job takes the lfs-payload artifact instead now.)
     - name: Compute LFS cache key
       id: lfs-key
       run: |
@@ -84,6 +85,30 @@ jobs:
           lfs-build-
     - name: Fetch required LFS objects
       run: git lfs pull --include="*.lz,*.ttf,*.bin.gz,*.onnx"
+    # Hand the materialised files to the publish matrix as an artifact so those legs never
+    # touch LFS at all. They used to restore the lfs-build- cache this job saves, which a
+    # Windows runner cannot read (actions/cache segregates Windows from POSIX entries unless
+    # enableCrossOsArchive is set), so both Windows legs always fell through to a live
+    # `git lfs pull` -- merely costly while the LFS budget held, fatal once it ran dry.
+    # Artifacts cross OSes freely, so the publish legs stop depending on the budget at all.
+    #
+    # Tar rather than handing upload-artifact a path list: it roots paths at their least
+    # common ancestor, which would flatten src/TianWen.Lib/... and src/TianWen.UI.Gui/...
+    # into one tree. The tar keeps repo-relative paths, so a leg unpacks it over its own
+    # checkout and every file lands where the csproj expects it.
+    #
+    # *.onnx is absent on purpose: it is a plain git blob now, so checkout carries it.
+    - name: Package LFS payload for the publish matrix
+      run: |
+        git ls-files '*.lz' '*.ttf' '*.bin.gz' > lfs-payload.list
+        tar -czf lfs-payload.tar.gz -T lfs-payload.list
+        echo "packaged $(wc -l < lfs-payload.list) files, $(du -h lfs-payload.tar.gz | cut -f1)"
+    - uses: actions/upload-artifact@v7
+      with:
+        name: lfs-payload
+        path: lfs-payload.tar.gz
+        if-no-files-found: error
+        retention-days: 1
     - uses: actions/setup-dotnet@v5
       with:
         dotnet-version: 10.0.x
@@ -446,41 +471,34 @@ jobs:
       with:
         submodules: recursive
         lfs: false
-    # Narrow LFS pull: AOT publish needs catalogs (TianWen.Lib EmbeddedResource),
-    # fonts and milkyway texture (TianWen.UI.Gui Content), and the in-repo AI model
-    # weights (TianWen.AI.Imaging Content). No FITS fixtures -- publish never builds
-    # the test projects.
+    # These legs do NOT touch LFS. The build job materialises the same set (catalogs .lz for
+    # TianWen.Lib EmbeddedResource, fonts + milkyway texture for TianWen.UI.Gui Content) and
+    # hands it over as the lfs-payload artifact. No FITS fixtures -- publish never builds the
+    # test projects.
     #
-    # The .onnx is not optional here and its absence is SILENT: without it the
-    # checkout holds a ~130-byte LFS pointer, Content copies that pointer into the
-    # release tarball's models/ dir, and the shipped binary looks complete while
-    # ModelResolver refuses the stub -- so `--ai-backend n2n` is missing from the
-    # release and nothing in the build says so. Test-unit pulled *.onnx from the day
-    # the weights landed; this job did not, which is the whole failure mode.
+    # Why not the lfs-build- cache this used to restore: actions/cache segregates Windows from
+    # POSIX entries unless enableCrossOsArchive is set, so the two Windows legs could not read
+    # the entry the ubuntu build job saves -- not by key, not by the restore-keys prefix -- and
+    # always fell through to a live `git lfs pull`. That merely cost bandwidth while the budget
+    # held, then failed outright once it ran dry: release run #1311 computed the SAME key on all
+    # six legs, all four POSIX legs hit it, and both Windows legs reported "Cache not found".
+    # They could not bootstrap an entry of their own either, since actions/cache saves only when
+    # the job succeeds and this one could not get that far.
     #
-    # Same key as the build job since they pull the same set of LFS objects --
-    # the build cache populates and the publish matrix restores from it.
-    - name: Compute LFS cache key
-      id: lfs-key
+    # The .onnx is not in the payload because it is a plain git blob now, so the checkout above
+    # carries it. It stays in the verify step below, because its absence is SILENT: a ~130-byte
+    # pointer is a valid file, Content copies it into the release tarball's models/ dir, and the
+    # binary looks complete while ModelResolver refuses the stub -- so `--ai-backend n2n` would
+    # go missing from a release with nothing in the build saying so.
+    - name: Download LFS payload
+      uses: actions/download-artifact@v8
+      with:
+        name: lfs-payload
+    - name: Unpack LFS payload
       shell: bash
       run: |
-        HASH=$(git ls-files '*.lz' '*.ttf' '*.bin.gz' '*.onnx' | xargs cat | sha256sum | cut -c1-16)
-        echo "key=lfs-build-${HASH}" >> $GITHUB_OUTPUT
-    - uses: actions/cache@v5
-      with:
-        path: .git/lfs
-        key: ${{ steps.lfs-key.outputs.key }}
-        # A changed key (any LFS pointer added or updated) restores the newest previous
-        # object set so `git lfs pull` fetches only the delta. Without this, adding one
-        # 3 MB file meant a full cold re-pull of every object in the glob per leg --
-        # which is what turned the 2026-08-17 LFS-budget refusal into a hard CI failure.
-        # (The budget itself was spent by non-CI pulls; every sampled run that month rode
-        # a cache hit and transferred nothing.)
-        restore-keys: |
-          lfs-build-
-    - name: Fetch required LFS objects
-      shell: bash
-      run: git lfs pull --include="*.lz,*.ttf,*.bin.gz,*.onnx"
+        tar -xzf lfs-payload.tar.gz
+        rm lfs-payload.tar.gz
     # An unmaterialised pointer does not fail anything on its own -- it is a valid ~130-byte
     # text file, so Content copies it into the tarball, EmbeddedResource embeds it, and the
     # release looks complete while the feature it backs is quietly missing. This is the only

--- a/docs/todo/infra.md
+++ b/docs/todo/infra.md
@@ -9,6 +9,22 @@ Part of the TianWen TODO set. See [TODO.md](../../TODO.md) for the index and the
 
 ## CI
 
+- [ ] **Set `enableCrossOsArchive: true` on the LFS cache steps** (deferred 2026-08-20; do it once the
+  LFS budget resets in 2026-09). `actions/cache` segregates Windows entries from POSIX ones unless this
+  is set, so a Windows job can never restore the `lfs-build-` entry the ubuntu `build` job saves -- not
+  by key, not by the `restore-keys` prefix -- and cannot bootstrap one of its own, because a cache is
+  saved only when the job succeeds. Measured on release run #1311: all six `publish-apps` legs computed
+  the same key `lfs-build-5dcb5df07512d63d`, both Linux legs AND both macOS legs hit it, and only the two
+  Windows legs reported `Cache not found`. macOS restoring a Linux-saved entry is what rules out a
+  generic per-OS scoping story -- the split is specifically Windows, which is what the flag exists for.
+  **Why deferred:** the flag changes the computed cache *version*, so enabling it invalidates every
+  existing `lfs-build-*` and `lfs-tests-*` entry. While the budget is dry a miss means a live
+  `git lfs pull` that gets refused, so turning it on today would take the currently-green `build`,
+  `test-unit` and `test-functional` jobs red -- including the ~197 MB test-fixture pull. After the reset
+  the same change costs one cheap re-save.
+  **Not blocking:** `publish-apps` no longer reads that cache at all (it takes its files from the
+  `lfs-payload` artifact), so this is about the remaining cache users and any future Windows job.
+
 - [ ] **REVERT the n2n model out of plain git and back into LFS** (added 2026-08-19, expected to revert 2026-09,
   when the replacement model lands). `src/TianWen.AI.Imaging/models/*.onnx` carries an `!filter !diff !merge`
   exception in `.gitattributes` so `tianwen_denoise_osc_v19d.onnx` is stored as an ordinary 3.1 MB blob.


### PR DESCRIPTION
## What broke

Release run [#1311](https://github.com/SharpAstro/tianwen/actions/runs/32304929337) failed on both Windows publish legs with:

```
batch response: This repository exceeded its LFS budget.
```

Tests were green and the other four RIDs published fine, so it reads like a flaky Windows publish. It is not.

## Why

Every job checks out with `lfs: false`, restores `.git/lfs` from `actions/cache`, then runs `git lfs pull` — so a cache **hit** costs no bandwidth, and once the budget is dry a cache **miss** is fatal rather than merely slow.

`actions/cache` segregates Windows entries from POSIX ones unless `enableCrossOsArchive` is set. So the two Windows legs could never restore the `lfs-build-` entry the ubuntu `build` job saves, and could not bootstrap one of their own either — a cache is saved only when the job succeeds, and theirs could not get that far.

Measured on #1311, where all six legs computed the **same** key `lfs-build-5dcb5df07512d63d`:

| leg | result |
|---|---|
| ubuntu-latest, ubuntu-24.04-arm | `Cache hit` → restored 39 MB |
| macos-latest (x64 **and** arm64) | `Cache hit` → restored 39 MB |
| windows-latest (x64 **and** arm64) | `Cache not found for input keys: lfs-build-5dcb5df07512d63d, lfs-build-` |

macOS restoring a Linux-saved entry is what rules out a generic per-OS scoping story — the split is specifically Windows, which is exactly what the flag exists for.

This was invisible for as long as the budget held, because the miss just fell through to a live fetch. Paying that on every release is part of what drained the budget in the first place.

## The change

Stop routing the publish matrix through LFS at all. `build` already materialises exactly the set those legs need, so it tars it with repo-relative paths and hands it over as the `lfs-payload` artifact; artifacts cross OSes freely.

- Tar rather than a bare path list, because `upload-artifact` roots paths at their least common ancestor, which would flatten `TianWen.Lib` and `TianWen.UI.Gui` into one tree.
- `*.onnx` is not in the payload — it is a plain git blob now, so checkout carries it. It stays in the **stub-verification** step, which is retained and is what stops a ~130-byte pointer shipping as if it were the model.
- Refreshed a comment in `build` that justified its `*.onnx` glob by "keeps this glob identical to publish-apps'", which is no longer true.

## Deliberately not in this PR

`enableCrossOsArchive: true` is the one-line alternative, and it would **not** unblock the release: it changes the computed cache *version*, so enabling it invalidates every existing `lfs-build-*` and `lfs-tests-*` entry, and with the budget dry that miss is a refused fetch on jobs that are currently green — including the ~197 MB test-fixture pull. Recorded in `docs/todo/infra.md` for after the budget resets.

## Verification

`publish-apps` is `workflow_dispatch`-only, so this PR's checks exercise `build` (including the new package + upload) but **not** the consuming side. The real proof is the release dispatch after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
