### PR TITLE
Ship Tycho-2 expanded, and load it by default

### DIFF
--- a/src/TianWen.Lib.Tests/HdHipCrossSnapshotTests.cs
+++ b/src/TianWen.Lib.Tests/HdHipCrossSnapshotTests.cs
@@ -33,7 +33,20 @@ public class HdHipCrossSnapshotTests(ITestOutputHelper output)
             ?? throw new InvalidOperationException("Snapshot resource stream was null.");
         _ = HdHipCrossSnapshotIo.Read(stream, out var storedHash);
 
-        var expectedHash = HdHipCrossInputHasher.Compute(assembly, manifestNames);
+        // Resolve each input from whichever assembly carries it. Most are in TianWen.Lib, but
+        // tyc2.bin.lz is embedded HERE now: the library ships Tycho-2 expanded so a region query can
+        // read its own bytes off the mapped image, and carrying the compressed copy too would be two
+        // copies of one catalogue in the product. The hash is over the same bytes either way, so the
+        // committed snapshot stays valid and this guard keeps its teeth.
+        var expectedHash = HdHipCrossInputHasher.Compute(suffix =>
+        {
+            var asm = Tycho2TestCatalog.AssemblyWith(suffix);
+            var manifest = asm.GetManifestResourceNames()
+                .FirstOrDefault(n => n.EndsWith(suffix, StringComparison.Ordinal))
+                ?? throw new InvalidOperationException($"Embedded resource not found in any assembly: {suffix}");
+            return asm.GetManifestResourceStream(manifest)
+                ?? throw new InvalidOperationException($"GetManifestResourceStream returned null for {manifest}");
+        });
         Convert.ToHexString(storedHash).ShouldBe(Convert.ToHexString(expectedHash),
             "Embedded hd_hip_cross.bin.gz is stale: at least one catalog input changed since the snapshot was baked. " +
             "Run tools/precompute-hd-hip-cross.ps1 to refresh, then commit the regenerated file.");

--- a/src/TianWen.Lib.Tests/StarMagnitudeIndexTests.cs
+++ b/src/TianWen.Lib.Tests/StarMagnitudeIndexTests.cs
@@ -179,7 +179,7 @@ namespace TianWen.Lib.Tests
         [Fact]
         public void OnTheRealCatalogTheDefaultLimitDrawsASmallFractionOfTheBuffer()
         {
-            var asm = typeof(ICelestialObjectDB).Assembly;
+            var asm = Tycho2TestCatalog.AssemblyWith(".tyc2.bin.lz");
             var name = asm.GetManifestResourceNames().FirstOrDefault(n => n.EndsWith(".tyc2.bin.lz", StringComparison.Ordinal));
             name.ShouldNotBeNull("tyc2.bin.lz must be embedded in the (non-Lightweight) test build");
 

--- a/src/TianWen.Lib.Tests/TianWen.Lib.Tests.csproj
+++ b/src/TianWen.Lib.Tests/TianWen.Lib.Tests.csproj
@@ -115,4 +115,17 @@
     <InternalsVisibleTo Include="TianWen.Lib.Tests.Simulators" />
   </ItemGroup>
 
+
+  <!-- The compressed Tycho-2 catalogue, embedded HERE rather than in TianWen.Lib. The library ships
+       tyc2.bin expanded so a region query can read its own bytes off the mapped image; carrying the
+       .lz too would be two copies of one catalogue in the product for no runtime gain. These tests
+       are about the compressed form itself (member boundaries, region selection, progressive
+       assembly, the WASM injection seam), so the fixture belongs with them. Same logical name, so
+       Tycho2TestCatalog finds it wherever it lives. -->
+  <ItemGroup Condition="Exists('$(MSBuildThisFileDirectory)..\TianWen.Lib\Astrometry\Catalogs\tyc2.bin.lz')">
+    <EmbeddedResource Include="..\TianWen.Lib\Astrometry\Catalogs\tyc2.bin.lz"
+                      LogicalName="TianWen.Lib.Astrometry.Catalogs.tyc2.bin.lz"
+                      WithCulture="false" />
+  </ItemGroup>
+
 </Project>

--- a/src/TianWen.Lib.Tests/Tycho2BulkInjectionTests.cs
+++ b/src/TianWen.Lib.Tests/Tycho2BulkInjectionTests.cs
@@ -27,7 +27,7 @@ public class Tycho2BulkInjectionTests
     // Lightweight/web build strips it, which is exactly why the injection seam exists.
     private static byte[] ReadEmbeddedTyc2Lz()
     {
-        var asm = typeof(ICelestialObjectDB).Assembly;
+        var asm = Tycho2TestCatalog.AssemblyWith(".tyc2.bin.lz");
         var name = asm.GetManifestResourceNames()
             .FirstOrDefault(n => n.EndsWith(".tyc2.bin.lz", StringComparison.Ordinal));
         name.ShouldNotBeNull("tyc2.bin.lz must be embedded in the (non-Lightweight) test build");

--- a/src/TianWen.Lib.Tests/Tycho2FovExploratoryTests.cs
+++ b/src/TianWen.Lib.Tests/Tycho2FovExploratoryTests.cs
@@ -47,7 +47,7 @@ public class Tycho2FovExploratoryTests(ITestOutputHelper output)
 
         // Also dump the manifest names that include "tyc2" to confirm the
         // assembly the DB is looking at actually contains the resource.
-        var asm = typeof(CelestialObjectDB).Assembly;
+        var asm = Tycho2TestCatalog.AssemblyWith(".tyc2.bin.lz");
         var names = asm.GetManifestResourceNames();
         foreach (var n in names.Where(n => n.Contains("tyc2", StringComparison.OrdinalIgnoreCase)))
         {

--- a/src/TianWen.Lib.Tests/Tycho2MappableResourceTests.cs
+++ b/src/TianWen.Lib.Tests/Tycho2MappableResourceTests.cs
@@ -1,0 +1,135 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+using Shouldly;
+using TianWen.Lib.Astrometry.Catalogs;
+using Xunit;
+
+namespace TianWen.Lib.Tests
+{
+    /// <summary>
+    /// Tycho-2 ships expanded, so a region query can read its own bytes instead of decompressing the
+    /// catalogue.
+    /// </summary>
+    /// <remarks>
+    /// <para><c>tyc2.bin</c> was always the format the runtime reads -- a stream count, a per-GSC-region
+    /// offset table, then region-major 17-byte records read straight out of a flat span. lzip was only
+    /// ever the container, and its members must be decoded WHOLE, so reaching one region's ~59 KB cost
+    /// decompressing all 43.5 MB. At 1.45x compression that container was buying little and costing the
+    /// largest single line item in a cold solve.</para>
+    /// <para>The committed artifact is still the <c>.lz</c>: the repository has no LFS budget to spend
+    /// and <c>.gitattributes</c> routes a bare <c>tyc2.bin</c> there too, so the expansion happens at
+    /// BUILD time into <c>obj/</c> (the <c>ExpandTycho2</c> target, short-circuited by MSBuild's
+    /// Inputs/Outputs once the output is newer than the input). Nothing about the repo, CI or the
+    /// pages.yml web staging changes.</para>
+    /// </remarks>
+    [Collection("Imaging")]
+    public class Tycho2MappableResourceTests(ITestOutputHelper output)
+    {
+        private static string[] Tycho2Resources() =>
+            [.. typeof(CelestialObjectDB).Assembly.GetManifestResourceNames()
+                .Where(n => n.Contains("tyc2", StringComparison.OrdinalIgnoreCase))
+                .Order()];
+
+        [Fact]
+        public void TheCatalogShipsExpandedAndTheCompressedCopyIsNotAlsoEmbedded()
+        {
+            var assembly = typeof(CelestialObjectDB).Assembly;
+            foreach (var n in Tycho2Resources())
+            {
+                using var s = assembly.GetManifestResourceStream(n);
+                output.WriteLine($"  {n,-56} {s?.Length ?? -1,12:N0} bytes");
+            }
+
+            var names = Tycho2Resources();
+            names.ShouldContain(n => n.EndsWith(".tyc2.bin"), "the expanded catalogue must be embedded");
+
+            // Both would be ~74 MB of assembly for one catalogue. The .lz stays in the source tree as
+            // the committed artifact and the web's static-asset source, but must not also ship.
+            names.ShouldNotContain(n => n.EndsWith(".tyc2.bin.lz"),
+                "the compressed copy must not ship alongside the expanded one");
+        }
+
+        [Fact]
+        public void TheExpandedCatalogIsSeekableSoARegionCanBeReadWithoutTheRest()
+        {
+            var assembly = typeof(CelestialObjectDB).Assembly;
+            var name = Tycho2Resources().FirstOrDefault(n => n.EndsWith(".tyc2.bin"));
+            name.ShouldNotBeNull();
+
+            using var stream = assembly.GetManifestResourceStream(name);
+            stream.ShouldNotBeNull();
+
+            // The whole point: an embedded resource is an UnmanagedMemoryStream over the mapped image,
+            // so this lands on an arbitrary offset without the preceding bytes ever being touched.
+            stream.CanSeek.ShouldBeTrue();
+            (stream is UnmanagedMemoryStream).ShouldBeTrue("must be mapped, not materialised, or partial reads save nothing");
+
+            var midpoint = stream.Length / 2;
+            stream.Seek(midpoint, SeekOrigin.Begin);
+            Span<byte> probe = stackalloc byte[16];
+            stream.ReadExactly(probe);
+            output.WriteLine($"{name}: {stream.Length:N0} bytes, seek to {midpoint:N0} read {Convert.ToHexString(probe)}");
+        }
+
+        /// <summary>
+        /// The catalogue still decodes to the same stars, which a container change must not move.
+        /// </summary>
+        [Fact]
+        public async Task TheExpandedCatalogDecodesToTheSameStars()
+        {
+            var ct = TestContext.Current.CancellationToken;
+            var db = await SharedCatalogDB.InitAsync(ct);
+
+            db.Tycho2StarCount.ShouldBe(2557501, "the expanded catalogue must hold exactly the stars the compressed one did");
+
+            var stars = new Tycho2StarLite[8];
+            db.CopyTycho2Stars(stars).ShouldBe(stars.Length);
+            foreach (var s in stars)
+            {
+                output.WriteLine($"  RA={s.RaHours:F6}h Dec={s.DecDeg:F6} V={s.VMag:F3} B-V={s.BMinusV:F3}");
+                double.IsNaN(s.RaHours).ShouldBeFalse();
+                s.RaHours.ShouldBeInRange(0, 24);
+                s.DecDeg.ShouldBeInRange(-90, 90);
+            }
+        }
+
+        /// <summary>
+        /// What the container change actually bought, on a DB that has never loaded it.
+        /// </summary>
+        /// <remarks>
+        /// Reports rather than asserts: a wall-clock threshold in a test is a flake on a busy box, and
+        /// the number that matters (a cold <c>tianwen solve</c>) is a whole-process measurement this
+        /// cannot make. <c>SharedCatalogDB</c> is deliberately not used -- it is process-cached, so it
+        /// would time a no-op.
+        /// </remarks>
+        [Fact]
+        public async Task ReportTycho2LoadCost()
+        {
+            var ct = TestContext.Current.CancellationToken;
+            var db = new CelestialObjectDB();
+
+            var sw = Stopwatch.StartNew();
+            await db.InitDBAsync(waitForTycho2BulkLoad: true, cancellationToken: ct);
+            sw.Stop();
+
+            output.WriteLine($"fresh InitDBAsync(waitForTycho2BulkLoad: true): {sw.Elapsed.TotalMilliseconds:F0} ms");
+            output.WriteLine($"Tycho-2 stars: {db.Tycho2StarCount:N0}");
+
+            // The per-phase breakdown is the point. Tycho-2 loads on a BACKGROUND task overlapped with
+            // the other phases, so the saving visible in the total is only the part that stuck out past
+            // them -- the "tycho2-join" phase, which is the idle wait. Reading the total alone
+            // understates what the container change did to the load itself and overstates what any
+            // further work on it can win.
+            foreach (var (phase, elapsed) in db.LastInitPhaseTimings)
+            {
+                output.WriteLine($"  {phase,-34} {elapsed.TotalMilliseconds,7:F1} ms");
+            }
+
+            db.Tycho2StarCount.ShouldBeGreaterThan(0);
+        }
+    }
+}

--- a/src/TianWen.Lib.Tests/Tycho2MemberManifestTests.cs
+++ b/src/TianWen.Lib.Tests/Tycho2MemberManifestTests.cs
@@ -146,7 +146,7 @@ namespace TianWen.Lib.Tests
         [Fact]
         public void OnTheRealCatalogEveryRegionMapsToTheMemberThatHoldsItsBytes()
         {
-            var asm = typeof(ICelestialObjectDB).Assembly;
+            var asm = Tycho2TestCatalog.AssemblyWith(".tyc2.bin.lz");
             var name = asm.GetManifestResourceNames()
                 .FirstOrDefault(n => n.EndsWith(".tyc2.bin.lz", StringComparison.Ordinal));
             name.ShouldNotBeNull("tyc2.bin.lz must be embedded in the (non-Lightweight) test build");

--- a/src/TianWen.Lib.Tests/Tycho2PartialCatalogTests.cs
+++ b/src/TianWen.Lib.Tests/Tycho2PartialCatalogTests.cs
@@ -22,7 +22,7 @@ namespace TianWen.Lib.Tests
 
         private static byte[] FullCatalog()
         {
-            var asm = typeof(ICelestialObjectDB).Assembly;
+            var asm = Tycho2TestCatalog.AssemblyWith(".tyc2.bin.lz");
             var name = asm.GetManifestResourceNames()
                 .FirstOrDefault(n => n.EndsWith(".tyc2.bin.lz", StringComparison.Ordinal));
             name.ShouldNotBeNull("tyc2.bin.lz must be embedded in the (non-Lightweight) test build");

--- a/src/TianWen.Lib.Tests/Tycho2RegionBakeProbe.cs
+++ b/src/TianWen.Lib.Tests/Tycho2RegionBakeProbe.cs
@@ -219,7 +219,7 @@ namespace TianWen.Lib.Tests
 
         private static byte[] LoadResource(string suffix)
         {
-            var asm = typeof(ICelestialObjectDB).Assembly;
+            var asm = Tycho2TestCatalog.AssemblyWith(suffix);
             var name = asm.GetManifestResourceNames()
                 .FirstOrDefault(n => n.EndsWith(suffix, StringComparison.Ordinal));
             name.ShouldNotBeNull($"{suffix} must be embedded in the (non-Lightweight) test build");

--- a/src/TianWen.Lib.Tests/Tycho2RegionSelectorTests.cs
+++ b/src/TianWen.Lib.Tests/Tycho2RegionSelectorTests.cs
@@ -47,7 +47,7 @@ namespace TianWen.Lib.Tests
 
         private static byte[] LoadResource(string suffix)
         {
-            var asm = typeof(ICelestialObjectDB).Assembly;
+            var asm = Tycho2TestCatalog.AssemblyWith(suffix);
             var name = asm.GetManifestResourceNames()
                 .FirstOrDefault(n => n.EndsWith(suffix, StringComparison.Ordinal));
             name.ShouldNotBeNull($"{suffix} must be embedded in the (non-Lightweight) test build");

--- a/src/TianWen.Lib.Tests/Tycho2TestCatalog.cs
+++ b/src/TianWen.Lib.Tests/Tycho2TestCatalog.cs
@@ -1,0 +1,55 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+
+namespace TianWen.Lib.Tests
+{
+    /// <summary>
+    /// The compressed Tycho-2 catalogue, for the tests that are ABOUT the compressed form.
+    /// </summary>
+    /// <remarks>
+    /// <para>TianWen.Lib ships <c>tyc2.bin</c> EXPANDED, so a region query reads its own bytes off the
+    /// mapped assembly image instead of decompressing 43.5 MB to reach 59 KB. Shipping the <c>.lz</c>
+    /// as well would put two copies of one catalogue in the library for no runtime gain.</para>
+    /// <para>But the <c>.lz</c> is still real and still matters: it is the committed artifact, it is
+    /// what <c>pages.yml</c> stages into the web app's static assets (whole-catalogue fallback plus 166
+    /// region-aligned members), and its MEMBER structure is the subject of
+    /// <c>Tycho2MemberManifest</c> / <c>Tycho2RegionSelector</c> / <c>Tycho2PartialCatalog</c> and the
+    /// <c>TryLoadTycho2BulkFromCompressed</c> injection seam the WASM build loads through. Those tests
+    /// need the compressed bytes by definition -- a decompressed catalogue cannot exercise
+    /// member-boundary logic.</para>
+    /// <para>So the test project embeds it instead, under the SAME logical name. The tests get their
+    /// input, the shipped library stays one copy, and the fixture lives with the tests that need it
+    /// rather than in the product.</para>
+    /// </remarks>
+    internal static class Tycho2TestCatalog
+    {
+        /// <summary>
+        /// Whichever assembly carries a catalogue resource: the test project first, then the library.
+        /// </summary>
+        /// <remarks>
+        /// Returning the ASSEMBLY rather than the bytes is what keeps the change at each call site to
+        /// one expression -- every one of them already does its own
+        /// <c>GetManifestResourceNames().FirstOrDefault(EndsWith(...))</c> and then opens the stream,
+        /// and those lines carry per-test detail worth leaving alone. It also covers the mixed case
+        /// honestly: <c>tyc2_gsc_bounds.bin.lz</c> is still in the LIBRARY (92 KB, and the runtime
+        /// spatial index is built from it), while <c>tyc2.bin.lz</c> now lives with the tests, so a
+        /// helper hard-coded to one assembly would be wrong for one of them.
+        /// </remarks>
+        internal static Assembly AssemblyWith(string resourceSuffix)
+        {
+            foreach (var asm in new[] { typeof(Tycho2TestCatalog).Assembly, typeof(Lib.Astrometry.Catalogs.ICelestialObjectDB).Assembly })
+            {
+                if (asm.GetManifestResourceNames().Any(n => n.EndsWith(resourceSuffix, StringComparison.Ordinal)))
+                {
+                    return asm;
+                }
+            }
+
+            // Neither has it (a lightweight build). Hand back the library so the caller's own
+            // "must be embedded" assertion is what reports it, rather than a null-reference here.
+            return typeof(Lib.Astrometry.Catalogs.ICelestialObjectDB).Assembly;
+        }
+    }
+}

--- a/src/TianWen.Lib/Astrometry/Catalogs/CelestialObjectDB.cs
+++ b/src/TianWen.Lib/Astrometry/Catalogs/CelestialObjectDB.cs
@@ -737,15 +737,52 @@ internal sealed partial class CelestialObjectDB : ICelestialObjectDB
     /// fall back to <see cref="BuildHdHipCrossIndicesViaTyc"/> (which needs <c>_tycho2Data</c>),
     /// or (c) a runtime caller invokes <see cref="EnsureTycho2DataLoadedAsync"/>.
     /// </summary>
+    /// <summary>
+    /// Reads an embedded resource into one exactly-sized array, in one allocation.
+    /// </summary>
+    /// <remarks>
+    /// <c>GetManifestResourceStream</c> returns an <see cref="UnmanagedMemoryStream"/> over the mapped
+    /// assembly image, so <see cref="Stream.Length"/> is exact and this is a single memcpy off pages
+    /// the OS faults in as it goes -- no growth, no re-copy, and no decompression. Reading it whole is
+    /// still the honest step for now, because <c>_tycho2Data</c> is a <c>byte[]</c> that ~31 call sites
+    /// index; handing them the mapped memory instead is the follow-up that turns 43.5 MB of resident
+    /// bytes into only the pages a query touches.
+    /// </remarks>
+    private static byte[] ReadFully(Stream stream)
+    {
+        var buffer = new byte[stream.Length];
+        stream.ReadExactly(buffer);
+        return buffer;
+    }
+
     private void ReadTycho2Bulk(Assembly assembly, string[] manifestNames)
     {
-        var tyc2Manifest = manifestNames.FirstOrDefault(p => p.EndsWith(".tyc2.bin.lz"));
-        if (tyc2Manifest is null || assembly.GetManifestResourceStream(tyc2Manifest) is not Stream tyc2Stream)
+        // EXPANDED FIRST, and it is the form the build embeds. tyc2.bin is already the layout this
+        // reads -- stream count, per-GSC-region offset table, region-major 17-byte records -- so lzip
+        // was only ever the container, and a ~4 MiB member has to be decoded WHOLE. That made reaching
+        // one region's ~59 KB cost decompressing all 43.5 MB, at 1.44x compression, on a catalogue
+        // where a 3.6 degree solve touches 0.138% of the records.
+        //
+        // The .lz remains the COMMITTED artifact and the fallback: the repository has no LFS budget to
+        // spend and .gitattributes routes a bare tyc2.bin there, so the expansion happens at build time
+        // into obj/ (see the ExpandTycho2 target). Keeping the fallback means a consumer building
+        // without that target, or a lightweight build, still works rather than silently losing the
+        // catalogue.
+        var expandedManifest = manifestNames.FirstOrDefault(p => p.EndsWith(".tyc2.bin"));
+        if (expandedManifest is not null && assembly.GetManifestResourceStream(expandedManifest) is Stream expandedStream)
         {
-            return;
+            WireTycho2BulkData(ReadFully(expandedStream));
         }
+        else
+        {
+            var tyc2Manifest = manifestNames.FirstOrDefault(p => p.EndsWith(".tyc2.bin.lz"));
+            if (tyc2Manifest is null || assembly.GetManifestResourceStream(tyc2Manifest) is not Stream tyc2Stream)
+            {
+                return;
+            }
 
-        WireTycho2BulkData(LzipDecoder.Decompress(tyc2Stream));
+            WireTycho2BulkData(LzipDecoder.Decompress(tyc2Stream));
+        }
 
         var boundsManifest = manifestNames.FirstOrDefault(p => p.EndsWith(".tyc2_gsc_bounds.bin.lz"));
         if (boundsManifest is not null && assembly.GetManifestResourceStream(boundsManifest) is Stream boundsStream)
@@ -1159,12 +1196,17 @@ internal sealed partial class CelestialObjectDB : ICelestialObjectDB
             return false;
         }
 
-        // A Lightweight build (-p:Lightweight=true, e.g. the browser/WASM app) strips tyc2.bin.lz,
-        // which is one of the hash-guard's inputs - verification is then IMPOSSIBLE, not merely
-        // stale (HdHipCrossInputHasher.Compute throws on the missing input). The guard protects a
-        // dev-time invariant (rebake the snapshot when inputs change) that every full build + CI
-        // still enforce, and the lightweight artifact embeds the very same snapshot bytes, so
-        // apply it unverified instead of failing init.
+        // tyc2.bin.lz is one of the hash-guard's inputs (the cross indices are built from the
+        // catalogue) and NO build embeds it any more: the library ships Tycho-2 expanded so a region
+        // query reads its own bytes off the mapped image, and the compressed copy now lives in the
+        // test project. Verification here is therefore IMPOSSIBLE rather than merely stale
+        // (HdHipCrossInputHasher.Compute throws on a missing input), so the snapshot is applied
+        // unverified and the phase is recorded as such below -- not silently.
+        //
+        // The guard itself did not go away, it MOVED: it protects a dev-time invariant (rebake the
+        // snapshot when an input changes), and HdHipCrossSnapshotTests still enforces it in CI by
+        // resolving each input from whichever assembly carries it. What is lost is a runtime
+        // re-check of bytes that shipped together in the same build, which never had much to say.
         var canVerify = manifestNames.Any(n => n.EndsWith(".tyc2.bin.lz", StringComparison.Ordinal));
 
         // Compute the input hash in parallel with snapshot read+decode: both touch ~22 MB of
@@ -1207,7 +1249,9 @@ internal sealed partial class CelestialObjectDB : ICelestialObjectDB
         }
         else
         {
-            _lastInitPhaseTimings.Add(("hd-hip-cross-snapshot:unverified-lightweight", subSw.Elapsed));
+            // Not "lightweight" any more: no build embeds tyc2.bin.lz, so this is now the normal path
+            // and the name has to say what it means rather than name the one build that used to hit it.
+            _lastInitPhaseTimings.Add(("hd-hip-cross-snapshot:unverified-no-tyc2-lz", subSw.Elapsed));
         }
 
         var beforeApply = subSw.Elapsed;

--- a/src/TianWen.Lib/Astrometry/Catalogs/CelestialObjectDB.cs
+++ b/src/TianWen.Lib/Astrometry/Catalogs/CelestialObjectDB.cs
@@ -403,7 +403,7 @@ internal sealed partial class CelestialObjectDB : ICelestialObjectDB
     }
 
     /// <inheritdoc/>
-    public async Task InitDBAsync(bool waitForTycho2BulkLoad = false, CancellationToken cancellationToken = default)
+    public async Task InitDBAsync(bool waitForTycho2BulkLoad = true, CancellationToken cancellationToken = default)
     {
         if (_isInitialized)
         {

--- a/src/TianWen.Lib/Astrometry/Catalogs/HdHipCrossSnapshot.cs
+++ b/src/TianWen.Lib/Astrometry/Catalogs/HdHipCrossSnapshot.cs
@@ -277,7 +277,31 @@ internal static class HdHipCrossInputHasher
         "vdB.gs.gz",
     ];
 
+    /// <summary>
+    /// Computes the input hash, opening each input from a single assembly.
+    /// </summary>
     public static byte[] Compute(System.Reflection.Assembly assembly, IReadOnlyList<string> manifestNames)
+        => Compute(suffix =>
+        {
+            var manifest = FindManifest(manifestNames, suffix)
+                ?? throw new InvalidOperationException($"Embedded resource not found while computing hd-hip-cross input hash: {suffix}");
+            return assembly.GetManifestResourceStream(manifest)
+                ?? throw new InvalidOperationException($"GetManifestResourceStream returned null for {manifest}");
+        });
+
+    /// <summary>
+    /// Computes the input hash, opening each input through <paramref name="openInput"/>.
+    /// </summary>
+    /// <remarks>
+    /// The inputs no longer all live in one assembly. TianWen.Lib ships Tycho-2 EXPANDED, so
+    /// <c>tyc2.bin.lz</c> -- which is one of the hashed inputs, because the cross indices are built
+    /// from the catalogue -- is embedded in the TEST project instead, where the tests that are about
+    /// the compressed form live. Hashing the expanded bytes instead would be defensible (the snapshot
+    /// derives from the catalogue's CONTENT, not its container) but would change the hash and force a
+    /// re-bake of the committed snapshot, which this repository has no LFS budget to spend. Resolving
+    /// each input from wherever it actually is keeps the stored hash valid and the guard meaningful.
+    /// </remarks>
+    public static byte[] Compute(Func<string, Stream> openInput)
     {
         using var sha = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
 
@@ -298,10 +322,7 @@ internal static class HdHipCrossInputHasher
                 sha.AppendData(algoBuf);
                 sha.AppendData(nameBytes);
 
-                var manifest = FindManifest(manifestNames, inputSuffix)
-                    ?? throw new InvalidOperationException($"Embedded resource not found while computing hd-hip-cross input hash: {inputSuffix}");
-                using var rawStream = assembly.GetManifestResourceStream(manifest)
-                    ?? throw new InvalidOperationException($"GetManifestResourceStream returned null for {manifest}");
+                using var rawStream = openInput(inputSuffix);
 
                 // Hash the *decompressed* content for .gs.gz so the input hash is invariant to
                 // gzip-encoder output differences across platforms / .NET versions. .lz inputs

--- a/src/TianWen.Lib/Astrometry/Catalogs/ICelestialObjectDB.cs
+++ b/src/TianWen.Lib/Astrometry/Catalogs/ICelestialObjectDB.cs
@@ -72,15 +72,27 @@ public interface ICelestialObjectDB
     /// Build all in-memory catalog indices from embedded resources. Idempotent: subsequent
     /// calls return immediately once the first init succeeded.
     /// <para>
-    /// The ~21 MB Tycho-2 binary catalog is decompressed in the background and is NOT awaited
-    /// before this returns by default. Callers that need it (sky map, plate solver, anything
-    /// touching <see cref="CoordinateGrid"/> / <see cref="CopyTycho2Stars"/>) must
-    /// <c>await</c> <see cref="EnsureTycho2DataLoadedAsync"/> first. Pass
-    /// <paramref name="waitForTycho2BulkLoad"/>=<c>true</c> to make init block until the bulk
-    /// Tycho-2 data is ready (precompute tools, tests that probe Tycho-2 state synchronously).
+    /// <b>Tycho-2 is loaded and awaited by DEFAULT</b>, because it is now free to wait for. It
+    /// loads on a background task overlapped with the other init phases, and since the catalogue
+    /// ships EXPANDED (a mapped read rather than a 43.5 MB decompression) that task finishes before
+    /// they do: the wait measures 0.2 ms warm, against 93-109 ms when it had to decompress. There is
+    /// no longer a reason to make callers opt in, and every consumer that needs stars was already
+    /// passing <c>true</c> -- the plate solver, the stacking pipeline, the CLI and the MCP server.
+    /// Not passing it is what made <c>tianwen solve</c> return zero catalogue stars once.
+    /// </para>
+    /// <para>
+    /// Pass <paramref name="waitForTycho2BulkLoad"/>=<c>false</c> to return without awaiting it. That
+    /// no longer saves the WORK, only the wait: the load is kicked off either way, so the only thing
+    /// it buys is returning before it lands, and a caller that then touches
+    /// <see cref="CoordinateGrid"/> / <see cref="CopyTycho2Stars"/> must
+    /// <c>await</c> <see cref="EnsureTycho2DataLoadedAsync"/> itself.
+    /// </para>
+    /// <para>
+    /// A build that embeds no catalogue (the browser/WASM app, <c>-p:Lightweight=true</c>) needs no
+    /// special case: there is nothing to load, so the background task no-ops and awaiting it is free.
     /// </para>
     /// </summary>
-    Task InitDBAsync(bool waitForTycho2BulkLoad = false, CancellationToken cancellationToken = default);
+    Task InitDBAsync(bool waitForTycho2BulkLoad = true, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// True once <see cref="InitDBAsync"/> has completed at least once (the main catalogs are

--- a/src/TianWen.Lib/TianWen.Lib.csproj
+++ b/src/TianWen.Lib/TianWen.Lib.csproj
@@ -56,7 +56,15 @@
          bright-star (HR) set and the planner is DSO-only. ReadTycho2Bulk (CelestialObjectDB) already
          no-ops gracefully when the tyc2 manifest entry is absent, so this needs no code change. The
          tiny GSC-bounds + pm-sidecar companions stay embedded but unread (harmless). Default keeps it. -->
-    <EmbeddedResource Remove="Astrometry/Catalogs/tyc2.bin.lz" Condition="'$(Lightweight)' == 'true'" />
+    <!-- Tycho-2 ships EXPANDED, and the .lz is never embedded. tyc2.bin is already the format the
+         runtime reads (stream count, per-GSC-region offset table, region-major 17-byte records read
+         straight out of a flat span); lzip was only ever the container, and its ~4 MiB members must
+         be decoded WHOLE, so reaching one region's ~59 KB cost decompressing all 43.5 MB at init.
+         Expanded, GetManifestResourceStream hands back an UnmanagedMemoryStream over the mapped
+         image, so a region query touches only its own pages. The .lz stays the COMMITTED artifact
+         and ExpandTycho2 expands it into obj/ on the way past: the repository has no LFS budget
+         to spend, and .gitattributes routes both *.lz and a bare tyc2.bin to LFS. -->
+    <EmbeddedResource Remove="Astrometry/Catalogs/tyc2.bin.lz" />
     <!-- Tracked .gz/.bin.gz catalog files: committed in git (filter_curves,
          hd_hip_cross, pickles_sed, sensor_qe, simbad_merge), so they exist at
          project-evaluation time. Listed explicitly because the previous
@@ -154,6 +162,49 @@
        lzip decoder that replaced the external `lzip -dc`) is resolved + copied, so we can
        hand its dll path to the script via -LzipAssembly (works for both the sibling
        ProjectReference and the NuGet PackageReference). -->
+  <!-- Expand tyc2.bin.lz into obj/ and embed THAT. See the EmbeddedResource Remove above for why
+       the container is the whole problem. Gated off for a lightweight build exactly as the .lz was:
+       the browser does not want 43.5 MB in its bundle, and does not need it. pages.yml stages the
+       committed .lz as same-origin static assets (whole-catalogue fallback plus 166 region-aligned
+       members), reading the source tree directly, so that pipeline is untouched by any of this. -->
+  <PropertyGroup Condition="'$(Lightweight)' != 'true'">
+    <_Tycho2Lz>$(MSBuildThisFileDirectory)Astrometry/Catalogs/tyc2.bin.lz</_Tycho2Lz>
+    <!-- BaseIntermediateOutputPath (obj\), NOT IntermediateOutputPath (obj\<config>\<tfm>\): the
+         latter is defined by the common TARGETS, which import after this body, so it evaluates EMPTY
+         here and the 43.5 MB expansion lands in the project ROOT. That is not a cosmetic slip:
+         .gitattributes routes a bare tyc2.bin to LFS, so a stray `git add -A` would commit it to a
+         repository with no LFS budget to spend. obj\ is gitignored, and the content does not vary by
+         configuration, so sharing one copy across them is right anyway. -->
+    <_Tycho2Expanded>$(BaseIntermediateOutputPath)tyc2.bin</_Tycho2Expanded>
+  </PropertyGroup>
+
+  <Target Name="ExpandTycho2"
+          BeforeTargets="AssignTargetPaths"
+          DependsOnTargets="ResolveReferences"
+          Condition="'$(Lightweight)' != 'true' AND Exists('$(_Tycho2Lz)')"
+          Inputs="$(_Tycho2Lz)"
+          Outputs="$(_Tycho2Expanded)">
+    <PropertyGroup>
+      <_LzipLibDllTyc>@(ReferenceCopyLocalPaths->WithMetadataValue('FileName','Lzip.Lib')->WithMetadataValue('Extension','.dll'))</_LzipLibDllTyc>
+    </PropertyGroup>
+    <Exec Command="pwsh -NoProfile -File &quot;$(MSBuildThisFileDirectory)..\..\tools\expand-tycho2.ps1&quot; -LzPath &quot;$(_Tycho2Lz)&quot; -OutPath &quot;$(_Tycho2Expanded)&quot; -LzipAssembly &quot;$(_LzipLibDllTyc)&quot;" />
+  </Target>
+
+  <!-- Registered in its own ungated target so the embed set is the same on an incremental build as
+       on a clean one, mirroring EmbedCatalogOutputs. LogicalName is stated explicitly because the
+       file lives in obj/, so the name MSBuild would derive from its path is not the one
+       ReadTycho2Bulk looks for. -->
+  <Target Name="EmbedTycho2Expanded"
+          BeforeTargets="AssignTargetPaths"
+          DependsOnTargets="ExpandTycho2"
+          Condition="'$(Lightweight)' != 'true' AND Exists('$(_Tycho2Lz)')">
+    <ItemGroup>
+      <EmbeddedResource Include="$(_Tycho2Expanded)"
+                        LogicalName="TianWen.Lib.Astrometry.Catalogs.tyc2.bin"
+                        WithCulture="false" />
+    </ItemGroup>
+  </Target>
+
   <Target Name="PreprocessCatalogs"
           BeforeTargets="AssignTargetPaths"
           DependsOnTargets="ResolveReferences"

--- a/tools/expand-tycho2.ps1
+++ b/tools/expand-tycho2.ps1
@@ -1,0 +1,46 @@
+<#
+.SYNOPSIS
+Expand the lzip-compressed Tycho-2 catalog into the flat, directly-mappable form that
+TianWen.Lib embeds.
+
+.DESCRIPTION
+`tyc2.bin` is already the format the runtime wants: a 4-byte stream count, a per-GSC-region
+offset table, then region-major 17-byte star records that `Tycho2RaDecIndex` and
+`CopyTycho2Stars` read straight out of a flat span. The only thing standing between a solve
+and its ~59 KB of records is the CONTAINER: lzip members are ~4 MiB and must be decoded whole,
+so reaching any one region costs decompressing all 43.5 MB.
+
+Embedding the expanded file instead makes the resource seekable over the mapped assembly image
+(`GetManifestResourceStream` returns an `UnmanagedMemoryStream`), so a region query reads only
+the pages it touches and init stops paying a decompression at all.
+
+.NOTES
+This runs at BUILD time and writes into `obj/`, deliberately, because the repository has no LFS
+budget to spend: `.gitattributes` routes both `*.lz` AND a bare `tyc2.bin` to LFS, so the
+expanded 43.5 MB must never land in the source tree where it could be committed. The committed
+artifact stays `tyc2.bin.lz` exactly as before -- CI, clones and LFS usage are unchanged, and
+this script is what turns it into the mappable form on the way past.
+#>
+param(
+    [Parameter(Mandatory)][string] $LzPath,
+    [Parameter(Mandatory)][string] $OutPath,
+    [string] $LzipAssembly
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+. "$PSScriptRoot/lzip-util.ps1"
+
+Initialize-Lzip -LzipAssembly $LzipAssembly
+
+$outDir = Split-Path -Parent $OutPath
+if ($outDir -and -not (Test-Path $outDir)) {
+    New-Item -ItemType Directory -Force -Path $outDir | Out-Null
+}
+
+Expand-LzToFile -LzPath $LzPath -OutPath $OutPath
+
+$inSize = (Get-Item $LzPath).Length
+$outSize = (Get-Item $OutPath).Length
+Write-Host ("expand-tycho2: {0:N0} -> {1:N0} bytes ({2:N2}x)" -f $inSize, $outSize, ($outSize / $inSize))


### PR DESCRIPTION
Two commits. The catalogue ships expanded so init stops decompressing 43.5 MB to reach 59 KB, and
waiting for it becomes free enough that the opt-in flag stops earning its keep.

## Why the container was the whole problem

`tyc2.bin` was always the format the runtime reads: a stream count, a per-GSC-region offset table,
then region-major 17-byte records read straight out of a flat span. lzip was only ever the wrapper,
and its ~4 MiB members must be decoded WHOLE, so reaching one region cost decompressing the
catalogue. A 3.6 degree solve touches **0.138%** of the records, 59 KB of 43.5 MB, and lzip was
buying only **1.45x**.

## Measured

`tycho2-bulk-wait`, the phase that is the actual wait, on the Horsehead fixture:

| | `.lz` | expanded |
|---|---|---|
| warm, n=3 | 93.3, 94.7, 108.8 ms | **0.2, 0.2, 0.3 ms** |
| cold first run | 279.3 ms | 32.5 ms |

**The whole-init total moves much less than that, and the reason is the point.** Tycho-2 loads on a
background task overlapped with ~314 ms of other phases (ngc-csv 79, hd-hip-cross 107, simbad 58,
shapes 38), so the only cost ever *visible* was the tail sticking out past them. That tail is now
gone: the load finishes before anything needs it. So this takes ~100% of what was exposed, not 20%
of what looked available. The plate-solver plan's ~500 ms estimate for this phase was a cold
whole-process AOT figure; **~250 ms is the honest cold-CLI number**.

## The .lz stays committed, and CI is unchanged

The repository has no LFS budget to spend, and `.gitattributes` routes both `*.lz` and a bare
`tyc2.bin` there. So the committed artifact is still `tyc2.bin.lz` and the expansion happens at
**build time into `obj/`** (`ExpandTycho2`, short-circuited by MSBuild `Inputs`/`Outputs` so an
incremental build does not even launch `pwsh`). Repo size, clone size and LFS usage are all
unchanged, and `pages.yml` still stages its 166 region-aligned members by reading the committed
`.lz` straight from the source tree.

Cost is **+13.4 MB of assembly** (30.1 -> 43.5), small only because lzip was managing 1.45x. Release
assets are `.tar.gz`, which recompresses it. The web build gates the expansion off exactly as it
gated the `.lz`; verified the lightweight configuration still embeds neither form (17.4 MB).

## Two things this moved

- **The `.lz`-dependent tests embed it themselves now.** Six files are about the COMPRESSED form
  (member boundaries, region selection, progressive assembly, the WASM injection seam) and a
  decompressed catalogue cannot exercise member-boundary logic. Shipping both from the library would
  put two copies of one catalogue in the product, so the fixture moved to where those tests live.
- **`HdHipCrossInputHasher` gained a per-input resolver overload.** `tyc2.bin.lz` is one of the
  hashed inputs (the cross indices are built from the catalogue), so the guard now resolves each
  input from whichever assembly carries it. The hash is over the same bytes, so the committed
  snapshot stays valid and needs **no re-bake** -- which would have cost an LFS write. Runtime
  re-verification is now always skipped and says so (`hd-hip-cross-snapshot:unverified-no-tyc2-lz`,
  renamed off "lightweight", no longer the build that hits it); the guard itself lives in
  `HdHipCrossSnapshotTests`, which is where a rebake-when-inputs-change invariant belongs.

## Loading it by default

`InitDBAsync` defaulted to NOT awaiting Tycho-2 because the bulk load was a 43.5 MB decompression
worth keeping off the critical path. At 0.2 ms it is not one any more, and the opt-in was costing
more than it saved: every consumer that needs stars already passed `true` (plate solver, stacking
pipeline, master post-processor and preview renderer, CLI solve and stack, MCP catalog tools), so
the flag mostly served as a way to get it wrong -- **silently**, since a query against an unloaded DB
returns zero stars. That is exactly how `tianwen solve` once shipped unable to solve anything.

Passing `false` still returns without awaiting, but no longer saves the WORK, only the wait. The
browser needs no exception: a lightweight build embeds no catalogue, so the load no-ops.

## Verification

Unit **5,035 passed / 0 failed**, functional **338 / 0**, lightweight build clean. New tests pin that
only the expanded form ships, that it is seekable over the mapped image, and that it decodes to the
same 2,557,501 stars.

One trap worth recording: the expansion must write to `BaseIntermediateOutputPath`, not
`IntermediateOutputPath` -- the latter is defined by the common TARGETS, imported after the project
body, so it evaluates empty there and drops 43.5 MB in the project root where `.gitattributes` routes
it to LFS. That happened once during development and `git add -A` staged it.