### PR TITLE
Stop the viewer racing its own textures, and pin the cached-layer facility

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -78,7 +78,7 @@
 
     <PackageVersion Include="Console.Lib" Version="4.26.*" />
 
-    <PackageVersion Include="SdlVulkan.Renderer" Version="7.23.*" />
+    <PackageVersion Include="SdlVulkan.Renderer" Version="7.24.*" />
 
     <PackageVersion Include="WebGl.Renderer" Version="1.26.*" />
     <PackageVersion Include="SDL3-CS" Version="3.5.0-preview.20260213-150035" />

--- a/src/TianWen.Lib.Tests/ViewerSplitTests.cs
+++ b/src/TianWen.Lib.Tests/ViewerSplitTests.cs
@@ -326,7 +326,44 @@ namespace TianWen.Lib.Tests
             viewer.Draws.Count.ShouldBe(1);
             viewer.Draws[0].Slot.ShouldBe(RenditionSlot.Live);
             viewer.Draws[0].SampleBefore.ShouldBeFalse();
-            viewer.Draws[0].Clip.ShouldBeNull();
+
+            // Clipped to the image PANE, which under HideChrome is the whole surface -- so this
+            // asserts the pane, not merely "some clip". It used to assert no clip at all: the split
+            // path clipped each half while this one clipped nothing, making the ordinary single-image
+            // view the worse-bounded of the two, and every fragment behind opaque chrome paid a full
+            // demosaic + stretch before being painted over. The chrome-on case is the one that shows
+            // the difference, and it is the test below.
+            var clip = viewer.Draws[0].Clip.ShouldNotBeNull();
+            clip.UpperLeft.X.ShouldBe(0);
+            clip.UpperLeft.Y.ShouldBe(0);
+            clip.Width.ShouldBe((int)SurfaceW);
+            clip.Height.ShouldBe((int)SurfaceH);
+        }
+
+        /// <summary>
+        /// With the chrome drawn, the image draw must be bounded to the pane the chrome leaves behind.
+        /// </summary>
+        /// <remarks>
+        /// The companion above cannot see this: its state sets <c>HideChrome</c>, so the pane IS the
+        /// surface and a missing clip is indistinguishable from a correct one. That is exactly how the
+        /// unclipped path survived having a test.
+        /// </remarks>
+        [Fact]
+        public void WithChromeShown_TheImageDrawIsBoundedToThePane()
+        {
+            using var renderer = new ClipRecordingRenderer(SurfaceW, SurfaceH);
+            var viewer = NewViewer(renderer);
+            var state = NewState();
+            state.HideChrome = false;
+
+            viewer.Render(null, state);
+
+            viewer.Draws.Count.ShouldBe(1);
+            var clip = viewer.Draws[0].Clip.ShouldNotBeNull();
+            clip.Height.ShouldBeLessThan((int)SurfaceH,
+                "the toolbar and status bar rows must be outside the clip, or their fragments are shaded and then painted over");
+            clip.Height.ShouldBeGreaterThan(0);
+            clip.Width.ShouldBeGreaterThan(0);
         }
 
         [Fact]

--- a/src/TianWen.UI.Abstractions/ImageRendererBase.cs
+++ b/src/TianWen.UI.Abstractions/ImageRendererBase.cs
@@ -896,15 +896,27 @@ namespace TianWen.UI.Abstractions
                 ReleaseBeforeImageTextures();
             }
 
+            var area = _layout.ImageArea;
+
             if (Split.ResolveDividerX(HasBeforeImageTextures, DpiScale) is not { } splitX)
             {
+                // Clipped to the pane, for the same reason the split halves below are: the quad is
+                // sized to the ZOOMED image, so once it exceeds the pane it reaches under the file
+                // list, the info panel and the toolbar -- and DIR.Lib's clip stack is a real
+                // vkCmdSetScissor (VkRenderer.ApplyClip), so those fragments are rejected before the
+                // shader runs rather than shaded and painted over. Every one of them would otherwise
+                // pay the full demosaic + stretch to end up behind opaque chrome.
+                //
+                // This path had NO clip at all while the split path had one per half, so the ordinary
+                // single-image view was the worse-bounded of the two.
+                PushClip(area.X, area.Y, area.Width, area.Height);
                 RenderImageQuad(source, state, live, gridWcs,
                     p.OffsetX, p.OffsetY, p.OffsetX + p.DrawW, p.OffsetY + p.DrawH, Width, Height,
                     RenditionSlot.Live, sampleBeforeChannels: false);
+                PopClip();
                 return;
             }
 
-            var area = _layout.ImageArea;
             var comparesPixels = Split.ComparesPixels;
             var comparison = Split.ComparisonRendition(live);
 

--- a/src/TianWen.UI.Abstractions/ImageRendererBase.cs
+++ b/src/TianWen.UI.Abstractions/ImageRendererBase.cs
@@ -11,7 +11,7 @@
 //   into a VkImage offscreen framebuffer. Only re-render when:
 //   - New image loaded (NeedsTextureUpdate)
 //   - Stretch parameters changed (mode, shadows, midtones, highlights, boost, HDR)
-//   - Zoom or pan changed
+//   - Zoom changed, or a pan left the cached margin (constraint 3 below)
 //   - Star overlay toggled
 //   - WCS grid toggled
 //   - Channel view changed
@@ -20,23 +20,51 @@
 //   Each frame: blit cached Layer 1 framebuffer → render toolbar, status bar,
 //   file list, info panel on top. This is just text quads; very cheap.
 //
-// Implementation steps:
-//   1. Add offscreen VkImage + VkFramebuffer to VkFitsImagePipeline (same size as swapchain)
-//   2. Add a "blit" shader (fullscreen quad sampling the offscreen texture)
-//   3. Add ImageContentDirty flag to ViewerState: set by stretch/zoom/pan/toggle changes
-//   4. In OnRender: if ImageContentDirty → render Layer 1 to offscreen → clear flag
-//   5. Always: blit offscreen → render chrome overlay → present
-//   6. Handle resize: recreate offscreen framebuffer
+// THREE CONSTRAINTS, each already paid for elsewhere. Read them before writing the code.
+//
+// 1. The cache render MUST ride the frame: no extra submit, no extra fence, no wait, and never a
+//    barrier against an image this process does not currently own. That last one is exactly the
+//    inspector screenshot mistake (SdlVulkan.Renderer 57eceb8) -- ReadbackSwapchainRgba ran after
+//    vkQueuePresentKHR and transitioned the presented image without re-acquiring it, which the
+//    Khronos layer reports as a WRITE_AFTER_PRESENT hazard and which entitles the driver to park the
+//    whole queue, making it the leading candidate for the Adreno stuck-fence wedge. Note this is NOT
+//    a new upstream feature: VulkanContext.ThumbnailCapture.cs is already a secondary render target
+//    on the LIVE device, opened on the frame's own command buffer from the OnPreRenderPass hook,
+//    with the projection redirected and the pre-baked pipelines binding unchanged (its render pass
+//    keeps the swapchain's attachment formats, sample count and subpass refs). The cached layer is
+//    that class with three changes: finalLayout ShaderReadOnlyOptimal rather than TransferSrcOptimal,
+//    no readback buffer and no copy, and it persists across frames instead of being consumed once.
+//
+// 2. ONE TARGET PER FRAME-IN-FLIGHT, never one shared target. Re-rendering a shared cache writes an
+//    image the previous submitted frame is still sampling -- the hazard VkFontAtlas.Grow guards with
+//    a drain, and which "the Adreno X1-85 punishes by failing the next vkQueueSubmit". Draining per
+//    dirty frame is not the answer here: during a zoom drag EVERY frame is dirty, so the stall would
+//    land on the hot path. With MaxFramesInFlight targets a content change marks all of them dirty
+//    and each re-renders on its next turn, so a change costs 2 image renders and then nothing, and a
+//    continuous zoom is never worse than today.
+//
+// 3. The cache is IMAGE-space with a margin, not pane-space, or panning gains nothing -- a pane-sized
+//    cache invalidates on every pan, which is a case this exists to fix. Allocate pane + margin once
+//    at capacity and never resize on the render thread (ThumbnailCapture holds the same discipline:
+//    "fixed allocated capacity, never resized on the render thread"); re-allocate only on window
+//    resize, which already drains. A pan inside the margin is then a blit at an offset and a pan
+//    beyond it re-renders. At 1.5x linear margin on a 1920x1080 pane that is 18.7 MB per slot, 37 MB
+//    for two.
 //
 // Expected impact: mouse-hover GPU usage drops from ~20% to <2% (just text rendering).
 // The full image render only runs on actual content changes (~1-5 fps during interaction).
+// Ablation on a solved frame, 1:1 and maximized: 2.94 ms baseline, 4.22 ms with the A/B split,
+// 4.97 ms with Calibrate + NeutBg -- so the shader, not the chrome, is what a redraw costs.
 //
 // Files to change:
-//   - SdlVulkan.Renderer: VkRenderer needs render-to-texture support (new feature)
+//   - SdlVulkan.Renderer: a sampleable variant of ThumbnailCapture (finalLayout, no readback), and
+//     make the bounded TryWaitPriorFramesIdle public so a consumer owning GPU images can honour the
+//     rule in constraint 2 without an unbounded vkDeviceWaitIdle
 //   - TianWen.UI.Shared/VkFitsImagePipeline.cs: offscreen framebuffer management
 //   - TianWen.UI.Shared/VkImageRenderer.cs: split RenderImageQuad into cached/blit paths
 //   - TianWen.UI.Abstractions/ImageRendererBase.cs: add ImageContentDirty flag logic
-//   - TianWen.UI.Abstractions/ViewerState.cs: add ImageContentDirty property
+//   - TianWen.UI.Abstractions/ViewerState.cs: add ImageContentDirty state (a per-slot dirty mask,
+//     not one bool, per constraint 2)
 
 using System;
 using System.IO;

--- a/src/TianWen.UI.Shared/VkFitsImagePipeline.cs
+++ b/src/TianWen.UI.Shared/VkFitsImagePipeline.cs
@@ -361,9 +361,11 @@ public sealed unsafe class VkFitsImagePipeline : IDisposable
     /// <para>A 1x1 placeholder rather than a null view, because Vulkan forbids binding a descriptor set
     /// that references a destroyed view even when the shader never samples it -- the same reason
     /// <see cref="CreatePlaceholderTextures"/> exists at all.</para>
-    /// <para>No device-idle wait, matching the recreate branch of <see cref="UploadStagedChannel"/>:
-    /// that already destroys a texture the previous frame sampled, and relies on the renderer having
-    /// waited on its frame fence. This is the same operation at the same point in the frame.</para>
+    /// <para>The in-flight hazard is handled once, in <see cref="DestroyChannelTexture"/>. This method
+    /// originally argued it needed no wait because the recreate branch of
+    /// <see cref="UploadStagedChannel"/> does the same thing and relies on the renderer having waited
+    /// its frame fence -- true about the precedent, wrong about the fence, and so wrong about both.
+    /// See that method for what the fence actually retires.</para>
     /// <para>The BEFORE slots are deliberately untouched. They hold the split's left half, which is a
     /// deliberate retention with its own release path (<see cref="ReleaseBeforeChannels"/>); freeing
     /// them here would empty the comparison the user is looking at.</para>
@@ -1299,9 +1301,42 @@ public sealed unsafe class VkFitsImagePipeline : IDisposable
         api.vkCreateImageView(&viewCI, null, out _histViews[channel]).CheckResult();
     }
 
+    /// <summary>
+    /// Frees a channel's view, image and memory, draining prior in-flight frames first because every
+    /// caller destroys an image a frame still in flight may be sampling.
+    /// </summary>
+    /// <remarks>
+    /// <para><b>Waiting the frame fence is not enough, and assuming it was is how this was missed.</b>
+    /// The renderer waits the fence for frame index <c>N % MaxFramesInFlight</c> at BeginFrame, which
+    /// retires frame N-2, NOT frame N-1. With two frames in flight there is therefore always one
+    /// submitted frame whose descriptor set still references this view when a destroy runs mid-record.
+    /// SdlVulkan.Renderer's <c>VkFontAtlas.Grow</c> names the cost on the hardware we ship on -- "the
+    /// Adreno X1-85 punishes that by failing the next vkQueueSubmit" -- and a run of rejected submits
+    /// is the observed shape of the viewer wedge, so this is not a theoretical hazard.</para>
+    /// <para>Every call site qualifies and none is per-frame: the geometry/format recreate in
+    /// <see cref="UploadStagedChannel"/> (a new document, a channel toggle, stepping to a frame of a
+    /// different size), <see cref="ReleaseChannelTexturesFrom"/>, and teardown. So the drain never
+    /// lands on the steady-state path, and once the first destroy of a batch has idled the queue the
+    /// rest cost nothing until something new is submitted.</para>
+    /// <para>Skipped when there is nothing allocated, so a placeholder slot pays no wait.</para>
+    /// <para>Guarded on <see cref="VulkanContext.IsGpuStuck"/> for the same reason
+    /// <see cref="Dispose"/> guards its own drain: an unbounded wait on an already-wedged device would
+    /// hard-freeze the render thread, turning a recoverable stall into a hang. The bounded form
+    /// upstream (<c>TryWaitPriorFramesIdle</c> -- waits every fence except the current frame's, capped,
+    /// and skips a known-stuck GPU) is what this should call; it is <c>internal</c> today.</para>
+    /// </remarks>
     private void DestroyChannelTexture(int channel)
     {
         var api = _ctx.DeviceApi;
+
+        if ((_channelViews[channel] != VkImageView.Null
+                || _channelImages[channel] != VkImage.Null
+                || _channelMemories[channel] != VkDeviceMemory.Null)
+            && !_ctx.IsGpuStuck)
+        {
+            api.vkDeviceWaitIdle();
+        }
+
         if (_channelViews[channel] != VkImageView.Null)
         {
             api.vkDestroyImageView(_channelViews[channel]);


### PR DESCRIPTION
Groundwork for the cached image layer, plus two real fixes found on the way to it.

## A destroy raced the frame still sampling it

`DestroyChannelTexture` freed a view, image and memory with no drain, and `ReleaseChannelTexturesFrom`'s remarks argued that was fine because `UploadStagedChannel`'s recreate branch does the same and relies on the renderer having waited its frame fence. Right about the precedent, **wrong about the fence**: BeginFrame waits the fence for frame index `N % MaxFramesInFlight`, which retires frame N-2, not N-1. With two frames in flight there is always one submitted frame whose descriptor set still references the view when a destroy runs mid-record, so the precedent was unguarded too, and had been since it was written.

SdlVulkan.Renderer's `VkFontAtlas.Grow` names the cost on the hardware we ship on -- *"the Adreno X1-85 punishes that by failing the next vkQueueSubmit"* -- and guards its own image swap with a bounded drain for exactly this reason. A run of rejected submits is the observed shape of the viewer wedge, which makes this a **candidate for that crash** rather than a tidy-up: opening a document at a new size, toggling a channel, and stepping to a differently sized frame all destroy an image the GPU may still be reading.

The drain goes at the one choke point every destroy passes through, so a future caller cannot forget it. Skipped for an unallocated slot, guarded on `IsGpuStuck` like `Dispose`'s own drain, and no call site is per-frame -- so it never lands on the steady-state path, and once the first destroy of a batch has idled the queue the rest cost nothing.

## The single-image draw had no clip

The split path clipped each half; the ordinary single-image path clipped nothing, so it shaded fragments under the toolbar, status bar, file list and info panel and then painted chrome over them. Each of those paid a full demosaic + stretch to end up invisible. Now wrapped in the same `PushClip`, which reaches a real `vkCmdSetScissor`, so they are rejected before the shader runs.

## Pin + corrected design

`SdlVulkan.Renderer` 7.23 -> 7.24 for `VulkanContext.CachedLayer`, the sampleable secondary target the cached image layer needs. Verified on the package path (`-c Release -p:UseLocalSiblings=false`), which resolved 7.24.2601 and built clean. Nothing consumes it yet.

The design note in `ImageRendererBase`'s header had three things wrong, each of which would have shaped the implementation:

- it called render-to-texture a new upstream feature, when `ThumbnailCapture` was already 90% of it;
- it invalidated on *"zoom or pan changed"*, which makes a pan re-render -- one of the two cases the cache exists to fix, and unfixable with a pane-space cache, so it has to be image-space with a margin;
- it specified one shared target plus one dirty bool, which is the same bug as the first section above, one layer up.

## Verification

- `TianWen.Lib.Tests`, the viewer/GPU surface: 28 passed, run against a freshly built dependency (a first run had used a stale copy).
- Package-path Release build of `TianWen.UI.FitsViewer`.
- Upstream 7.24 ships a real-device test whose decisive case was confirmed to fail when the feature is removed.

The wedge itself is still unexplained; this closes one mechanism that matches its symptom, it does not prove causation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TY5kFz4Qxox1aAHxPKf2ek