### PR TITLE
fix(astrometry): a seeded solve must not re-open the blind match tolerance

### DIFF
--- a/docs/plans/plate-solver-performance.md
+++ b/docs/plans/plate-solver-performance.md
@@ -1,0 +1,160 @@
+# Plate-solver performance: closing the gap to ASTAP
+
+Status: PLANNED. The correctness work is done and shipped; everything below is performance only,
+and must not cost a single solve.
+
+## Where this came from
+
+A 135-frame 10P/Tempel stack (QHY294C, SV 545 f/4.5, 5.4 deg field at 4.72"/px) exposed a real
+solver bug: a seeded solve re-opened the blind match tolerance, so `CatalogPlateSolver` failed on
+4 of 10 frames that ASTAP solves 10 of 10. Fixed. While measuring that fix the timings turned out
+to deserve their own plan.
+
+## The measured budget
+
+Whole-process wall clock, AOT-published `tianwen solve`, frame 0018, fresh file per rep, median of
+4. Stage numbers come from `PlateSolveFailureProbe` (`TIANWEN_STAR_PROBE_FITS`).
+
+| | wall (median) |
+|---|---|
+| ASTAP `astap_cli`, 5 deg hint | **162 ms** |
+| `tianwen` AOT, same 5 deg hint | **1158 ms** |
+| `tianwen` AOT, blind | 1203 ms |
+| `tianwen` via `dotnet run`, blind | 2412 ms |
+
+Read two things off that before optimising anything. **AOT is half the story**: 2412 -> 1203 ms is
+pure managed startup, and the shipped artifact is the AOT one, so 1.2 s is the honest user-facing
+number. And **a hint buys us only 45 ms**, so the remaining 7.1x is structural, not an artifact of
+how the two were invoked. (An earlier comparison was invalid because ASTAP was hinted and ours was
+not; that is why the hinted row exists at all.)
+
+The 1158 ms decomposes:
+
+| stage | time | share |
+|---|---|---|
+| fixed init (Tycho-2 bulk decode dominant) | ~590 ms | 51% |
+| matching iterations | 446 ms | 39% |
+| star detection (1600 stars, 4164x2795) | 83 ms | 7% |
+| catalog query (2694 stars, R=4.04 deg) | 54 ms | 5% |
+
+## What ASTAP does differently
+
+From `C:/temp/astap/command-line_version/unit_command_line_solving.pas`. Four decisions, each
+mapping onto one phase below.
+
+1. **Bin before detecting.** `report_binning` returns 2 when image height exceeds 2500 px. Our
+   frames are 2795 high, so ASTAP detects on 2082x1397: a quarter of the pixels.
+2. **Cap the star list hard.** `get_brightest_stars(max_stars {500}, ...)`. It solved this field
+   from 527 stars where we carry 1600 into matching.
+3. **Match scale-invariant quad DESCRIPTORS, not positions.** `find_quads` stores six values per
+   quad: index 0 the longest side, indices 1..5 the other five distances *scaled to it*.
+   `find_fit` is a double loop over ~409 image quads x ~275 database quads of five cheap `abs`
+   compares with early-out: about 110k comparisons, once.
+4. **Derive scale from the match.** The median longest-side ratio over matching quads IS the plate
+   scale, with outlier rejection on that ratio. The header focal length is never trusted.
+
+Ours runs a pair-RANSAC seed (up to 916k hypotheses on the parity that does not lock) and then an
+O(n^2) proximity loop of 1600 detected x ~2000 projected, ~3.2M distance computations **per
+iteration, times four iterations, times two parities**. That is the gap: ASTAP does ~110k cheap
+comparisons once; we do millions, repeatedly.
+
+**We already own a quad matcher.** `FrameRegistration.TryMatchAsync` and
+`SortedStarList.FindQuadsAsync` do exactly this for frame-to-frame stacking registration (the
+`--quad-stars` knob). It has never been pointed at the catalog side.
+
+## Phases
+
+Ordered by return per unit of risk; each independently shippable and measurable.
+
+| # | change | expected | risk |
+|---|---|---|---|
+| A | Short-circuit the losing parity | -200 ms | low |
+| B | Tycho-2 pre-baked region index (TODO 2C) | -500 ms | low |
+| C | Quad-descriptor matching against the catalog | -300 ms | medium |
+| D | Bin before detection, cap the star list | -60 ms | low |
+
+Target after all four: **~200 ms**, against ASTAP's 162 ms.
+
+### A. Short-circuit the losing parity
+
+Both parities run as `Task.Run` siblings and the loser is pure waste: on frame 0018 the correct
+parity locked after **32,179 hypotheses** while the wrong one ground through **915,994**, twice
+(anchor margin 0% and 10%). Cancel the sibling once one seeds with consensus far above chance.
+This is the only phase that helps the FIRST solve of a session, which is why it leads.
+
+Parity can also be carried rather than rediscovered, and `WCS.HasCDMatrix` plus
+`sign(CD1_1*CD2_2 - CD1_2*CD2_1)` IS the parity. `searchOrigin` is already a parameter on
+`SolveFileAsync` / `SolveImageAsync`, and today a hint is used for POSITION only while its
+orientation is discarded. A header hint carries no CD matrix (the probe prints `hasCD=False`), so
+this pays off only where a caller feeds back a previous solve, which `IncrementalSolver` and the
+polar-align loop already do.
+
+**Cache it per CAMERA, never per rig or per OTA.** Parity is set by the number of reflections in
+that camera's own light path, and an off-axis guider inserts one: its pick-off prism is a single
+reflection before the imaging plane, so on a refractor + OAG the main camera is even-parity and the
+guide camera is ODD -- opposite parity, same rig, at the same time. This is not hypothetical here:
+the polar-align loop solves GUIDER frames while the session solves IMAGING frames, so one cached
+parity per rig would be actively wrong for one of them. Key it by camera device id, the way
+per-focuser backlash is keyed in `Profiles/BacklashHistory/`.
+
+**Do not try to infer parity from the declared optical train.** Counting reflections is
+insufficient even in principle, because FITS ROW ORDER contributes: a `BOTTOM-UP` frame read as
+`TOP-DOWN` is a vertical flip, i.e. a parity change with no mirror anywhere in the optics.
+Conventions differ across capture software. Learning parity from the first successful solve
+captures optics and convention together, needs no user declaration, and is self-correcting.
+
+**Parity stays a hint, never a constraint.** A stale cached parity (someone added a diagonal, moved
+the camera to the OAG port, changed capture software) must not turn a solvable frame into a
+permanent failure. Skip the other branch speculatively; fall back to trying both on failure. That
+costs nothing in the common case and stays correct in the rare one.
+
+### B. Tycho-2 pre-baked region index
+
+Half the wall clock is init, and it is one known item: `TODO.md` "Catalog cold-start Phase 2", where
+2A (`hd_hip_cross.bin.gz`) and 2B (`simbad_merge.bin.gz`) shipped and **2C, the Tycho-2 bulk load,
+is deferred**. ASTAP never pays this: its `.1476` files are indexed by sky region and it reads only
+the window it needs (342 database stars for this field). This measurement is the argument for doing
+2C -- largest single line item, already scoped.
+
+### C. Quad-descriptor matching against the catalog
+
+The substantive one. Build quads from the top-K detected stars (existing machinery), build quads
+from the catalog window, match on the five scaled distances, take the plate scale from the median
+longest-side ratio. This replaces the iterative proximity loop and also removes our dependence on
+the header scale -- right independently of speed, since `FOCALLEN` was 1.2% wrong on this rig
+(205 mm nominal against a solved 202.4 mm) and is only ever a hint.
+
+Keep the pair-RANSAC seed: it is what makes dense fields work (see the Vela notes) and it is cheap
+once phase A stops paying for its losing parity. The quad path replaces the REFINEMENT loop, not
+the seed.
+
+### D. Bin before detection, cap the star list
+
+Follow `report_binning`: bin 2x above ~2500 px height, and cap the list carried into matching at
+~500 brightest. A `detectionScale` downsample path already exists but is gated on a target pixel
+scale, and at 4.66"/px it does not trigger -- a height-based rule is the missing half. Smallest of
+the four, listed because it is nearly free.
+
+## Correctness gates
+
+Speed that costs accuracy is a regression, so every phase is measured against the same oracles.
+
+1. **`VelaMosaicFieldTests`** -- 24 real pointings / 96 frames / 78k catalog stars with
+   gate-verified WCS as ground truth, including 106 overlapping and 272 disjoint panel pairs. The
+   disjoint pairs are the negative case: none may start locking.
+2. **This comet field** -- 10 of 10 frames, plate scale within 4.7160-4.7180 (ASTAP: 4.7172 +/-
+   0.0013), SIP rms 0.11 px at order 3, and the 135-frame master solving blind at 457/1680.
+3. **The acceptance gate stays exactly as strict.** It behaved correctly throughout: it refused a
+   27.75 px fit rather than emit a wrong WCS. Nothing here may loosen `GateTolerancePx` or the
+   chance threshold to make a number look better.
+
+Add `PlateSolveBenchmarks` to `TianWen.UI.Benchmarks` so these figures stop being hand-timed wall
+clock. Everything above was measured by hand: fine for deciding what to do, not fine for detecting
+a regression.
+
+## Explicitly not in scope
+
+Matching 162 ms exactly. ASTAP is a mature dedicated solver with its own on-disk catalog format;
+the goal is to stop being 7x slower, not to win. Phases A and B alone reach roughly 460 ms with no
+algorithmic risk, which is already the difference between "noticeable" and "unnoticed" in a session
+that solves once per target.

--- a/docs/plans/plate-solver-performance.md
+++ b/docs/plans/plate-solver-performance.md
@@ -77,12 +77,12 @@ comparisons once; we do millions, repeatedly.
 
 Ordered by return per unit of risk; each independently shippable and measurable.
 
-| # | change | expected | risk |
-|---|---|---|---|
-| A | Short-circuit the losing parity | -200 ms | low |
-| B | Tycho-2 pre-baked region index (TODO 2C) | -500 ms | low |
-| C | Quad-descriptor matching against the catalog | -300 ms | medium |
-| D | Cap the star list (bin only if sampling allows) | -60 ms | low / see D |
+| # | change | saves | costs accuracy? | risk |
+|---|---|---|---|---|
+| A | Cancel the losing parity (916k wasted hypotheses) | ~200 ms | nothing | low |
+| B | Tycho-2 pre-baked region index -- this is TODO 2C, now justified | ~500 ms | nothing | low |
+| C | Quad-descriptor matching, reusing `FrameRegistration`'s existing matcher | ~300 ms | nothing, and it *removes* our reliance on `FOCALLEN` | medium |
+| D | Cap the star list to ~500 -> yes; bin -> **no** | ~60 ms | binning does, so it is gated on measured FWHM and default off | low |
 
 Target after A-C: **~260 ms**, against ASTAP's 162 ms. D is optional and mostly will not apply
 (see below), so it is not counted on.

--- a/docs/plans/plate-solver-performance.md
+++ b/docs/plans/plate-solver-performance.md
@@ -1,7 +1,18 @@
 # Plate-solver performance: closing the gap to ASTAP
 
-Status: PLANNED. The correctness work is done and shipped; everything below is performance only,
-and must not cost a single solve.
+Status: PLANNED. The correctness work is done and shipped; everything below is performance only.
+
+## The governing rule
+
+**Optimise only where it is provably free of accuracy cost. Where it is not, take the slower path
+and say so.** A plate solve here is not a yes/no answer, it is a MEASUREMENT: the comet
+ephemeris-to-pixel conversion, the polar-alignment error vector and mosaic panel placement all
+consume the WCS quantitatively. ASTAP is free to trade centroid precision for speed because
+"solved" is its whole output; we are not.
+
+That distinction has teeth. ASTAP binned this very field 2x and solved it fine -- and we
+deliberately will not (see phase D). Every phase below therefore states what it costs accuracy,
+and the answer has to be "nothing" before it ships.
 
 ## Where this came from
 
@@ -71,9 +82,10 @@ Ordered by return per unit of risk; each independently shippable and measurable.
 | A | Short-circuit the losing parity | -200 ms | low |
 | B | Tycho-2 pre-baked region index (TODO 2C) | -500 ms | low |
 | C | Quad-descriptor matching against the catalog | -300 ms | medium |
-| D | Bin before detection, cap the star list | -60 ms | low |
+| D | Cap the star list (bin only if sampling allows) | -60 ms | low / see D |
 
-Target after all four: **~200 ms**, against ASTAP's 162 ms.
+Target after A-C: **~260 ms**, against ASTAP's 162 ms. D is optional and mostly will not apply
+(see below), so it is not counted on.
 
 ### A. Short-circuit the losing parity
 
@@ -128,12 +140,31 @@ Keep the pair-RANSAC seed: it is what makes dense fields work (see the Vela note
 once phase A stops paying for its losing parity. The quad path replaces the REFINEMENT loop, not
 the seed.
 
-### D. Bin before detection, cap the star list
+### D. Cap the star list; bin ONLY where sampling allows it
 
-Follow `report_binning`: bin 2x above ~2500 px height, and cap the list carried into matching at
-~500 brightest. A `detectionScale` downsample path already exists but is gated on a target pixel
-scale, and at 4.66"/px it does not trigger -- a height-based rule is the missing half. Smallest of
-the four, listed because it is nearly free.
+Two halves with very different risk, and they must not be conflated.
+
+**Cap the star list: do it.** Carry ~500 brightest into matching instead of 1600. This costs no
+accuracy at all -- the discarded stars are the faintest, they are not what a fit is anchored on, and
+ASTAP solves this field from 527. Phase C makes this mostly moot anyway, since quad matching is
+driven off the top-K.
+
+**Bin before detection: NO, not on this class of frame, and not on ASTAP's rule.**
+`report_binning` gates on image HEIGHT (> 2500 px -> bin 2). Height is the wrong variable: it is a
+proxy for "big sensor, therefore probably oversampled", and this rig breaks the proxy. Measured on
+frame 0018, median star **FWHM = 2.15 px** (10.16" at 4.7172"/px; HFD 2.65 px, from
+`solve --export-stars`). That is already AT critical sampling, so binning 2x lands at 1.08 px FWHM
+-- below Nyquist. The cost is not a slightly softer centroid, it is aliasing, and a 1 px FWHM star
+stops being reliably separable from a hot pixel. Our unbinned SIP rms is 0.11 px (0.52"); that is
+the number downstream consumers are relying on.
+
+So if this is done at all, gate it on MEASURED sampling rather than on frame size: bin only while
+the binned FWHM stays comfortably above Nyquist, i.e. roughly FWHM >= 4 px before binning. A
+0.5"/px setup in 3" seeing (FWHM ~6 px) can bin to 3 px for free; this field cannot bin at all.
+Detection already measures FWHM/HFD, so the input is in hand.
+
+Default OFF, and skip the whole phase if phases A-C land the budget. It is the smallest win of the
+four and the only one that can cost accuracy.
 
 ## Correctness gates
 

--- a/src/TianWen.Lib.Tests/UnitScaleClassificationTests.cs
+++ b/src/TianWen.Lib.Tests/UnitScaleClassificationTests.cs
@@ -110,14 +110,44 @@ public class UnitScaleClassificationTests
         overshoot.Count.ShouldBe(clean.Count);
     }
 
+    [Fact]
+    public async Task AnIntegratedMastersSaturatedCoresDoNotEmptyTheStarList()
+    {
+        var ct = TestContext.Current.CancellationToken;
+
+        // 1.025 is not decode noise, it is what a real 135-frame stack measured: saturated star cores
+        // sit at the top of the scale and per-frame normalisation lifts them a little past one. The
+        // old 1e-3 bound called that ADU, so the histogram binned [0,1] data at face value, Background
+        // reported 0, and FindStarsAsync returned an empty list -- which surfaced only as the stacking
+        // pipeline's plate solve failing with a warning and no WCS.
+        var master = Build(blueOutlier: 1.025f);
+        master.MaxValue.ShouldBeGreaterThan(1.0f, "the fixture must actually exceed one");
+        master.HasUnitScalePeak.ShouldBeTrue("a 2.5% overshoot is still unit-referred, not ADU");
+
+        var clean = await Build(blueOutlier: Sky).FindStarsAsync(
+            channel: 0, snrMin: 10f, maxStars: 2000, cancellationToken: ct);
+        var stars = await master.FindStarsAsync(
+            channel: 0, snrMin: 10f, maxStars: 2000, cancellationToken: ct);
+
+        stars.Count.ShouldBe(clean.Count);
+    }
+
     [Theory]
     // Unit-referred: at one, a hair over from decode noise, and comfortably under.
     [InlineData(1.0f, true)]
     [InlineData(1.0000018f, true)]
     [InlineData(0.4f, true)]
-    // The tolerance band's far edge, and just past it.
+    // Flat-division overshoot on a real integrated master: a saturated pixel normalises to exactly
+    // 1.0, and dividing it by a vignetted flat below one must exceed one. Measured 1.025 on a
+    // 135-frame stack, at saturated stars off axis (flat 0.949 there, 1.018 at the centre where
+    // nothing overshoots). Classifying that as ADU emptied the star list on re-read.
     [InlineData(1.0009f, true)]
-    [InlineData(1.01f, false)]
+    [InlineData(1.01f, true)]
+    [InlineData(1.025f, true)]
+    // The band's far edge, and past it. 2.0 is two orders of magnitude below the nearest competing
+    // scale, so the bound can be this generous without ever mistaking 8-bit data for unit-referred.
+    [InlineData(2.0f, true)]
+    [InlineData(2.5f, false)]
     // ADU scale, which must keep binning at face value.
     [InlineData(255f, false)]
     [InlineData(65535f, false)]

--- a/src/TianWen.Lib/Astrometry/PlateSolve/CatalogPlateSolver.cs
+++ b/src/TianWen.Lib/Astrometry/PlateSolve/CatalogPlateSolver.cs
@@ -69,6 +69,17 @@ internal sealed class CatalogPlateSolver(ICelestialObjectDB db, ILogger logger) 
     private const double GateTolerancePx = 3.0;
 
     /// <summary>
+    /// How many rungs of the proximity-match tolerance schedule a successful pair-lock seed skips.
+    /// </summary>
+    /// <remarks>
+    /// The seed verifies its transform at <c>PairRansacLock</c>'s 4 px radius across the whole frame,
+    /// so the first rung it justifies is the 0.3%-of-diagonal one (15 px on a 4164x2795 field) rather
+    /// than the blind 10% rung (229 px). Three rungs, not more: the point is to enter the loop at a
+    /// tolerance the seed has earned, while still leaving the loop room to tighten.
+    /// </remarks>
+    private const int SeededToleranceRungOffset = 3;
+
+    /// <summary>
     /// Acceptance-gate sample: the brightest N detected stars. Kept to the bright end where
     /// Tycho-2 is complete, so every genuine detected star in the sample has a catalog
     /// counterpart and a real solve scores near 100%.
@@ -485,6 +496,7 @@ internal sealed class CatalogPlateSolver(ICelestialObjectDB db, ILogger logger) 
         // frame edges of any field rotated more than ~0.1 degrees, because projections are
         // axis-aligned and rotation only ever lived in the final CD matrix.
         Matrix3x2? lastFitted = null;
+        var seeded = false;
 
         // Geometric pair-lock seed (see PairRansacLock): locks translation + rotation + scale
         // from bright-pair hypotheses verified against the whole detected field, immune to the
@@ -509,6 +521,7 @@ internal sealed class CatalogPlateSolver(ICelestialObjectDB db, ILogger logger) 
                 lastMinv = seedInv;
                 hasMinv = true;
                 lastFitted = locked.Transform;
+                seeded = true;
             }
         }
 
@@ -557,7 +570,21 @@ internal sealed class CatalogPlateSolver(ICelestialObjectDB db, ILogger logger) 
             // stars) from overlapping multiple catalog candidates per detection.
             var diagonal = Math.Sqrt(dim.Width * dim.Width + dim.Height * dim.Height);
             var avgSpacing = Math.Sqrt((double)dim.Width * dim.Height / Math.Max(projected.Count, 1));
-            var diagFraction = iteration switch
+
+            // A pair-lock seed has ALREADY verified this WCS to within PairRansacLock's 4 px verify
+            // radius over the whole field, so the coarse rungs below do not apply to it. They exist
+            // for the blind case the schedule was written for ("mount pointing may be 45deg off"),
+            // and re-opening the tolerance to 10% of the diagonal after a lock does not add slack, it
+            // adds AMBIGUITY: on a 4164x2795 field the rung is 229 px while mean star spacing is only
+            // 76 px, so several catalog stars sit inside tolerance for every detection, the affine fit
+            // is pulled onto the wrong ones, and the WCS walks away from the seed. Measured on a
+            // 5.4 deg 4.72"/px frame: the seed locked at consensus 101/160 (chance 1.1) and the loop
+            // still ended at 27.75 px rms on 620 pairs, whereupon iteration 3's tighter rung found
+            // almost nothing, tripped the divergence floor, and rolled back to that loose set -- the
+            // exact rollback the comment on divergeFloor below describes. The gate then rejected a
+            // field ASTAP solves every time.
+            var toleranceIteration = seeded ? iteration + SeededToleranceRungOffset : iteration;
+            var diagFraction = toleranceIteration switch
             {
                 0 => 0.10,
                 1 => 0.03,
@@ -565,7 +592,7 @@ internal sealed class CatalogPlateSolver(ICelestialObjectDB db, ILogger logger) 
                 3 => 0.003,
                 _ => 0.001,
             };
-            var spacingFraction = iteration == 0 ? 3.0 : iteration == 1 ? 2.0 : iteration == 2 ? 1.0 : 0.5;
+            var spacingFraction = toleranceIteration == 0 ? 3.0 : toleranceIteration == 1 ? 2.0 : toleranceIteration == 2 ? 1.0 : 0.5;
             var matchTolerance = (float)Math.Min(diagonal * diagFraction, avgSpacing * spacingFraction);
 
             // In dense fields (>500 projected), limit early iterations to brightest

--- a/src/TianWen.Lib/Imaging/Image.Fits.cs
+++ b/src/TianWen.Lib/Imaging/Image.Fits.cs
@@ -917,8 +917,8 @@ public partial class Image
         AddHeaderValueIfHasValue("SITELONG", imageMeta.Longitude, "degrees");
         if (!double.IsNaN(imageMeta.TargetRA) && !double.IsNaN(imageMeta.TargetDec))
         {
-            AddHeaderValueIfHasValue("OBJCTRA", Astrometry.CoordinateUtils.HoursToHMS(imageMeta.TargetRA, ' '), "");
-            AddHeaderValueIfHasValue("OBJCTDEC", Astrometry.CoordinateUtils.DegreesToDMS(imageMeta.TargetDec, degreeSign: ' '), "");
+            AddHeaderValueIfHasValue("OBJCTRA", Astrometry.CoordinateUtils.HoursToHMS(imageMeta.TargetRA, ' ', minuteSeparator: ' '), "");
+            AddHeaderValueIfHasValue("OBJCTDEC", Astrometry.CoordinateUtils.DegreesToDMS(imageMeta.TargetDec, degreeSign: ' ', arcMinuteSign: ' '), "");
             AddHeaderValueIfHasValue("RA", imageMeta.TargetRA * 15.0, "degrees");
             AddHeaderValueIfHasValue("DEC", imageMeta.TargetDec, "degrees");
         }

--- a/src/TianWen.Lib/Imaging/Image.cs
+++ b/src/TianWen.Lib/Imaging/Image.cs
@@ -858,14 +858,32 @@ public partial class Image(ImmutableArray<Channel> initialChannels, BitDepth bit
     /// How far above 1.0 a peak may sit and still count as unit-referred.
     /// </summary>
     /// <remarks>
-    /// A tolerance is required, not merely nice: the exact maximum is not a property of the SCALE, it
-    /// is one pixel. A quantized <c>.fz</c> decode is 1-ulp noisy, so a master written normalised reads
-    /// back a hair over one -- and on the frame that exposed this, exactly ONE pixel of 24.9 million
-    /// exceeded 1.0, by 15 ulps, in the BLUE channel, while <see cref="MaxValue"/> is image-wide, so it
-    /// changed how the RED channel was measured. This bound sits four orders of magnitude above that
-    /// noise and five below the nearest competing scale (8-bit, 255), so it cannot confuse the two.
+    /// <para>A tolerance is required, not merely nice: the exact maximum is not a property of the
+    /// SCALE, it is one pixel. A quantized <c>.fz</c> decode is 1-ulp noisy, so a master written
+    /// normalised reads back a hair over one -- and on the frame that exposed this, exactly ONE pixel
+    /// of 24.9 million exceeded 1.0, by 15 ulps, in the BLUE channel, while <see cref="MaxValue"/> is
+    /// image-wide, so it changed how the RED channel was measured.</para>
+    /// <para>Decode noise is NOT the only way a unit-referred frame overshoots, which is what a
+    /// 1e-3 bound got wrong, and the other way is arithmetic rather than noise: FLAT DIVISION. A
+    /// saturated pixel normalises to exactly 1.0, and dividing it by a normalised flat that sits
+    /// BELOW one -- which is what vignetting means -- must land above one. So every saturated star
+    /// off the optical axis exceeds unit scale by construction, and the ceiling is
+    /// <c>1 / min(flat)</c>.</para>
+    /// <para>Measured on a 135-frame 10P/Tempel stack (QHY294C, SV 545 at f/4.5): 45 samples of 12.1
+    /// million reached 1.025, twenty-five times the old bound. Each sits at a saturated star well off
+    /// axis -- flat 0.9591 at (4095,1485) gives 1.0427, flat 0.9487 at (71,2303) gives 1.0541 --
+    /// while the same arithmetic at the field centre (flat 1.0183) yields 0.9820 and overshoots
+    /// nothing. Read back from disk that master was classified ADU, so the histogram binned [0,1]
+    /// data at face value and <c>FindStarsAsync</c> returned NO stars.</para>
+    /// <para>So the bound is a factor, not an epsilon: anything at or under 2.0 is unit-referred.
+    /// Real vignetting reaches perhaps 30-40%, i.e. an overshoot ceiling near 1.4-1.7, and 2.0 is two
+    /// orders of magnitude below the nearest competing scale (8-bit, 255) -- so it covers the physics
+    /// without ever mistaking one scale for the other, while a float image carrying real ADU peaks in
+    /// the thousands and is nowhere near it. It is a bound and not a guarantee: a pathological flat
+    /// (this one dips to 0.0218 in an unilluminated corner, implying 45.96) could still exceed it, so
+    /// a producer must not rely on this to launder an unnormalised frame.</para>
     /// </remarks>
-    private const float UnitScaleTolerance = 1e-3f;
+    private const float UnitScaleTolerance = 1.0f;
 
     /// <summary>
     /// Is the peak at or near 1.0 -- i.e. are the samples unit-referred rather than ADU?


### PR DESCRIPTION
Two fixes and a plan, all found by putting a real 135-frame comet dataset (QHY294C, SV 545, IDAS D3, 5.4 deg field at 4.72"/px) through `tianwen solve` and `tianwen stack`.

## fix(astrometry): a seeded solve must not re-open the blind match tolerance

The headline bug. `CatalogPlateSolver` failed on **4 of 10** frames that ASTAP solves 10 of 10, and the failure was not in the seed.

`PairRansacLock` guarantees its transform to within `verifyRadiusPx = 4f`, and the probe confirmed it seeded cleanly: consensus 101 of 160 anchors, chance 1.1. The refinement loop then threw that away, because it always starts its proximity-match tolerance at iteration 0 -- a diagonal fraction of 0.10, which on a 5.4 deg frame is a **229 px** match radius where mean star spacing is 76 px. So the fit re-associated stars essentially at random, landed at 27.75 px rms with a near-identity affine, and clipping kept 620 of 620 pairs because at that tolerance nothing looks like an outlier.

The acceptance gate did its job and refused to emit a wrong WCS, which is why this surfaced as "fails to solve" rather than as bad astrometry.

Fix: a seeded solve enters the tolerance schedule three rungs in, since the seed has already delivered better than the first three rungs promise. A blind solve is untouched, and neither the gate nor the chance threshold moves.

| | before | after |
|---|---|---|
| frames solved | 6/10 | **10/10** |
| plate scale spread | 1.2% | **0.04%** |
| SIP rms | 27.75 px | **0.11 px** |
| 135-frame master, blind | failed | 457/1680 stars |

## fix(imaging): a flat-divided saturated star is still unit-referred

Two silent bugs in one commit.

**`UnitScaleTolerance` was an epsilon where it needed to be a factor.** At `1e-3` it was sized for decode noise (the case on record: one pixel in 24.9 million over 1.0 by 15 ulps from a quantized .fz decode). But a unit-referred frame overshoots for a purely arithmetic reason and by far more: a saturated pixel normalises to exactly 1.0, and dividing by a normalised flat below one -- which is what vignetting means -- must land above one. Every saturated star off the optical axis therefore exceeds unit scale by construction.

Measured on this stack: 45 samples of 12.1 million reached 1.025, twenty-five times the old bound, and the flat explains each one (0.9591 at (4095,1485) gives 1.0427) while the same arithmetic at the field centre overshoots nothing. Read back from disk, that master classified as ADU, so the histogram binned [0,1] data at face value, `Background` reported 0, and `FindStarsAsync` returned **no stars** where the same pixels clipped to 1.0 give 1620 and solve.

The bound is now 2.0. Real vignetting reaches 30-40% (overshoot 1.4-1.7) and 2.0 is still two orders of magnitude below the nearest competing scale. It is a bound and not a guarantee, and the remark says so: this flat dips to 0.0218 in an unilluminated corner, so a producer must not use this to launder an unnormalised frame.

**The `OBJCTRA`/`OBJCTDEC` writer emitted a mixed form no convention describes.** `HoursToHMS` and `DegreesToDMS` each take *two* separators defaulting to a colon, and the call sites passed only the first, so we wrote `22 08:26`. Our own readers survive it by accident (the split uses `RemoveEmptyEntries`, so `22:08::26` still parses), which is exactly why it went unnoticed; an external consumer has no such luck. This matters because `OBJCTRA` is the keyword that describes the frame, where `RA`/`DEC` is only what the mount reported.

## docs: docs/plans/plate-solver-performance.md

Measuring the solver fix turned up a 7x gap to ASTAP that deserved a plan rather than an opportunistic commit. AOT `tianwen solve` is 1158 ms against ASTAP's 162 ms on the same frame with the same hint; half of ours is fixed init (Tycho-2 bulk decode) and 39% is the proximity-match loop. A hint buys us only 45 ms, so the gap is structural rather than an artifact of how the two were invoked.

Four phases, targeting ~260 ms from A-C: cancel the losing parity (916k wasted hypotheses on frame 0018 against 32k on the winner), the deferred Tycho-2 region index (this is TODO 2C, now with a number attached), quad-descriptor matching against the catalog reusing the matcher `FrameRegistration` already has, and a star-list cap.

The plan opens with the rule it is written under: **optimise only where it is provably free of accuracy cost.** A plate solve here is a measurement, not a yes/no answer -- the comet ephemeris-to-pixel step, the polar-alignment error vector and mosaic panel placement all consume the WCS quantitatively, where "solved" is ASTAP's entire output. So binning is deliberately refused on this class of frame even though ASTAP binned this very field 2x and solved it fine: measured median FWHM is 2.15 px, already at critical sampling, and 2x puts it below Nyquist. If binning ships at all it is gated on measured FWHM, not on ASTAP's frame-height proxy.

Two details in the parity phase that changed the design. Parity is cached **per camera**, never per rig: an OAG's pick-off prism is one reflection, so on a refractor the main camera is even-parity and the guide camera is odd, on the same rig at the same time -- and TianWen solves both, since polar-align uses guider frames. And parity cannot be inferred from the declared optics, because FITS `ROWORDER` contributes a flip with no mirror anywhere. It stays a hint and never a constraint, so a stale value cannot turn a solvable frame into a permanent failure.

Phase C has upside beyond speed: taking plate scale from the median quad-side ratio means we stop trusting `FOCALLEN`, which on this rig is 205 mm nominal against 202.4 mm solved.

## Verification

- 4830 unit + 338 functional tests green locally, including `VelaMosaicFieldTests` (24 real pointings, 96 frames, 78k catalog stars, 272 disjoint panel pairs that must never start locking).
- `UnitScaleClassificationTests` re-pinned around the new bound, plus `AnIntegratedMastersSaturatedCoresDoNotEmptyTheStarList` for the regression that motivated it.
- 0 warnings.
