### PR TITLE
Viewer memory footprint: M1, M2, memory-mapped TIFF, and the M3 design

### DIFF
--- a/docs/plans/viewer-memory-footprint.md
+++ b/docs/plans/viewer-memory-footprint.md
@@ -149,34 +149,95 @@ Two things this deliberately does not fix:
   `ReadAllBytes` version, so it measures the mapping rather than assuming it.
 - `ExifReader.FromTiff(bytes)` needs the header bytes, so it keeps its current input.
 
-## M3. Let the viewer hold the source bit depth
+## M3. Let the viewer hold the source bit depth -- DESIGN
 
-The part that makes this tractable: **the shader does not care.** `texture()` on a `R8Unorm` or
-`R16Unorm` sampled image returns a float in [0,1] exactly as `R32Sfloat` does, so `image.frag` and the
-whole stretch chain are untouched -- the sampler performs the normalisation the CPU currently
-materialises 1.4 GiB to precompute. Those formats also have *wider* linear-filtering support than
-`R32Sfloat`, which the pipeline already probes for (`R32SfloatLinearFilterSupported`).
+M1, M2 and the mapping removed everything that was not the data. What is left is the data model, and
+for the reference document it is now the *entire* cost: **1,485 MB of float planes on the CPU and
+1,485 MB of `R32Sfloat` device images**, 2,227 MB of the 2,251 MB measured. Nothing else is material.
 
-So the work is not in the shader, it is in three places:
+The premise from the top of this file still holds -- `TianWen.Lib.Imaging` is right to be float, and
+making `Image` polymorphic over bit depth is not worth it. **The viewer is not the pipeline.** It
+displays; it does not calibrate, integrate or deconvolve. For an 8-bit document it converts 354 MiB
+of samples into 1,416 MiB of floats, uploads them, and asks the GPU to sample them back into
+normalised floats -- which is what an `R8Unorm` texture does for free.
 
-1. **Texture format selection** in `VkFitsImagePipeline`, from the document's `BitDepth`. Per-channel,
-   since `UploadChannelTexture` is already per-channel.
-2. **What `AstroImageDocument` holds.** Today it holds a float `Image` and derives its median/MAD
-   stats from it. Those statistics are computable from 8- or 16-bit samples directly (cheaper, in
-   fact), so the question is whether the document can carry the raw raster plus stats instead of a
-   float `Image` -- and what that does to the paths that legitimately need floats: **Enhance**
-   (`SharpenPipeline` is float end to end) and plate solving.
-3. **A fallback that is not a cliff.** The honest shape is that a display-only document keeps its
-   source depth and materialises floats *on demand* for the operations that need them -- Enhance
-   already writes a temp FITS, so it is closer to that model than it looks.
+### What the design turns on, and it is not the shader
 
-**Effect for this document: 12 B/px -> 3 B/px on the CPU and the same on the GPU**, i.e. 354 MiB
-instead of 1,416 MiB resident, and 354 MiB instead of 1,383 MiB of device memory. For a 16-bit
-astronomical frame it is 6 B/px instead of 12.
+The shader is a non-issue: `texture()` on `R8Unorm` / `R16Unorm` returns a float in [0,1] exactly as
+`R32Sfloat` does, so `image.frag` and the whole stretch chain are untouched, and those formats have
+*wider* linear-filtering support than `R32Sfloat` (which the pipeline already probes for).
 
-**This is the largest win and the least certain scope.** It needs its own design pass before it is
-committed to; the entry here exists so the 12 B/px is recorded as a floor of *this design* rather than
-a law, and so the reason it is viewer-local is written down.
+What it turns on is **who still needs floats, and whether they need them resident**. Auditing the
+consumers of `AstroImageDocument.UnstretchedImage`:
+
+| Consumer | Needs | When |
+|---|---|---|
+| Most of the viewer chrome | metadata only (`ChannelCount`, `SensorType`, Bayer offsets) | always -- no pixels at all |
+| GPU upload (`IPreviewSource.GetChannelData`) | pixels | always -- **but the sampler can normalise, so floats are not required** |
+| Stretch stats (median / MAD / histogram) | pixels | once, at load -- computable from integer samples directly, and *cheaper* |
+| **Star detection (`FindStarsAsync`)** | an `Image` | **automatically at every load** (`ViewerController.StartStarDetection`) |
+| Colour calibration / auto-WB | pixels | on demand |
+| Enhance (`SharpenPipeline`) | float end to end | on demand -- and it already round-trips a temp FITS |
+| Plate solve | detected centroids, not pixels | on demand |
+| Info-panel probe | one pixel | per frame, trivial either way |
+
+**Star detection is the finding that shapes this.** It runs on every document open, not on demand, so
+if it needs a float `Image` then the float planes exist anyway and M3 would save only the device half.
+That single fact is the difference between a 1,114 MB win and a 2,227 MB one, and it is not visible
+from the memory table at all.
+
+### Options, in increasing order of both reward and scope
+
+**D1 -- Floats become transient rather than resident.** The document holds the source raster; the
+float planes are materialised at load for the stats and the star pass, then released. This is exactly
+what M2 did to the decoded raster: demote a resident representation to a transient of the one step
+that needs it.
+
+- Steady state: **3 B/px raster + 3 B/px device = 6 B/px**, against 24 today.
+- Peak: 3 + 12 (transient floats) + 3 = **18 B/px**, against 24.
+- So it wins big on steady state and modestly on peak, which is the right shape -- the complaint this
+  plan exists to answer is "it got slow after I opened that file", which is a steady-state complaint.
+
+**D2 -- Make star detection depth-agnostic**, so no float materialisation happens at all. Peak and
+steady both land at 6 B/px. Bigger change: the detector is `Image`-typed, so this means either
+templating it over the sample type or giving it a span-plus-scale entry point.
+
+**D3 -- Device-only.** Upload the source depth, keep the CPU floats. Saves the 1,114 MB device half
+with no change to what the document holds. Cheapest by far, and worth naming because it is a
+*separable* half rather than a compromise: it can ship before D1 and D1 does not redo it.
+
+### The two things that will actually bite
+
+**`IPreviewSource.GetChannelData` returns `ReadOnlySpan<float>`.** That is the API decision, and it
+has four implementers (`AstroImageDocument`, `LiveFramePreviewSource`, `SerPreviewSource`,
+`LiveStackPreviewSource`). Three of them are live/streaming sources whose frames are genuinely float
+already, so a blanket change would cost them a conversion to save nothing. The shape that fits is a
+sibling member describing the *native* samples (depth + span) with the float accessor kept for
+sources that have floats natively -- not a replacement.
+
+**FITS is the case M3 does NOT pay for, and that is worth stating up front.** A 32-bit float FITS is
+already `R32Sfloat`, so there is nothing to narrow. A 16-bit integer FITS carries `BZERO`/`BSCALE` and
+is signed, so its raw samples are *not* directly uploadable to `R16Unorm` without applying that
+offset -- and applying it is what the float conversion currently does. So the clean win is 8-bit
+display documents: TIFF, PNG, JPEG. Which is precisely the document that motivated this plan (a 5.7 MB
+architectural drawing costing 2.5 GB), and precisely *not* the astronomical frames the app exists for.
+
+That asymmetry is the honest summary of M3's value: **it makes the viewer good at documents it was
+never designed for, and changes nothing for the ones it was.** Worth doing -- opening a big TIFF
+should not cost 2.2 GB -- but it should be sized against that, not against the astro path.
+
+### Recommendation
+
+Ship **D3** first (device-only, self-contained, no API change, half the win), then decide D1 against
+measurements taken with D3 in place. Do not start D2 until star detection has been shown to be the
+thing holding the floats resident -- that is an assumption above, not a measurement, and the whole
+reason this section exists is that the last two attempts to reason about this file's memory were both
+wrong until something deterministic was measured.
+
+**Verification must be allocation- and device-memory-based, never working set.** Established the hard
+way in M2: run-to-run variance on this document exceeds 1,200 MB, which is larger than anything M3
+would deliver. `GC.GetAllocatedBytesForCurrentThread` for the CPU half; the pipeline's own image
+sizes (the `StagingBufferSize` pattern) for the device half.
 
 ## Phasing
 
@@ -185,7 +246,7 @@ a law, and so the reason it is viewer-local is written down.
 | A | **DONE** -- M1 | Self-contained, one repo, no API design. Fixes the cost that persists across documents -- the one a user experiences as "it got slow after I opened that file". |
 | B | **DONE** -- M2 in `Codecs` (3.11) | A new public API on `SharpAstro.Tiff` plus a release. Second, so A has shipped by the time the pin moves. |
 | C | **CODE DONE**, pin held until 3.11 publishes -- M2 in `tianwen` | Follows B's release; the codec family floats per minor, so the pin edit is one line. |
-| D | M3 design | Needs a decision on what `AstroImageDocument` holds and how Enhance / plate solve get floats. Do not start it as an implementation. |
+| D | **DESIGNED** -- M3, split into D1/D2/D3 above | The design is written; D3 (device-only) is the recommended first step and needs no API change. D1 demotes the float planes to a transient. D2 (depth-agnostic star detection) is gated on MEASURING that star detection is what holds them resident. |
 
 ## Verification
 
@@ -201,7 +262,10 @@ either way, which is exactly why none of this was noticed.
   A unit test asserts the shape rather than the bytes: the decode-into path must produce a
   byte-identical `Image` to `Read`-then-convert for a predictor file, a `MinIsWhite` file and a CMYK
   file -- the three cases that post-process whole planes.
-- **M3**: same working-set comparison, plus a pixel-identity check that an 8-bit document renders
-  byte-identically through the `R8Unorm` path and the float path. If it does not, the sampler
-  normalisation and `Image.StretchValue`'s normalisation have diverged, which is a real bug and not a
-  tolerance to widen.
+- **M3**: NOT a working-set comparison -- M2 established that run-to-run variance on this document
+  exceeds 1,200 MB, which is larger than anything M3 delivers. `GC.GetAllocatedBytesForCurrentThread`
+  for the CPU half, the pipeline's own image sizes (the `StagingBufferSize` pattern) for the device
+  half. Plus a pixel-identity check that an 8-bit document renders byte-identically through the
+  `R8Unorm` path and the float path. If it does not, the sampler normalisation and
+  `Image.StretchValue`'s normalisation have diverged, which is a real bug and not a tolerance to
+  widen.

--- a/docs/plans/viewer-memory-footprint.md
+++ b/docs/plans/viewer-memory-footprint.md
@@ -99,7 +99,7 @@ release itself is pinned on a real device by
 `GpuStretchPipelineTests.TrimmingTheStagingBufferReleasesItAndTheNextUploadStillWorks`, which also
 covers re-uploading afterwards and a double trim.
 
-## M2. Decode strips straight into the float planes
+## M2. Decode strips straight into the float planes -- SHIPPED (tianwen half pending the pin)
 
 `Codecs`: `src/SharpAstro.Tiff/TiffReader.cs` -- a decode-into entry point beside `Read`, handing the
 caller each decoded strip (page index, first row, row count, `ReadOnlySpan<byte>` of samples) instead
@@ -112,6 +112,27 @@ converter writing into the already-allocated `float[h,w]` planes. Existing behav
 as now.
 
 **Effect: 354 MiB (3 B/px) off the peak**, scaling with the document rather than being fixed overhead.
+
+**MEASURED DETERMINISTICALLY, and not the way this section first tried.** A working-set A/B said
+"1564 MB off the peak" and was noise: the SAME unmodified build then measured 3362 MB steady in one
+run and 2143 MB in another, so run-to-run variance exceeds 1200 MB and cannot resolve a 371 MB
+change. `GC.GetAllocatedBytesForCurrentThread` around the decode can:
+`TiffStreamingDecodeAllocationTests` shows the removed allocation is **exactly one raster** --
+3,240,000 B at test size against a 12,960,000 B float-plane output, with the rest accounted for to
+within 5 KB. Scaled to the document above that is 371 MB. The test fails when the whole-raster path
+is restored, so it measures the change rather than restating it.
+
+**`File.ReadAllBytes` is now the dominant term for uncompressed input**, which the note below
+predicted and the test had to encode in its ceiling: for an uncompressed page the file IS
+raster-sized, so M2 alone trades one for the other there. Closing it is the memory-mapping item.
+
+**One bug found on the way, in `TiffWriter`.** It stamped the requested compression into the IFD while
+its encoder switch fell through to the raw bytes, so asking for LZW wrote unlabelled-as-what-it-is
+data: a file whose content and label disagree, which no reader can decode. It surfaced only because
+the pixel-equality test above read 50 where it had written 3 -- two test suites had LZW cases passing
+over it, since a corrupt file decodes to the same garbage through both readers and an equivalence
+assertion then holds while asserting nothing. Fixed in SharpAstro.Tiff 3.11 by refusing what the
+writer cannot apply.
 
 Two things this deliberately does not fix:
 
@@ -155,8 +176,8 @@ a law, and so the reason it is viewer-local is written down.
 | Phase | Items | Rationale |
 |-------|-------|-----------|
 | A | **DONE** -- M1 | Self-contained, one repo, no API design. Fixes the cost that persists across documents -- the one a user experiences as "it got slow after I opened that file". |
-| B | M2 in `Codecs` | A new public API on `SharpAstro.Tiff` plus a release. Second, so A has shipped by the time the pin moves. |
-| C | M2 in `tianwen` | Follows B's release; the codec family floats per minor, so the pin edit is one line. |
+| B | **DONE** -- M2 in `Codecs` (3.11) | A new public API on `SharpAstro.Tiff` plus a release. Second, so A has shipped by the time the pin moves. |
+| C | **CODE DONE**, pin held until 3.11 publishes -- M2 in `tianwen` | Follows B's release; the codec family floats per minor, so the pin edit is one line. |
 | D | M3 design | Needs a decision on what `AstroImageDocument` holds and how Enhance / plate solve get floats. Do not start it as an implementation. |
 
 ## Verification

--- a/docs/plans/viewer-memory-footprint.md
+++ b/docs/plans/viewer-memory-footprint.md
@@ -58,7 +58,7 @@ So M1 changes what the process holds forever, M2 changes how high it spikes, and
 for the one consumer that does not need the float model. They are independent and land in that order
 of increasing cost.
 
-## M1. Release the staging buffer when a burst of uploads ends
+## M1. Release the staging buffer when a burst of uploads ends -- SHIPPED
 
 `tianwen`: `src/TianWen.UI.Shared/VkFitsImagePipeline.cs` plus one call site. Nothing in `Codecs`.
 
@@ -80,6 +80,24 @@ placeholder-upload loop -- so releasing immediately after it returns needs no fe
 
 **Effect: 472 MiB (4 B/px) off the steady state, and the high-water mark stops following the process
 around.** Peak during load is unchanged; the buffer is genuinely in use at that moment.
+
+**MEASURED, A/B on the same document and the same build otherwise: 3948 MB without the trim, 3399 MB
+with it -- 549 MB back**, a little more than the 495 MB predicted (the buffer is sized to the padded
+memory requirement, not to the pixel bytes). The absolute figures are higher than the 2.5 GB recorded
+above because this box has a shared-memory GPU and a Debug build, which is the ~3.57 GiB case the
+device-memory note predicts.
+
+**What ships is gated on `ViewerState.SourceGeneration`, not on the upload itself.** That distinction
+is the whole implementation: `UploadDocumentTextures` is ALSO the per-frame path for a live camera
+feed (`LiveSessionTab`, `GuiderTab`), so trimming on every call would be the alloc/free-per-frame
+regression this section warns about one paragraph up. `SourceGeneration` already increments on each
+source replacement in `ViewerController` and is untouched by the live path, so it separates "a
+document loaded" from "another frame arrived" without adding a flag. Pinned by
+`ViewerUploadScratchTrimTests`, whose load-bearing cases are the ones asserting NO trim -- ten live
+frames and three re-uploads of one document -- both of which fail against an unconditional trim. The
+release itself is pinned on a real device by
+`GpuStretchPipelineTests.TrimmingTheStagingBufferReleasesItAndTheNextUploadStillWorks`, which also
+covers re-uploading afterwards and a double trim.
 
 ## M2. Decode strips straight into the float planes
 
@@ -136,7 +154,7 @@ a law, and so the reason it is viewer-local is written down.
 
 | Phase | Items | Rationale |
 |-------|-------|-----------|
-| A | M1 | Self-contained, one repo, no API design. Fixes the cost that persists across documents -- the one a user experiences as "it got slow after I opened that file". |
+| A | **DONE** -- M1 | Self-contained, one repo, no API design. Fixes the cost that persists across documents -- the one a user experiences as "it got slow after I opened that file". |
 | B | M2 in `Codecs` | A new public API on `SharpAstro.Tiff` plus a release. Second, so A has shipped by the time the pin moves. |
 | C | M2 in `tianwen` | Follows B's release; the codec family floats per minor, so the pin edit is one line. |
 | D | M3 design | Needs a decision on what `AstroImageDocument` holds and how Enhance / plate solve get floats. Do not start it as an implementation. |
@@ -146,9 +164,11 @@ a law, and so the reason it is viewer-local is written down.
 **Measure, do not reason.** All three are invisible to a functional test -- the picture is identical
 either way, which is exactly why none of this was noticed.
 
-- **M1**: open the document, close it, open a small FITS, reading the process working set at each
-  step. Before, the 472 MiB persists past the close; after, it is gone. Assertable headlessly by
-  exposing `_stagingSize` and checking it is zero after the trim.
+- **M1** -- DONE. The A/B above (same document, trim on vs off) is the measurement: 549 MB. Done that
+  way rather than "open, close, open a small FITS" because with the trim in place the buffer is
+  already gone by the end of the first load, so the small-FITS step has nothing left to reveal; the
+  comparison has to be against a build without the trim. Headless assertions as planned, via the now
+  public `StagingBufferSize`.
 - **M2**: peak working set during the load of the same file, before and after; expect ~354 MiB lower.
   A unit test asserts the shape rather than the bytes: the decode-into path must produce a
   byte-identical `Image` to `Read`-then-convert for a predictor file, a `MinIsWhite` file and a CMYK

--- a/docs/plans/viewer-memory-footprint.md
+++ b/docs/plans/viewer-memory-footprint.md
@@ -136,10 +136,17 @@ writer cannot apply.
 
 Two things this deliberately does not fix:
 
-- **`File.ReadAllBytes` still reads the file whole.** That is 5.7 MB here and irrelevant, but an
-  *uncompressed* TIFF of these dimensions is 354 MB on disk and the streaming win is then cancelled by
-  the file buffer. A stream- or mmap-based reader is the complement and is a much larger change to
-  `SharpAstro.Tiff`'s entry points.
+- ~~**`File.ReadAllBytes` still reads the file whole.**~~ **DONE, and it was not the large change this
+  predicted.** `TiffReader` already had a `Read(ReadOnlySpan<byte>)` overload whose own doc recommended
+  mapping the file, so no `SharpAstro.Tiff` entry point had to move: `TryReadTiff` maps the file and
+  passes the view. It matters exactly where predicted -- an uncompressed TIFF of these dimensions is
+  354 MB on disk, so `ReadAllBytes` was handing back a byte[] as large as the raster M2 had just
+  removed, trading one term for the other. Measured on the allocation test: the uncompressed case went
+  19,444,760 B (raster + file) -> 16,204,608 B (M2, file only) -> **12,965,424 B**, against float
+  planes of 12,960,000 B. The decode now allocates its own output plus 5.4 KB. Scaled to this
+  document, that is 371 MB of raster plus 371 MB of file gone, leaving only the 1,485 MB of planes.
+  The test's ceiling was tightened to exclude the file bytes and was seen to fail against the
+  `ReadAllBytes` version, so it measures the mapping rather than assuming it.
 - `ExifReader.FromTiff(bytes)` needs the header bytes, so it keeps its current input.
 
 ## M3. Let the viewer hold the source bit depth

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -4,7 +4,7 @@
 
     <CentralPackageFloatingVersionsEnabled>true</CentralPackageFloatingVersionsEnabled>
 
-    <SharpAstroCodecsVersion>3.10.*</SharpAstroCodecsVersion>
+    <SharpAstroCodecsVersion>3.11.*</SharpAstroCodecsVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="5.3.0" />

--- a/src/TianWen.Lib.Tests/GpuStretchPipelineTests.cs
+++ b/src/TianWen.Lib.Tests/GpuStretchPipelineTests.cs
@@ -76,6 +76,68 @@ public sealed class GpuStretchPipelineTests : IClassFixture<OffscreenGpuFixture>
         }
     }
 
+    /// <summary>
+    /// The staging buffer is grow-only and was freed only on dispose, so one large upload pinned that
+    /// much host-visible memory for the process lifetime -- 472 MiB for the document measured in
+    /// <c>docs/plans/viewer-memory-footprint.md</c>, carried through every subsequent small file.
+    ///
+    /// <para>Asserted here rather than by watching managed memory because a <c>VkBuffer</c> is invisible
+    /// to the GC: it does not even register as GC pressure, which is precisely why the cost went
+    /// unnoticed. <c>StagingBufferSize</c> exists for this.</para>
+    ///
+    /// <para>The re-upload at the end is the half that matters as much as the release: a trim that left
+    /// the pipeline unable to upload again would be worse than the leak, and
+    /// <c>EnsureStagingBuffer</c> has to take its create-fresh branch from a nulled handle.</para>
+    /// </summary>
+    [Fact]
+    public void TrimmingTheStagingBufferReleasesItAndTheNextUploadStillWorks()
+    {
+        if (!_gpu.VulkanAvailable)
+        {
+            output.WriteLine($"Vulkan unavailable: {_gpu.UnavailableReason}");
+            Assert.Skip($"Vulkan runtime not available on this host ({_gpu.UnavailableReason})");
+            return;
+        }
+
+        var pixels = new float[64 * 64];
+        for (var i = 0; i < pixels.Length; i++)
+        {
+            pixels[i] = i / (float)pixels.Length;
+        }
+
+        // Every call below touches the device, so it all runs on the fixture's queue thread --
+        // VulkanDevice.AssertQueueThread rejects it otherwise. Observations come back as values and are
+        // asserted outside, so a failure reports as an assertion rather than as an exception marshalled
+        // off that thread.
+        var (afterUpload, afterTrim, afterSecondTrim, afterReupload, probed) = _gpu.Invoke(() =>
+        {
+            var pipeline = _gpu.Pipeline!;
+
+            pipeline.UploadChannelTexture(pixels, 0, 64, 64);
+            var allocated = pipeline.StagingBufferSize;
+
+            pipeline.TrimStagingBuffer();
+            var trimmed = pipeline.StagingBufferSize;
+
+            // Idempotent: the trim nulls the handle, so a second call must not double-free.
+            pipeline.TrimStagingBuffer();
+            var trimmedTwice = pipeline.StagingBufferSize;
+
+            pipeline.UploadChannelTexture(pixels, 0, 64, 64);
+            var reallocated = pipeline.StagingBufferSize;
+
+            Span<float> probe = stackalloc float[4];
+            pipeline.ReadbackChannelFirstFloats(0, probe);
+            return (allocated, trimmed, trimmedTwice, reallocated, probe[1]);
+        });
+
+        afterUpload.ShouldBeGreaterThan(0UL, "an upload must have allocated the scratch");
+        afterTrim.ShouldBe(0UL);
+        afterSecondTrim.ShouldBe(0UL);
+        afterReupload.ShouldBeGreaterThan(0UL, "the pipeline must still upload after a trim");
+        probed.ShouldBe(pixels[1], 1e-6f);
+    }
+
     [Fact]
     public async Task GivenSyntheticSpccField_GpuRenderMatchesCpuRender()
     {

--- a/src/TianWen.Lib.Tests/TiffStreamingDecodeAllocationTests.cs
+++ b/src/TianWen.Lib.Tests/TiffStreamingDecodeAllocationTests.cs
@@ -1,0 +1,164 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using SharpAstro.Tiff;
+using Shouldly;
+using TianWen.Lib.Imaging;
+using Xunit;
+
+namespace TianWen.Lib.Tests;
+
+/// <summary>
+/// M2 of <c>docs/plans/viewer-memory-footprint.md</c>: reading a TIFF used to assemble the whole
+/// raster and then convert it, so the raster and the float planes were both fully resident. For the
+/// plan's 13228x9354 RGB page that is 354 MiB of intermediate whose only purpose is to be read once.
+/// <c>TiffReader.ReadInto</c> converts each strip as it arrives instead.
+///
+/// <para><b>Why this is an ALLOCATION test and not a working-set measurement.</b> I tried the obvious
+/// thing first -- open the document in the viewer and read the process working set with and without
+/// the change -- and it produced a confident, completely wrong answer: 1564 MB "off the peak". Then
+/// the SAME unmodified build measured 3362 MB steady in one run and 2143 MB in another. Run-to-run
+/// variance is over 1200 MB, which swamps the 371 MB this change is worth, so working set cannot
+/// measure it at all; the first result was noise that happened to point the right way.</para>
+///
+/// <para><see cref="GC.GetAllocatedBytesForCurrentThread"/> has none of that problem. The decode is
+/// synchronous on the calling thread, the raster is one big array, and the count is exact -- so
+/// "was a raster allocated" becomes a question with a yes/no answer instead of a statistic.</para>
+/// </summary>
+[Collection("Imaging")]
+public class TiffStreamingDecodeAllocationTests
+{
+    // Big enough that the raster dominates the noise floor, small enough to stay a unit test.
+    private const int Width = 1200;
+    private const int Height = 900;
+    private const int Channels = 3;
+
+    /// <summary>
+    /// The float planes are unavoidable -- they are the output. What must NOT appear beside them is a
+    /// second, raster-sized allocation. The bound is generous on purpose: it only has to be tight
+    /// enough to exclude the raster, and a bound tuned finer than that would fail on an unrelated
+    /// allocation change and teach everyone to widen it.
+    /// </summary>
+    /// <remarks>No LZW: TiffWriter cannot ENCODE it, and until SharpAstro.Tiff 3.11 asking for it
+    /// silently wrote raw bytes labelled LZW. That corrupt fixture is what surfaced the writer bug --
+    /// this test read 50 where it had written 3.</remarks>
+    [Theory]
+    [InlineData(TiffCompression.Uncompressed)]
+    [InlineData(TiffCompression.Deflate)]
+    public async Task DecodingATiffDoesNotAllocateTheWholeRasterBesideTheFloatPlanes(TiffCompression compression)
+    {
+        var path = await WriteTiffAsync(compression);
+        try
+        {
+            var floatPlaneBytes = (long)Width * Height * Channels * sizeof(float);
+            var rasterBytes = (long)Width * Height * Channels;   // 8-bit samples
+
+            // Warm the path once: first-touch statics, the file read buffer and any JIT allocations
+            // would otherwise land in the measured window and make the bound meaningless.
+            Image.TryReadTiff(path, out var warm).ShouldBeTrue();
+            warm.ShouldNotBeNull();
+
+            var before = GC.GetAllocatedBytesForCurrentThread();
+            Image.TryReadTiff(path, out var image).ShouldBeTrue();
+            var allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+
+            image.ShouldNotBeNull();
+            image.Width.ShouldBe(Width);
+            image.Height.ShouldBe(Height);
+
+            // File.ReadAllBytes is still in this path, and for an UNCOMPRESSED page the file is
+            // raster-sized -- so it has to be in the ceiling or this test fails for a reason that has
+            // nothing to do with the change. My first version omitted it and failed exactly there,
+            // which is the plan's own warning arriving as a test result: M2 removes the raster, and
+            // for uncompressed input the file buffer then becomes the dominant term. Closing THAT is
+            // the memory-mapping milestone, not this one.
+            var fileBytes = new FileInfo(path).Length;
+
+            // Half a raster of headroom above the unavoidable terms: comfortably clear of the
+            // per-strip scratch, comfortably below "a whole raster got allocated".
+            var ceiling = floatPlaneBytes + fileBytes + rasterBytes / 2;
+            allocated.ShouldBeLessThan(ceiling,
+                $"allocated {allocated:N0} B; float planes {floatPlaneBytes:N0} B + file {fileBytes:N0} B " +
+                $"are unavoidable here, and a raster would add {rasterBytes:N0} B");
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    /// <summary>
+    /// The streaming conversion must produce the same pixels as the whole-raster one did -- strip
+    /// offsets are the obvious thing to get wrong, and a row written at the wrong y is a picture that
+    /// still looks like a picture. Compared against the buffering reader, which is the behaviour being
+    /// preserved rather than a value I chose.
+    /// </summary>
+    [Theory]
+    [InlineData(TiffCompression.Uncompressed)]
+    [InlineData(TiffCompression.Deflate)]
+    public async Task TheStreamedDecodeMatchesTheBufferedRasterPixelForPixel(TiffCompression compression)
+    {
+        var path = await WriteTiffAsync(compression);
+        try
+        {
+            Image.TryReadTiff(path, out var image).ShouldBeTrue();
+            image.ShouldNotBeNull();
+
+            // The oracle: decode the same file the old way and convert it here, in the test.
+            var expected = TiffReader.Read(File.ReadAllBytes(path)).Pages[0];
+            expected.Pixels.Length.ShouldBe(Width * Height * Channels);
+
+            var span = image.GetChannelSpan(0);
+            const float inv = 1f / 255f;
+            for (var y = 0; y < Height; y++)
+            {
+                for (var x = 0; x < Width; x++)
+                {
+                    var fromRaster = expected.Pixels[(y * Width + x) * Channels] * inv;
+                    span[y * Width + x].ShouldBe(fromRaster, 1e-6f,
+                        $"channel 0 at ({x}, {y}) -- a mismatch confined to whole rows means a strip " +
+                        "landed at the wrong y");
+                }
+            }
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    /// <summary>
+    /// A gradient in both axes plus a per-channel offset, so a strip written at the wrong row, or
+    /// channels transposed, changes the VALUES rather than producing a differently-plausible image.
+    /// </summary>
+    private static async Task<string> WriteTiffAsync(TiffCompression compression)
+    {
+        var pixels = new byte[Width * Height * Channels];
+        for (var y = 0; y < Height; y++)
+        {
+            for (var x = 0; x < Width; x++)
+            {
+                var p = (y * Width + x) * Channels;
+                pixels[p] = (byte)(x * 3 + y * 5);
+                pixels[p + 1] = (byte)(x * 7 + y * 11 + 40);
+                pixels[p + 2] = (byte)(x * 13 + y * 17 + 80);
+            }
+        }
+
+        var path = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName() + ".tif");
+        using (var fs = File.Create(path))
+        await using (var writer = TiffWriter.Create(fs))
+        {
+            await writer.AddPageAsync(pixels, Width, Height, new TiffPageOptions
+            {
+                SamplesPerPixel = Channels,
+                BitsPerSample = 8,
+                Photometric = TiffPhotometric.Rgb,
+                SampleFormat = TiffSampleFormat.Uint,
+                Compression = compression,
+            });
+            await writer.FlushAsync();
+        }
+        return path;
+    }
+}

--- a/src/TianWen.Lib.Tests/TiffStreamingDecodeAllocationTests.cs
+++ b/src/TianWen.Lib.Tests/TiffStreamingDecodeAllocationTests.cs
@@ -66,20 +66,20 @@ public class TiffStreamingDecodeAllocationTests
             image.Width.ShouldBe(Width);
             image.Height.ShouldBe(Height);
 
-            // File.ReadAllBytes is still in this path, and for an UNCOMPRESSED page the file is
-            // raster-sized -- so it has to be in the ceiling or this test fails for a reason that has
-            // nothing to do with the change. My first version omitted it and failed exactly there,
-            // which is the plan's own warning arriving as a test result: M2 removes the raster, and
-            // for uncompressed input the file buffer then becomes the dominant term. Closing THAT is
-            // the memory-mapping milestone, not this one.
+            // The float planes are the ONLY large term left. This ceiling deliberately excludes the
+            // file: it used to have to include it, because File.ReadAllBytes returned a byte[] as big
+            // as the raster for an uncompressed page -- M2 removed the raster and simply traded it for
+            // the file buffer. The file is now memory-mapped, so there is no array for it at all, and
+            // the bound can say so.
             var fileBytes = new FileInfo(path).Length;
 
-            // Half a raster of headroom above the unavoidable terms: comfortably clear of the
-            // per-strip scratch, comfortably below "a whole raster got allocated".
-            var ceiling = floatPlaneBytes + fileBytes + rasterBytes / 2;
+            // Half a raster of headroom above the output: comfortably clear of the per-strip scratch,
+            // comfortably below either "a raster got allocated" or "the file got slurped".
+            var ceiling = floatPlaneBytes + rasterBytes / 2;
             allocated.ShouldBeLessThan(ceiling,
-                $"allocated {allocated:N0} B; float planes {floatPlaneBytes:N0} B + file {fileBytes:N0} B " +
-                $"are unavoidable here, and a raster would add {rasterBytes:N0} B");
+                $"allocated {allocated:N0} B; the float planes are {floatPlaneBytes:N0} B and are the only " +
+                $"large term that should remain -- a raster would add {rasterBytes:N0} B, slurping the " +
+                $"file would add {fileBytes:N0} B");
         }
         finally
         {

--- a/src/TianWen.Lib.Tests/ViewerUploadScratchTrimTests.cs
+++ b/src/TianWen.Lib.Tests/ViewerUploadScratchTrimTests.cs
@@ -1,0 +1,173 @@
+using System;
+using DIR.Lib;
+using Shouldly;
+using TianWen.Lib.Astrometry;
+using TianWen.Lib.Imaging;
+using TianWen.UI.Abstractions;
+using Xunit;
+
+namespace TianWen.Lib.Tests;
+
+/// <summary>
+/// The host-visible staging buffer the texture uploads go through is grow-only and used to be freed
+/// only on dispose, so one channel of a large document pinned that much memory for the process
+/// lifetime -- 472 MiB for the 13228x9354 case measured in
+/// <c>docs/plans/viewer-memory-footprint.md</c>, still resident while every subsequent small FITS was
+/// viewed. M1 of that plan releases it after a document load.
+///
+/// <para><b>What these tests are really guarding is the GATE, not the release.</b> Trimming is one
+/// line; trimming at the wrong moment is a performance regression on the imaging hot path, because
+/// this same upload method runs PER FRAME for a live camera feed and a colour sensor's mosaic is one
+/// large channel (~104 MB on an ASI2600). Freeing there would turn a stable allocation into an
+/// alloc/free every frame. So the interesting assertions below are the ones that require NO trim.</para>
+///
+/// <para>A <c>VkBuffer</c> is invisible to the GC, which is why the cost went unnoticed for so long
+/// and why the release itself is asserted on the Vulkan pipeline (see
+/// <c>GpuStretchPipelineTests</c>) rather than by watching managed memory.</para>
+/// </summary>
+public class ViewerUploadScratchTrimTests
+{
+    [Fact]
+    public void ADocumentLoadTrimsTheUploadScratchOnce()
+    {
+        using var renderer = new RgbaImageRenderer(800, 600);
+        var viewer = new TrimCountingViewer(renderer);
+        var state = new ViewerState();
+
+        // What ViewerController does on every source replacement, and the only thing that marks an
+        // upload as belonging to a NEW document.
+        state.NotifySourceReplaced();
+        viewer.UploadDocumentTextures(new StubSource(), state);
+
+        viewer.TrimCalls.ShouldBe(1);
+    }
+
+    /// <summary>
+    /// The regression this gate exists for. A live camera feed re-uploads through the same method every
+    /// frame against ONE source, so its generation never moves and the scratch must be retained. Ten
+    /// uploads stand in for ten frames; the count that matters is zero.
+    /// </summary>
+    [Fact]
+    public void RepeatedLiveFrameUploadsNeverTrim()
+    {
+        using var renderer = new RgbaImageRenderer(800, 600);
+        var viewer = new TrimCountingViewer(renderer);
+        var state = new ViewerState();
+        var source = new StubSource();
+
+        for (var frame = 0; frame < 10; frame++)
+        {
+            state.NeedsTextureUpdate = true;
+            viewer.UploadDocumentTextures(source, state);
+        }
+
+        viewer.TrimCalls.ShouldBe(0);
+    }
+
+    /// <summary>
+    /// Re-uploads of the SAME document -- a channel switch, a debayer change, a stretch that needs new
+    /// textures -- are not a new burst either. Only the load is.
+    /// </summary>
+    [Fact]
+    public void ReUploadingTheSameDocumentTrimsOnlyOnTheLoad()
+    {
+        using var renderer = new RgbaImageRenderer(800, 600);
+        var viewer = new TrimCountingViewer(renderer);
+        var state = new ViewerState();
+        var source = new StubSource();
+
+        state.NotifySourceReplaced();
+        viewer.UploadDocumentTextures(source, state);
+        viewer.UploadDocumentTextures(source, state);
+        viewer.UploadDocumentTextures(source, state);
+
+        viewer.TrimCalls.ShouldBe(1);
+    }
+
+    /// <summary>Opening a second file is a second burst, so it trims again -- otherwise the buffer would
+    /// only ever be released once per process and a later, larger document would re-establish the
+    /// high-water mark permanently.</summary>
+    [Fact]
+    public void EachDocumentLoadTrimsAgain()
+    {
+        using var renderer = new RgbaImageRenderer(800, 600);
+        var viewer = new TrimCountingViewer(renderer);
+        var state = new ViewerState();
+        var source = new StubSource();
+
+        for (var document = 0; document < 3; document++)
+        {
+            state.NotifySourceReplaced();
+            viewer.UploadDocumentTextures(source, state);
+        }
+
+        viewer.TrimCalls.ShouldBe(3);
+    }
+
+    private sealed class TrimCountingViewer : ImageRendererBase<RgbaImage>
+    {
+        public TrimCountingViewer(RgbaImageRenderer renderer) : base(renderer)
+        {
+            Width = renderer.Width;
+            Height = renderer.Height;
+        }
+
+        public int TrimCalls { get; private set; }
+
+        protected override void TrimUploadScratch() => TrimCalls++;
+
+        protected override void RenderImageQuad(IPreviewSource? source, ViewerState state,
+            in DisplayRendition rendition, WCS? wcs,
+            float left, float top, float right, float bottom, uint projW, uint projH,
+            RenditionSlot slot, bool sampleBeforeChannels) { }
+
+        protected override void RenderHistogramQuad(StretchUniforms stretch, HistogramDisplay histogram,
+            ViewerState state, float left, float top, float right, float bottom, uint projW, uint projH) { }
+
+        protected override void DrawEllipseOverlay(float cx, float cy, float semiMajor, float semiMinor,
+            float rotationRad, RGBAColor32 color, float thickness) { }
+
+        protected override void DrawCrossOverlay(float cx, float cy, float armLength, RGBAColor32 color) { }
+
+        protected override void DrawLineOverlay(float x0, float y0, float x1, float y1,
+            RGBAColor32 color, float thickness) { }
+
+        protected override void OnResize(uint width, uint height) { }
+
+        public override void UploadImageTexture(ReadOnlySpan<float> data, int channel,
+            int width, int height) { }
+
+        public override void UploadHistogramData(IPreviewSource source) { }
+
+        protected override HistogramDisplay? GetHistogramDisplay() => null;
+    }
+
+    /// <summary>Geometry and channel count are all <c>UploadDocumentTextures</c> needs to pick its
+    /// path; nothing here reads pixels.</summary>
+    private sealed class StubSource : IPreviewSource
+    {
+        public int Width => 400;
+        public int Height => 300;
+        public int ChannelCount => 1;
+        public SensorType SensorType => SensorType.Monochrome;
+        public int BayerOffsetX => 0;
+        public int BayerOffsetY => 0;
+        public int FrameCount => 1;
+        public int FrameIndex => 0;
+        public float[] PerChannelBackground => [0f];
+        public float LumaBackground => 0f;
+        public ImageHistogram[] ChannelStatistics => [];
+        public ReadOnlySpan<float> GetChannelData(int channel) => default;
+        public bool SelectFrame(int index) => false;
+        public bool HasTimestamps => false;
+        public DateTimeOffset TimestampOf(int index) => DateTimeOffset.MinValue;
+
+        public StretchUniforms ComputeStretchUniforms(
+            StretchMode mode, StretchParameters parameters,
+            LumaWeighting weighting = LumaWeighting.Rec709, float lumaBlend = 1f, bool normalize = false,
+            int curvesMode = 0, ReadOnlySpan<float> curveLut = default, float curvesBoost = 0f,
+            float curvesMidpoint = 0.25f, float hdrAmount = 0f, float hdrKnee = 0.8f,
+            float bgNeutralizationStrength = 1f, (float R, float G, float B)? manualWhiteBalance = null)
+            => new StretchUniforms(mode, 1f, default, default, default, default, default);
+    }
+}

--- a/src/TianWen.Lib/Imaging/Image.Import.cs
+++ b/src/TianWen.Lib/Imaging/Image.Import.cs
@@ -6,6 +6,7 @@ using System;
 using System.Buffers.Binary;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
+using System.IO.MemoryMappedFiles;
 using System.Runtime.InteropServices;
 using TianWen.Lib.Astrometry;
 using CodecSampleFormat = SharpAstro.Codecs.Abstractions.SampleFormat;
@@ -181,55 +182,104 @@ public partial class Image
     /// is what this method allocates, and going through the extension-dispatching entry point would put
     /// unrelated work inside the measured window.
     /// </summary>
-    internal static bool TryReadTiff(string fileName, [NotNullWhen(true)] out Image? image)
+    internal static unsafe bool TryReadTiff(string fileName, [NotNullWhen(true)] out Image? image)
     {
         try
         {
-            var bytes = File.ReadAllBytes(fileName);
+            // MEMORY-MAPPED, not File.ReadAllBytes. With the strip-streaming decode below, the file
+            // buffer became the largest single allocation on this path: an UNCOMPRESSED TIFF is
+            // raster-sized on disk (354 MB for the 13228x9354 page in
+            // docs/plans/viewer-memory-footprint.md), so ReadAllBytes was handing back a byte[] as big
+            // as the raster the streaming decode had just eliminated -- one term traded for another.
+            // A mapping has no such array: the pages are file-backed, so they need no managed heap, no
+            // LOH allocation, and can be evicted under pressure instead of swapped.
+            //
+            // It also completes the zero-copy path. SharpAstro.Tiff hands an uncompressed, unpredicted
+            // strip over as a slice of its INPUT, so with the input being the mapping those samples are
+            // converted straight out of the file with no intermediate copy anywhere.
+            var info = new FileInfo(fileName);
 
-            // ReadInto, not Read: Read returns the page as one assembled raster, so converting it here
-            // means the raster and these float planes are BOTH fully resident. For a 13228x9354 RGB
-            // page that is 354 MiB of intermediate whose only purpose is to be read once, left-to-right
-            // -- see docs/plans/viewer-memory-footprint.md (M2). The sink converts each strip as it
-            // arrives and the raster never exists.
-            var sink = new TiffChannelSink();
-            var doc = TiffReader.ReadInto(bytes, ref sink);
-            if (doc.Pages.Count == 0 || sink.Channels is not { } channels)
+            // Zero length has nothing to map (CreateFromFile rejects a 0-capacity mapping), and past
+            // int.MaxValue a span cannot address it -- academic for this reader, which does not support
+            // BigTIFF and so cannot follow 64-bit offsets anyway, but a wrong answer is worse than a
+            // refusal.
+            if (info.Length is 0 or > int.MaxValue)
             {
-                // No pages, or the sink declined the first one (an unsupported photometric). Either way
-                // the caller is told we could not read it, which is the same answer as before.
                 image = null;
                 return false;
             }
 
-            var page = doc.Pages[0];
-            var width = page.Width;
-            var height = page.Height;
-            var isSeparated = sink.IsSeparated;
-            var bitDepth = sink.BitDepth;
+            // FileShare.Read to match what ReadAllBytes did, so a file another process holds open for
+            // writing is refused exactly as before rather than newly succeeding on a half-written file.
+            using var stream = new FileStream(fileName, FileMode.Open, FileAccess.Read, FileShare.Read);
+            using var mapping = MemoryMappedFile.CreateFromFile(stream, mapName: null, capacity: 0,
+                MemoryMappedFileAccess.Read, HandleInheritability.None, leaveOpen: false);
+            using var view = mapping.CreateViewAccessor(0, info.Length, MemoryMappedFileAccess.Read);
 
-            // The photometric interpretation decides what the samples MEAN, and ignoring it is not a
-            // graceful degradation -- it renders a confidently wrong picture. A Separated (CMYK)
-            // print export read as RGB comes out as a colour-shifted NEGATIVE, because a high CMYK
-            // value is more ink, i.e. darker. That is worse than refusing the file, since nothing on
-            // screen says the interpretation was guessed.
-            if (page.Photometric == TiffPhotometric.MinIsWhite)
+            byte* origin = null;
+            try
             {
-                // Zero means WHITE for this photometric (scanners and fax), so the stored samples are
-                // a negative of the intensity every consumer downstream assumes.
-                InvertSamplesInPlace(channels);
+                view.SafeMemoryMappedViewHandle.AcquirePointer(ref origin);
+
+                // PointerOffset, because a view is aligned to an allocation granularity boundary and the
+                // pointer is to that boundary, not to the requested offset. It is 0 for offset 0 on every
+                // platform we run, but reading it is free and assuming it is not.
+                var bytes = new ReadOnlySpan<byte>(origin + view.PointerOffset, (int)info.Length);
+
+                // ReadInto, not Read: Read returns the page as one assembled raster, so converting it here
+                // means the raster and these float planes are BOTH fully resident. For a 13228x9354 RGB
+                // page that is 354 MiB of intermediate whose only purpose is to be read once, left-to-right
+                // -- see docs/plans/viewer-memory-footprint.md (M2). The sink converts each strip as it
+                // arrives and the raster never exists.
+                var sink = new TiffChannelSink();
+                var doc = TiffReader.ReadInto(bytes, ref sink);
+                if (doc.Pages.Count == 0 || sink.Channels is not { } channels)
+                {
+                    // No pages, or the sink declined the first one (an unsupported photometric). Either way
+                    // the caller is told we could not read it, which is the same answer as before.
+                    image = null;
+                    return false;
+                }
+
+                var page = doc.Pages[0];
+                var width = page.Width;
+                var height = page.Height;
+                var isSeparated = sink.IsSeparated;
+                var bitDepth = sink.BitDepth;
+
+                // The photometric interpretation decides what the samples MEAN, and ignoring it is not a
+                // graceful degradation -- it renders a confidently wrong picture. A Separated (CMYK)
+                // print export read as RGB comes out as a colour-shifted NEGATIVE, because a high CMYK
+                // value is more ink, i.e. darker. That is worse than refusing the file, since nothing on
+                // screen says the interpretation was guessed.
+                if (page.Photometric == TiffPhotometric.MinIsWhite)
+                {
+                    // Zero means WHITE for this photometric (scanners and fax), so the stored samples are
+                    // a negative of the intensity every consumer downstream assumes.
+                    InvertSamplesInPlace(channels);
+                }
+                else if (isSeparated)
+                {
+                    channels = ConvertSeparatedToRgb(channels, width, height);
+                }
+
+                var exif = ExifReader.FromTiff(bytes);
+                var imageMeta = BuildImageMetaFromExif(exif, page.FileIsLittleEndian);
+
+                // Values are now in [0, 1] (DecodeTiffPixels normalises by sample-format max).
+                image = new Image(channels, bitDepth, 1.0f, 0f, 0f, imageMeta);
+                return true;
             }
-            else if (isSeparated)
+            finally
             {
-                channels = ConvertSeparatedToRgb(channels, width, height);
+                if (origin is not null)
+                {
+                    // Paired with AcquirePointer. Without it the handle keeps a reference count and the
+                    // mapping is never released, which is a leak that only shows up as a file staying
+                    // locked -- so it presents as "cannot delete that file" long after the decode.
+                    view.SafeMemoryMappedViewHandle.ReleasePointer();
+                }
             }
-
-            var exif = ExifReader.FromTiff(bytes);
-            var imageMeta = BuildImageMetaFromExif(exif, page.FileIsLittleEndian);
-
-            // Values are now in [0, 1] (DecodeTiffPixels normalises by sample-format max).
-            image = new Image(channels, bitDepth, 1.0f, 0f, 0f, imageMeta);
-            return true;
         }
         catch
         {

--- a/src/TianWen.Lib/Imaging/Image.Import.cs
+++ b/src/TianWen.Lib/Imaging/Image.Import.cs
@@ -176,14 +176,28 @@ public partial class Image
         ) { CameraToSrgbMatrix = cameraToSrgb };
     }
 
-    private static bool TryReadTiff(string fileName, [NotNullWhen(true)] out Image? image)
+    /// <summary>
+    /// Internal rather than private so the allocation test can call it directly: the point of that test
+    /// is what this method allocates, and going through the extension-dispatching entry point would put
+    /// unrelated work inside the measured window.
+    /// </summary>
+    internal static bool TryReadTiff(string fileName, [NotNullWhen(true)] out Image? image)
     {
         try
         {
             var bytes = File.ReadAllBytes(fileName);
-            var doc = TiffReader.Read(bytes);
-            if (doc.Pages.Count == 0)
+
+            // ReadInto, not Read: Read returns the page as one assembled raster, so converting it here
+            // means the raster and these float planes are BOTH fully resident. For a 13228x9354 RGB
+            // page that is 354 MiB of intermediate whose only purpose is to be read once, left-to-right
+            // -- see docs/plans/viewer-memory-footprint.md (M2). The sink converts each strip as it
+            // arrives and the raster never exists.
+            var sink = new TiffChannelSink();
+            var doc = TiffReader.ReadInto(bytes, ref sink);
+            if (doc.Pages.Count == 0 || sink.Channels is not { } channels)
             {
+                // No pages, or the sink declined the first one (an unsupported photometric). Either way
+                // the caller is told we could not read it, which is the same answer as before.
                 image = null;
                 return false;
             }
@@ -191,39 +205,14 @@ public partial class Image
             var page = doc.Pages[0];
             var width = page.Width;
             var height = page.Height;
+            var isSeparated = sink.IsSeparated;
+            var bitDepth = sink.BitDepth;
 
             // The photometric interpretation decides what the samples MEAN, and ignoring it is not a
             // graceful degradation -- it renders a confidently wrong picture. A Separated (CMYK)
             // print export read as RGB comes out as a colour-shifted NEGATIVE, because a high CMYK
             // value is more ink, i.e. darker. That is worse than refusing the file, since nothing on
             // screen says the interpretation was guessed.
-            if (page.Photometric is not (TiffPhotometric.Rgb or TiffPhotometric.MinIsBlack
-                or TiffPhotometric.MinIsWhite or TiffPhotometric.Cmyk))
-            {
-                // Palette / YCbCr / CIELab need a colour transform this reader does not carry. Refuse
-                // rather than reinterpret; the caller reports that it could not read the file.
-                image = null;
-                return false;
-            }
-
-            // CMYK is the one case where the output channel count is not the input's: K is needed to
-            // convert and then discarded, so decode 4 and emit 3.
-            var isSeparated = page.Photometric == TiffPhotometric.Cmyk && page.SamplesPerPixel >= 4;
-            // Drop alpha / extras: Image carries mono (1) or RGB (3); the prior Magick path
-            // also extracted only R/G/B from interleaved RGBA strides.
-            var decodeChannels = isSeparated ? 4 : page.SamplesPerPixel >= 3 ? 3 : 1;
-            var outChannels = isSeparated ? 3 : decodeChannels;
-            var bitDepth = (page.SampleFormat, page.BitsPerSample) switch
-            {
-                (TiffSampleFormat.IeeeFloat, _) => BitDepth.Float32,
-                (_, <= 8) => BitDepth.Int8,
-                (_, <= 16) => BitDepth.Int16,
-                _ => BitDepth.Float32,
-            };
-
-            var channels = CreateChannelData(decodeChannels, height, width);
-            DecodeTiffPixels(page, channels, decodeChannels);
-
             if (page.Photometric == TiffPhotometric.MinIsWhite)
             {
                 // Zero means WHITE for this photometric (scanners and fax), so the stored samples are
@@ -390,22 +379,112 @@ public partial class Image
         return rgb;
     }
 
-    private static void DecodeTiffPixels(TiffPage page, float[][,] channels, int outChannels)
+    /// <summary>
+    /// Converts a TIFF page into float planes STRIP BY STRIP, so the assembled raster never exists.
+    /// </summary>
+    /// <remarks>
+    /// <para>A mutable struct, passed by <c>ref</c> to <see cref="TiffReader.ReadInto{TSink}"/> so it is
+    /// neither boxed nor allocated -- the point of this path is to stop materialising things.</para>
+    ///
+    /// <para>It also owns the decisions that used to sit in <c>TryReadTiff</c> (which photometrics are
+    /// supported, how many channels to decode versus emit, the bit depth), because
+    /// <see cref="ITiffStripSink.BeginPage"/> is where they can be made -- before a single pixel is
+    /// decoded -- and refusing there means an unsupported file costs no decode at all.</para>
+    /// </remarks>
+    private struct TiffChannelSink : ITiffStripSink
     {
-        var width = page.Width;
-        var height = page.Height;
-        var srcChannels = page.SamplesPerPixel;
-        var bps = page.BitsPerSample;
-        var isFloat = page.SampleFormat == TiffSampleFormat.IeeeFloat;
+        public float[][,]? Channels;
+        public bool IsSeparated;
+        public BitDepth BitDepth;
+        private int _width;
+        private int _srcChannels;
+        private int _decodeChannels;
+        private int _bitsPerSample;
+        private bool _isFloat;
 
+        public bool BeginPage(int pageIndex, TiffPage page)
+        {
+            // Image carries ONE page, and page 0 is the one TryReadTiff has always used. Declining the
+            // rest is not merely tidy: their strips are then never decoded, so a multi-page TIFF costs
+            // what its first page costs.
+            if (pageIndex != 0)
+            {
+                return false;
+            }
+
+            if (page.Photometric is not (TiffPhotometric.Rgb or TiffPhotometric.MinIsBlack
+                or TiffPhotometric.MinIsWhite or TiffPhotometric.Cmyk))
+            {
+                // Palette / YCbCr / CIELab need a colour transform this reader does not carry. Refuse
+                // rather than reinterpret; the caller reports that it could not read the file. Channels
+                // stays null, which is how TryReadTiff sees the refusal.
+                return false;
+            }
+
+            // CMYK is the one case where the output channel count is not the input's: K is needed to
+            // convert and then discarded, so decode 4 and emit 3.
+            IsSeparated = page.Photometric == TiffPhotometric.Cmyk && page.SamplesPerPixel >= 4;
+            // Drop alpha / extras: Image carries mono (1) or RGB (3); the prior Magick path
+            // also extracted only R/G/B from interleaved RGBA strides.
+            _decodeChannels = IsSeparated ? 4 : page.SamplesPerPixel >= 3 ? 3 : 1;
+            BitDepth = (page.SampleFormat, page.BitsPerSample) switch
+            {
+                (TiffSampleFormat.IeeeFloat, _) => BitDepth.Float32,
+                (_, <= 8) => BitDepth.Int8,
+                (_, <= 16) => BitDepth.Int16,
+                _ => BitDepth.Float32,
+            };
+
+            _width = page.Width;
+            _srcChannels = page.SamplesPerPixel;
+            _bitsPerSample = page.BitsPerSample;
+            _isFloat = page.SampleFormat == TiffSampleFormat.IeeeFloat;
+
+            // The one allocation this path makes, and the destination the strips write straight into.
+            Channels = CreateChannelData(_decodeChannels, page.Height, page.Width);
+            return true;
+        }
+
+        public void Strip(int pageIndex, int firstRow, int rowCount, ReadOnlySpan<byte> samples)
+        {
+            if (Channels is not { } channels)
+            {
+                return;
+            }
+
+            // Rows the strip actually delivered, which is not always rowCount: a truncated file gives a
+            // short final strip, and converting past it would read the neighbouring row's samples as
+            // this row's. Trusting the span's length is what makes a partial file decode to a partial
+            // image rather than to a garbled one.
+            var bytesPerRow = _width * _srcChannels * (_bitsPerSample / 8);
+            var rows = bytesPerRow > 0 ? Math.Min(rowCount, samples.Length / bytesPerRow) : 0;
+            if (rows <= 0)
+            {
+                return;
+            }
+
+            ConvertTiffStrip(samples, channels, _decodeChannels, _width, _srcChannels, _bitsPerSample,
+                _isFloat, firstRow, rows);
+        }
+    }
+
+    /// <summary>
+    /// One strip's interleaved samples into the float planes, normalised to [0, 1] by sample-format
+    /// max. <paramref name="firstRow"/> is where the strip sits in the image, which is the only thing
+    /// that changed when this stopped being a whole-raster pass.
+    /// </summary>
+    private static void ConvertTiffStrip(ReadOnlySpan<byte> samples, float[][,] channels, int outChannels,
+        int width, int srcChannels, int bps, bool isFloat, int firstRow, int rowCount)
+    {
         if (isFloat && bps == 32)
         {
             // Float TIFFs follow the [0, 1] convention regardless of writer (Magick.NET via
             // SMin/SMax, scientific tools as literal scene-linear values). Store as-is.
-            var floats = MemoryMarshal.Cast<byte, float>(page.Pixels.AsSpan());
-            for (var y = 0; y < height; y++)
+            var floats = MemoryMarshal.Cast<byte, float>(samples);
+            for (var localRow = 0; localRow < rowCount; localRow++)
             {
-                var row = y * width;
+                var row = localRow * width;
+                var y = firstRow + localRow;
                 for (var x = 0; x < width; x++)
                 {
                     var pix = (row + x) * srcChannels;
@@ -418,11 +497,12 @@ public partial class Image
         }
         else if (!isFloat && bps == 16)
         {
-            var shorts = MemoryMarshal.Cast<byte, ushort>(page.Pixels.AsSpan());
+            var shorts = MemoryMarshal.Cast<byte, ushort>(samples);
             const float inv = 1f / 65535f;
-            for (var y = 0; y < height; y++)
+            for (var localRow = 0; localRow < rowCount; localRow++)
             {
-                var row = y * width;
+                var row = localRow * width;
+                var y = firstRow + localRow;
                 for (var x = 0; x < width; x++)
                 {
                     var pix = (row + x) * srcChannels;
@@ -436,15 +516,16 @@ public partial class Image
         else if (!isFloat && bps == 8)
         {
             const float inv = 1f / 255f;
-            for (var y = 0; y < height; y++)
+            for (var localRow = 0; localRow < rowCount; localRow++)
             {
-                var row = y * width;
+                var row = localRow * width;
+                var y = firstRow + localRow;
                 for (var x = 0; x < width; x++)
                 {
                     var pix = (row + x) * srcChannels;
                     for (var c = 0; c < outChannels; c++)
                     {
-                        channels[c][y, x] = page.Pixels[pix + c] * inv;
+                        channels[c][y, x] = samples[pix + c] * inv;
                     }
                 }
             }
@@ -452,7 +533,7 @@ public partial class Image
         else
         {
             throw new NotSupportedException(
-                $"TIFF BitsPerSample={bps} SampleFormat={page.SampleFormat} not supported by DIR.Lib path");
+                $"TIFF BitsPerSample={bps} isFloat={isFloat} not supported by the SharpAstro.Tiff path");
         }
     }
 

--- a/src/TianWen.UI.Abstractions/ImageRendererBase.cs
+++ b/src/TianWen.UI.Abstractions/ImageRendererBase.cs
@@ -494,7 +494,39 @@ namespace TianWen.UI.Abstractions
             }
 
             UploadHistogramData(source);
+
+            // A DOCUMENT load ends a burst of uploads, so the host-visible scratch the uploads went
+            // through can go back. A LIVE frame does not -- this same method runs per frame for a camera
+            // feed (LiveSessionTab, GuiderTab), where releasing the buffer would mean an alloc/free every
+            // frame on the imaging hot path.
+            //
+            // SourceGeneration is what tells them apart, and it is an existing fact rather than a new
+            // flag: ViewerController bumps it on each source replacement and nothing in the live path
+            // touches it, so a camera feed holds one generation for its whole life while every opened
+            // file gets a fresh one. Deliberately not a size threshold -- a large live frame and a
+            // document look identical by size, which is exactly the case that must not churn.
+            if (state.SourceGeneration != _lastUploadSourceGeneration)
+            {
+                _lastUploadSourceGeneration = state.SourceGeneration;
+                TrimUploadScratch();
+            }
+
             state.StatusMessage = null;
+        }
+
+        /// <summary>
+        /// The <see cref="ViewerState.SourceGeneration"/> the last upload belonged to. Starts at 0, which
+        /// is the generation a never-replaced source has, so a live feed never trims.
+        /// </summary>
+        private int _lastUploadSourceGeneration;
+
+        /// <summary>
+        /// Releases whatever host-visible scratch the texture uploads went through. Called once per
+        /// document load, after the last channel. No-op by default: a backend with no such buffer, and
+        /// the offline renderer used by the layout tests, have nothing to release.
+        /// </summary>
+        protected virtual void TrimUploadScratch()
+        {
         }
 
         // -----------------------------------------------------------------------

--- a/src/TianWen.UI.Shared/VkFitsImagePipeline.cs
+++ b/src/TianWen.UI.Shared/VkFitsImagePipeline.cs
@@ -1190,6 +1190,56 @@ public sealed unsafe class VkFitsImagePipeline : IDisposable
         api.vkUpdateDescriptorSets(1, &write, 0, null);
     }
 
+    /// <summary>
+    /// The host-visible staging buffer's current size in bytes, 0 when none is allocated. Exposed so a
+    /// headless test can assert the trim happened -- a <c>VkBuffer</c> is invisible to the GC, so there
+    /// is nothing else to observe it by, which is also why this cost went unnoticed for so long.
+    ///
+    /// <para>Public rather than internal because this assembly grants no <c>InternalsVisibleTo</c>, and
+    /// the neighbouring test-facing members (<see cref="R32SfloatOptimalTilingFeatures"/>,
+    /// <see cref="ReadbackChannelFirstFloats"/>) are public for the same reason.</para>
+    /// </summary>
+    public ulong StagingBufferSize => _stagingSize;
+
+    /// <summary>
+    /// Releases the staging buffer, so the high-water mark of one large upload stops following the
+    /// process around.
+    /// </summary>
+    /// <remarks>
+    /// <para><see cref="EnsureStagingBuffer"/> is grow-only and was freed ONLY on dispose, so one channel
+    /// of a big document pinned that much host-visible memory for the process lifetime: a 13228x9354
+    /// document measures 472 MiB, and every small FITS opened afterwards still carried it. Nothing
+    /// reported it either -- a Vulkan buffer is not managed memory, so it does not even show as GC
+    /// pressure.</para>
+    ///
+    /// <para><b>This is deliberately NOT done inside <see cref="UploadChannelTexture"/>.</b> That is the
+    /// obvious shape and it is wrong: the live preview path uploads a channel PER FRAME, and a colour
+    /// sensor's mosaic is one large channel (an ASI2600 frame is ~104 MB), so freeing after every upload
+    /// would turn a stable allocation into an alloc/free per frame on the imaging hot path. Only the
+    /// caller knows a burst of uploads has ended, which is why this is an explicit trim.</para>
+    ///
+    /// <para>A size cap ("release anything over 32 MiB") was considered and rejected for the same reason:
+    /// it cannot tell a document load from a large live frame, so it would churn exactly the path that
+    /// needs the buffer retained.</para>
+    ///
+    /// <para>Needs no fence: <see cref="UploadToImage"/> is synchronous, so by the time a caller can ask
+    /// for this the copy has already completed.</para>
+    /// </remarks>
+    public void TrimStagingBuffer()
+    {
+        if (_stagingBuffer == VkBuffer.Null)
+        {
+            return;
+        }
+
+        var api = _ctx.DeviceApi;
+        api.vkDestroyBuffer(_stagingBuffer);
+        api.vkFreeMemory(_stagingMemory);
+        _stagingBuffer = VkBuffer.Null;
+        _stagingMemory = VkDeviceMemory.Null;
+        _stagingSize = 0;
+    }
+
     private void EnsureStagingBuffer(ulong size)
     {
         if (_stagingBuffer != VkBuffer.Null && _stagingSize >= size)

--- a/src/TianWen.UI.Shared/VkImageRenderer.cs
+++ b/src/TianWen.UI.Shared/VkImageRenderer.cs
@@ -51,6 +51,13 @@ public class VkImageRenderer : ImageRendererBase<VulkanContext>, IDisposable
         _fitsPipeline.UploadChannelTexture(data, channel, imageWidth, imageHeight);
     }
 
+    /// <summary>Hands the pipeline's staging buffer back after a document load. See
+    /// <see cref="VkFitsImagePipeline.TrimStagingBuffer"/> for why this is caller-driven.</summary>
+    protected override void TrimUploadScratch()
+    {
+        _fitsPipeline.TrimStagingBuffer();
+    }
+
     public override void UploadHistogramData(IPreviewSource source)
     {
         var stats = source.ChannelStatistics;


### PR DESCRIPTION
Four milestones of `docs/plans/viewer-memory-footprint.md` (the HIGH-priority entry) plus the design for the fifth. Opening one 5.7 MB architectural drawing cost ~2.5 GB; the TIFF decode now allocates **its own output plus 5.4 KB**.

One commit per milestone.

## M1 — hand back the upload scratch (`0f952d4d`)

`VkFitsImagePipeline`'s host-visible staging buffer is grow-only and was freed only on dispose, so one channel of a large document pinned that much memory for the **process lifetime** and every small FITS opened afterwards still carried it. Invisible to the GC — a `VkBuffer` isn't managed memory, so it doesn't even register as pressure.

**Measured A/B: 3948 → 3399 MB, 549 MB recovered.**

**The gate is the implementation.** Releasing the buffer is one line; releasing it at the wrong moment is a hot-path regression, because `UploadDocumentTextures` is *also* the per-frame path for a live camera and an ASI2600 mosaic is one ~104 MB channel. `ViewerState.SourceGeneration` separates "a document loaded" from "another frame arrived" and needed no new flag. Accordingly the load-bearing tests are the ones asserting **no** trim — ten live frames, three re-uploads of one document — and both fail against an unconditional trim.

## M2 — convert strips as they arrive (`6af28d60`, + Codecs 3.11)

`TryReadTiff` assembled the whole page and then converted it, so the raster and the float planes were both fully resident — 354 MiB of intermediate whose only purpose was to be read once, left to right. It now decodes through `TiffReader.ReadInto` with a struct sink, which also took over the photometric/channel/bit-depth decisions because `BeginPage` is where they can be made *before* any pixel is decoded. An unsupported file now costs no decode, and a multi-page TIFF costs what page 0 costs.

## Memory-mapped file (`db5a89ce`)

Once the raster was gone, `File.ReadAllBytes` became the dominant term: an **uncompressed** TIFF is raster-sized on disk, so it was handing back a `byte[]` as large as the raster M2 had just removed — one term traded for the other. Mapping the file removes the array entirely and completes the zero-copy path: `SharpAstro.Tiff` hands an uncompressed, unpredicted strip over as a slice of its *input*, and the input is now the mapping.

The plan predicted this would be "a much larger change to `SharpAstro.Tiff`'s entry points". It wasn't — `Read(ReadOnlySpan<byte>)` already existed with a comment *recommending* you map the file, and `ExifReader.FromTiff` already took a span.

| Uncompressed case | Allocated |
|---|---|
| Original (raster + file) | 19,444,760 B |
| After M2 (file only) | 16,204,608 B |
| After mapping | **12,965,424 B** |
| Float planes — the output itself | 12,960,000 B |

Scaled to the reference document: 371 MB of raster plus 371 MB of file, leaving only the 1,485 MB of planes.

## The measurement method changed, because the first one lied

I began with a working-set A/B in the viewer. It reported **"1564 MB off the peak"** for M2 — and it was noise: the *same unmodified build* then measured 3362 MB steady in one run and **2143 MB** in another. Run-to-run variance exceeds 1200 MB against a change worth 371 MB. I was one step from putting that number in a commit message.

`GC.GetAllocatedBytesForCurrentThread` resolves it exactly, and the removed allocation is **precisely one raster** — everything else accounted for within 5 KB. It's a permanent test, and I confirmed it fails when the raster path is restored, and again when the mapping is reverted.

M1's 549 MB is the one figure here that came from working set. The mechanism is certain and the direction is right, but given the above it deserves an asterisk.

## A bug found on the way — `TiffWriter` was mislabelling

It stamped the requested compression into the IFD while its encoder switch fell through to raw bytes, so asking for LZW wrote **uncompressed data announced as LZW**: a file whose content and label disagree, undecodable by anything, with no error, a plausible size and correct dimensions.

It had **two of my own test suites passing over it**, because a corrupt file decodes to identical garbage through both readers, so an equivalence assertion holds while asserting nothing at all. It surfaced only when a pixel-equality test read 50 where it had written 3. Fixed in 3.11 by refusing what the writer cannot apply; the vacuous fixtures are gone with the reason recorded.

## M3 design (`5be3bb12`) — designed, not started

The data model is now the entire remaining cost: 1,485 MB of float planes + 1,485 MB of `R32Sfloat` device images = 2,227 MB of the 2,251 measured.

**The shader was never the obstacle** — `texture()` on `R8Unorm` returns a float in [0,1] exactly as `R32Sfloat` does. What the design turns on is that **star detection runs automatically on every document open**, not on demand: if it needs a float `Image`, the planes exist regardless and M3 saves only the device half. That's the difference between 1,114 MB and 2,227 MB, and it's invisible in the memory table.

Split into D3 (device-only, no API change, half the win, separable), D1 (floats demoted to a transient — 24 → 6 B/px steady), D2 (depth-agnostic star detection — peak too). Recommendation: D3 first, then decide D1 on measurements with D3 in place, and don't start D2 until star detection is *shown* to be what holds the floats resident.

Two things stated up front: `IPreviewSource.GetChannelData` is float-typed with four implementers, three of them live sources whose frames genuinely are float. And **FITS is the case M3 does not pay for** — float FITS is already `R32Sfloat`, and 16-bit integer FITS carries `BZERO`/`BSCALE`, so raw samples aren't directly uploadable. The clean win is 8-bit TIFF/PNG/JPEG — i.e. M3 makes the viewer good at documents it was never designed for and changes nothing for the ones it was.

## Pin

`3.11.751`, verified indexed across all eleven family packages before moving. Verified on the **package** path (`-p:UseLocalSiblings=false`), since a sibling build proves nothing about a pin: Release build clean, 29 TIFF/import tests green against the published packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TY5kFz4Qxox1aAHxPKf2ek
