### PR TITLE
ImageLease: the borrow is a disposable token

### DIFF
--- a/docs/plans/frame-lifecycle.md
+++ b/docs/plans/frame-lifecycle.md
@@ -608,6 +608,17 @@ BREAKING public-API change on the package). `default(ImageLease)` is inert: `Dis
 `Image` throws. The own-side counterpart stays `Release` on `Image` itself, mirrored privately by
 `ArchiveSolveSurvey.OwnedFrame`.
 
+**The bespoke analyzer is deliberately NOT built, and the reasoning is worth keeping.** Two rules
+were on the table. "Never release a parameter" (own-side): audited universally true in P4, but the
+naive form only catches the direct spelling -- `Calibrator.Apply` launders through a local, so a real
+guard needs dataflow, and the runtime tripwires (the recycled-read throw, the over-release throw, the
+DEBUG leak tracker) already make a violation loud in tests. "A lease must be disposed" (borrow-side):
+**CA2000 cannot do this -- it ignores value-type disposables** (measured: a forgotten `ImageLease`
+beside a forgotten `FileStream`, only the stream fired), so it would need a bespoke analyzer too --
+for a pattern with two production call sites, both `using`. A dropped buffered lease surfaces in the
+DEBUG leak tracker instead. Revisit if either mistake actually appears in a PR; the repo also carries
+36 latent CA2000 warnings on CLASS disposables (measured 2026-08-24), a separate cleanup if wanted.
+
 **The cut also closed a latent poison: the bufferless lease is now a DISTINCT image.** The old
 bufferless branch returned `this`, so the borrower's release marked the SOURCE released and every
 later `TryLease` of the same published frame refused -- a repeat-polling preview got one frame and

--- a/docs/plans/frame-lifecycle.md
+++ b/docs/plans/frame-lifecycle.md
@@ -598,7 +598,23 @@ Out of a review of D1: *"maybe a LeasedImage subclass that has the fast access m
 splits into two, and they land differently -- worth recording both, because the appealing half is the
 one that does not work.
 
-### Adopted in principle: type the OWNERSHIP obligation
+### Adopted in principle: type the OWNERSHIP obligation -- SHIPPED 2026-08-23 as `ImageLease`
+
+**Shipped the day after the paragraph below resolved the design question.** `ImageLease` is a public
+`readonly struct : IDisposable` wrapping the leased image; `TryLease(out Image?)` became
+`TryLease(out ImageLease)` in one wave (two production consumers -- `GuidePreview`, the
+`FakeGuider.SaveImageAsync` retry -- plus the test suite; no compatibility overload left behind, a
+BREAKING public-API change on the package). `default(ImageLease)` is inert: `Dispose` no-ops,
+`Image` throws. The own-side counterpart stays `Release` on `Image` itself, mirrored privately by
+`ArchiveSolveSurvey.OwnedFrame`.
+
+**The cut also closed a latent poison: the bufferless lease is now a DISTINCT image.** The old
+bufferless branch returned `this`, so the borrower's release marked the SOURCE released and every
+later `TryLease` of the same published frame refused -- a repeat-polling preview got one frame and
+then 404s until the frame swapped. The lease is now always a fresh `Image` sharing the planes (the
+harvest finds no buffers, so disposing it is a self-owned no-op); pinned by
+`TryLease_OnAnImageWithNoRecycledBuffers_Succeeds_AndTheSourceStaysLeasable`, seen to fail against
+the `this`-wrapping form.
 
 `TryLease` hands back an `Image` whose "you MUST `Release()` this" lives only in a doc comment, which
 is convention 3 of the table above in its purest form: a rule that exists, is real, and is enforced

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -20,7 +20,7 @@
       A release bump is 1.0 -> 1.1 additive, 1.x -> 2.x breaking. The patch segment is CI's
       (github.run_number) and is never written by hand.
     -->
-    <VersionMajorMinor>6.3</VersionMajorMinor>
+    <VersionMajorMinor>7.0</VersionMajorMinor>
     <!--
       Local builds get Major.Minor.0; CI passes -p:Version=Major.Minor.<run><attempt>+<sha> and the
       condition lets it win. This applies to EVERY project, which also closes a latent bug:

--- a/src/TianWen.Hosting/Api/GuidePreview.cs
+++ b/src/TianWen.Hosting/Api/GuidePreview.cs
@@ -44,22 +44,19 @@ namespace TianWen.Hosting.Api
                 return (null, frameNumber, NoFrameFailure);
             }
 
-            // The guide loop does LastFrame?.Release() before publishing the next one, so holding
-            // `published` across the encode would be reading a buffer the camera may already have taken
-            // back. Losing that race is normal at guiding cadence and simply means "not right now".
-            if (!published.TryLease(out var leased))
+            // The guide loop swaps its published pointer before releasing the superseded frame, but
+            // the superseded frame IS then released -- so holding `published` across the encode
+            // without a lease would be reading a buffer the camera may already have taken back.
+            // Losing the lease race is normal at guiding cadence and simply means "not right now".
+            if (!published.TryLease(out var lease))
             {
                 return (null, frameNumber, NoFrameFailure);
             }
 
-            try
+            using (lease)
             {
-                var jpeg = await PreviewEncoder.EncodeJpegAsync(leased, quality, scale, cancellationToken);
+                var jpeg = await PreviewEncoder.EncodeJpegAsync(lease.Image, quality, scale, cancellationToken);
                 return (jpeg, frameNumber, null);
-            }
-            finally
-            {
-                leased.Release();
             }
         }
     }

--- a/src/TianWen.Lib.Tests/ImageLeaseTests.cs
+++ b/src/TianWen.Lib.Tests/ImageLeaseTests.cs
@@ -10,8 +10,8 @@ namespace TianWen.Lib.Tests;
 
 /// <summary>
 /// Pins the borrow path a hosted consumer needs to read a live driver frame: <see cref="ChannelBuffer.TryAddRef"/>
-/// never resurrecting a released buffer, and <see cref="Image.TryLease"/> handing out an independently
-/// releasable image (or refusing) so the camera cannot recycle the pixels mid-read.
+/// never resurrecting a released buffer, and <see cref="Image.TryLease"/> handing out a disposable
+/// <see cref="ImageLease"/> token (or refusing) so the camera cannot recycle the pixels mid-read.
 /// <para>
 /// The race test below is the reason <c>TryAddRef</c> is a CAS loop rather than a liveness check followed
 /// by an increment. The old shape would let a borrower observe "alive", lose the count to zero on the
@@ -176,29 +176,29 @@ public class ImageLeaseTests
         var channel = BufferedChannel(out _, out var releases);
         var owner = new Image([channel], BitDepth.Float32, pedestal: 0f, new ImageMeta());
 
-        owner.TryLease(out var leased).ShouldBeTrue();
-        leased.ShouldNotBeNull();
+        owner.TryLease(out var lease).ShouldBeTrue();
 
         // The owner publishing its next frame must not pull the pixels out from under the borrower.
         owner.Release();
         releases[0].ShouldBe(0);
 
-        leased.Release();
+        lease.Dispose();
         releases[0].ShouldBe(1); // recycled exactly once, by the last holder
     }
 
     [Fact]
-    public void TryLease_HandsBackADistinctImage_SoTheTwoReleasesAreIndependent()
+    public void TryLease_HandsBackADistinctImage_SoDisposeAndTheOwnersReleaseAreIndependent()
     {
         var channel = BufferedChannel(out _, out var releases);
         var owner = new Image([channel], BitDepth.Float32, pedestal: 0f, new ImageMeta());
 
-        owner.TryLease(out var leased).ShouldBeTrue();
-        leased.ShouldNotBeSameAs(owner);
+        owner.TryLease(out var lease).ShouldBeTrue();
+        lease.Image.ShouldNotBeSameAs(owner);
 
-        // Releasing the lease twice must not consume the owner's ref: Image.Release is one-shot.
-        leased.Release();
-        leased.Release();
+        // Disposing the lease twice must not consume the owner's ref: the leased image's Release is
+        // one-shot, which is what makes a copied lease struct harmless.
+        lease.Dispose();
+        lease.Dispose();
         releases[0].ShouldBe(0);
 
         owner.Release();
@@ -206,15 +206,29 @@ public class ImageLeaseTests
     }
 
     [Fact]
-    public void TryLease_AfterTheFrameIsReleased_Refuses()
+    public void TryLease_AfterTheFrameIsReleased_RefusesWithAnInertLease()
     {
         var channel = BufferedChannel(out _, out var releases);
         var owner = new Image([channel], BitDepth.Float32, pedestal: 0f, new ImageMeta());
         owner.Release();
         releases[0].ShouldBe(1);
 
-        owner.TryLease(out var leased).ShouldBeFalse();
-        leased.ShouldBeNull();
+        owner.TryLease(out var lease).ShouldBeFalse();
+
+        // The refused lease is default(ImageLease): reading it is a call-site bug and says so, and
+        // disposing it is a no-op rather than a second spend of anything.
+        Should.Throw<InvalidOperationException>(() => lease.Image);
+        lease.Dispose();
+        releases[0].ShouldBe(1);
+    }
+
+    [Fact]
+    public void ADefaultLease_IsInert()
+    {
+        var lease = default(ImageLease);
+
+        lease.Dispose(); // must not throw: an empty lease has nothing to give back
+        Should.Throw<InvalidOperationException>(() => lease.Image);
     }
 
     [Fact]
@@ -238,23 +252,31 @@ public class ImageLeaseTests
         // the ref taken on the healthy plane is unwound rather than leaked to a caller who cannot see it.
         doomedBuffer.Release();
 
-        image.TryLease(out var leased).ShouldBeFalse();
-        leased.ShouldBeNull();
+        image.TryLease(out var lease).ShouldBeFalse();
+        Should.Throw<InvalidOperationException>(() => lease.Image);
         aliveBuffer.RefCount.ShouldBe(1);
     }
 
     [Fact]
-    public void TryLease_OnAnImageWithNoRecycledBuffers_LeasesItselfAndStaysUsable()
+    public void TryLease_OnAnImageWithNoRecycledBuffers_Succeeds_AndTheSourceStaysLeasable()
     {
         // File loads, debayer output and the synthetic fake frames carry no ChannelBuffer at all, and
         // this is the common case for a remote preview - it has to succeed, not fall through to a 404.
         var image = PlainImage();
 
-        image.TryLease(out var leased).ShouldBeTrue();
-        leased.ShouldBeSameAs(image);
+        image.TryLease(out var first).ShouldBeTrue();
 
-        leased.Release(); // a no-op, so the image is still readable afterwards
+        // Distinct, so disposing the borrow cannot mark the SOURCE released. When the lease was the
+        // source itself, one borrow cycle poisoned every later lease of the same published frame: a
+        // repeat-polling preview got its first frame and then 404s until the frame happened to swap.
+        first.Image.ShouldNotBeSameAs(image);
+        first.Dispose();
         image.Width.ShouldBe(4);
+
+        // The regression the distinct lease closes: the SECOND borrow of the same frame.
+        image.TryLease(out var second).ShouldBeTrue();
+        second.Image.Width.ShouldBe(4);
+        second.Dispose();
     }
 
     [Fact]
@@ -263,7 +285,7 @@ public class ImageLeaseTests
         var image = PlainImage();
         image.Release();
 
-        image.TryLease(out var leased).ShouldBeFalse();
-        leased.ShouldBeNull();
+        image.TryLease(out var lease).ShouldBeFalse();
+        Should.Throw<InvalidOperationException>(() => lease.Image);
     }
 }

--- a/src/TianWen.Lib/Devices/Fake/FakeGuider.cs
+++ b/src/TianWen.Lib/Devices/Fake/FakeGuider.cs
@@ -550,26 +550,24 @@ internal class FakeGuider(FakeDevice fakeDevice, IServiceProvider serviceProvide
         // superseded between our read and the lease. Re-reading then observes the successor, which
         // is live until the capture after it completes -- one retry converges; the extras are
         // insurance against stacked swaps. No frame at all is a real "no", not a race.
-        Image? image = null;
-        for (var attempt = 0; attempt < 3; attempt++)
+        var lease = default(ImageLease);
+        var haveLease = false;
+        for (var attempt = 0; attempt < 3 && !haveLease; attempt++)
         {
             if ((_guideLoop?.LastFrame ?? _lastLoopFrame) is not { } source)
             {
                 return null;
             }
 
-            if (source.TryLease(out image))
-            {
-                break;
-            }
+            haveLease = source.TryLease(out lease);
         }
 
-        if (image is null)
+        if (!haveLease)
         {
             return null;
         }
 
-        try
+        using (lease)
         {
             Directory.CreateDirectory(outputFolder);
             var path = Path.Combine(outputFolder, $"guider_{TimeProvider.GetUtcNow().UtcDateTime:yyyyMMdd_HHmmss}.fits");
@@ -599,15 +597,9 @@ internal class FakeGuider(FakeDevice fakeDevice, IServiceProvider serviceProvide
                 wcs = new WCS(PointingRA, PointingDec);
             }
 
-            image.WriteToFitsFile(path, wcs);
+            lease.Image.WriteToFitsFile(path, wcs);
 
             return path;
-        }
-        finally
-        {
-            // The LEASE, never the guide loop's own frame: releasing that would drop the ref the
-            // loop still holds.
-            image.Release();
         }
     }
 

--- a/src/TianWen.Lib/Imaging/Image.Lease.cs
+++ b/src/TianWen.Lib/Imaging/Image.Lease.cs
@@ -1,38 +1,39 @@
-using System.Diagnostics.CodeAnalysis;
-
 namespace TianWen.Lib.Imaging;
 
 public partial class Image
 {
     /// <summary>
-    /// Borrows this image for a consumer that outlives the frame's owner, taking a reference on every
-    /// recycled channel buffer so the camera cannot reuse the pixels mid-read. On success the caller
-    /// owns the returned image and MUST <see cref="Release"/> it; on failure the frame is already gone
-    /// and the caller has nothing to release.
+    /// Borrows this frame: on success <paramref name="lease"/> wraps a DISTINCT image that shares
+    /// these pixel planes and holds a reference on every recycled channel buffer, so the camera
+    /// cannot reuse the pixels mid-read. Disposing the lease is the borrower's whole obligation --
+    /// there is no <c>Release</c> to pair by hand and no way to spend the owner's ref by mistake.
     /// <para>
     /// <b>Why this exists rather than just reading <c>LastGuideFrame</c> (or any other live frame)
-    /// directly.</b> A frame published by a driver is valid only until that driver publishes the next
-    /// one: the guide loop does <c>LastFrame?.Release(); LastFrame = frame;</c> on every exposure, so
-    /// at guiding cadence a reader that holds the reference across any await is reading a buffer the
-    /// camera has already taken back. The GUI gets away with a bare reference because it draws on the
-    /// render thread within the same frame it read; a hosted request encoding a JPEG does not, and
-    /// that difference is the whole reason for a lease.
+    /// directly.</b> A frame published by a driver is valid only until that driver publishes the
+    /// next one: publishers swap the pointer BEFORE releasing the superseded frame, but the
+    /// superseded frame IS then released, so a reader holding a bare reference across any await is
+    /// reading a buffer the camera may already have taken back. The GUI gets away with a bare
+    /// reference because it draws on the render thread within the same frame it read; a hosted
+    /// request encoding a JPEG does not, and that difference is the whole reason for a lease.
     /// </para>
     /// <para>
-    /// Losing the race is normal and is reported as <see langword="false"/>, not an exception: the
-    /// honest answer for a poller is "no frame right now", and the next poll succeeds.
+    /// Losing the race is normal and is reported as <see langword="false"/>, not an exception --
+    /// and because publishers swap first, a refusal has exactly one meaning: this frame was
+    /// superseded between the caller's read of the published pointer and the lease. Re-reading the
+    /// pointer observes the live successor, so a retry converges in one step.
     /// </para>
     /// <para>
     /// <b>Frame ownership: this is the BORROW primitive.</b> Everyone who is not the owner reads
-    /// through here, and releases the LEASE rather than the original. See the frame-ownership notes
-    /// on <see cref="Image"/>.
+    /// through here and disposes the lease, never the original. See the frame-ownership notes on
+    /// <see cref="Image"/> and the token rationale on <see cref="ImageLease"/>.
     /// </para>
     /// </summary>
-    /// <param name="leased">
-    /// The borrowed image on success. It shares this image's pixel arrays and metadata, so it must be
-    /// treated as read-only for exactly the reasons the class-level mutability notes give.
+    /// <param name="lease">
+    /// The borrow on success; <c>default</c> (inert) on failure. The leased image shares this
+    /// image's pixel arrays and metadata, so it must be treated as read-only for exactly the
+    /// reasons the class-level mutability notes give.
     /// </param>
-    public bool TryLease([NotNullWhen(true)] out Image? leased)
+    public bool TryLease(out ImageLease lease)
     {
         // Read the buffer array BEFORE consulting _released, which is what makes the two branches below
         // sound. Release() nulls the array, so a null read is ambiguous on its own (an image that never
@@ -46,11 +47,22 @@ public partial class Image
         if (buffers is null)
         {
             // Nothing to recycle: the planes are ordinary GC arrays (a file load, a debayer output, a
-            // synthetic fake frame), so no camera can pull them out from under the borrower and the
-            // image itself is the lease. Release() on it is a no-op, so the caller's release still
-            // balances. A released image is refused, because its planes may since have been reused.
-            leased = _released ? null : this;
-            return !_released;
+            // synthetic fake frame), so no camera can pull them out from under the borrower. A
+            // released image is still refused, because its planes may since have been reused.
+            //
+            // The lease is a DISTINCT image here too, not `this`. Handing out `this` made the
+            // borrower's dispose mark the SOURCE released, so one borrow cycle poisoned every later
+            // lease of the same published frame -- a repeat-polling preview 404s from the second poll
+            // on. Distinct costs one small allocation and cannot poison anything: the harvest finds
+            // no buffers, so disposing the lease is a self-owned no-op.
+            if (_released)
+            {
+                lease = default;
+                return false;
+            }
+
+            lease = new ImageLease(new Image(_planes, bitDepth, pedestal, imageMeta, samplesAreUnitReferred, sourceRaster));
+            return true;
         }
 
         // All-or-nothing: a partially referenced multi-channel frame is not a frame, and unwinding is
@@ -65,16 +77,17 @@ public partial class Image
                     buffers[undo]?.Release();
                 }
 
-                leased = null;
+                lease = default;
                 return false;
             }
 
             taken++;
         }
 
-        // A distinct instance, so the refs just taken get their own one-shot Release (Image.Release
-        // clears _channelBuffers via Interlocked.Exchange). Handing back `this` would make the
-        // borrower's release indistinguishable from the owner's and drop the frame early.
+        // A distinct instance, so the refs just taken get their own one-shot Release when the lease
+        // is disposed (Image.Release clears _channelBuffers via Interlocked.Exchange). Wrapping
+        // `this` would make the borrower's dispose indistinguishable from the owner's release and
+        // drop the frame early.
         //
         // The LIVE planes, not the constructor argument: residency can move after construction, and
         // seeding a lease from the original array would hand the borrower float planes this image has
@@ -86,7 +99,7 @@ public partial class Image
         // bytes. (The rule against forwarding a raster is about transforms that RECOMPUTE pixels,
         // which is what makes the raster a lie; sharing them recomputes nothing.) Dropping the flag
         // made a leased frame claim ADU scale while carrying unit-referred samples.
-        leased = new Image(_planes, bitDepth, pedestal, imageMeta, samplesAreUnitReferred, sourceRaster);
+        lease = new ImageLease(new Image(_planes, bitDepth, pedestal, imageMeta, samplesAreUnitReferred, sourceRaster));
         return true;
     }
 }

--- a/src/TianWen.Lib/Imaging/Image.cs
+++ b/src/TianWen.Lib/Imaging/Image.cs
@@ -24,8 +24,8 @@ namespace TianWen.Lib.Imaging;
 ///
 /// <para><b>Own</b> -- the frame was handed to you, so you <see cref="Release"/> it exactly once and
 /// never touch it afterwards. <b>Borrow</b> -- you did not receive ownership, so take
-/// <see cref="TryLease"/> if you need the pixels beyond the current frame, and release the LEASE,
-/// never the original. <b>Consume</b> -- you hand your frame to a method that writes through its
+/// <see cref="TryLease"/> if you need the pixels beyond the current frame, and dispose the
+/// <see cref="ImageLease"/>, never release the original. <b>Consume</b> -- you hand your frame to a method that writes through its
 /// arrays and returns a view of them; the input is spent, and only the result may be used.</para>
 ///
 /// <para><b>Four conventions coexist and an <see cref="Image"/> carries no runtime indication of

--- a/src/TianWen.Lib/Imaging/ImageLease.cs
+++ b/src/TianWen.Lib/Imaging/ImageLease.cs
@@ -1,0 +1,48 @@
+using System;
+
+namespace TianWen.Lib.Imaging;
+
+/// <summary>
+/// A disposable borrow of an <see cref="Imaging.Image"/> -- the token side of the frame-ownership
+/// policy. <see cref="Imaging.Image.TryLease"/> hands one out; disposing it is the borrower's whole
+/// obligation, spent exactly once however many copies of the struct exist.
+/// </summary>
+/// <remarks>
+/// <para><b>Why a token rather than a returned <see cref="Imaging.Image"/>.</b> A shared refcount can
+/// DETECT a double-release but cannot prevent one: the offending call is byte-identical to a
+/// legitimate last release, so <see cref="ChannelBuffer"/> can only throw at the NEXT, innocent
+/// release. A token is 1:1 with a claim -- disposing it ends this borrower's whole claim,
+/// unconditionally, and the frame's fate is computed from the surviving claims rather than asserted
+/// by whoever called last. It also hands the obligation to the compiler: CA2000 flags a forgotten
+/// lease, a borrowed frame offers no <c>Release</c> to call by mistake, and <c>using</c> makes the
+/// common shape the correct one.</para>
+/// <para>The wrapped image is DISTINCT from the source frame -- it shares the pixel planes and holds
+/// its own buffer refs -- so disposing a lease can never mark the source released, and repeated
+/// borrow cycles against the same published frame all succeed. <c>default(ImageLease)</c> is inert:
+/// <see cref="Dispose"/> is a no-op and <see cref="Image"/> throws, because reading an empty lease
+/// is a bug at the call site, not a race.</para>
+/// <para>This is the BORROW token only. An owner spends ownership with
+/// <see cref="Imaging.Image.Release"/> directly (a no-op for self-owned frames, which stay
+/// readable) -- see the frame-ownership notes on <see cref="Imaging.Image"/>.</para>
+/// </remarks>
+public readonly struct ImageLease : IDisposable
+{
+    private readonly Image? _leased;
+
+    internal ImageLease(Image leased) => _leased = leased;
+
+    /// <summary>The borrowed frame, valid until <see cref="Dispose"/>.</summary>
+    /// <exception cref="InvalidOperationException">
+    /// The lease is empty: <see cref="Imaging.Image.TryLease"/> answered <see langword="false"/>, or
+    /// this is <c>default(ImageLease)</c>.
+    /// </exception>
+    public Image Image => _leased ?? throw new InvalidOperationException(
+        "Empty lease: TryLease answered false (or this is default(ImageLease)), so there is no frame to read.");
+
+    /// <summary>
+    /// Gives the borrow back. Safe on an empty lease, and idempotent per lease: the leased image's
+    /// own <see cref="Imaging.Image.Release"/> is one-shot, so a copied struct disposing again is a
+    /// no-op rather than a second spend.
+    /// </summary>
+    public void Dispose() => _leased?.Release();
+}

--- a/src/TianWen.Lib/Imaging/ImageLease.cs
+++ b/src/TianWen.Lib/Imaging/ImageLease.cs
@@ -13,9 +13,11 @@ namespace TianWen.Lib.Imaging;
 /// legitimate last release, so <see cref="ChannelBuffer"/> can only throw at the NEXT, innocent
 /// release. A token is 1:1 with a claim -- disposing it ends this borrower's whole claim,
 /// unconditionally, and the frame's fate is computed from the surviving claims rather than asserted
-/// by whoever called last. It also hands the obligation to the compiler: CA2000 flags a forgotten
-/// lease, a borrowed frame offers no <c>Release</c> to call by mistake, and <c>using</c> makes the
-/// common shape the correct one.</para>
+/// by whoever called last. It also puts the obligation where the language can carry it: a borrowed
+/// frame offers no <c>Release</c> to call by mistake, and <c>using</c> makes the common shape the
+/// correct one. (NOT the analyzers: CA2000 ignores value-type disposables -- measured with a
+/// forgotten lease beside a forgotten <c>FileStream</c>, and only the stream fired -- so a dropped
+/// lease is caught by the DEBUG <see cref="ChannelBufferLeakTracker"/>, not at compile time.)</para>
 /// <para>The wrapped image is DISTINCT from the source frame -- it shares the pixel planes and holds
 /// its own buffer refs -- so disposing a lease can never mark the source released, and repeated
 /// borrow cycles against the same published frame all succeed. <c>default(ImageLease)</c> is inert:


### PR DESCRIPTION
## What

`ImageLease`, the compile-time half of the frame-ownership policy (`docs/plans/frame-lifecycle.md`, "type the OWNERSHIP obligation" -- adopted in principle 2026-08-22, shipped here). A public `readonly struct : IDisposable` wrapping the leased image; `Image.TryLease(out Image?)` becomes `TryLease(out ImageLease)` in one wave, no compatibility overload.

## Why a token

A shared refcount detects a double-release but cannot prevent one -- the offending call is byte-identical to a legitimate last release, so `ChannelBuffer` can only throw at the *next*, innocent release (PR #189). A token is 1:1 with a claim: disposing it ends the borrower's whole claim unconditionally, `using` makes the common shape the correct one, a borrowed frame offers no `Release` to call by mistake.

## Also closed: the bufferless-lease poison

The bufferless branch used to return `this`, so a borrower's dispose marked the **source** released and every later lease of the same published frame refused -- a repeat-polling preview got one frame and then 404s until the frame swapped. The lease is now always a distinct image sharing the planes; pinned by `TryLease_OnAnImageWithNoRecycledBuffers_Succeeds_AndTheSourceStaysLeasable`, seen to fail against the `this`-wrapping form.

## Breaking change / version

Replacing a public signature on the published `TianWen.Lib` package. Org rule reads this as a major (6.x -> 7.x); counterpoint: `TryLease` shipped 2026-08-05 and its known consumers are in-repo. **Bumped to 7.0 in this PR** at the maintainer's direction (one line; VersionPrefix, AssemblyVersion and CI's VERSION_PREFIX derive).

## Verification

- Unit 4765/0 (45 skipped), functional 338/338, Debug + Release builds clean
- Lease tests 12/12; the poison-regression test sabotage-verified to fail pre-fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AcDb8T6NuDSyCRGTe7nKvy

