### PR TITLE
Viewer GPU-lifetime hardening: device-loss + swapchain fixes, SPCC toggle, Auto stretch

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1753,6 +1753,17 @@ set a pending frame holds may not be written. `VkTexture.Dispose` defers too. Ne
 object a frame may have bound directly again, and never write a single shared descriptor set from an
 upload path; the renderer's `docs/deferred-destroy-adoption.md` is the how-to.
 
+**A window resize is a distinct GPU-lifetime path from a document swap, and is validated separately.**
+Drive maximize/restore, not just file loads. The swapchain-teardown race a resize exposes was invisible
+to the viewer's file-load validation and surfaced only under GUI resize testing: `RecreateSwapchain`
+destroyed the swapchain and its per-image present semaphores while `vkQueuePresentKHR` was still in
+flight, because the bounded fence drain (`TryDrainDevice`) only ever waited on the graphics-SUBMIT
+fences and present is gated by no fence. 10 messages over 5 recreations
+(VUID-vkDestroySwapchainKHR-swapchain-01282 / VUID-vkDestroySemaphore-semaphore-05149); benign on
+desktop NVIDIA, a rejected `vkQueueSubmit` on Adreno. Fixed in **SdlVulkan.Renderer 7.29**
+(`FlushPresentQueueAfterDrain`: a `vkQueueWaitIdle` after a *successful* drain, skipped on a wedged-GPU
+drain timeout so the no-hang-on-resize property `TryDrainDevice` exists for still holds).
+
 **The cached image layer samples in TEXTURE space, and a fixed-capacity target is not the size you
 asked for this frame.** `VulkanContext.CachedLayer` allocates once and answers any smaller request out
 of the same texture, so after the pane shrinks the layer occupies the top-left of something larger; UVs

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1724,6 +1724,28 @@ the common case where the bar runs through the middle of the handle, and
 `static TrackFrac(RectF32, px)` (the cursor-X -> fraction drag math). A new track-style control calls
 these; never re-triplicate the bar/fill/handle/clamp math.
 
+**A document may change only BETWEEN frames, and its textures are uploaded in `PrepareFrame`, before
+anything in the frame samples them.** A swap recreates the channel textures, and the recreate destroys
+the old views after draining PRIOR frames; it cannot un-record what THIS frame's command buffer already
+holds. The upload used to run from each host's render callback (`Program.cs` `OnRender`, `GuiderTab`,
+`LiveSessionTab`, `VkPlanetaryTab`), AFTER the cached-layer pre-pass had bound the old views: the frame
+went to the GPU with a dangling view and the GPU faulted. That is the `nvlddmkm 153` pair plus
+`LiveKernelEvent 141` watchdog that killed the Store viewer on 2026-08-27 (two loads of differently
+sized files 1.3 s apart), reproduced at HEAD under `SDLVK_VALIDATION=1` as
+"`vkCmdBindDescriptorSets(): ... invalid state ... VkImageView was destroyed`" followed by
+`VK_ERROR_DEVICE_LOST`, with the same driver signature to the second. The standalone host also SWAPPED
+the document inside `OnRender` (completions, file request, enhance result); those steps now run in
+`loop.OnBeforeFrame`, before `BeginFrame`, and a swap forces full damage there. Never call
+`UploadDocumentTextures` from a render callback again; `PrepareFrame` is the one path. Pinned by
+`ANewDocumentIsUploadedBeforeTheLayerPassThatSamplesIt`. Two more things the validation round found:
+the earlier `nvlddmkm 153`s this month were TianWen GPU benchmarks (08-09) and the sleep transition
+(08-23/24), not the driver at rest; and the damage pass's `loadOp LOAD` needed COLOR_ATTACHMENT_READ on
+the SHARED external dependency (SdlVulkan.Renderer `FillSubpassDependencies`), shared because
+dependencies are not exempt from render-pass compatibility (widening only the LOAD pass tripped VUID
+00904/02684 on every partial frame). **Run the viewer under `SDLVK_VALIDATION=1 SDLVK_SYNC_VALIDATION=1`
+and read `validation_report` after driving it** whenever GPU resource lifetime is touched; that is what
+turned a watchdog dump into a named line of code.
+
 **The cached image layer samples in TEXTURE space, and a fixed-capacity target is not the size you
 asked for this frame.** `VulkanContext.CachedLayer` allocates once and answers any smaller request out
 of the same texture, so after the pane shrinks the layer occupies the top-left of something larger; UVs

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1905,6 +1905,21 @@ are in the same coordinate space. `ConvergeStretchFactor` takes a `whiteBalance`
 operates entirely in post-WB space (median, mad, binNorm all multiplied) so the converged
 stretchFactor matches the per-channel rendering.
 
+**The SPCC / Calibrate toggle gates the RENDER, not the measurement, and an enhance INHERITS the
+calibration rather than re-fitting it.** `ComputeStretchUniforms` and `ComputeBackgroundNeutralization`
+take `applyColorCalibration` (from `state.ColorCalibrationEnabled`): false renders as if no auto triple
+existed while `AstroImageDocument.ColorCalibration` keeps holding it, so toggling off shows the raw
+frame and toggling on restores the exact render with no re-fit. It used to gate only the toolbar
+highlight and the manual-WB stash, so "turning SPCC off" and pressing W changed nothing on screen. Two
+things ride with it: **W is a toggle** (`SetColorCalibrationEnabled(!enabled)` then
+`TryStartColorCalibration`), not start-only, or it is a no-op on an already-calibrated document; and the
+AI enhance calls `AstroImageDocument.InheritColorCalibration(original)`, because the enhanced raster has
+its own star list and the auto-retrigger would re-fit SPCC on deconvolved/denoised pixels and land a
+different triple, so a calibrated frame took on a NEW cast a moment after the enhance landed (the "adds
+another colour cast" report). Only the WB triple is inherited; background neutralisation is re-solved
+per document, since an enhanced background genuinely differs (the same share-only-the-WB rule the
+stacking plates follow). Pinned by `ColorCalibrationToggleTests`.
+
 **Two WB facts the viewer's manual WB sliders depend on (don't regress):** (1) The stat scaling only
 makes sense for the AUTO calibration (`ColorCalibration`); its whole job is to keep the background
 neutral. A MANUAL WB multiplier that ALSO scaled the stats would be cancelled by a per-channel

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1878,9 +1878,23 @@ only place the distinction exists and the only place it can silently collapse. *
 curve into all three slots**, derived from the mean of the per-channel WB-applied medians and MADs
 (PI's and Siril's linked STF), so a white balance survives as colour. **Unlinked writes each channel's
 own auto-normalised curve**, which absorbs the auto calibration and neutralises the background -- that
-is what the mode is FOR, not a bug. `ViewerActions.DefaultStretchMode` (= `StretchLinkModes[0]` =
-Linked) is the single source for every default; `MasterPreviewRenderer` and `PreviewEncoder` both
-render Linked.
+is what the mode is FOR, not a bug. `ViewerActions.DefaultStretchMode` (= `StretchLinkModes[0]`) is the
+single source for every VIEWER default and is **`StretchMode.Auto`**; `MasterPreviewRenderer` and
+`PreviewEncoder` still render **Linked explicitly** (a baked master carries its calibration, so there is
+nothing to resolve per frame).
+
+**`StretchMode.Auto` is a UI intent, resolved to a concrete mode before any `StretchUniforms` is built,
+never a shader mode.** It is LAST in the enum so the shader's numeric values for None/Linked/Unlinked/Luma
+are unchanged, and `StretchSolver` maps a stray Auto to Linked as a backstop. Resolution is the pure
+extension `mode.ResolveAuto(isColour, calibrationActive)` (`ViewerActions`): colour + a calibration being
+applied -> Linked (the WB shows as colour); colour without one -> Unlinked (each channel's background
+neutralises, no cast asserted); mono -> Linked. The two producers resolve it with what only they know --
+`AstroImageDocument` from its channels and `autoWb is not null` (which already honours the SPCC toggle),
+`LiveFramePreviewSource` from channel count with no calibration. So running SPCC on an Auto frame flips it
+to Linked on its own, which is the decision the user otherwise made by hand. The StretchLink button names
+what Auto resolved to ("Auto (Linked)"). Pinned by `ColorCalibrationToggleTests` +
+`ViewerActionsTests.DefaultStretchMode_IsAuto`. A test or renderer that needs a fixed curve passes an
+explicit mode, never Auto.
 
 Linked used to replicate channel 0's *stats* and scale each copy by that channel's own multiplier,
 giving three curves whose anchors tracked the multipliers and divided them back out: a WB had **no

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1744,7 +1744,14 @@ the SHARED external dependency (SdlVulkan.Renderer `FillSubpassDependencies`), s
 dependencies are not exempt from render-pass compatibility (widening only the LOAD pass tripped VUID
 00904/02684 on every partial frame). **Run the viewer under `SDLVK_VALIDATION=1 SDLVK_SYNC_VALIDATION=1`
 and read `validation_report` after driving it** whenever GPU resource lifetime is touched; that is what
-turned a watchdog dump into a named line of code.
+turned a watchdog dump into a named line of code. **Since SdlVulkan.Renderer 7.28 the class is closed
+structurally, not by call order:** `VkFitsImagePipeline` hands every channel, before and histogram texture
+to `VulkanContext.DeferDestroy`, which destroys it once every frame that could reference it has retired
+(no drain, so no render-thread stall per document swap), and its sampler descriptor sets are **one per
+frame in flight**, rewritten at draw time when the views' stamp moved (`EnsureSamplerSet`), because a
+set a pending frame holds may not be written. `VkTexture.Dispose` defers too. Never destroy a Vulkan
+object a frame may have bound directly again, and never write a single shared descriptor set from an
+upload path; the renderer's `docs/deferred-destroy-adoption.md` is the how-to.
 
 **The cached image layer samples in TEXTURE space, and a fixed-capacity target is not the size you
 asked for this frame.** `VulkanContext.CachedLayer` allocates once and answers any smaller request out

--- a/docs/plans/damage-based-repaint.md
+++ b/docs/plans/damage-based-repaint.md
@@ -94,6 +94,63 @@ SdlVulkan.Renderer release before TianWen can re-pin. D3 is a second SdlVulkan.R
 this is two cascades, not one -- worth batching D1-D3 into a single DIR.Lib + renderer pair if the
 damage API can be settled before the frame work starts.
 
+## The device loss: a document swap mid-frame destroyed views the frame had bound (found 2026-08-27, fixed)
+
+The Store viewer (6.3.1352) died at 12:19 while the user stepped through the files of a stack run:
+two `nvlddmkm 153` errors within half a second of two document loads 1.3 s apart, then
+`LiveKernelEvent 141` (the GPU watchdog) and the process gone with no .NET exception. Windows keeps
+no process list for a past instant, so the earlier `153`s this month were read from what the event
+logs held around them: the three on 08-09 had `TianWen.UI.Benchmarks.exe` running GPU benchmarks
+(and the 22:12 watchdog killed the very process the inspector's `batch` was driving: its socket
+reported "connection forcibly closed by the remote host" the same second); 08-23 and 08-24 fired
+within two seconds of `Kernel-Power 42`, the system entering sleep; 08-12 had nothing. No `4101`
+"driver recovered" event exists at all: this driver goes straight to the watchdog.
+
+**Reproduced at HEAD under the validation layer**, `SDLVK_VALIDATION=1 SDLVK_SYNC_VALIDATION=1`, by
+loading three files of different geometry. The layer named it seconds before the loss:
+
+    vkCmdBindDescriptorSets(): was called in VkCommandBuffer 0x14eed70ca20 which is now in an invalid
+    state (instead of recording state) because the following objects bound to the command buffer were
+    invalidated: VkImageView 0xab00000000ab was destroyed
+    ... (vkCmdSetScissor, vkCmdEndRenderPass, vkEndCommandBuffer, then again for VkImageView 0xa8)
+    [VulkanContext] VK_ERROR_DEVICE_LOST from vkWaitForFences
+
+and the driver logged the identical pair of `153`s at 14:33:15.3 / 15.8 against a load at 14:33:15.25,
+then `WATCHDOG-20260827-1433.dmp`.
+
+**Mechanism.** The standalone frame is `BeginFrame` -> `OnPreRenderPass` (`PrepareFrame` +
+`PrepareCachedImageLayer`, which records the layer pass sampling the channel views) -> `OnRender` ->
+`EndFrame`. Every host uploaded the new document's textures from its render callback, and the
+standalone even performed the SWAP there (`tracker.ProcessCompletions`, `HandleFileRequest`,
+`TryApplyPendingEnhance`). A new geometry makes `UploadStagedChannel` destroy and recreate the channel
+textures. `DestroyChannelTexture` drains the fences of PRIOR frames (its remarks are explicit about
+that), but nothing can un-record what THIS frame's command buffer already holds: the layer pass had
+bound the old views, so the frame was submitted referencing destroyed views, the GPU faulted, the
+watchdog fired. Only a change of geometry or format destroys anything, which is why stepping between
+files of the same size never showed it, and why the run folder (3348x3089 comet layer, 3065x3037 star
+layer and composite, 2956x2983 autocrops, one-channel rejection maps) was the perfect trigger.
+
+**Fix.** The swap steps run in `loop.OnBeforeFrame`, before `BeginFrame`, and a swap requests full
+damage there (a mouse move in the same tick could otherwise narrow a frame that shows a new document).
+The upload itself moved into `PrepareFrame`, the one point every host passes before recording anything
+that samples, so the four host-side `UploadDocumentTextures` calls are gone (`Program.cs`,
+`GuiderTab`, `LiveSessionTab`, `VkPlanetaryTab`) and the layout in the same `PrepareFrame` sees the new
+document's size at once instead of a frame late. Under the layer, five swaps across three geometries
+then produced zero messages and no loss. `ANewDocumentIsUploadedBeforeTheLayerPassThatSamplesIt` pins
+the order on the fake backend (it fails with the upload taken out of `PrepareFrame`) and asserts that
+the layer built that frame is the one drawn, where the old order built it from the previous document,
+invalidated it and drew directly.
+
+**The other finding of the validation round**, independent of the crash: the damage pass's `loadOp
+LOAD` reads the attachment, and the shared external dependency admitted COLOR_ATTACHMENT_WRITE only,
+so the read was not ordered after the pass's own PresentSrc -> ColorAttachmentOptimal transition
+(READ_AFTER_WRITE, once per swapchain image on every partial frame). Fixed in SdlVulkan.Renderer's
+`FillSubpassDependencies` by admitting the read for every pass. Widening the LOAD pass alone was tried
+first and made it incompatible with the framebuffers and pipelines built against the clearing pass
+(VUID-VkRenderPassBeginInfo-renderPass-00904 and vkCmdDraw-renderPass-02684 on every partial frame):
+dependencies are not among the things render-pass compatibility exempts, which load/store ops and
+layouts are.
+
 ## The cached layer squashed the image after the pane shrank (found 2026-08-27, fixed)
 
 The user widened the file list in the Store build and the picture compressed horizontally instead of

--- a/docs/plans/damage-based-repaint.md
+++ b/docs/plans/damage-based-repaint.md
@@ -141,6 +141,24 @@ the order on the fake backend (it fails with the upload taken out of `PrepareFra
 the layer built that frame is the one drawn, where the old order built it from the previous document,
 invalidated it and drew directly.
 
+**Upstreamed (SdlVulkan.Renderer 7.28), so the class cannot recur in any consumer.** The
+ordering fix above is necessary but rests on call order, which is exactly what went wrong. The
+renderer now owns the lifetime: `VulkanContext.DeferDestroy(view, image, memory, buffer,
+descriptorSet)` (and an `Action` overload) stamps the handles with the current frame ordinal and
+destroys them right after the fence wait that proves that frame and every frame in flight retired,
+with `RecoverFromGpuError` and `Dispose` flushing the queue after their own drains. `VkTexture.Dispose`
+defers, so disposing a texture in the frame that drew it is legal for every consumer.
+`VkFitsImagePipeline` hands every channel, before and histogram texture to it and drops the
+`TryWaitAllFramesIdle` drain that used to stall the render thread per document swap. The second half:
+a set a pending frame holds may not be written, and the drain was what made the in-place
+`vkUpdateDescriptorSets` legal, so the image and before sampler sets are now one per frame in flight,
+each rewritten at draw time when the views' stamp has moved (`EnsureSamplerSet`). Pinned in the
+renderer by `DeferredDestroyTests`: the schedule on the plain fixture (pending until the ordinal has
+advanced by `MaxFramesInFlight`, then destroyed at that `BeginFrame`), and texture disposal in the
+frame that drew it under the validation layer with zero errors. Adoption guide for other consumers:
+`SdlVulkan.Renderer/docs/deferred-destroy-adoption.md`. Not covered, and noted there: host-written
+per-frame UBOs are the same class on the host side and want a region per frame in flight.
+
 **The other finding of the validation round**, independent of the crash: the damage pass's `loadOp
 LOAD` reads the attachment, and the shared external dependency admitted COLOR_ATTACHMENT_WRITE only,
 so the read was not ordered after the pass's own PresentSrc -> ColorAttachmentOptimal transition

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -79,7 +79,7 @@
 
     <PackageVersion Include="Console.Lib" Version="4.28.*" />
 
-    <PackageVersion Include="SdlVulkan.Renderer" Version="7.25.*" />
+    <PackageVersion Include="SdlVulkan.Renderer" Version="7.28.*" />
 
     <PackageVersion Include="WebGl.Renderer" Version="1.26.*" />
     <PackageVersion Include="SDL3-CS" Version="3.5.0-preview.20260213-150035" />

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -60,7 +60,7 @@
     <PackageVersion Include="Pastel" Version="7.0.1" />
     <PackageVersion Include="System.CommandLine" Version="2.0.6" />
 
-    <PackageVersion Include="DIR.Lib" Version="8.9.*" />
+    <PackageVersion Include="DIR.Lib" Version="8.13.*" />
 
     <PackageVersion Include="SharpAstro.Tiff" Version="$(SharpAstroCodecsVersion)" />
     <PackageVersion Include="SharpAstro.Exif" Version="$(SharpAstroCodecsVersion)" />
@@ -79,7 +79,7 @@
 
     <PackageVersion Include="Console.Lib" Version="4.28.*" />
 
-    <PackageVersion Include="SdlVulkan.Renderer" Version="7.28.*" />
+    <PackageVersion Include="SdlVulkan.Renderer" Version="7.29.*" />
 
     <PackageVersion Include="WebGl.Renderer" Version="1.26.*" />
     <PackageVersion Include="SDL3-CS" Version="3.5.0-preview.20260213-150035" />

--- a/src/TianWen.Lib.Tests/ColorCalibrationToggleTests.cs
+++ b/src/TianWen.Lib.Tests/ColorCalibrationToggleTests.cs
@@ -1,0 +1,150 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Shouldly;
+using TianWen.Lib.Imaging;
+using TianWen.UI.Abstractions;
+using Xunit;
+
+namespace TianWen.Lib.Tests
+{
+    /// <summary>
+    /// The SPCC / Calibrate toggle must gate the RENDER, not just the measurement. The bug: switching
+    /// SPCC off (or pressing W) changed the toolbar highlight and stashed the manual WB, but the shader
+    /// still received the calibrated triple, so nothing on screen moved. And an AI enhance re-fitted the
+    /// calibration on the enhanced pixels, so a nicely-calibrated frame took on a new cast the moment that
+    /// fit landed. Both are properties of what <see cref="AstroImageDocument.ComputeStretchUniforms"/>
+    /// writes, so they are pinned here rather than through the GPU.
+    /// </summary>
+    public sealed class ColorCalibrationToggleTests
+    {
+        // A frame with a deliberate blue sky cast and a handful of high-SNR stars, so the sky-background
+        // calibration (which declares the sky neutral) lands a firmly non-neutral triple -- the Vela
+        // fixture's sky is already near-neutral, which is nothing to gate.
+        private static Image CastStarField()
+        {
+            const int W = 200, H = 200;
+            var bg = new[] { 200f, 200f, 600f };   // R, G, B background: blue is 3x
+            var rng = new Random(42);
+            var planes = new float[3][,];
+            for (var c = 0; c < 3; c++)
+            {
+                var p = new float[H, W];
+                for (var y = 0; y < H; y++)
+                {
+                    for (var x = 0; x < W; x++)
+                    {
+                        p[y, x] = bg[c] + (float)(rng.NextDouble() * 20.0 - 10.0);
+                    }
+                }
+                planes[c] = p;
+            }
+            // 16 bright stars on a grid, well clear of the edges; the same star in every channel.
+            for (var i = 0; i < 16; i++)
+            {
+                var sx = 20 + i % 4 * 45;
+                var sy = 20 + i / 4 * 45;
+                for (var dy = -4; dy <= 4; dy++)
+                {
+                    for (var dx = -4; dx <= 4; dx++)
+                    {
+                        var g = 6000f * MathF.Exp(-(dx * dx + dy * dy) / (2f * 1.4f * 1.4f));
+                        for (var c = 0; c < 3; c++)
+                        {
+                            planes[c][sy + dy, sx + dx] += g;
+                        }
+                    }
+                }
+            }
+            var meta = new ImageMeta("synth", DateTimeOffset.UtcNow, TimeSpan.FromSeconds(1),
+                FrameType.Light, "", 3.76f, 3.76f, 500, -1, Filter.Luminance, 1, 1,
+                float.NaN, SensorType.Color, 0, 0, RowOrder.TopDown, float.NaN, float.NaN);
+            return new Image(planes, BitDepth.Float32, maxValue: 8192f, minValue: 0f, pedestal: 0f, imageMeta: meta);
+        }
+
+        private static async Task<AstroImageDocument> CalibratedDocAsync(CancellationToken ct)
+        {
+            var doc = await AstroImageDocument.AdoptImageAsync(CastStarField(), DebayerAlgorithm.None, cancellationToken: ct);
+            await doc.DetectStarsAsync(ct);
+            doc.Stars.ShouldNotBeNull();
+            doc.Stars!.Count.ShouldBeGreaterThanOrEqualTo(5, "the synthetic field must give the sky-bg path enough stars");
+            // Sky-background calibration (no catalog needed) declares the cast sky neutral.
+            await doc.ComputeColorCalibrationAsync(null!, ct);
+            doc.ColorCalibration.ShouldNotBeNull("the cast frame must calibrate to a triple");
+            var wb = doc.ColorCalibration!.Value;
+            (MathF.Abs(wb.R - 1f) + MathF.Abs(wb.B - 1f)).ShouldBeGreaterThan(0.1f,
+                "the whole point is a non-neutral triple to gate");
+            return doc;
+        }
+
+        [Fact]
+        public async Task TheCalibrationToggleGatesTheRenderedWhiteBalance()
+        {
+            var ct = TestContext.Current.CancellationToken;
+            var doc = await CalibratedDocAsync(ct);
+            var wb = doc.ColorCalibration!.Value;
+
+            var mode = ViewerActions.DefaultStretchMode;
+            var p = new StretchParameters(0.25, -2.8);
+
+            var on = doc.ComputeStretchUniforms(mode, p, applyColorCalibration: true);
+            var off = doc.ComputeStretchUniforms(mode, p, applyColorCalibration: false);
+
+            off.WhiteBalance.R.ShouldBe(1f, 1e-6f);
+            off.WhiteBalance.G.ShouldBe(1f, 1e-6f);
+            off.WhiteBalance.B.ShouldBe(1f, 1e-6f);
+            on.WhiteBalance.ShouldNotBe(off.WhiteBalance, "turning the calibration on must change what the shader receives");
+            on.WhiteBalance.R.ShouldBe(wb.R, 1e-4f);
+            on.WhiteBalance.B.ShouldBe(wb.B, 1e-4f);
+        }
+
+        [Fact]
+        public async Task TogglingOffThenOnIsBitIdenticalToNeverTogglingBecauseTheTripleIsKept()
+        {
+            var ct = TestContext.Current.CancellationToken;
+            var doc = await CalibratedDocAsync(ct);
+            var mode = ViewerActions.DefaultStretchMode;
+            var p = new StretchParameters(0.25, -2.8);
+
+            var first = doc.ComputeStretchUniforms(mode, p, applyColorCalibration: true);
+            _ = doc.ComputeStretchUniforms(mode, p, applyColorCalibration: false); // "switch off"
+            var again = doc.ComputeStretchUniforms(mode, p, applyColorCalibration: true); // "switch on"
+
+            again.WhiteBalance.ShouldBe(first.WhiteBalance, "the measured triple is kept, so re-enabling restores the exact render");
+        }
+
+        [Fact]
+        public async Task BackgroundNeutralizationHonoursTheToggleSoTheGainsMatchTheAppliedWhiteBalance()
+        {
+            var ct = TestContext.Current.CancellationToken;
+            var doc = await CalibratedDocAsync(ct);
+
+            // The gains are solved for a neutral background AFTER the WB multiply, so they depend on the
+            // WB that is actually applied: with the calibration off the applied WB is identity, so the
+            // gains must differ from the calibrated-WB ones.
+            var withCal = doc.ComputeBackgroundNeutralization(BackgroundNeutralizationMethod.Mean, applyColorCalibration: true);
+            var withoutCal = doc.ComputeBackgroundNeutralization(BackgroundNeutralizationMethod.Mean, applyColorCalibration: false);
+
+            withCal.ShouldNotBeNull();
+            withoutCal.ShouldNotBeNull();
+            withCal!.Value.ShouldNotBe(withoutCal!.Value, "the neutralisation gains depend on the WB that is actually applied");
+        }
+
+        [Fact]
+        public async Task AnEnhancedDocumentInheritsTheCalibrationInsteadOfRefittingIt()
+        {
+            var ct = TestContext.Current.CancellationToken;
+            var original = await CalibratedDocAsync(ct);
+
+            // Stand in for the enhance output: a fresh, uncalibrated document from a copy of the pixels.
+            var enhanced = await AstroImageDocument.AdoptImageAsync(CastStarField(), DebayerAlgorithm.None, cancellationToken: ct);
+            enhanced.ColorCalibration.ShouldBeNull();
+
+            enhanced.InheritColorCalibration(original);
+
+            enhanced.ColorCalibration.ShouldBe(original.ColorCalibration,
+                "the enhanced frame carries the triple measured on the original stars, so no re-fit re-casts it");
+            enhanced.ColorCalibrationSummary.ShouldBe(original.ColorCalibrationSummary);
+        }
+    }
+}

--- a/src/TianWen.Lib.Tests/ColorCalibrationToggleTests.cs
+++ b/src/TianWen.Lib.Tests/ColorCalibrationToggleTests.cs
@@ -131,6 +131,39 @@ namespace TianWen.Lib.Tests
         }
 
         [Fact]
+        public void AutoIsTheDefaultAndResolvesFromColourAndCalibration()
+        {
+            ViewerActions.DefaultStretchMode.ShouldBe(StretchMode.Auto);
+
+            // The pure resolution (extension on StretchMode): colour + a calibration to show -> Linked,
+            // colour without one -> Unlinked, mono -> Linked, and a non-Auto mode passes through.
+            StretchMode.Auto.ResolveAuto(isColour: true, calibrationActive: true).ShouldBe(StretchMode.Linked);
+            StretchMode.Auto.ResolveAuto(isColour: true, calibrationActive: false).ShouldBe(StretchMode.Unlinked);
+            StretchMode.Auto.ResolveAuto(isColour: false, calibrationActive: false).ShouldBe(StretchMode.Linked);
+            StretchMode.Luma.ResolveAuto(isColour: true, calibrationActive: false).ShouldBe(StretchMode.Luma);
+        }
+
+        [Fact]
+        public async Task AutoRendersAsTheConcreteModeItPicksForTheFrame()
+        {
+            var ct = TestContext.Current.CancellationToken;
+            var doc = await CalibratedDocAsync(ct);
+            var p = new StretchParameters(0.25, -2.8);
+
+            // Calibrated colour: Auto must render byte-for-byte as Linked, so the measured WB shows.
+            var autoOn = doc.ComputeStretchUniforms(StretchMode.Auto, p, applyColorCalibration: true);
+            var linked = doc.ComputeStretchUniforms(StretchMode.Linked, p, applyColorCalibration: true);
+            autoOn.ShouldBe(linked);
+
+            // Uncalibrated colour: Auto must render as Unlinked, neutralising each channel's background.
+            var autoOff = doc.ComputeStretchUniforms(StretchMode.Auto, p, applyColorCalibration: false);
+            var unlinked = doc.ComputeStretchUniforms(StretchMode.Unlinked, p, applyColorCalibration: false);
+            autoOff.ShouldBe(unlinked);
+
+            autoOn.ShouldNotBe(autoOff, "flipping the calibration on flips Auto from Unlinked to Linked");
+        }
+
+        [Fact]
         public async Task AnEnhancedDocumentInheritsTheCalibrationInsteadOfRefittingIt()
         {
             var ct = TestContext.Current.CancellationToken;

--- a/src/TianWen.Lib.Tests/ViewerActionsTests.cs
+++ b/src/TianWen.Lib.Tests/ViewerActionsTests.cs
@@ -35,23 +35,22 @@ public class ViewerActionsTests
         ViewerActions.ToggleStretch(state);
 
         // Re-enabling lands on whatever a fresh viewer would show, not on a mode named here: the
-        // default was Unlinked and is now Linked, and stating it twice is how the two drift.
+        // default was Unlinked, then Linked, now Auto, and stating it twice is how the two drift.
         state.StretchMode.ShouldBe(ViewerActions.DefaultStretchMode);
         state.HistogramLogScale.ShouldBeFalse();
     }
 
     [Fact]
-    public void DefaultStretchMode_IsLinked()
+    public void DefaultStretchMode_IsAuto()
     {
         // Named explicitly ONCE, because it is a deliberate behavioural choice and not an
-        // implementation detail: Linked is PixInsight's and Siril's default and, since the
-        // shared-curve fix, means the same thing here -- so a colour-calibrated image opens showing
-        // the colour it was calibrated to. Under Unlinked (the old default) each channel
-        // auto-normalises against its own stats, which discards exactly the per-channel differences
-        // a white balance consists of, and SPCC looked like a no-op on a fresh viewer.
-        ViewerActions.DefaultStretchMode.ShouldBe(StretchMode.Linked);
-        new ViewerState().StretchMode.ShouldBe(StretchMode.Linked);
-        DisplayControls.Defaults.StretchMode.ShouldBe(StretchMode.Linked);
+        // implementation detail: Auto resolves per frame to Linked when a colour calibration is
+        // active (so the WB shows) and Unlinked otherwise (so an uncalibrated frame has no cast to
+        // guess at). The default was Unlinked (SPCC looked like a no-op), then Linked (an
+        // uncalibrated frame could open on a cast); Auto picks the right one of the two per frame.
+        ViewerActions.DefaultStretchMode.ShouldBe(StretchMode.Auto);
+        new ViewerState().StretchMode.ShouldBe(StretchMode.Auto);
+        DisplayControls.Defaults.StretchMode.ShouldBe(StretchMode.Auto);
     }
 
     // --- CycleStretchLink ---

--- a/src/TianWen.Lib.Tests/ViewerCachedLayerTests.cs
+++ b/src/TianWen.Lib.Tests/ViewerCachedLayerTests.cs
@@ -242,6 +242,59 @@ namespace TianWen.Lib.Tests
             viewer.DirectDraws.ShouldBe(1, "the safe answer is the direct render");
         }
 
+        /// <summary>
+        /// The crash. A document swap recreates the channel textures, which destroys the previous views
+        /// after draining PRIOR frames; it cannot un-record what THIS frame's command buffer already holds.
+        /// When the hosts uploaded from their render callbacks, the cached-layer pre-pass had already bound
+        /// the old views, the upload destroyed them, and the frame was submitted with a dangling view:
+        /// under the validation layer "vkCmdBindDescriptorSets(): ... invalid state ... VkImageView was
+        /// destroyed", then VK_ERROR_DEVICE_LOST; on the Store build, a GPU watchdog (2026-08-27). The
+        /// upload therefore belongs to PrepareFrame, ahead of anything that samples.
+        /// </summary>
+        [Fact]
+        public void ANewDocumentIsUploadedBeforeTheLayerPassThatSamplesIt()
+        {
+            var viewer = new CachingViewer(new RgbaImageRenderer(SurfaceW, SurfaceH));
+            var source = new LiveFramePreviewSource();
+            source.AcceptFrame(MonoImage(ImageW, ImageH), freezeStats: false);
+            var state = NewState();
+            state.NeedsTextureUpdate = true;
+
+            // The standalone host's frame: pre-pass (PrepareFrame + layer), then Render.
+            viewer.PrepareFrame(source, state);
+            viewer.PrepareCachedImageLayer();
+            viewer.Render(source, state);
+
+            state.NeedsTextureUpdate.ShouldBeFalse("PrepareFrame consumed the upload");
+            viewer.Events.ShouldNotBeEmpty();
+            var firstPass = viewer.Events.IndexOf("layerPass");
+            var lastUpload = viewer.Events.FindLastIndex(e => e.StartsWith("upload:", StringComparison.Ordinal));
+            lastUpload.ShouldBeGreaterThanOrEqualTo(0, "the new document's textures were uploaded");
+            firstPass.ShouldBeGreaterThan(lastUpload,
+                $"every upload must precede the layer pass that samples the textures; got [{string.Join(", ", viewer.Events)}]");
+            // And the frame then USES the layer it built from the new textures, instead of invalidating it
+            // and drawing directly as the old order did.
+            viewer.LayerPasses.Count.ShouldBe(1);
+            viewer.Blits.Count.ShouldBe(1, "the layer built this frame is the one drawn this frame");
+            viewer.DirectDraws.ShouldBe(0);
+        }
+
+        private static Image MonoImage(int w, int h)
+        {
+            var ch = new float[h, w];
+            for (var y = 0; y < h; y++)
+            {
+                for (var x = 0; x < w; x++)
+                {
+                    ch[y, x] = 500f + (x + y) % 7;
+                }
+            }
+            var meta = new ImageMeta("synth", DateTimeOffset.UtcNow, TimeSpan.FromSeconds(1),
+                FrameType.Light, "", 3.76f, 3.76f, 500, -1, Filter.Luminance, 1, 1,
+                float.NaN, SensorType.Monochrome, 0, 0, RowOrder.TopDown, float.NaN, float.NaN);
+            return new Image([ch], BitDepth.Float32, maxValue: 1000f, minValue: 0f, pedestal: 0f, imageMeta: meta);
+        }
+
         private static void Frame(TestViewerBase viewer, ViewerState state)
         {
             viewer.PrepareFrame(null, state);
@@ -329,6 +382,13 @@ namespace TianWen.Lib.Tests
             public List<(float U0, float V0, float U1, float V1)> Blits { get; } = [];
             public int LayerDraws { get; private set; }
 
+            /// <summary>Texture uploads and layer passes in the order the frame issued them. A layer pass
+            /// samples the channel textures, so an upload that recreates them must come first.</summary>
+            public List<string> Events { get; } = [];
+
+            public override void UploadImageTexture(ReadOnlySpan<float> data, int channel, int imageWidth, int imageHeight)
+                => Events.Add($"upload:{channel}");
+
             /// <summary>The texture size the fake "allocated". Zero means exactly what was asked for,
             /// the case every earlier test ran in; a real backend allocates once and keeps answering
             /// smaller requests out of the same texture, which is the case the capacity test sets up.</summary>
@@ -345,6 +405,7 @@ namespace TianWen.Lib.Tests
             protected override bool TryBeginCachedLayerPass(int width, int height)
             {
                 LayerPasses.Add((width, height));
+                Events.Add("layerPass");
                 _inLayer = true;
                 return true;
             }

--- a/src/TianWen.Lib.Tests/ViewerSplitTests.cs
+++ b/src/TianWen.Lib.Tests/ViewerSplitTests.cs
@@ -288,10 +288,11 @@ namespace TianWen.Lib.Tests
         {
             // Stretch mode has no "off" state -- every mode IS a mode -- so going back to the default
             // is a CHANGE to that default, not the absence of the pinned one. "No Unlinked" would be
-            // nonsense. The default is Linked, so Unlinked is what gets pinned to move away from it.
+            // nonsense. The default is Auto, so Unlinked is what gets pinned to move away from it, and
+            // the live half is named by the default itself.
             var split = PinnedAt(DisplayControls.Defaults with { StretchMode = StretchMode.Unlinked });
 
-            split.HalfLabels(DisplayControls.Defaults).ShouldBe(("Pinned: Unlinked", "Live: Linked"));
+            split.HalfLabels(DisplayControls.Defaults).ShouldBe(("Pinned: Unlinked", "Live: Auto"));
         }
 
         [Fact]

--- a/src/TianWen.Lib.Tests/ViewerSplitTests.cs
+++ b/src/TianWen.Lib.Tests/ViewerSplitTests.cs
@@ -715,7 +715,8 @@ namespace TianWen.Lib.Tests
                 LumaWeighting weighting = LumaWeighting.Rec709, float lumaBlend = 1f, bool normalize = false,
                 int curvesMode = 0, ReadOnlySpan<float> curveLut = default, float curvesBoost = 0f,
                 float curvesMidpoint = 0.25f, float hdrAmount = 0f, float hdrKnee = 0.8f,
-                float bgNeutralizationStrength = 1f, (float R, float G, float B)? manualWhiteBalance = null)
+                float bgNeutralizationStrength = 1f, (float R, float G, float B)? manualWhiteBalance = null,
+                bool applyColorCalibration = true)
                 => new StretchUniforms(mode, 1f, default, default, default, default, default);
         }
 

--- a/src/TianWen.Lib.Tests/ViewerUploadScratchTrimTests.cs
+++ b/src/TianWen.Lib.Tests/ViewerUploadScratchTrimTests.cs
@@ -167,7 +167,8 @@ public class ViewerUploadScratchTrimTests
             LumaWeighting weighting = LumaWeighting.Rec709, float lumaBlend = 1f, bool normalize = false,
             int curvesMode = 0, ReadOnlySpan<float> curveLut = default, float curvesBoost = 0f,
             float curvesMidpoint = 0.25f, float hdrAmount = 0f, float hdrKnee = 0.8f,
-            float bgNeutralizationStrength = 1f, (float R, float G, float B)? manualWhiteBalance = null)
+            float bgNeutralizationStrength = 1f, (float R, float G, float B)? manualWhiteBalance = null,
+            bool applyColorCalibration = true)
             => new StretchUniforms(mode, 1f, default, default, default, default, default);
     }
 }

--- a/src/TianWen.Lib/Imaging/StretchMode.cs
+++ b/src/TianWen.Lib/Imaging/StretchMode.cs
@@ -5,5 +5,14 @@ public enum StretchMode
     None,
     Linked,
     Unlinked,
-    Luma
+    Luma,
+
+    /// <summary>
+    /// Let the viewer pick between <see cref="Linked"/> and <see cref="Unlinked"/> from the frame and
+    /// whether a colour calibration is active. A UI-level intent, NOT a shader mode: it is resolved to a
+    /// concrete mode before <see cref="StretchUniforms"/> is built, so it never reaches the GLSL/CPU
+    /// stretch (which only ever sees None/Linked/Unlinked/Luma). Deliberately LAST so the numeric values
+    /// the shader reads for the real modes are unchanged. Resolution: ViewerActions.ResolveAutoStretchMode.
+    /// </summary>
+    Auto
 }

--- a/src/TianWen.Lib/Imaging/StretchSolver.cs
+++ b/src/TianWen.Lib/Imaging/StretchSolver.cs
@@ -52,6 +52,15 @@ public static class StretchSolver
         // The shader multiply defaults to the stat-scaling WB, so single-WB callers are unchanged.
         var shaderWb = shaderWhiteBalance ?? whiteBalance ?? (1f, 1f, 1f);
 
+        // Auto is a UI intent resolved by the producer (ViewerActions.ResolveAutoStretchMode) and must
+        // not reach here; if one ever does, treat it as Linked rather than write mode 4 into a uniform
+        // the shader has no branch for. Not the resolution point on purpose: this layer is pure math and
+        // knows nothing about whether a calibration is active.
+        if (mode is StretchMode.Auto)
+        {
+            mode = StretchMode.Linked;
+        }
+
         if (mode is StretchMode.None)
         {
             // Linear display: there is no stretch curve to carry a WB multiply, so the WB is applied

--- a/src/TianWen.UI.Abstractions/AstroImageDocument.cs
+++ b/src/TianWen.UI.Abstractions/AstroImageDocument.cs
@@ -524,6 +524,13 @@ public sealed class AstroImageDocument : IPreviewSource
         var autoWb = applyColorCalibration ? ColorCalibration : null;
         var shaderWb = StretchSolver.ComposeWhiteBalance(autoWb, manualWhiteBalance);
 
+        // Resolve the Auto intent here, where both inputs are known: whether this frame is colour, and
+        // whether a calibration is actually being applied to it. A calibrated colour frame renders
+        // Linked so the WB shows; an uncalibrated one Unlinked so each channel's background neutralises.
+        var isColour = UnstretchedImage.ChannelCount >= 3
+            || UnstretchedImage.ImageMeta.SensorType is SensorType.RGGB;
+        mode = mode.ResolveAuto(isColour, autoWb is not null);
+
         if (UseIterativeConvergence && StarMaskedStats is { } masked)
         {
             // Star-masked stats have a lower median (stars excluded), so a fixed

--- a/src/TianWen.UI.Abstractions/AstroImageDocument.cs
+++ b/src/TianWen.UI.Abstractions/AstroImageDocument.cs
@@ -108,6 +108,27 @@ public sealed class AstroImageDocument : IPreviewSource
     /// </summary>
     public ColorCalibrationSummary? ColorCalibrationSummary { get; private set; }
 
+    /// <summary>
+    /// Carries <paramref name="from"/>'s colour calibration and its provenance over to this document,
+    /// for a document derived from it by a spatial operation (the AI enhance). The enhanced raster is a
+    /// different image with its own star list, so the calibration auto-retrigger would otherwise re-fit
+    /// SPCC on deconvolved, denoised and recombined pixels and land on a different triple: the frame
+    /// rendered right for a moment under the inherited nothing and then took on a new cast when the
+    /// re-fit arrived. The measurement made on the original stars is the trustworthy one, and a spatial
+    /// operation does not change what white is. Only the WB triple travels; background neutralisation is
+    /// re-solved per document, because an enhanced background IS different (the same "share only the WB"
+    /// rule the stacking pipeline's plates follow).
+    /// </summary>
+    public void InheritColorCalibration(AstroImageDocument from)
+    {
+        if (from.ColorCalibration is not { } wb)
+        {
+            return;
+        }
+        ColorCalibration = wb;
+        ColorCalibrationSummary = from.ColorCalibrationSummary;
+    }
+
     // SPCC in-flight gate. The compute task runs on a thread-pool thread and
     // writes 0 from its finally; Render reads + tries to set 1 from the UI
     // thread. Plain bool would give no memory-ordering guarantee across the
@@ -127,8 +148,24 @@ public sealed class AstroImageDocument : IPreviewSource
         Interlocked.CompareExchange(ref _colorCalibrationInFlight, 1, 0) == 0;
 
     /// <summary>Marks the SPCC task as no longer in flight. Always called from
-    /// the task's finally so a faulted compute still releases the slot.</summary>
-    public void EndColorCalibration() => Volatile.Write(ref _colorCalibrationInFlight, 0);
+    /// the task's finally so a faulted compute still releases the slot. Also records
+    /// that an attempt HAPPENED (<see cref="ColorCalibrationAttempted"/>), so the
+    /// per-frame auto-retrigger fires once per document rather than every frame when
+    /// the fit cannot succeed.</summary>
+    public void EndColorCalibration()
+    {
+        ColorCalibrationAttempted = true;
+        Volatile.Write(ref _colorCalibrationInFlight, 0);
+    }
+
+    /// <summary>
+    /// True once a calibration has been attempted on this document, whether it landed a triple or not.
+    /// The auto-retrigger checks it so a document the fit cannot calibrate -- a starless comet layer has
+    /// too few stars, and SPCC can decline -- is not re-attempted on every frame, which flickered the
+    /// SPCC button's in-flight state. An explicit press (button / W) does not consult it, so the user can
+    /// always retry; it resets naturally because a new document is a new instance.
+    /// </summary>
+    public bool ColorCalibrationAttempted { get; private set; }
 
     /// <summary>Background neutralization gains from pivot1 sampling (1,1,1) = no neutralization.</summary>
     public (float R, float G, float B)? BackgroundNeutralization { get; set; }
@@ -460,7 +497,8 @@ public sealed class AstroImageDocument : IPreviewSource
         float hdrAmount = 0f,
         float hdrKnee = 0.8f,
         float bgNeutralizationStrength = 1f,
-        (float R, float G, float B)? manualWhiteBalance = null)
+        (float R, float G, float B)? manualWhiteBalance = null,
+        bool applyColorCalibration = true)
     {
         var stats = PerChannelStats;
         var luma = LumaStats;
@@ -479,7 +517,11 @@ public sealed class AstroImageDocument : IPreviewSource
         // multiply (autoWb scales the stats; autoWb x manual is the multiply), giving a direct, always-
         // visible colour shift. A neutral/null manual triple leaves shaderWb == autoWb, so the existing
         // auto-only numeric path is bit-identical.
-        var autoWb = ColorCalibration;
+        // The toggle gates the RENDER here, not the measurement: switching SPCC off must show the frame
+        // as if no calibration existed, and switching it on again must bring the same triple back
+        // without a re-fit. It used to gate only the toolbar highlight and the manual-WB stash, so
+        // "turning SPCC off" changed nothing on screen.
+        var autoWb = applyColorCalibration ? ColorCalibration : null;
         var shaderWb = StretchSolver.ComposeWhiteBalance(autoWb, manualWhiteBalance);
 
         if (UseIterativeConvergence && StarMaskedStats is { } masked)
@@ -681,7 +723,8 @@ public sealed class AstroImageDocument : IPreviewSource
     /// document hits the cache, never re-walks pixels.
     /// </summary>
     public (float R, float G, float B)? ComputeBackgroundNeutralization(
-        Lib.Imaging.BackgroundNeutralizationMethod method = Lib.Imaging.BackgroundNeutralizationMethod.Mean)
+        Lib.Imaging.BackgroundNeutralizationMethod method = Lib.Imaging.BackgroundNeutralizationMethod.Mean,
+        bool applyColorCalibration = true)
     {
         if (PerChannelBackground is not { Length: >= 3 } bg)
             return null;
@@ -691,7 +734,7 @@ public sealed class AstroImageDocument : IPreviewSource
         // cache key. Keyed on method alone, a calibration landing after the first neutralisation
         // would keep serving gains computed for the previous (or absent) triple: the same
         // stale-cached-projection shape as a palette-derived texture that outlives a theme switch.
-        var wb = ColorCalibration ?? (1f, 1f, 1f);
+        var wb = (applyColorCalibration ? ColorCalibration : null) ?? (1f, 1f, 1f);
         var key = (method, wb);
         if (!_bnGainsByMethod.TryGetValue(key, out var gains))
         {

--- a/src/TianWen.UI.Abstractions/GuiderTab.cs
+++ b/src/TianWen.UI.Abstractions/GuiderTab.cs
@@ -303,10 +303,8 @@ namespace TianWen.UI.Abstractions
 
             viewer.SetSurfaceSize((uint)Renderer.Width, (uint)Renderer.Height);
             viewer.SetContentRegion(rect);
-            if (_guideState.NeedsTextureUpdate && _guideSource.Width > 0)
-            {
-                viewer.UploadDocumentTextures(_guideSource, _guideState);
-            }
+            // The texture upload NeedsTextureUpdate asks for happens inside Render's PrepareFrame, before
+            // anything in the frame samples the channel views; see the remarks there.
             viewer.Render(_guideSource, _guideState);
 
             // Compute image→screen transform for overlays

--- a/src/TianWen.UI.Abstractions/IPreviewSource.cs
+++ b/src/TianWen.UI.Abstractions/IPreviewSource.cs
@@ -51,7 +51,10 @@ public interface IPreviewSource
 
     /// <summary>Computes display stretch uniforms from the (cached) statistics. Cheap to call per frame.
     /// <paramref name="manualWhiteBalance"/> is the user's WB-slider triple, composed with any auto color
-    /// calibration; (1,1,1) or null leaves the existing (auto-only) behaviour bit-identical.</summary>
+    /// calibration; (1,1,1) or null leaves the existing (auto-only) behaviour bit-identical.
+    /// <paramref name="applyColorCalibration"/> is the viewer's SPCC / Calibrate toggle: false renders as
+    /// if no auto calibration existed, without discarding the measured triple. A source that carries no
+    /// calibration ignores it.</summary>
     StretchUniforms ComputeStretchUniforms(
         StretchMode mode,
         StretchParameters parameters,
@@ -65,7 +68,8 @@ public interface IPreviewSource
         float hdrAmount = 0f,
         float hdrKnee = 0.8f,
         float bgNeutralizationStrength = 1f,
-        (float R, float G, float B)? manualWhiteBalance = null);
+        (float R, float G, float B)? manualWhiteBalance = null,
+        bool applyColorCalibration = true);
 
     /// <summary>Number of frames (1 for a still image).</summary>
     int FrameCount { get; }

--- a/src/TianWen.UI.Abstractions/ImageRendererBase.Input.cs
+++ b/src/TianWen.UI.Abstractions/ImageRendererBase.Input.cs
@@ -238,7 +238,12 @@ namespace TianWen.UI.Abstractions
                     TryToggleBackgroundNeutralization(state);
                     return true;
                 case InputKey.W:
+                    // The same gesture as the SPCC toolbar button: toggle the calibration, and start one
+                    // if the document has none yet. It used to only START, which on a calibrated document
+                    // was a no-op, so W could neither switch the calibration off nor back on.
+                    ViewerActions.SetColorCalibrationEnabled(state, !state.ColorCalibrationEnabled);
                     TryStartColorCalibration(state);
+                    state.NeedsRedraw = true;
                     return true;
                 case InputKey.R:
                     ViewerActions.ZoomToActual(state);
@@ -391,7 +396,9 @@ namespace TianWen.UI.Abstractions
                 // once seen, and the background scan itself is already done.
                 if (state.BackgroundNeutralizationEnabled)
                 {
-                    document.ComputeBackgroundNeutralization(state.BackgroundNeutralizationMethod);
+                    // A calibration just landed and is being enabled, so its triple is the one to solve
+                    // the neutralisation against.
+                    document.ComputeBackgroundNeutralization(state.BackgroundNeutralizationMethod, applyColorCalibration: true);
                 }
 
                 // The manual triple is dropped, because the pipeline MULTIPLIES the two
@@ -443,7 +450,7 @@ namespace TianWen.UI.Abstractions
                 return;
             }
 
-            var gains = _document?.ComputeBackgroundNeutralization(state.BackgroundNeutralizationMethod);
+            var gains = _document?.ComputeBackgroundNeutralization(state.BackgroundNeutralizationMethod, state.ColorCalibrationEnabled);
             if (gains is { } g)
             {
                 state.BackgroundNeutralizationEnabled = true;

--- a/src/TianWen.UI.Abstractions/ImageRendererBase.Toolbar.cs
+++ b/src/TianWen.UI.Abstractions/ImageRendererBase.Toolbar.cs
@@ -681,7 +681,7 @@ namespace TianWen.UI.Abstractions
                             // Compute (or hit per-method cache) and pin gain onto document.
                             // User picked a method explicitly, so the toolbar reflects that
                             // even if this image's gain happens to land near identity.
-                            var gain = _document?.ComputeBackgroundNeutralization(m);
+                            var gain = _document?.ComputeBackgroundNeutralization(m, state.ColorCalibrationEnabled);
                             state.BackgroundNeutralizationEnabled = true;
                             state.StatusMessage = gain is { } g
                                 // FOUR decimals, because two are useless here and actively

--- a/src/TianWen.UI.Abstractions/ImageRendererBase.Toolbar.cs
+++ b/src/TianWen.UI.Abstractions/ImageRendererBase.Toolbar.cs
@@ -1173,7 +1173,7 @@ namespace TianWen.UI.Abstractions
         {
             ToolbarAction.Open => "Open a FITS / TIFF / SER file",
             ToolbarAction.StretchToggle => "Screen transfer function on / off (T)",
-            ToolbarAction.StretchLink => "Stretch mode: linked keeps colour, unlinked neutralises the background, luma stretches luminance",
+            ToolbarAction.StretchLink => "Stretch mode: auto picks linked when calibrated and unlinked otherwise; linked keeps colour, unlinked neutralises the background, luma stretches luminance",
             ToolbarAction.StretchParams => "Stretch strength preset (+ / -)",
             ToolbarAction.Channel => "Channel view: RGB or one channel (C cycles)",
             ToolbarAction.Debayer => "Demosaic algorithm; the swatch is the sensor's CFA phase (D cycles)",
@@ -1360,6 +1360,21 @@ namespace TianWen.UI.Abstractions
             "Esc                  Quit",
         ];
 
+        // What Auto resolved to for the frame on screen, named for the StretchLink button. Mirrors the
+        // producer's inputs: colour vs mono, and whether a calibration is actually being applied.
+        private static string ResolvedAutoLabel(AstroImageDocument? document, ViewerState state)
+        {
+            var isColour = document is { } d
+                && (d.UnstretchedImage.ChannelCount >= 3
+                    || d.UnstretchedImage.ImageMeta.SensorType is SensorType.RGGB);
+            var calibrationActive = state.ColorCalibrationEnabled && document?.ColorCalibration is not null;
+            return StretchMode.Auto.ResolveAuto(isColour, calibrationActive) switch
+            {
+                StretchMode.Unlinked => "Unlinked",
+                _ => "Linked",
+            };
+        }
+
         private string GetToolbarButtonLabel(string baseLabel, ToolbarAction action, AstroImageDocument? document, ViewerState state)
         {
             return action switch
@@ -1367,6 +1382,8 @@ namespace TianWen.UI.Abstractions
                 ToolbarAction.StretchToggle => "STF",
                 ToolbarAction.StretchLink => state.StretchMode switch
                 {
+                    // Auto names what it resolved to, so the mode it picked is never a mystery.
+                    StretchMode.Auto => $"Auto ({ResolvedAutoLabel(document, state)})",
                     StretchMode.Linked => "Linked",
                     StretchMode.Luma => "Luma",
                     _ => "Unlinked"

--- a/src/TianWen.UI.Abstractions/ImageRendererBase.cs
+++ b/src/TianWen.UI.Abstractions/ImageRendererBase.cs
@@ -949,7 +949,8 @@ namespace TianWen.UI.Abstractions
             _preparedStretch = source?.ComputeStretchUniforms(
                     state.StretchMode, state.StretchParameters,
                     bgNeutralizationStrength: state.BackgroundNeutralizationStrength,
-                    manualWhiteBalance: state.ManualWhiteBalance)
+                    manualWhiteBalance: state.ManualWhiteBalance,
+                    applyColorCalibration: state.ColorCalibrationEnabled)
                 ?? new StretchUniforms(StretchMode.None, 1f, default, default, default, default, default);
 
             // Grid WCS: the document's (still image), or the caller-supplied OverrideWcs for a
@@ -984,7 +985,9 @@ namespace TianWen.UI.Abstractions
             // per-method dict makes the re-call a cheap dictionary lookup.
             if (state.BackgroundNeutralizationEnabled)
             {
-                document.ComputeBackgroundNeutralization(state.BackgroundNeutralizationMethod);
+                // Solved for the WB that will actually be applied: with the calibration toggled off the
+                // gains for the calibrated triple would re-tint a frame that no longer receives it.
+                document.ComputeBackgroundNeutralization(state.BackgroundNeutralizationMethod, state.ColorCalibrationEnabled);
             }
 
             // ColorCalibration auto-retrigger on file switch. The ColorCalibrationInFlight guard inside
@@ -993,6 +996,7 @@ namespace TianWen.UI.Abstractions
             if (state.ColorCalibrationEnabled
                 && document.ColorCalibration is null
                 && !document.ColorCalibrationInFlight
+                && !document.ColorCalibrationAttempted
                 && document.Stars is { Count: >= 5 })
             {
                 TryStartColorCalibration(state);

--- a/src/TianWen.UI.Abstractions/ImageRendererBase.cs
+++ b/src/TianWen.UI.Abstractions/ImageRendererBase.cs
@@ -917,6 +917,22 @@ namespace TianWen.UI.Abstractions
             var document = source as AstroImageDocument;
             _document = document;
 
+            // Textures FIRST, before anything in this frame samples them. A document swap recreates the
+            // channel textures, and the recreate destroys the old views after draining PRIOR frames; it
+            // cannot un-record what THIS frame's command buffer already holds. The upload used to run
+            // from each host's render callback, which comes AFTER the cached-layer pre-pass: the pass
+            // bound the old views, the upload destroyed them, the frame was submitted with a dangling
+            // view and the GPU faulted. That is the watchdog (LiveKernelEvent 141) that took the Store
+            // viewer down on 2026-08-27 and, reproduced under the validation layer, reads
+            // "vkCmdBindDescriptorSets(): ... invalid state ... VkImageView was destroyed" followed by
+            // VK_ERROR_DEVICE_LOST. PrepareFrame is the one point every host passes before recording
+            // anything that samples, so the upload lives here and nowhere else; it also means the layout
+            // below already sees the new document's size instead of lagging it by a frame.
+            if (source is not null && state.NeedsTextureUpdate && source.Width > 0 && source.Height > 0)
+            {
+                UploadDocumentTextures(source, state);
+            }
+
             RestoreDocumentCalibration(document, state);
 
             // The toolbar band's HEIGHT is an input to the layout pass below, and what decides it is the

--- a/src/TianWen.UI.Abstractions/LiveFramePreviewSource.cs
+++ b/src/TianWen.UI.Abstractions/LiveFramePreviewSource.cs
@@ -134,6 +134,10 @@ namespace TianWen.UI.Abstractions
             // applied here. The static producer is the single source of the stretch math (shared with the
             // document + SER paths).
             var shaderWb = StretchSolver.ComposeWhiteBalance(null, manualWhiteBalance);
+            // A live frame carries no measured calibration, so Auto resolves on channel count alone:
+            // colour -> Unlinked (neutralise per channel), mono -> Linked.
+            var isColour = _channelCount >= 3 || _sensorType is SensorType.RGGB;
+            mode = mode.ResolveAuto(isColour, calibrationActive: false);
             return StretchSolver.ComputeStretchUniforms(
                 mode, parameters, _stats, lumaStats: null, imageMaxValue: 1f,
                 whiteBalance: null, lumaWeights: null, shaderWhiteBalance: shaderWb);

--- a/src/TianWen.UI.Abstractions/LiveFramePreviewSource.cs
+++ b/src/TianWen.UI.Abstractions/LiveFramePreviewSource.cs
@@ -117,8 +117,11 @@ namespace TianWen.UI.Abstractions
             float hdrAmount = 0f,
             float hdrKnee = 0.8f,
             float bgNeutralizationStrength = 1f,
-            (float R, float G, float B)? manualWhiteBalance = null)
+            (float R, float G, float B)? manualWhiteBalance = null,
+            bool applyColorCalibration = true)
         {
+            // applyColorCalibration is a document concern: a live frame carries no measured calibration
+            // to switch off, so the flag has nothing to act on here.
             if (_stats.Length == 0)
             {
                 return new StretchUniforms(StretchMode.None, 1f, default, default, default, default, default);

--- a/src/TianWen.UI.Abstractions/LiveSessionTab.cs
+++ b/src/TianWen.UI.Abstractions/LiveSessionTab.cs
@@ -333,10 +333,8 @@ namespace TianWen.UI.Abstractions
 
                 viewer.SetSurfaceSize((uint)Renderer.Width, (uint)Renderer.Height);
                 viewer.SetContentRegion(imageRect);
-                if (pst.NeedsTextureUpdate && _previewSource.Width > 0)
-                {
-                    viewer.UploadDocumentTextures(_previewSource, pst);
-                }
+                // The texture upload NeedsTextureUpdate asks for happens inside Render's PrepareFrame,
+                // before anything in the frame samples the channel views; see the remarks there.
                 viewer.Render(_previewSource, pst);
             }
             else if (viewerW > 0)

--- a/src/TianWen.UI.Abstractions/LiveStackPreviewSource.cs
+++ b/src/TianWen.UI.Abstractions/LiveStackPreviewSource.cs
@@ -358,10 +358,11 @@ public sealed class LiveStackPreviewSource : IPreviewSource, IDisposable, IAsync
         float lumaBlend = 1f, bool normalize = false, int curvesMode = 0,
         ReadOnlySpan<float> curveLut = default, float curvesBoost = 0f, float curvesMidpoint = 0.25f,
         float hdrAmount = 0f, float hdrKnee = 0.8f, float bgNeutralizationStrength = 1f,
-        (float R, float G, float B)? manualWhiteBalance = null)
+        (float R, float G, float B)? manualWhiteBalance = null, bool applyColorCalibration = true)
         => _doc is { } doc
             ? doc.ComputeStretchUniforms(mode, parameters, weighting, lumaBlend, normalize, curvesMode,
-                curveLut, curvesBoost, curvesMidpoint, hdrAmount, hdrKnee, bgNeutralizationStrength, manualWhiteBalance)
+                curveLut, curvesBoost, curvesMidpoint, hdrAmount, hdrKnee, bgNeutralizationStrength, manualWhiteBalance,
+                applyColorCalibration)
             : new StretchUniforms(StretchMode.None, 1f, default, default, default, default, default);
 
     // --- IPreviewSource: sequence members come from the stream (so the transport tracks the raw playhead) ---

--- a/src/TianWen.UI.Abstractions/SerPreviewSource.cs
+++ b/src/TianWen.UI.Abstractions/SerPreviewSource.cs
@@ -127,9 +127,10 @@ public sealed class SerPreviewSource : IPreviewSource, ISequencePlaybackSource, 
         float lumaBlend = 1f, bool normalize = false, int curvesMode = 0,
         ReadOnlySpan<float> curveLut = default, float curvesBoost = 0f, float curvesMidpoint = 0.25f,
         float hdrAmount = 0f, float hdrKnee = 0.8f, float bgNeutralizationStrength = 1f,
-        (float R, float G, float B)? manualWhiteBalance = null)
+        (float R, float G, float B)? manualWhiteBalance = null, bool applyColorCalibration = true)
         => _statsFrame.ComputeStretchUniforms(mode, parameters, weighting, lumaBlend, normalize, curvesMode,
-            curveLut, curvesBoost, curvesMidpoint, hdrAmount, hdrKnee, bgNeutralizationStrength, manualWhiteBalance);
+            curveLut, curvesBoost, curvesMidpoint, hdrAmount, hdrKnee, bgNeutralizationStrength, manualWhiteBalance,
+            applyColorCalibration);
 
     public int FrameCount => _reader.FrameCount;
     public int FrameIndex => _frameIndex;

--- a/src/TianWen.UI.Abstractions/ViewerActions.cs
+++ b/src/TianWen.UI.Abstractions/ViewerActions.cs
@@ -27,24 +27,43 @@ public static class ViewerActions
     // Cycle order for stretch link: excludes None. Internal so the dropdown
     // selector in <see cref="ImageRendererBase{TSurface}"/> can reuse the same
     // mode list (single source of truth: cycle order matches dropdown order).
-    internal static readonly StretchMode[] StretchLinkModes = [StretchMode.Linked, StretchMode.Unlinked, StretchMode.Luma];
+    // Auto leads, and is the default (see DefaultStretchMode).
+    internal static readonly StretchMode[] StretchLinkModes =
+        [StretchMode.Auto, StretchMode.Linked, StretchMode.Unlinked, StretchMode.Luma];
 
     /// <summary>
     /// What a viewer shows when it has to pick a stretch for itself: first entry of
-    /// <see cref="StretchLinkModes"/>.
+    /// <see cref="StretchLinkModes"/>, which is <see cref="StretchMode.Auto"/>.
     ///
-    /// <para>Linked, which is PixInsight's and Siril's default and now means the same thing here: ONE
-    /// curve shared across R/G/B, so a colour-calibrated image renders with the colour it was
-    /// calibrated to. Unlinked normalises each channel against its own stats, which neutralises the
-    /// background and in doing so discards exactly the per-channel differences a white balance
-    /// consists of -- correct behaviour for that mode, and the wrong thing to open on.</para>
+    /// <para>Auto resolves per frame (<see cref="ResolveAutoStretchMode"/>): a colour frame with an
+    /// active colour calibration renders LINKED, so the measured white balance shows as colour; a
+    /// colour frame without one renders UNLINKED, which neutralises each channel's background for a
+    /// clean look with no cast to guess at; a mono frame renders LINKED (Linked and Unlinked coincide
+    /// on one channel). So running SPCC on an Auto frame flips it to Linked on its own and the
+    /// calibration is visible immediately, which is the decision a user otherwise had to make by hand.</para>
     ///
-    /// <para>It used to be Unlinked, which made a photometric calibration look like a no-op on a
-    /// fresh viewer: run SPCC, watch nothing happen. Named once here so the several places that need
-    /// a default -- the toggle above, ViewerState's initialiser, DisplayControls.Defaults, the CLI
-    /// view command -- cannot drift apart again.</para>
+    /// <para>The default used to be Unlinked, which made a photometric calibration look like a no-op on
+    /// a fresh viewer; then Linked, which opened an uncalibrated frame on a possible colour cast. Auto
+    /// picks the right one of the two per frame. Named once here so the several places that need a
+    /// default -- the toggle above, ViewerState's initialiser, DisplayControls.Defaults, the CLI view
+    /// command -- cannot drift apart again.</para>
     /// </summary>
     public static StretchMode DefaultStretchMode => StretchLinkModes[0];
+
+    extension(StretchMode mode)
+    {
+        /// <summary>
+        /// Resolves <see cref="StretchMode.Auto"/> to a concrete mode; returns any other mode unchanged.
+        /// Colour + a calibration to show -&gt; Linked (the WB survives as colour); colour without one -&gt;
+        /// Unlinked (each channel's background neutralised, no cast asserted); mono -&gt; Linked (the two
+        /// coincide). Called by the producers before a <see cref="StretchUniforms"/> is built, so Auto
+        /// never reaches the shader.
+        /// </summary>
+        public StretchMode ResolveAuto(bool isColour, bool calibrationActive)
+            => mode is not StretchMode.Auto ? mode
+                : !isColour ? StretchMode.Linked
+                : calibrationActive ? StretchMode.Linked : StretchMode.Unlinked;
+    }
 
     public static void CycleStretchLink(ViewerState state, bool reverse = false)
     {

--- a/src/TianWen.UI.Abstractions/ViewerController.cs
+++ b/src/TianWen.UI.Abstractions/ViewerController.cs
@@ -615,6 +615,13 @@ public sealed class ViewerController(
         if (task.IsCompletedSuccessfully && task.Result is { } enhancedDoc)
         {
             state.IsEnhanced = true;
+            // The colour calibration measured on the ORIGINAL stars travels with the enhance; without
+            // this the auto-retrigger re-fitted SPCC on the enhanced pixels and the frame took on a new
+            // cast the moment that fit landed. See AstroImageDocument.InheritColorCalibration.
+            if (Document is { } original)
+            {
+                enhancedDoc.InheritColorCalibration(original);
+            }
             Document = enhancedDoc;
             _rawSource = enhancedDoc;
             _liveSource = null;

--- a/src/TianWen.UI.FitsViewer/Program.cs
+++ b/src/TianWen.UI.FitsViewer/Program.cs
@@ -374,27 +374,11 @@ var loop = new SdlEventLoop(sdlWindow, renderer)
 
     OnRender = () =>
     {
-        // Retire finished background work (the file dialog, a plate solve) and log anything that
-        // faulted. Deliberately NOT gated on tracker.HasPending in CheckNeedsRedraw: that would spin
-        // the render loop for the whole of a multi-second solve on a GPU we want quiet. Each guarded
-        // operation flags a redraw in its onFinally instead, so the loop wakes exactly once, here.
-        tracker.ProcessCompletions(logger);
-
-        controller.HandleFileRequest(cts.Token);
-
-        // Apply a finished AI-enhance result (swaps in the enhanced document + flags a texture
-        // re-upload). No-op until the background enhance task completes.
-        controller.TryApplyPendingEnhance(cts.Token);
-
-        if (state.NeedsReprocess)
-        {
-            ViewerActions.Reprocess(state);
-        }
-
-        if (controller.Source is not null && state.NeedsTextureUpdate)
-        {
-            imageRenderer.UploadDocumentTextures(controller.Source, state);
-        }
+        // Everything that can SWAP the document (finished background work, a file request, an enhance
+        // result) runs in OnBeforeFrame, before this frame's command buffer exists; the texture upload
+        // it implies runs inside PrepareFrame, from the pre-render-pass hook. Both used to happen here,
+        // AFTER the cached-layer pre-pass had already bound the previous document's views into this
+        // very command buffer -- see the remarks on PrepareFrame for what that cost.
 
         // Which repaint path the frame took. Counted because a partial frame is IDENTICAL on screen to
     // a full one -- that is the point -- so no screenshot can tell them apart and this is the only
@@ -433,6 +417,38 @@ bus.Subscribe<EnhanceImageSignal>(_ =>
 var frameDamage = new List<RectF32>();
 loop.OnBeforeFrame = () =>
 {
+    // The document may only change BETWEEN frames. A swap recreates the channel textures, and the
+    // recreate destroys the previous views; done inside a frame it invalidated whatever this frame's
+    // command buffer had already recorded against them (the cached-layer pre-pass), and the GPU
+    // faulted on submit -- the LiveKernelEvent 141 that took the Store viewer down on 2026-08-27,
+    // "VkImageView was destroyed" under the validation layer. So every step that can replace
+    // controller.Source runs here, before BeginFrame, and the upload itself runs in PrepareFrame.
+    //
+    // Retire finished background work (the file dialog, a plate solve) and log anything that
+    // faulted. Deliberately NOT gated on tracker.HasPending in CheckNeedsRedraw: that would spin
+    // the render loop for the whole of a multi-second solve on a GPU we want quiet. Each guarded
+    // operation flags a redraw in its onFinally instead, so the loop wakes exactly once, here.
+    tracker.ProcessCompletions(logger);
+
+    controller.HandleFileRequest(cts.Token);
+
+    // Apply a finished AI-enhance result (swaps in the enhanced document + flags a texture
+    // re-upload). No-op until the background enhance task completes.
+    controller.TryApplyPendingEnhance(cts.Token);
+
+    if (state.NeedsReprocess)
+    {
+        ViewerActions.Reprocess(state);
+    }
+
+    // A frame that swaps its document repaints everything, whatever narrowing a mouse move in the
+    // same tick may have declared: stale pixels from the previous document are the one failure the
+    // damage tracking must never produce.
+    if (state.NeedsTextureUpdate)
+    {
+        imageRenderer.RequestFullFrameDamage();
+    }
+
     frameDamage.Clear();
     if (imageRenderer.TryTakeFrameDamage(frameDamage))
     {

--- a/src/TianWen.UI.Gui/VkPlanetaryTab.cs
+++ b/src/TianWen.UI.Gui/VkPlanetaryTab.cs
@@ -206,10 +206,8 @@ public sealed class VkPlanetaryTab : VkImageRenderer, IPlanetaryViewWidget
         // + render through the shared viewer -- mirroring the FITS viewer's OnRender drive sequence.
         controller.Tick();
         var source = controller.Source;
-        if (source is not null && state.NeedsTextureUpdate)
-        {
-            UploadDocumentTextures(source, state);
-        }
+        // The texture upload NeedsTextureUpdate asks for happens inside Render's PrepareFrame, before
+        // anything in the frame samples the channel views; see the remarks there.
 
         // base.Render calls BeginFrame() (which clears the clickable tracker) before drawing the viewer
         // chrome, so the panel's clickables MUST be registered AFTER this call to survive.

--- a/src/TianWen.UI.Shared/VkFitsImagePipeline.cs
+++ b/src/TianWen.UI.Shared/VkFitsImagePipeline.cs
@@ -62,13 +62,25 @@ public sealed unsafe class VkFitsImagePipeline : IDisposable
     private VkDescriptorPool _descriptorPool;
 
     // Descriptor sets: image UBO (slot 0) + image UBO (slot 1, the comparison rendition) + histogram
-    // UBO + image samplers + before-image samplers + histogram samplers.
+    // UBO + image samplers + before-image samplers (both PER FRAME IN FLIGHT) + histogram samplers.
     private VkDescriptorSet _imageUboSet;
     private VkDescriptorSet _imageUboSetComparison;
     private VkDescriptorSet _histogramUboSet;
-    private VkDescriptorSet _imageSamplerSet;
-    private VkDescriptorSet _beforeSamplerSet;
     private VkDescriptorSet _histogramSamplerSet;
+
+    // The sampler sets exist once per frame in flight, and a frame binds the set of ITS slot. A frame's
+    // command buffer references the set it bound until that frame retires, and vkUpdateDescriptorSets on
+    // a set a pending frame holds is illegal; the drain that used to make it legal is gone with deferred
+    // destruction (SdlVulkan.Renderer 7.28, docs/deferred-destroy-adoption.md). So the views are stamped
+    // whenever one changes, each slot remembers the stamp it was last written at, and RecordImageDraw
+    // rewrites a slot's set first when it is behind: the slot's previous frame retired at the BeginFrame
+    // that handed out this command buffer, so the write is legal and the bind sees the current views.
+    private readonly VkDescriptorSet[] _imageSamplerSets = new VkDescriptorSet[VulkanContext.MaxFramesInFlight];
+    private readonly VkDescriptorSet[] _beforeSamplerSets = new VkDescriptorSet[VulkanContext.MaxFramesInFlight];
+    private readonly int[] _imageSamplerSetStamp = new int[VulkanContext.MaxFramesInFlight];
+    private readonly int[] _beforeSamplerSetStamp = new int[VulkanContext.MaxFramesInFlight];
+    // Starts above the slots' zero so every set is written before its first bind.
+    private int _samplerViewsStamp = 1;
 
     // Shared pipeline layout
     private VkPipelineLayout _pipelineLayout;
@@ -339,13 +351,9 @@ public sealed unsafe class VkFitsImagePipeline : IDisposable
         {
             DestroyChannelTexture(channel);
             CreateChannelTextureOrFreeBefore(channel, width, height, format);
-            BindChannelSampler(channel, _channelViews[channel], _imageSamplerSet);
-            if (!HasBeforeChannels)
-            {
-                // Keep the before set pointing at live views while nothing is retained, so it can
-                // never reference the view this recreation just destroyed.
-                BindChannelSampler(channel, _channelViews[channel], _beforeSamplerSet);
-            }
+            // The sets are rewritten per slot at draw time (see the sampler-set fields); nothing is
+            // written here, where a frame in flight may still hold the set that points at the old view.
+            SamplerViewsChanged();
         }
 
         UploadToImage(_channelImages[channel], (uint)width, (uint)height, byteSize, format);
@@ -407,13 +415,7 @@ public sealed unsafe class VkFitsImagePipeline : IDisposable
             }
 
             CreateChannelTexture(i, 1, 1, VkFormat.R32Sfloat);
-            BindChannelSampler(i, _channelViews[i], _imageSamplerSet);
-            if (!HasBeforeChannels)
-            {
-                // Same rule as the recreate branch: while nothing is retained the before set mirrors
-                // the live views, so it must never be left pointing at the view just destroyed.
-                BindChannelSampler(i, _channelViews[i], _beforeSamplerSet);
-            }
+            SamplerViewsChanged();
 
             UploadToImage(_channelImages[i], 1, 1, byteSize, VkFormat.R32Sfloat);
             _channelWidth[i] = 1;
@@ -508,12 +510,8 @@ public sealed unsafe class VkFitsImagePipeline : IDisposable
             _channelHeight[i] = 0;
             _channelFormats[i] = VkFormat.R32Sfloat;
             _channelBytes[i] = 0;
-
-            if (_beforeViews[i] != VkImageView.Null)
-            {
-                BindChannelSampler(i, _beforeViews[i], _beforeSamplerSet);
-            }
         }
+        SamplerViewsChanged();
 
         _beforeChannelBytes = bytes;
         HasBeforeChannels = true;
@@ -536,24 +534,14 @@ public sealed unsafe class VkFitsImagePipeline : IDisposable
             return;
         }
 
-        var api = _ctx.DeviceApi;
         for (var i = 0; i < ChannelCount; i++)
         {
-            if (_beforeViews[i] != VkImageView.Null)
-            {
-                api.vkDestroyImageView(_beforeViews[i]);
-                _beforeViews[i] = VkImageView.Null;
-            }
-            if (_beforeImages[i] != VkImage.Null)
-            {
-                api.vkDestroyImage(_beforeImages[i]);
-                _beforeImages[i] = VkImage.Null;
-            }
-            if (_beforeMemories[i] != VkDeviceMemory.Null)
-            {
-                api.vkFreeMemory(_beforeMemories[i]);
-                _beforeMemories[i] = VkDeviceMemory.Null;
-            }
+            // Deferred: a frame in flight, or the one being recorded, may hold the set that samples
+            // these. The context destroys them once every such frame has retired.
+            _ctx.DeferDestroy(view: _beforeViews[i], image: _beforeImages[i], memory: _beforeMemories[i]);
+            _beforeViews[i] = VkImageView.Null;
+            _beforeImages[i] = VkImage.Null;
+            _beforeMemories[i] = VkDeviceMemory.Null;
             _beforeWidth[i] = 0;
             _beforeHeight[i] = 0;
         }
@@ -565,28 +553,11 @@ public sealed unsafe class VkFitsImagePipeline : IDisposable
         _beforeChannelBytes = 0;
         HasBeforeChannels = false;
 
-        // Re-point the (still bindable) before set at the live views, so it can never reference the
-        // views just destroyed.
-        //
-        // NOT during teardown. Dispose destroys the descriptor pool (which frees every set, this one
-        // included) and the sampler BEFORE it releases the before channels, so re-pointing there
-        // writes a freed descriptor set with a destroyed sampler -- an access violation inside
-        // vkUpdateDescriptorSets that takes the process down with exit 139 on window close. Guarding
-        // on _disposed rather than reordering Dispose: the flag is set before anything is destroyed,
-        // so this holds no matter how the teardown sequence is later rearranged, and there is nothing
-        // to re-point at when every descriptor is about to be freed anyway.
-        if (_disposed)
-        {
-            return;
-        }
-
-        for (var i = 0; i < ChannelCount; i++)
-        {
-            if (_channelViews[i] != VkImageView.Null)
-            {
-                BindChannelSampler(i, _channelViews[i], _beforeSamplerSet);
-            }
-        }
+        // The before sets are rewritten per slot at draw time from whatever is retained then (the live
+        // views when nothing is), so nothing is written here. That also removes the teardown trap this
+        // used to guard against: Dispose frees the pool before it releases the before channels, and a
+        // write into a freed set with a destroyed sampler was an access violation on window close.
+        SamplerViewsChanged();
     }
 
     // Creates a live channel texture, and if the device is out of memory, frees the retained before
@@ -880,9 +851,13 @@ public sealed unsafe class VkFitsImagePipeline : IDisposable
 
         api.vkCmdBindPipeline(cmd, VkPipelineBindPoint.Graphics, _imagePipeline);
 
-        // Bind set 0 (UBO) and set 1 (samplers)
+        // Bind set 0 (UBO) and set 1 (samplers). The sampler set is THIS frame's slot's copy, brought
+        // up to date first if a view changed since that slot last drew; see the sampler-set fields.
         var uboSet = uboSlot == UboSlotComparison ? _imageUboSetComparison : _imageUboSet;
-        var samplerSet = sampleBeforeChannels && HasBeforeChannels ? _beforeSamplerSet : _imageSamplerSet;
+        var frameSlot = ctx.CurrentFrame;
+        var samplerSet = sampleBeforeChannels && HasBeforeChannels
+            ? EnsureSamplerSet(frameSlot, _beforeSamplerSets, _beforeSamplerSetStamp, _beforeViews)
+            : EnsureSamplerSet(frameSlot, _imageSamplerSets, _imageSamplerSetStamp, _channelViews);
         api.vkCmdBindDescriptorSets(cmd, VkPipelineBindPoint.Graphics, _pipelineLayout,
             0, 1, &uboSet, 0, null);
         api.vkCmdBindDescriptorSets(cmd, VkPipelineBindPoint.Graphics, _pipelineLayout,
@@ -1027,8 +1002,9 @@ public sealed unsafe class VkFitsImagePipeline : IDisposable
     {
         var api = _ctx.DeviceApi;
 
-        // 3 UBO descriptors (image slot 0 + image slot 1 + histogram) + 9 sampler descriptors
-        // (3 image + 3 before-image + 3 histogram).
+        // 3 UBO descriptors (image slot 0 + image slot 1 + histogram) + sampler descriptors for the
+        // image and before-image sets, one of each PER FRAME IN FLIGHT, plus the histogram set.
+        const int SamplerSets = 2 * VulkanContext.MaxFramesInFlight + 1;
         var poolSizes = stackalloc VkDescriptorPoolSize[2];
         poolSizes[0] = new VkDescriptorPoolSize
         {
@@ -1038,12 +1014,12 @@ public sealed unsafe class VkFitsImagePipeline : IDisposable
         poolSizes[1] = new VkDescriptorPoolSize
         {
             type = VkDescriptorType.CombinedImageSampler,
-            descriptorCount = 3 * ChannelCount
+            descriptorCount = SamplerSets * ChannelCount
         };
 
         VkDescriptorPoolCreateInfo dpCI = new()
         {
-            maxSets = 6, // imageUBO + imageUBO(comparison) + histUBO + imageSamplers + beforeSamplers + histSamplers
+            maxSets = 3 + SamplerSets,
             poolSizeCount = 2,
             pPoolSizes = poolSizes
         };
@@ -1054,15 +1030,19 @@ public sealed unsafe class VkFitsImagePipeline : IDisposable
     {
         var api = _ctx.DeviceApi;
 
-        // Allocate all 6 sets at once
-        const int SetCount = 6;
+        // Allocate every set at once: the three UBO sets, the histogram sampler set, then one image
+        // sampler set and one before-image sampler set per frame in flight.
+        const int Frames = VulkanContext.MaxFramesInFlight;
+        const int SetCount = 4 + 2 * Frames;
         var layouts = stackalloc VkDescriptorSetLayout[SetCount];
         layouts[0] = _uboSetLayout;       // image UBO, slot 0 (live)
         layouts[1] = _uboSetLayout;       // image UBO, slot 1 (comparison)
         layouts[2] = _uboSetLayout;       // histogram UBO
-        layouts[3] = _samplerSetLayout;   // image samplers
-        layouts[4] = _samplerSetLayout;   // before-image samplers
-        layouts[5] = _samplerSetLayout;   // histogram samplers
+        layouts[3] = _samplerSetLayout;   // histogram samplers
+        for (var i = 4; i < SetCount; i++)
+        {
+            layouts[i] = _samplerSetLayout;   // image samplers x Frames, then before-image samplers x Frames
+        }
 
         var sets = stackalloc VkDescriptorSet[SetCount];
         VkDescriptorSetAllocateInfo dsAI = new()
@@ -1076,9 +1056,12 @@ public sealed unsafe class VkFitsImagePipeline : IDisposable
         _imageUboSet = sets[0];
         _imageUboSetComparison = sets[1];
         _histogramUboSet = sets[2];
-        _imageSamplerSet = sets[3];
-        _beforeSamplerSet = sets[4];
-        _histogramSamplerSet = sets[5];
+        _histogramSamplerSet = sets[3];
+        for (var f = 0; f < Frames; f++)
+        {
+            _imageSamplerSets[f] = sets[4 + f];
+            _beforeSamplerSets[f] = sets[4 + Frames + f];
+        }
     }
 
     private void CreatePipelineLayout()
@@ -1228,12 +1211,10 @@ public sealed unsafe class VkFitsImagePipeline : IDisposable
             UploadToImage(_channelImages[i], 1, 1, byteSize, VkFormat.R32Sfloat);
             _channelWidth[i] = 1;
             _channelHeight[i] = 1;
-            BindChannelSampler(i, _channelViews[i], _imageSamplerSet);
-            // The before set must hold VALID descriptors from the start: it is a bindable set, and
-            // Vulkan forbids binding one that references a destroyed view even if the shader never
-            // samples it. With no before retained it simply mirrors the live views.
-            BindChannelSampler(i, _channelViews[i], _beforeSamplerSet);
         }
+        // Every sampler set is written from the current views at its first bind (the slots start behind
+        // the stamp), so a set can never be bound holding a destroyed or absent view.
+        SamplerViewsChanged();
 
         // The histogram placeholders are FULL-WIDTH (HistogramBins x 1), unlike the 1x1 channel
         // placeholders above, so they need their own staging of HistogramBins zero floats -- staged
@@ -1343,8 +1324,8 @@ public sealed unsafe class VkFitsImagePipeline : IDisposable
     }
 
     /// <summary>
-    /// Frees a channel's view, image and memory, draining the in-flight frames first because every
-    /// caller destroys an image a frame still in flight may be sampling.
+    /// Releases a channel's view, image and memory through the context's deferred destruction, because
+    /// every caller destroys an image a frame in flight, or the frame being recorded, may be sampling.
     /// </summary>
     /// <remarks>
     /// <para><b>Waiting the frame fence is not enough, and assuming it was is how this was missed.</b>
@@ -1377,35 +1358,23 @@ public sealed unsafe class VkFitsImagePipeline : IDisposable
     /// destroy has no rebuild behind it, so proceeding frees an image the GPU may still be reading -- a
     /// low-probability fault on a device that could not signal its fences inside the cap, set against a
     /// guaranteed hang of the render thread. The fault was chosen.</para>
+    /// <para><b>Superseded by deferred destruction (SdlVulkan.Renderer 7.28).</b> Everything above
+    /// argued about frames already SUBMITTED, and it was right about those. It could not be right
+    /// about the frame being RECORDED: a drain retires previous frames, and nothing can retire a
+    /// command buffer that has not been submitted, so a destroy mid-record was correct only if nothing
+    /// earlier in the same frame had bound the view. The cached-layer pre-pass had, the frame went to
+    /// the GPU with a dangling view, and the watchdog took the process (2026-08-27, twice). The context
+    /// now takes the handles and destroys them once every frame that could reference them has retired,
+    /// with no wait at all, so the stall this method used to cost per document swap is gone too. The
+    /// descriptor sets that pointed at the view are per frame in flight and rewritten at draw time,
+    /// which is the other half of making the wait unnecessary (see the sampler-set fields).</para>
     /// </remarks>
     private void DestroyChannelTexture(int channel)
     {
-        var api = _ctx.DeviceApi;
-
-        if (_channelViews[channel] != VkImageView.Null
-            || _channelImages[channel] != VkImage.Null
-            || _channelMemories[channel] != VkDeviceMemory.Null)
-        {
-            // The timed-out (false) return is deliberately not acted on -- see the remarks. The renderer
-            // has already logged it under this label.
-            _ = _ctx.TryWaitAllFramesIdle("channel texture destroy");
-        }
-
-        if (_channelViews[channel] != VkImageView.Null)
-        {
-            api.vkDestroyImageView(_channelViews[channel]);
-            _channelViews[channel] = VkImageView.Null;
-        }
-        if (_channelImages[channel] != VkImage.Null)
-        {
-            api.vkDestroyImage(_channelImages[channel]);
-            _channelImages[channel] = VkImage.Null;
-        }
-        if (_channelMemories[channel] != VkDeviceMemory.Null)
-        {
-            api.vkFreeMemory(_channelMemories[channel]);
-            _channelMemories[channel] = VkDeviceMemory.Null;
-        }
+        _ctx.DeferDestroy(view: _channelViews[channel], image: _channelImages[channel], memory: _channelMemories[channel]);
+        _channelViews[channel] = VkImageView.Null;
+        _channelImages[channel] = VkImage.Null;
+        _channelMemories[channel] = VkDeviceMemory.Null;
         _channelWidth[channel] = 0;
         _channelHeight[channel] = 0;
         _channelBytes[channel] = 0;
@@ -1413,22 +1382,41 @@ public sealed unsafe class VkFitsImagePipeline : IDisposable
 
     private void DestroyHistogramTexture(int channel)
     {
-        var api = _ctx.DeviceApi;
-        if (_histViews[channel] != VkImageView.Null)
+        // Only reached from Dispose, after its device wait, but deferred like every other texture so
+        // there is one rule for a texture a frame may have sampled.
+        _ctx.DeferDestroy(view: _histViews[channel], image: _histImages[channel], memory: _histMemories[channel]);
+        _histViews[channel] = VkImageView.Null;
+        _histImages[channel] = VkImage.Null;
+        _histMemories[channel] = VkDeviceMemory.Null;
+    }
+
+    /// <summary>Records that a channel or before view was replaced, so every per-frame sampler set is
+    /// rewritten before its next bind. Never writes a set itself: a frame in flight may hold one.</summary>
+    private void SamplerViewsChanged() => _samplerViewsStamp++;
+
+    /// <summary>
+    /// The sampler set for <paramref name="slot"/>, rewritten from <paramref name="views"/> first if a
+    /// view changed since that slot last drew. Legal because the slot's previous frame retired at the
+    /// BeginFrame that produced the command buffer being recorded, so no pending frame holds this set.
+    /// A view a channel does not have (a vacated before slot) falls back to the live view, so a set can
+    /// never hold a null or destroyed one.
+    /// </summary>
+    private VkDescriptorSet EnsureSamplerSet(int slot, VkDescriptorSet[] sets, int[] stamps, VkImageView[] views)
+    {
+        var set = sets[slot];
+        if (stamps[slot] != _samplerViewsStamp)
         {
-            api.vkDestroyImageView(_histViews[channel]);
-            _histViews[channel] = VkImageView.Null;
+            for (var i = 0; i < ChannelCount; i++)
+            {
+                var view = views[i] != VkImageView.Null ? views[i] : _channelViews[i];
+                if (view != VkImageView.Null)
+                {
+                    BindChannelSampler(i, view, set);
+                }
+            }
+            stamps[slot] = _samplerViewsStamp;
         }
-        if (_histImages[channel] != VkImage.Null)
-        {
-            api.vkDestroyImage(_histImages[channel]);
-            _histImages[channel] = VkImage.Null;
-        }
-        if (_histMemories[channel] != VkDeviceMemory.Null)
-        {
-            api.vkFreeMemory(_histMemories[channel]);
-            _histMemories[channel] = VkDeviceMemory.Null;
-        }
+        return set;
     }
 
     private void BindChannelSampler(int channel, VkImageView view, VkDescriptorSet set)


### PR DESCRIPTION
Found and fixed via a round of Vulkan validation-layer testing (`SDLVK_VALIDATION=1 SDLVK_SYNC_VALIDATION=1`) on the FITS viewer and then the GUI. Two of these are renderer-wide hazards upstreamed to SdlVulkan.Renderer (7.28 + 7.29) and consumed here via the pin.

## Viewer device loss (the crash)

A document may change only BETWEEN frames, and its textures upload in `PrepareFrame`, before anything samples them. The standalone host uploaded in the render callback and swapped the document there too, so a frame reached the GPU with views a pre-pass had already bound and the swap had destroyed: `nvlddmkm 153` / `LiveKernelEvent 141` watchdog on NVIDIA, reproduced under validation as `vkCmdBindDescriptorSets ... VkImageView was destroyed` then `VK_ERROR_DEVICE_LOST`.

- Uploads move to `PrepareFrame`; swaps move to `OnBeforeFrame`. Pinned by `ANewDocumentIsUploadedBeforeTheLayerPassThatSamplesIt`.
- Channel/before/histogram textures now go through the renderer's **deferred destruction** (SdlVulkan.Renderer 7.28 `VulkanContext.DeferDestroy`) with **per-frame-in-flight sampler descriptor sets** (`EnsureSamplerSet`), so a texture disposed in the frame that drew it is legal and no shared set is written while a frame holds it.

## Swapchain teardown races present (new, found validating the GUI)

Window resize / maximize / restore recreated the swapchain and destroyed it plus its per-image render-finished semaphores while `vkQueuePresentKHR` was still in flight, because the bounded fence drain only waits on graphics-submit fences and present is gated by no fence (VUID-vkDestroySwapchainKHR-swapchain-01282 / VUID-vkDestroySemaphore-semaphore-05149). Benign on desktop NVIDIA, a rejected `vkQueueSubmit` on Adreno. Fixed in **SdlVulkan.Renderer 7.29** (`FlushPresentQueueAfterDrain`: a `vkQueueWaitIdle` after a *successful* drain, skipped on a wedged-GPU timeout so the no-hang property holds). The resize sequence that logged 10 validation messages now logs 0.

## Cached-layer squash (the file-list resize bug)

The cached image layer samples in TEXTURE space, and a fixed-capacity target is not the size requested this frame; UVs divided by the request rather than the capacity drew the image squashed by `capacity/request` when a pane shrank. Fixed to divide by the reported capacity. Pinned by `TheBlitSamplesInTextureSpaceWhenTheTargetIsLargerThanTheLayer`.

## SPCC / Calibrate toggle

- The toggle (and `W`) now gate the **render** via `applyColorCalibration`, not just the toolbar highlight; the measured triple is kept, so off/on is a no-op round trip with no re-fit.
- An AI enhance **inherits** the calibration (`InheritColorCalibration`) instead of re-fitting SPCC on the enhanced pixels (the "Auto Enhance adds another colour cast" report).
- `W` is a real toggle; the per-document `ColorCalibrationAttempted` guard fixes the SPCC button flicker (auto-retrigger fired every frame on a document the fit cannot calibrate).

## Auto stretch mode (new default)

`StretchMode.Auto`, resolved before any `StretchUniforms` is built (never a shader mode): colour + a calibration to show -> Linked, colour without one -> Unlinked, mono -> Linked. So running SPCC on an Auto frame flips it to Linked itself. Pure `mode.ResolveAuto(isColour, calibrationActive)` extension; the button reads "Auto (Linked)".

## Dependency bumps

- `SdlVulkan.Renderer` 7.28.* -> **7.29.***
- `DIR.Lib` 8.9.* -> **8.13.*** (coordinated: SdlVulkan.Renderer has required DIR.Lib 8.13.2681 since 7.26; the skew was invisible under `UseLocalSiblings` and surfaced only on the CI-path restore).

## Verification

- Full unit suite: 5008 passed, 50 skipped, 0 failed.
- SdlVulkan.Renderer suite: 73/73.
- Live validation (viewer + GUI): 0 messages across tab-switching, sky-map pan/zoom, document swaps and 7 resize cycles; render thread alive throughout.
- CI-path restore (`-p:UseLocalSiblings=false`): solution + web project both clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)