### PR TITLE
CI: bring the GitHub action majors up to current

### DIFF
--- a/.github/workflows/analyze-crash-dump.yml
+++ b/.github/workflows/analyze-crash-dump.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Match the runtime the crashed test host ran on, so dotnet-dump resolves the right DAC.
-      - uses: actions/setup-dotnet@v5
+      - uses: actions/setup-dotnet@v6
         with:
           dotnet-version: 10.0.x
 

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -45,7 +45,7 @@ jobs:
     # the managed lzip decoder (Lzip.Lib) and writing the .gs.gz output via .NET
     # GZipStream -- no external `lzip` binary is needed. *.gs.gz is gitignored,
     # so a fresh checkout regenerates it during build.
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
       with:
         submodules: recursive
         lfs: false
@@ -71,7 +71,7 @@ jobs:
         # set of LFS objects we'd be pulling. Cache hit -> no LFS bandwidth.
         HASH=$(git ls-files '*.lz' '*.ttf' '*.bin.gz' '*.onnx' | xargs cat | sha256sum | cut -c1-16)
         echo "key=lfs-build-${HASH}" >> $GITHUB_OUTPUT
-    - uses: actions/cache@v5
+    - uses: actions/cache@v6
       with:
         path: .git/lfs
         key: ${{ steps.lfs-key.outputs.key }}
@@ -109,7 +109,7 @@ jobs:
         path: lfs-payload.tar.gz
         if-no-files-found: error
         retention-days: 1
-    - uses: actions/setup-dotnet@v5
+    - uses: actions/setup-dotnet@v6
       with:
         dotnet-version: 10.0.x
         cache: true
@@ -237,7 +237,7 @@ jobs:
     # a round trip when debugging.
     - name: Vulkan ICD summary
       run: vulkaninfo --summary || true
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
       with:
         submodules: recursive
         lfs: false
@@ -250,7 +250,7 @@ jobs:
       run: |
         HASH=$(git ls-files '*.lz' '*.ttf' '*.bin.gz' '*.fits.gz' '*.CR2' '*.CR3' '*.cr2' '*.cr3' '*.onnx' | xargs cat | sha256sum | cut -c1-16)
         echo "key=lfs-tests-${HASH}" >> $GITHUB_OUTPUT
-    - uses: actions/cache@v5
+    - uses: actions/cache@v6
       with:
         path: .git/lfs
         key: ${{ steps.lfs-key.outputs.key }}
@@ -282,7 +282,7 @@ jobs:
         path: src/TianWen.Lib/Astrometry/Catalogs/
     - name: Refresh preprocessed catalog mtimes
       run: touch src/TianWen.Lib/Astrometry/Catalogs/*.gs.gz
-    - uses: actions/setup-dotnet@v5
+    - uses: actions/setup-dotnet@v6
       with:
         dotnet-version: 10.0.x
         cache: true
@@ -382,7 +382,7 @@ jobs:
       with:
         packages: astrometry.net astrometry-data-2mass-08-19
         version: 1.0
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
       with:
         submodules: recursive
         lfs: false
@@ -392,7 +392,7 @@ jobs:
       run: |
         HASH=$(git ls-files '*.lz' '*.ttf' '*.bin.gz' '*.fits.gz' | xargs cat | sha256sum | cut -c1-16)
         echo "key=lfs-tests-${HASH}" >> $GITHUB_OUTPUT
-    - uses: actions/cache@v5
+    - uses: actions/cache@v6
       with:
         path: .git/lfs
         key: ${{ steps.lfs-key.outputs.key }}
@@ -415,7 +415,7 @@ jobs:
         path: src/TianWen.Lib/Astrometry/Catalogs/
     - name: Refresh preprocessed catalog mtimes
       run: touch src/TianWen.Lib/Astrometry/Catalogs/*.gs.gz
-    - uses: actions/setup-dotnet@v5
+    - uses: actions/setup-dotnet@v6
       with:
         dotnet-version: 10.0.x
         cache: true
@@ -467,7 +467,7 @@ jobs:
       if: runner.os == 'Windows'
       shell: pwsh
       run: Add-MpPreference -ExclusionPath "$env:GITHUB_WORKSPACE", "$env:RUNNER_TEMP", "$env:USERPROFILE\.nuget"
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
       with:
         submodules: recursive
         lfs: false
@@ -532,7 +532,7 @@ jobs:
       run: |
         Get-ChildItem -Path src/TianWen.Lib/Astrometry/Catalogs/ -Filter *.gs.gz |
           ForEach-Object { $_.LastWriteTime = Get-Date }
-    - uses: actions/setup-dotnet@v5
+    - uses: actions/setup-dotnet@v6
       with:
         dotnet-version: 10.0.x
         cache: true

--- a/.github/workflows/gpu-stress.yml
+++ b/.github/workflows/gpu-stress.yml
@@ -42,14 +42,14 @@ jobs:
       - name: Vulkan ICD summary
         run: vulkaninfo --summary || true
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           ref: ${{ inputs.ref }}     # the code under stress -- decoupled from this workflow file (on main)
           submodules: recursive
           lfs: false
       - name: Fetch required LFS objects
         run: git lfs pull --include="*.lz,*.ttf,*.bin.gz,*.fits.gz"
-      - uses: actions/setup-dotnet@v5
+      - uses: actions/setup-dotnet@v6
         with:
           dotnet-version: 10.0.x
           cache: true

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -75,7 +75,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           lfs: false
 
@@ -92,7 +92,7 @@ jobs:
           # instead of storing a byte-identical duplicate.
           HASH=$(git ls-files '*.lz' '*.ttf' '*.bin.gz' | xargs cat | sha256sum | cut -c1-16)
           echo "key=lfs-build-${HASH}" >> $GITHUB_OUTPUT
-      - uses: actions/cache@v5
+      - uses: actions/cache@v6
         with:
           path: .git/lfs
           key: ${{ steps.lfs-key.outputs.key }}
@@ -105,7 +105,7 @@ jobs:
         run: git lfs pull --include="*.lz,*.ttf,*.bin.gz"
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@v6
         with:
           dotnet-version: '10.0.x'
 
@@ -198,7 +198,7 @@ jobs:
           cp publish/wwwroot/index.html publish/wwwroot/404.html
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: publish/wwwroot
 
@@ -212,4 +212,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/simulators.yml
+++ b/.github/workflows/simulators.yml
@@ -43,7 +43,7 @@ jobs:
     timeout-minutes: 25
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
       with:
         submodules: recursive
         lfs: false
@@ -56,7 +56,7 @@ jobs:
       run: |
         HASH=$(git ls-files '*.lz' '*.ttf' '*.bin.gz' | xargs cat | sha256sum | cut -c1-16)
         echo "key=lfs-build-${HASH}" >> $GITHUB_OUTPUT
-    - uses: actions/cache@v5
+    - uses: actions/cache@v6
       with:
         path: .git/lfs
         key: ${{ steps.lfs-key.outputs.key }}
@@ -64,7 +64,7 @@ jobs:
           lfs-build-
     - name: Fetch catalog LFS objects
       run: git lfs pull --include="*.lz,*.bin.gz"
-    - uses: actions/setup-dotnet@v5
+    - uses: actions/setup-dotnet@v6
       with:
         dotnet-version: 10.0.x
         cache: true
@@ -87,11 +87,11 @@ jobs:
     if: ${{ github.event_name == 'schedule' || github.event.inputs.suite == 'both' || github.event.inputs.suite == 'alpaca' }}
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
       with:
         submodules: recursive
         lfs: false
-    - uses: actions/setup-dotnet@v5
+    - uses: actions/setup-dotnet@v6
       with:
         dotnet-version: 10.0.x
         cache: true
@@ -159,11 +159,11 @@ jobs:
     if: ${{ github.event.inputs.suite == 'both' || github.event.inputs.suite == 'ascom' }}
     runs-on: windows-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
       with:
         submodules: recursive
         lfs: false
-    - uses: actions/setup-dotnet@v5
+    - uses: actions/setup-dotnet@v6
       with:
         dotnet-version: 10.0.x
         cache: true


### PR DESCRIPTION
## Why

The action versions had drifted into three vintages at once, and the repo disagreed with itself: the composite action added last week (`.github/actions/apt-install`) already used `actions/cache@v6` while every workflow beside it used `v5`.

| action | was | now |
|---|---|---|
| `actions/checkout` | v6 | **v7** |
| `actions/setup-dotnet` | v5 | **v6** |
| `actions/cache` | v5 | **v6** |
| `actions/deploy-pages` | v4 | **v5** |
| `actions/upload-pages-artifact` | v3 | **v5** |
| `actions/upload-artifact` | v7 | v7 (already current) |
| `actions/download-artifact` | v8 | v8 (already current) |

`pages.yml` was furthest behind — `upload-pages-artifact` was two majors old.

## Scope

26 references across `analyze-crash-dump.yml`, `dotnet.yml`, `gpu-stress.yml`, `pages.yml` and `simulators.yml`. Nothing about what the workflows *do* changes.

`SharpAstro/action-gh-release@v3` and `SharpAstro/cache-apt-pkgs-action@v1` are deliberately untouched — those are our own forks, so their majors are a decision about those repos rather than tracking upstream.

Worth noting the pair with a genuinely breaking history — `upload-artifact`/`download-artifact`, whose v4 changed artifact semantics — were the two already on current majors, so nothing here touches them.

## Verification

The workflows in this PR run themselves: `build`, `test-unit` on both runners and `test-functional` exercise `checkout@v7`, `setup-dotnet@v6` and `cache@v6` directly. Two legs are **not** covered by PR checks and are worth knowing about:

- `pages.yml` — where both Pages action bumps are. It only runs on a push to `main`, so the deploy is first exercised after merge.
- `simulators.yml` — dispatch/schedule only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
