### PR TITLE
The wheel over a multi-option toolbar button steps its options

### DIFF
--- a/src/TianWen.Lib.Tests/ViewerActionsTests.cs
+++ b/src/TianWen.Lib.Tests/ViewerActionsTests.cs
@@ -368,4 +368,275 @@ public class ViewerActionsTests
     // File-list scroll clamping / wheel accumulation now lives in the DIR.Lib ListScrollController (the
     // renderer owns the offset); ScrollFileList + FileListScrollOffset were removed, and the clamp/accumulate
     // coverage moved to DIR.Lib.Tests.ListScrollControllerTests.
+    // --- Wheel over a multi-option toolbar button (TryHandleToolbarWheel) ---
+
+    /// <summary>
+    /// The gesture as asked for: scroll up on the boost button boosts UP. The presets are an ascending
+    /// ladder ([0, 0.25, 0.50, 1.0, 1.5]), so the direction has a meaning the click does not have.
+    /// </summary>
+    [Fact]
+    public void ToolbarWheel_UpOnBoost_StepsToTheNextStrongerPreset()
+    {
+        var state = new ViewerState();
+
+        ViewerActions.TryHandleToolbarWheel(state, document: null, ToolbarAction.CurvesBoost, steps: 1).ShouldBeTrue();
+
+        state.CurvesBoostIndex.ShouldBe(1);
+        state.CurvesBoost.ShouldBe(ViewerState.CurvesBoostPresets[1]);
+        state.NeedsRedraw.ShouldBeTrue();
+    }
+
+    /// <summary>
+    /// The reason the ramps clamp instead of wrapping, and the case worth pinning: one notch past the
+    /// top must NOT land back on zero. A wrap there turns the effect off in response to a request for
+    /// more of it, which reads as a broken control rather than as a cycle.
+    /// </summary>
+    [Fact]
+    public void ToolbarWheel_UpAtTheStrongestBoost_StaysThereRatherThanWrappingToOff()
+    {
+        var top = ViewerState.CurvesBoostPresets.Length - 1;
+        var state = new ViewerState();
+        ViewerActions.SetCurvesBoostIndex(state, top);
+
+        ViewerActions.TryHandleToolbarWheel(state, document: null, ToolbarAction.CurvesBoost, steps: 1).ShouldBeTrue();
+
+        state.CurvesBoostIndex.ShouldBe(top);
+        state.CurvesBoost.ShouldBe(ViewerState.CurvesBoostPresets[top]);
+    }
+
+    [Fact]
+    public void ToolbarWheel_DownAtZeroBoost_StaysAtZero()
+    {
+        var state = new ViewerState();
+
+        ViewerActions.TryHandleToolbarWheel(state, document: null, ToolbarAction.CurvesBoost, steps: -1).ShouldBeTrue();
+
+        state.CurvesBoostIndex.ShouldBe(0);
+        state.CurvesBoost.ShouldBe(ViewerState.CurvesBoostPresets[0]);
+    }
+
+    /// <summary>HDR is the other ascending ladder, so it clamps for the same reason.</summary>
+    [Fact]
+    public void ToolbarWheel_UpAtTheStrongestHdr_StaysThereRatherThanWrappingToOff()
+    {
+        var top = ViewerState.HdrPresets.Length - 1;
+        var state = new ViewerState();
+        ViewerActions.SetHdrPresetIndex(state, top);
+
+        ViewerActions.TryHandleToolbarWheel(state, document: null, ToolbarAction.Hdr, steps: 1).ShouldBeTrue();
+
+        state.HdrPresetIndex.ShouldBe(top);
+        state.HdrAmount.ShouldBe(ViewerState.HdrPresets[top].Amount);
+    }
+
+    /// <summary>
+    /// An unordered set wraps, because clamping would strand the user at an end with no way onward.
+    /// Three modes, so a fourth notch returns to the first.
+    /// </summary>
+    [Fact]
+    public void ToolbarWheel_OnStretchLink_WrapsThroughEveryMode()
+    {
+        var state = new ViewerState { StretchMode = ViewerActions.StretchLinkModes[0] };
+
+        for (var i = 0; i < ViewerActions.StretchLinkModes.Length; i++)
+        {
+            ViewerActions.TryHandleToolbarWheel(state, document: null, ToolbarAction.StretchLink, steps: 1).ShouldBeTrue();
+        }
+
+        state.StretchMode.ShouldBe(ViewerActions.StretchLinkModes[0]);
+    }
+
+    /// <summary>
+    /// Scrolling down must undo scrolling up exactly, for every starting point. This is what the added
+    /// reverse branch has to satisfy, and asserting the round trip pins it without restating the
+    /// forward order in the test (which would just be the implementation written twice).
+    /// </summary>
+    [Theory]
+    [InlineData(ChannelView.Composite)]
+    [InlineData(ChannelView.Red)]
+    [InlineData(ChannelView.Green)]
+    [InlineData(ChannelView.Blue)]
+    public void CycleChannelView_ReverseIsTheExactInverseOfForward(ChannelView start)
+    {
+        var state = new ViewerState { ChannelView = start };
+
+        ViewerActions.CycleChannelView(state, channelCount: 3);
+        ViewerActions.CycleChannelView(state, channelCount: 3, reverse: true);
+
+        state.ChannelView.ShouldBe(start);
+    }
+
+    /// <summary>
+    /// The whole reason this is not <c>HandleToolbarAction(reverse: !up)</c>. These three overload
+    /// <c>reverse</c> to mean a different action, so the wheel must not reach them: a scroll down on
+    /// Compare would re-pin the before image and discard the comparison baseline, on Zoom it would
+    /// toggle Fit/1:1, and Grid is a plain toggle with no cycle to step. Reporting NOT handled is what
+    /// leaves the event for whatever claims it next.
+    /// </summary>
+    [Theory]
+    [InlineData(ToolbarAction.Compare)]
+    [InlineData(ToolbarAction.Grid)]
+    [InlineData(ToolbarAction.Open)]
+    [InlineData(ToolbarAction.Enhance)]
+    public void ToolbarWheel_OnAnActionWhoseReverseMeansSomethingElse_IsNotHandled(ToolbarAction action)
+    {
+        // NeedsRedraw defaults to TRUE (a fresh state wants its first paint), so it has to be cleared
+        // for the assertion below to mean anything -- asserting it false on a fresh state would be
+        // checking a default rather than an effect.
+        var state = new ViewerState { NeedsRedraw = false };
+        var boostBefore = state.CurvesBoostIndex;
+
+        ViewerActions.TryHandleToolbarWheel(state, document: null, action, steps: -1).ShouldBeFalse();
+
+        state.ShowGrid.ShouldBeFalse();
+        state.CurvesBoostIndex.ShouldBe(boostBefore);
+        state.NeedsRedraw.ShouldBeFalse();
+    }
+    /// <summary>A single event carrying several notches moves several options, rather than one.</summary>
+    [Fact]
+    public void ToolbarWheel_WithAMultiNotchDelta_StepsThatManyOptions()
+    {
+        var state = new ViewerState();
+
+        ViewerActions.TryHandleToolbarWheel(state, document: null, ToolbarAction.CurvesBoost, steps: 3).ShouldBeTrue();
+
+        state.CurvesBoostIndex.ShouldBe(3);
+    }
+
+    /// <summary>
+    /// The partial-notch case a trackpad produces: the caller has accumulated less than one notch, so it
+    /// passes 0. That must be reported HANDLED (the wheel does drive this button, so the event is claimed
+    /// and must not fall through to the image zoom) while changing nothing.
+    /// </summary>
+    [Fact]
+    public void ToolbarWheel_WithZeroSteps_IsHandledAndChangesNothing()
+    {
+        var state = new ViewerState { NeedsRedraw = false };
+        ViewerActions.SetCurvesBoostIndex(state, 2);
+        state.NeedsRedraw = false;
+
+        ViewerActions.TryHandleToolbarWheel(state, document: null, ToolbarAction.CurvesBoost, steps: 0).ShouldBeTrue();
+
+        state.CurvesBoostIndex.ShouldBe(2);
+    }
+
+    /// <summary>Multi-notch on a WRAPPING cycler applies the cycle repeatedly, so a full lap returns to
+    /// the start rather than landing somewhere an index-offset would have put it.</summary>
+    [Fact]
+    public void ToolbarWheel_MultiNotchOnStretchLink_WrapsRatherThanClamping()
+    {
+        var len = ViewerActions.StretchLinkModes.Length;
+        var state = new ViewerState { StretchMode = ViewerActions.StretchLinkModes[0] };
+
+        ViewerActions.TryHandleToolbarWheel(state, document: null, ToolbarAction.StretchLink, steps: len).ShouldBeTrue();
+
+        state.StretchMode.ShouldBe(ViewerActions.StretchLinkModes[0]);
+    }
+    // --- Wheel over the Zoom button: a ratio ladder whose axis runs backwards ---
+
+    /// <summary>Up means zoom IN, which on this control means a SMALLER denominator. Getting the sign
+    /// wrong is invisible in a build and obvious in the hand.</summary>
+    [Fact]
+    public void ToolbarWheel_UpOnZoom_MovesTowardOneToOne()
+    {
+        var state = new ViewerState { ZoomToFit = false, Zoom = 1f / 4f };
+
+        ViewerActions.TryHandleToolbarWheel(state, document: null, ToolbarAction.Zoom, steps: 1).ShouldBeTrue();
+
+        state.Zoom.ShouldBe(1f / 3f, 0.0001f);
+        state.ZoomToFit.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void ToolbarWheel_DownOnZoom_MovesAwayFromOneToOne()
+    {
+        var state = new ViewerState { ZoomToFit = false, Zoom = 1f / 4f };
+
+        ViewerActions.TryHandleToolbarWheel(state, document: null, ToolbarAction.Zoom, steps: -1).ShouldBeTrue();
+
+        state.Zoom.ShouldBe(1f / 5f, 0.0001f);
+    }
+
+    [Theory]
+    [InlineData(1, 1)]                                             // at 1:1, up stays
+    [InlineData(9, -1)]                                            // at 1:9, down stays
+    public void ToolbarWheel_AtEitherEndOfTheZoomLadder_Clamps(int denominator, int steps)
+    {
+        var state = new ViewerState { ZoomToFit = false, Zoom = 1f / denominator };
+
+        ViewerActions.TryHandleToolbarWheel(state, document: null, ToolbarAction.Zoom, steps).ShouldBeTrue();
+
+        state.Zoom.ShouldBe(1f / denominator, 0.0001f);
+    }
+
+    /// <summary>
+    /// The wheel over the IMAGE zooms by a 1.15 factor, so the zoom is routinely BETWEEN rungs. One
+    /// notch from there must land on the adjacent rung in the direction asked for, not skip past it:
+    /// 43% up is 1:2 (50%), and 43% down is 1:3 (33%).
+    /// </summary>
+    [Theory]
+    [InlineData(1, 2)]
+    [InlineData(-1, 3)]
+    public void ToolbarWheel_FromAnOffRungZoom_SnapsTowardTheDirectionOfTravel(int steps, int expectedDenominator)
+    {
+        var state = new ViewerState { ZoomToFit = false, Zoom = 0.43f };
+
+        ViewerActions.TryHandleToolbarWheel(state, document: null, ToolbarAction.Zoom, steps).ShouldBeTrue();
+
+        state.Zoom.ShouldBe(1f / expectedDenominator, 0.0001f);
+    }
+
+    /// <summary>
+    /// A zoom magnified past 1:1 is above the ladder, so an up-notch must do NOTHING. Clamping to the
+    /// top rung would zoom OUT in answer to a zoom-IN request -- the same surprise the boost ramp clamps
+    /// to avoid, in the one place where the clamp itself would cause it.
+    /// </summary>
+    [Fact]
+    public void ToolbarWheel_UpFromAZoomBeyondOneToOne_DoesNotClampBackDownToIt()
+    {
+        var state = new ViewerState { ZoomToFit = false, Zoom = 2f };
+
+        ViewerActions.TryHandleToolbarWheel(state, document: null, ToolbarAction.Zoom, steps: 1).ShouldBeTrue();
+
+        state.Zoom.ShouldBe(2f, 0.0001f);
+    }
+
+    /// <summary>Down from a magnified zoom DOES rejoin the ladder at the top rung, which is the correct
+    /// direction and the reason the guard above is one-sided.</summary>
+    [Fact]
+    public void ToolbarWheel_DownFromAZoomBeyondOneToOne_RejoinsTheLadderAtOneToOne()
+    {
+        var state = new ViewerState { ZoomToFit = false, Zoom = 2f };
+
+        ViewerActions.TryHandleToolbarWheel(state, document: null, ToolbarAction.Zoom, steps: -1).ShouldBeTrue();
+
+        state.Zoom.ShouldBe(1f, 0.0001f);
+    }
+
+    /// <summary>
+    /// Fit is a mode, not a rung: it has no number to step from (ZoomToFit does not write Zoom at all --
+    /// the renderer derives the fit scale) and no fixed place on the ladder, since for a large image it
+    /// sits below 1:9 and for a small one above 1:1. So up leaves it for the one rung that means
+    /// something absolute, and down stays put rather than guessing.
+    /// </summary>
+    [Fact]
+    public void ToolbarWheel_UpFromFit_LandsOnOneToOne()
+    {
+        var state = new ViewerState { ZoomToFit = true };
+
+        ViewerActions.TryHandleToolbarWheel(state, document: null, ToolbarAction.Zoom, steps: 1).ShouldBeTrue();
+
+        state.ZoomToFit.ShouldBeFalse();
+        state.Zoom.ShouldBe(1f, 0.0001f);
+    }
+
+    [Fact]
+    public void ToolbarWheel_DownFromFit_StaysOnFit()
+    {
+        var state = new ViewerState { ZoomToFit = true };
+
+        ViewerActions.TryHandleToolbarWheel(state, document: null, ToolbarAction.Zoom, steps: -1).ShouldBeTrue();
+
+        state.ZoomToFit.ShouldBeTrue();
+    }
 }

--- a/src/TianWen.UI.Abstractions/ImageRendererBase.Input.cs
+++ b/src/TianWen.UI.Abstractions/ImageRendererBase.Input.cs
@@ -651,11 +651,58 @@ namespace TianWen.UI.Abstractions
             return false;
         }
 
+        /// <summary>Which toolbar button <see cref="_toolbarWheelAccumulator"/> belongs to; null when the
+        /// wheel is not over a wheel-driven button. Moving between buttons resets the accumulation.</summary>
+        private ToolbarAction? _toolbarWheelAction;
+
+        /// <summary>Unconsumed wheel delta over that button, carried between events so a trackpad's
+        /// sub-1.0 deltas add up to a notch instead of each counting as one.</summary>
+        private float _toolbarWheelAccumulator;
+
         private bool HandleViewerScroll(float scrollY, float mouseX, float mouseY)
         {
             if (_state is not { } state)
             {
                 return false;
+            }
+
+            // A wheel notch over a multi-option toolbar button steps that button's options (up = forward),
+            // which is the only gesture the toolbar gives the wheel -- so this is checked before the panes
+            // below even though the toolbar overlaps neither of them.
+            //
+            // HitTest, NOT HitTestAndDispatch: dispatching fires the region's OnClick, so scrolling over a
+            // button would also PRESS it. And going through the region system rather than the toolbar's own
+            // rects is what makes an open dropdown win -- it registers a full-viewport backdrop, so that
+            // answers the hit and the wheel cannot reach a button drawn underneath it.
+            if (HitTest(mouseX, mouseY) is HitResult.ButtonHit { Action: var buttonAction }
+                && Enum.TryParse<ToolbarAction>(buttonAction, out var wheelAction))
+            {
+                // Accumulate, and step only per WHOLE notch. A trackpad delivers many sub-1.0 deltas --
+                // the file-list controller below accumulates them for the same reason -- and stepping
+                // one option per event would run through a five-entry preset list on one gentle swipe.
+                // Moving to a different button starts a fresh accumulation so a leftover fraction from
+                // the neighbour cannot make the first notch land early.
+                if (_toolbarWheelAction != wheelAction)
+                {
+                    _toolbarWheelAction = wheelAction;
+                    _toolbarWheelAccumulator = 0f;
+                }
+                _toolbarWheelAccumulator += scrollY;
+
+                // Truncation toward zero, so the remainder keeps its sign and a slow swipe accumulates
+                // instead of being repeatedly discarded.
+                var steps = (int)_toolbarWheelAccumulator;
+                if (ViewerActions.TryHandleToolbarWheel(state, _document, wheelAction, steps))
+                {
+                    _toolbarWheelAccumulator -= steps;
+                    state.NeedsRedraw = true;
+                    return true;
+                }
+
+                // Not a wheel-driven button: drop the accumulation rather than leaving a fraction to
+                // surprise the next button that is.
+                _toolbarWheelAction = null;
+                _toolbarWheelAccumulator = 0f;
             }
 
             // Scroll file list when hovering over it (pane rect from the single arranged layout). The wheel

--- a/src/TianWen.UI.Abstractions/ImageRendererBase.Toolbar.cs
+++ b/src/TianWen.UI.Abstractions/ImageRendererBase.Toolbar.cs
@@ -488,8 +488,22 @@ namespace TianWen.UI.Abstractions
         // Fit plus every ratio Ctrl+1..Ctrl+9 reaches. The index is the denominator (entry 3 is "1:3"),
         // which is what lets the select handler be arithmetic instead of a parallel table that can drift
         // out of step with these strings.
-        private static readonly ImmutableArray<string> ZoomMenuLabels =
-            ["Fit", "1:1", "1:2", "1:3", "1:4", "1:5", "1:6", "1:7", "1:8", "1:9"];
+        //
+        // BUILT from ViewerActions.MaxZoomRatioDenominator rather than written out, because the wheel
+        // steps the same ladder (ViewerActions.StepZoomRatio) and a hand-written list here could offer a
+        // rung the wheel cannot reach, or stop short of one it can. One number, three consumers.
+        private static readonly ImmutableArray<string> ZoomMenuLabels = BuildZoomMenuLabels();
+
+        private static ImmutableArray<string> BuildZoomMenuLabels()
+        {
+            var builder = ImmutableArray.CreateBuilder<string>(ViewerActions.MaxZoomRatioDenominator + 1);
+            builder.Add("Fit");
+            for (var n = 1; n <= ViewerActions.MaxZoomRatioDenominator; n++)
+            {
+                builder.Add($"1:{n}");
+            }
+            return builder.MoveToImmutable();
+        }
 
         // Zoom is a float, so "am I at 1:3" is a near-comparison. Tight enough that a wheel notch away
         // from a ratio does not claim to BE it -- ZoomStepFactor is 1.15, so the nearest neighbour is

--- a/src/TianWen.UI.Abstractions/ViewerActions.cs
+++ b/src/TianWen.UI.Abstractions/ViewerActions.cs
@@ -39,23 +39,37 @@ public static class ViewerActions
         state.NeedsRedraw = true;
     }
 
-    public static void CycleChannelView(ViewerState state, int channelCount)
+    public static void CycleChannelView(ViewerState state, int channelCount, bool reverse = false)
     {
         if (channelCount >= 3)
         {
-            state.ChannelView = state.ChannelView switch
-            {
-                ChannelView.Composite => ChannelView.Red,
-                ChannelView.Red => ChannelView.Green,
-                ChannelView.Green => ChannelView.Blue,
-                ChannelView.Blue => ChannelView.Composite,
-                _ => ChannelView.Composite
-            };
+            state.ChannelView = reverse
+                ? state.ChannelView switch
+                {
+                    ChannelView.Composite => ChannelView.Blue,
+                    ChannelView.Blue => ChannelView.Green,
+                    ChannelView.Green => ChannelView.Red,
+                    ChannelView.Red => ChannelView.Composite,
+                    _ => ChannelView.Composite
+                }
+                : state.ChannelView switch
+                {
+                    ChannelView.Composite => ChannelView.Red,
+                    ChannelView.Red => ChannelView.Green,
+                    ChannelView.Green => ChannelView.Blue,
+                    ChannelView.Blue => ChannelView.Composite,
+                    _ => ChannelView.Composite
+                };
         }
         else if (channelCount > 1)
         {
+            // The exact inverse of the forward walk rather than a re-derivation: forward climbs to
+            // `last` then wraps to Composite, so reverse descends to Composite then wraps to `last`.
+            var last = (int)ChannelView.Channel0 + channelCount - 1;
             var ch = (int)state.ChannelView;
-            ch = ch < (int)ChannelView.Channel0 + channelCount - 1 ? ch + 1 : (int)ChannelView.Composite;
+            ch = reverse
+                ? (ch > (int)ChannelView.Composite ? ch - 1 : last)
+                : (ch < last ? ch + 1 : (int)ChannelView.Composite);
             state.ChannelView = (ChannelView)ch;
         }
         state.NeedsTextureUpdate = true;
@@ -73,14 +87,24 @@ public static class ViewerActions
         state.NeedsTextureUpdate = true;
     }
 
+    /// <summary>
+    /// Applies a curves-boost preset by index, CLAMPED to the preset range. The single place that
+    /// writes the boost state, so a wrapping caller (a click, which has no direction) and a clamping
+    /// one (a wheel notch, which does) cannot drift in what else they update.
+    /// </summary>
+    public static void SetCurvesBoostIndex(ViewerState state, int index)
+    {
+        state.CurvesBoostIndex = Math.Clamp(index, 0, ViewerState.CurvesBoostPresets.Length - 1);
+        state.CurvesBoost = ViewerState.CurvesBoostPresets[state.CurvesBoostIndex];
+        state.NeedsRedraw = true;
+    }
+
     public static void CycleCurvesBoost(ViewerState state, bool reverse = false)
     {
         var len = ViewerState.CurvesBoostPresets.Length;
-        state.CurvesBoostIndex = reverse
+        SetCurvesBoostIndex(state, reverse
             ? (state.CurvesBoostIndex - 1 + len) % len
-            : (state.CurvesBoostIndex + 1) % len;
-        state.CurvesBoost = ViewerState.CurvesBoostPresets[state.CurvesBoostIndex];
-        state.NeedsRedraw = true;
+            : (state.CurvesBoostIndex + 1) % len);
     }
 
     /// <summary>Cycles between power-law boost (mode 0) and spline LUT (mode 1).</summary>
@@ -97,17 +121,24 @@ public static class ViewerActions
         state.StatusMessage = state.CurvesMode == 1 ? "Curve: Spline LUT" : "Curve: Boost";
     }
 
-    public static void CycleHdr(ViewerState state, bool reverse = false)
+    /// <summary>Applies an HDR preset by index, CLAMPED to the preset range. Counterpart of
+    /// <see cref="SetCurvesBoostIndex"/> and the single writer of the HDR state.</summary>
+    public static void SetHdrPresetIndex(ViewerState state, int index)
     {
-        var len = ViewerState.HdrPresets.Length;
-        state.HdrPresetIndex = reverse
-            ? (state.HdrPresetIndex - 1 + len) % len
-            : (state.HdrPresetIndex + 1) % len;
+        state.HdrPresetIndex = Math.Clamp(index, 0, ViewerState.HdrPresets.Length - 1);
         var (amount, knee) = ViewerState.HdrPresets[state.HdrPresetIndex];
         state.HdrAmount = amount;
         state.HdrKnee = knee;
         state.NeedsRedraw = true;
         state.StatusMessage = amount > 0f ? $"HDR: {amount:F1} (knee {knee:F2})" : "HDR: Off";
+    }
+
+    public static void CycleHdr(ViewerState state, bool reverse = false)
+    {
+        var len = ViewerState.HdrPresets.Length;
+        SetHdrPresetIndex(state, reverse
+            ? (state.HdrPresetIndex - 1 + len) % len
+            : (state.HdrPresetIndex + 1) % len);
     }
 
     public static void CycleStretchPreset(ViewerState state, bool reverse = false)
@@ -395,6 +426,157 @@ public static class ViewerActions
     /// <param name="hasBeforePixels">Whether the backend is holding pre-enhance pixels, which decides
     /// which comparison <see cref="ToolbarAction.Compare"/> turns on. Passed in rather than read from
     /// state because it is a property of the GPU backend, not of the view state.</param>
+    /// <summary>
+    /// The largest denominator the zoom ladder reaches, i.e. 1:9. This is the shared vocabulary of the
+    /// zoom control -- the keyboard's Ctrl+1..Ctrl+9, the dropdown's rows, and the wheel all speak it,
+    /// and the dropdown's label list is BUILT from this so a change here cannot leave them disagreeing.
+    /// </summary>
+    public const int MaxZoomRatioDenominator = 9;
+
+    /// <summary>A zoom counts as being ON a ladder rung within this much of it. Loose enough to survive
+    /// float division, far tighter than the 15% gap to the neighbouring rung.</summary>
+    private const float ZoomRatioSnapTolerance = 0.001f;
+
+    /// <summary>
+    /// Steps the zoom along the 1:1 .. 1:<see cref="MaxZoomRatioDenominator"/> ladder, where a POSITIVE
+    /// step means zoom IN.
+    /// </summary>
+    /// <remarks>
+    /// <para><b>The axis runs backwards from every other cycler here</b>, which is the whole reason this
+    /// is not a plain index step: the rung is the DENOMINATOR, so zooming in means a smaller number.
+    /// Up therefore subtracts.</para>
+    ///
+    /// <para><b>Fit is deliberately not a rung.</b> It is a mode, not a magnification: for a large image
+    /// it sits below 1:9 and for a small one above 1:1, so it has no fixed place on the ladder, and
+    /// <see cref="ZoomToFit"/> does not even write <see cref="ViewerState.Zoom"/> (the renderer derives
+    /// the fit scale), so there is no number to step from. Up out of Fit lands on 1:1 -- the one rung
+    /// that means something absolute -- and down stays put rather than guessing. Fit remains one click
+    /// or right-click away.</para>
+    ///
+    /// <para><b>An off-rung zoom snaps toward the direction of travel, and that snap IS the notch.</b>
+    /// The wheel over the IMAGE zooms by a 1.15 factor, so it readily leaves the zoom between rungs
+    /// (43%); one notch up from there should land on the next rung up (1:2 = 50%), not jump two.</para>
+    ///
+    /// <para><b>A zoom already past 1:1 must not be clamped down onto it.</b> The image can be magnified
+    /// beyond 100% by the wheel, and clamping an up-notch to the top rung would zoom OUT in answer to a
+    /// zoom-IN request -- the same class of surprise the ramps clamp to avoid.</para>
+    /// </remarks>
+    private static void StepZoomRatio(ViewerState state, int steps)
+    {
+        if (steps == 0)
+        {
+            return;
+        }
+
+        if (state.ZoomToFit)
+        {
+            if (steps > 0)
+            {
+                ZoomTo(state, 1f);
+            }
+            return;
+        }
+
+        // Already magnified past the top rung: an up-notch has nowhere to go, and must not land on 1:1.
+        if (steps > 0 && state.Zoom > 1f + ZoomRatioSnapTolerance)
+        {
+            return;
+        }
+
+        var exact = 1f / MathF.Max(state.Zoom, ZoomRatioSnapTolerance);
+        var rounded = (int)MathF.Round(exact);
+        int rung;
+        var remaining = steps;
+        if (rounded >= 1 && MathF.Abs(exact - rounded) < ZoomRatioSnapTolerance)
+        {
+            rung = rounded;
+        }
+        else
+        {
+            rung = steps > 0 ? (int)MathF.Floor(exact) : (int)MathF.Ceiling(exact);
+            remaining -= steps > 0 ? 1 : -1;
+        }
+
+        // Up subtracts: see the remark above on the axis running backwards.
+        ZoomTo(state, 1f / Math.Clamp(rung - remaining, 1, MaxZoomRatioDenominator));
+    }
+
+    /// <summary>
+    /// A wheel notch over a multi-option toolbar button steps that button's options: up = forward,
+    /// down = back. Returns <c>false</c> for a button the wheel does not drive, so the caller can fall
+    /// through rather than swallowing the event.
+    /// </summary>
+    /// <remarks>
+    /// <para><b>Why this is not simply <see cref="HandleToolbarAction"/> with
+    /// <c>reverse: !up</c>.</b> Three actions overload <c>reverse</c> to mean a DIFFERENT action
+    /// rather than the same cycle backwards, so routing the wheel through the click dispatcher would
+    /// hand each of them a gesture nobody asked for: a scroll down on Compare would RE-PIN the before
+    /// image (silently discarding the comparison baseline), on Boost it would switch the curve MODE, and
+    /// on Zoom it would toggle Fit/1:1 instead of stepping the ratio ladder. This lists only the genuine
+    /// cyclers -- Zoom among them, but through its own stepper -- and calls their cycle
+    /// helper directly. A button added later is opt-in: absent from this switch it keeps ignoring the
+    /// wheel, which is the safe default for an action whose reverse means something else.</para>
+    ///
+    /// <para><b>Intensity ramps clamp; sets wrap.</b> Boost and HDR are ascending ladders, so wrapping
+    /// would mean one notch past the top silently turns the effect OFF -- the exact opposite of what
+    /// "scroll up" asked for, and indistinguishable from a bug. The rest (stretch link, stretch preset,
+    /// channel, debayer) are unordered sets, where wrapping is natural and clamping would strand the
+    /// user at an end with no way onward.</para>
+    ///
+    /// <para><b><paramref name="steps"/> is a signed WHOLE-notch count, and may be 0.</b> The caller
+    /// accumulates the raw wheel delta, because a trackpad delivers many sub-1.0 deltas (the file-list
+    /// scroller in this same viewer accumulates them for exactly that reason) and one option per event
+    /// would race through a five-entry list on a single gentle swipe. A 0-step call still reports
+    /// handled: the return value says "the wheel drives this button", not "something changed", which is
+    /// what lets the caller reset its accumulator on the buttons it does not drive.</para>
+    ///
+    /// <para>An end-of-ramp notch still reports handled. It is a no-op the user asked for, and
+    /// returning false there would fall through to whatever claims the event next.</para>
+    /// </remarks>
+    public static bool TryHandleToolbarWheel(ViewerState state, AstroImageDocument? document, ToolbarAction action, int steps)
+    {
+        var reverse = steps < 0;
+        var count = Math.Abs(steps);
+        switch (action)
+        {
+            // Ramps take the step count as an index offset, so the clamp does the bounding once
+            // regardless of how big a delta arrived.
+            case ToolbarAction.CurvesBoost:
+                SetCurvesBoostIndex(state, state.CurvesBoostIndex + steps);
+                return true;
+            case ToolbarAction.Hdr:
+                SetHdrPresetIndex(state, state.HdrPresetIndex + steps);
+                return true;
+            // Wrapping cyclers step one at a time: the mapping is a cycle, not an index, and
+            // CycleChannelView's is not even arithmetic, so repeating the helper is the only form that
+            // cannot disagree with what a click does.
+            case ToolbarAction.StretchLink:
+                for (var i = 0; i < count; i++) CycleStretchLink(state, reverse);
+                return true;
+            case ToolbarAction.StretchParams:
+                for (var i = 0; i < count; i++) CycleStretchPreset(state, reverse);
+                return true;
+            case ToolbarAction.Debayer:
+                for (var i = 0; i < count; i++) CycleDebayerAlgorithm(state, reverse);
+                return true;
+            case ToolbarAction.Channel:
+                if (document is not null)
+                {
+                    var channels = document.UnstretchedImage.ChannelCount;
+                    for (var i = 0; i < count; i++) CycleChannelView(state, channels, reverse);
+                }
+                return true;
+            // Its own stepper, because the rung is a DENOMINATOR (so up subtracts) and Fit is not a
+            // rung at all. See StepZoomRatio.
+            case ToolbarAction.Zoom:
+                StepZoomRatio(state, steps);
+                state.NeedsRedraw = true;
+                return true;
+            default:
+                return false;
+        }
+    }
+
     public static bool HandleToolbarAction(ViewerState state, AstroImageDocument? document, ToolbarAction action, bool reverse = false,
         SplitCompareController? split = null, bool hasBeforePixels = false)
     {


### PR DESCRIPTION
Scroll up on Boost and it boosts up. Six buttons participate — **Boost, HDR, stretch link, stretch preset, channel, debayer** — plus **Zoom** through its own stepper.

## Three decisions carry the design

**This is deliberately not `HandleToolbarAction(reverse: !up)`.** Three actions overload `reverse` to mean a *different action* rather than the same cycle backwards, so routing the wheel through the click dispatcher would hand each of them a gesture nobody asked for:

| Button | What `reverse: true` actually does |
|---|---|
| Compare | **re-pins the before image**, silently discarding the comparison baseline |
| Boost | switches the curve *mode* |
| Zoom | toggles Fit/1:1 |

So the wheel has its own switch listing only genuine cyclers. A button added later is **opt-in**: absent from that switch it keeps ignoring the wheel, which is the safe default precisely for actions whose reverse means something else.

**Intensity ramps clamp; sets wrap.** Boost and HDR are ascending ladders, so wrapping would mean one notch past the top silently turning the effect **off** — the exact opposite of what "scroll up" asked for, and indistinguishable from a bug. The unordered sets (stretch link, stretch preset, channel, debayer) wrap, because clamping would strand you at an end. To stop the two paths drifting in what else they update, `SetCurvesBoostIndex` / `SetHdrPresetIndex` are now the single writers of that state and the wrapping click path goes through them too.

**The caller accumulates.** A trackpad delivers many sub-1.0 deltas — the file-list scroller in this same viewer accumulates them for exactly that reason — so one option per event would run through a five-entry list on one gentle swipe. The renderer keeps a per-button accumulator and passes whole notches. A zero-step call still reports *handled*, because the return value says "the wheel drives this button", not "something changed"; that is also what lets the caller drop its accumulation on a button the wheel doesn't drive.

## Zoom needed its own stepper

Two reasons, both of which would have produced a plausible-looking wrong answer:

- **The rung is a denominator, so the axis runs backwards** — up *subtracts*. Getting this wrong is invisible in a build and immediately obvious in the hand.
- **Fit is a mode, not a magnification.** It has no number to step from (`ZoomToFit` never writes `Zoom`; the renderer derives the fit scale) and no fixed place on the ladder — below 1:9 for a large image, above 1:1 for a small one. So up out of Fit lands on 1:1 and down stays put rather than guessing. Fit remains one click away.

Two further cases the ladder handles explicitly:

- An **off-rung** zoom snaps to the adjacent rung in the direction asked for, and that snap *is* the notch. The wheel over the image zooms by 1.15×, so 43% is a routine starting point; up lands on 1:2, down on 1:3.
- A zoom **already magnified past 1:1** refuses an up-notch rather than clamping onto the top rung — clamping there would zoom *out* in answer to a zoom-*in* request, which is the very surprise the ramps clamp to avoid.

The dropdown's label list is now **built from `ViewerActions.MaxZoomRatioDenominator`** instead of written out, so the menu, `Ctrl+1..9` and the wheel cannot come to offer different rungs.

## Wiring

`HitTest`, **not** `HitTestAndDispatch` — dispatching fires the region's `OnClick`, so scrolling over a button would also press it. Going through the region system rather than the toolbar's own rects is also what makes an open dropdown win: it registers a full-viewport backdrop, so the wheel can't reach a button drawn underneath it.

`CycleChannelView` gained a reverse written as the exact inverse of its forward walk rather than a re-derivation, and the test asserts the round trip instead of restating the forward order (which would just be the implementation written twice).

## Verification

Driven in the running viewer via the inspector: a notch steps Boost; **four 0.3 deltas produce exactly one step** (the trackpad case, which no unit test can reach); a 5-notch event moves five and **saturates at 150% instead of wrapping to off**; and the image does not zoom while the toolbar claims the event.

60 `ViewerActions` tests, 124 across the viewer suites, solution builds clean.

**The tests were seen to fail before passing**, which matters because a bound like "index stays at the top" is also satisfied by the feature never running: the clamp tests fail against the wrapping form (2 failures) and the zoom tests against an inverted sign (4 failures). One earlier assertion of mine was checking a *default* rather than an effect — `NeedsRedraw` starts `true` — and is now cleared first so it means something.

## Known limitation, left in by decision

A value-carrying label changes its button's width: Boost measures 112px at "Boost" and 198px at "Boost 150%", shifting HDR right by the difference. So the control can move out from under the cursor mid-gesture, and scrolling down through the list can end up driving a neighbour. It affects every wheel-driven button, not just Boost (`Debayer` spans "None"→"BilinearMono", `Zoom` spans "Fit"→"43%").

Reserving the widest label's width fixes it and was declined for now — it widens the toolbar by ~90px and leaves short labels looking padded. Iconifying these buttons (the `font-roles-and-icon-baking` plan, F1–F3) would shrink the swing without removing it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TY5kFz4Qxox1aAHxPKf2ek
