### PR TITLE
Fix LDN 1089: the plate solver's anchor pool was neither the brightest stars nor on the sensor

### DIFF
--- a/src/TianWen.Lib.Tests/CatalogQueryOrderTests.cs
+++ b/src/TianWen.Lib.Tests/CatalogQueryOrderTests.cs
@@ -1,0 +1,59 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Shouldly;
+using System.Threading.Tasks;
+using TianWen.Lib.Astrometry;
+using TianWen.Lib.Astrometry.PlateSolve;
+using Xunit;
+
+namespace TianWen.Lib.Tests
+{
+    /// <summary>
+    /// The catalog query answers brightest-first, and everything downstream assumes it.
+    /// </summary>
+    /// <remarks>
+    /// <para>This is deliberately a test of the QUERY and not of a solve, because nothing else can
+    /// be. Both consumers truncate the list as though it were a brightness ranking --
+    /// <c>PairRansacLock</c> keeps the first 160 as anchors and probes the first 8 as its Stage 1
+    /// gate, and the matching loop takes the first 50 then 100 on a dense field and penalises by
+    /// rank -- so an unsorted list does not fail loudly, it quietly hands both of them an arbitrary
+    /// spatial slice of the sky. On LDN 1089 that slice put ZERO of the first 20 anchors on real
+    /// stars, the true hypothesis was discarded at Stage 1 on every one of a million tries, and the
+    /// only symptom was "no pair-lock seed".</para>
+    /// <para>The frozen Vela regression cannot cover this: it replaces the query with a recorded
+    /// catalogue, so the replay never executes the code under test here. It stayed green through
+    /// the whole bug for exactly that reason -- see the note in <c>VelaMosaicStarListExport</c>.
+    /// </para>
+    /// </remarks>
+    public class CatalogQueryOrderTests(ITestOutputHelper output)
+    {
+        [Fact]
+        public async Task TheCatalogQueryReturnsBrightestFirst()
+        {
+            var ct = TestContext.Current.CancellationToken;
+            var solver = new CatalogPlateSolver(await SharedCatalogDB.InitAsync(ct), NullLogger.Instance);
+
+            // A dense low-galactic-latitude field, so the query walks many grid cells and any
+            // scan-order leak is obvious rather than marginal. (Cygnus, near LDN 1089.)
+            var stars = solver.QueryCatalogStarsInRegion(new WCS(20.552, 63.476), 2.0, 0.0);
+            stars.Count.ShouldBeGreaterThan(200, "the probe field must be dense enough to order meaningfully");
+
+            var outOfOrder = 0;
+            for (var i = 1; i < stars.Count; i++)
+            {
+                if (stars[i].VMag < stars[i - 1].VMag)
+                {
+                    outOfOrder++;
+                }
+            }
+
+            output.WriteLine($"{stars.Count} stars, V {stars[0].VMag:F2}..{stars[^1].VMag:F2}, " +
+                $"{outOfOrder} inversions");
+            outOfOrder.ShouldBe(0, "every consumer truncates this list as a brightness ranking");
+
+            // And the head must actually be the bright end -- an ordering assertion alone passes on
+            // a list sorted the wrong way, and faintest-first would be a far worse anchor pool than
+            // the scan order this replaced.
+            stars[0].VMag.ShouldBeLessThan(stars[^1].VMag);
+        }
+    }
+}

--- a/src/TianWen.Lib.Tests/FitsPixelScaleTests.cs
+++ b/src/TianWen.Lib.Tests/FitsPixelScaleTests.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Threading.Tasks;
 using System.IO;
+using TianWen.Lib.Astrometry;
 using TianWen.Lib.Imaging;
 using TianWen.Lib.Imaging.Calibration;
 using TianWen.Lib.Imaging.Stacking;
@@ -85,6 +86,49 @@ public class FitsPixelScaleTests
     public void WithNeitherScaleNorFocalLengthThereIsNoAnswerRatherThanAGuess()
     {
         ImageWith(Meta(focalLength: -1, declaredPixelScale: float.NaN)).GetImageDim().ShouldBeNull();
+    }
+
+    /// <summary>
+    /// A frame that already carries a solved CD matrix knows its scale, even with no scale header.
+    /// </summary>
+    /// <remarks>
+    /// <para>This is the state EVERY master TianWen writes is in: a full CD matrix and no
+    /// <c>FOCALLEN</c>. The header-only overload answers null for it, which is correct for what it can
+    /// see and wrong for the frame, and a solver handed that null refuses before detecting a single
+    /// star -- measured at 3 ms on a 6248x4176 LDN 1089 master whose own header stated
+    /// 1.3814 arcsec/px. That is why "cannot solve our own stacker's output" keeps coming back.</para>
+    /// <para>Ordering matters as much as the fallback: a declared PIXSCALE must still win, or a frame
+    /// that states its scale would be overridden by a WCS that may be stale.</para>
+    /// </remarks>
+    [Fact]
+    public void AFrameWithOnlyACdMatrixStillKnowsItsScale()
+    {
+        var image = ImageWith(Meta(focalLength: -1, declaredPixelScale: float.NaN));
+        image.GetImageDim().ShouldBeNull("premise: the headers alone cannot answer");
+
+        // 1.3814"/px, as a CD matrix rotated ~91.8 degrees -- the LDN 1089 master's own geometry, so
+        // the scale has to come out of the determinant rather than off a diagonal term.
+        var scaleDeg = 1.3814 / 3600.0;
+        var theta = 91.76 * Math.PI / 180.0;
+        var wcs = new WCS(CenterRA: 20.555, CenterDec: 63.4572)
+        {
+            CRPix1 = 4,
+            CRPix2 = 4,
+            CD1_1 = -scaleDeg * Math.Cos(theta),
+            CD1_2 = -scaleDeg * Math.Sin(theta),
+            CD2_1 = scaleDeg * Math.Sin(theta),
+            CD2_2 = -scaleDeg * Math.Cos(theta),
+        };
+
+        wcs.HasCDMatrix.ShouldBeTrue();
+        var fromWcs = image.GetImageDim(wcs);
+        fromWcs.ShouldNotBeNull();
+        fromWcs.Value.PixelScale.ShouldBe(1.3814, tolerance: 1e-3);
+
+        // And a declared scale still wins over it.
+        var declared = ImageWith(Meta(focalLength: -1, declaredPixelScale: 2.5f)).GetImageDim(wcs);
+        declared.ShouldNotBeNull();
+        declared.Value.PixelScale.ShouldBe(2.5, tolerance: 1e-4);
     }
 
     [Fact]

--- a/src/TianWen.Lib.Tests/FrameWcsAgreementProbe.cs
+++ b/src/TianWen.Lib.Tests/FrameWcsAgreementProbe.cs
@@ -1,0 +1,110 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using TianWen.Lib.Astrometry;
+using TianWen.Lib.Astrometry.Catalogs;
+using TianWen.Lib.Imaging;
+using Xunit;
+
+namespace TianWen.Lib.Tests
+{
+    /// <summary>
+    /// Does a frame's OWN WCS agree with its OWN pixels?
+    /// </summary>
+    /// <remarks>
+    /// <para>The question to ask before blaming a solver. When a solve fails, there are three
+    /// candidates -- the detections are junk, the catalogue is absent, or the matcher cannot form a
+    /// correspondence -- and they are indistinguishable from the solver's own output, which only ever
+    /// says "no lock". A frame that already carries a CD matrix settles it without solving anything:
+    /// project the catalogue through the WCS the FILE claims and count how many detected stars land on
+    /// a catalogue star.</para>
+    /// <para>A high hit rate means the pixels, the catalogue and the stated WCS all agree, so a solver
+    /// that cannot find that correspondence has a matching defect. A low one means the stated WCS is
+    /// stale or the detections are not stars, and the solver was right to refuse.</para>
+    /// <para>Gated: set <c>TIANWEN_WCS_AGREE_FITS</c> to a plate-solved FITS.</para>
+    /// </remarks>
+    [Collection("Imaging")]
+    public class FrameWcsAgreementProbe(ITestOutputHelper output)
+    {
+        [Fact]
+        public async Task ReportWhetherTheFramesWcsMatchesItsStars()
+        {
+            var path = Environment.GetEnvironmentVariable("TIANWEN_WCS_AGREE_FITS");
+            Assert.SkipWhen(string.IsNullOrWhiteSpace(path), "Set TIANWEN_WCS_AGREE_FITS to a solved FITS");
+
+            var ct = TestContext.Current.CancellationToken;
+            Image.TryReadFitsFile(path!, out var image, out var fileWcs);
+            Assert.NotNull(image);
+            Assert.NotNull(fileWcs);
+
+            var wcs = fileWcs!.Value;
+            output.WriteLine($"{System.IO.Path.GetFileName(path)}: {image!.Width}x{image.Height}x{image.ChannelCount}");
+            output.WriteLine($"file WCS  RA={wcs.CenterRA:F5}h Dec={wcs.CenterDec:F4} scale={wcs.PixelScaleArcsec:F4}\"/px hasCD={wcs.HasCDMatrix}");
+
+            var stars = (await image.FindStarsAsync(
+                image.ReferenceStarChannel, snrMin: 5f, maxStars: 5000, minStars: 100,
+                maxFirstPassNoiseSigma: Image.MaxFirstPassNoiseSigma, cancellationToken: ct)).ToArray();
+            output.WriteLine($"detected  {stars.Length} stars on channel {image.ReferenceStarChannel}");
+
+            var db = await SharedCatalogDB.InitAsync(ct);
+            var all = new Tycho2StarLite[db.Tycho2StarCount];
+            var copied = db.CopyTycho2Stars(all);
+
+            var inFrame = new List<(double X, double Y, float V)>();
+            for (var i = 0; i < copied; i++)
+            {
+                var s = all[i];
+                if (wcs.SkyToPixel(s.RaHours, s.DecDeg) is { } px
+                    && px.X >= 0 && px.Y >= 0 && px.X < image.Width && px.Y < image.Height)
+                {
+                    inFrame.Add((px.X, px.Y, s.VMag));
+                }
+            }
+
+            output.WriteLine($"catalog   {inFrame.Count} Tycho-2 stars project inside the frame under the FILE's WCS");
+            if (inFrame.Count == 0)
+            {
+                output.WriteLine("  -> nothing to match against; the WCS points somewhere with no catalogue coverage");
+                return;
+            }
+
+            // Hit rate at a few tolerances. A correct WCS puts most bright stars within a pixel or two;
+            // a stale one puts them nowhere, and a WRONG SCALE puts the centre right and the edges out,
+            // which is why the radial breakdown below matters as much as the totals.
+            foreach (var tol in new[] { 2.0, 6.0, 20.0, 60.0 })
+            {
+                var hits = 0;
+                foreach (var s in stars)
+                {
+                    if (inFrame.Any(c => Math.Abs(c.X - s.XCentroid) < tol && Math.Abs(c.Y - s.YCentroid) < tol
+                                         && Math.Sqrt((c.X - s.XCentroid) * (c.X - s.XCentroid) + (c.Y - s.YCentroid) * (c.Y - s.YCentroid)) <= tol))
+                    {
+                        hits++;
+                    }
+                }
+                output.WriteLine($"  within {tol,5:F1} px: {hits,5} of {stars.Length} detections ({(double)hits / stars.Length:P1})");
+            }
+
+            // Nearest-catalogue distance for the brightest detections, split by field radius. A constant
+            // offset reads the same everywhere; a scale error grows with radius; distortion grows faster.
+            var cx = image.Width / 2.0;
+            var cy = image.Height / 2.0;
+            output.WriteLine("\n  brightest 20 detections: nearest catalogue star, by field radius");
+            foreach (var s in stars.OrderByDescending(s => s.Flux).Take(20))
+            {
+                var best = double.MaxValue;
+                foreach (var c in inFrame)
+                {
+                    var d = Math.Sqrt((c.X - s.XCentroid) * (c.X - s.XCentroid) + (c.Y - s.YCentroid) * (c.Y - s.YCentroid));
+                    if (d < best)
+                    {
+                        best = d;
+                    }
+                }
+                var r = Math.Sqrt((s.XCentroid - cx) * (s.XCentroid - cx) + (s.YCentroid - cy) * (s.YCentroid - cy));
+                output.WriteLine($"    ({s.XCentroid,8:F1},{s.YCentroid,8:F1}) r={r,7:F0}px  nearest {best,8:F1}px  hfd={s.HFD:F2} snr={s.SNR:F0}");
+            }
+        }
+    }
+}

--- a/src/TianWen.Lib.Tests/PlateSolveFailureProbe.cs
+++ b/src/TianWen.Lib.Tests/PlateSolveFailureProbe.cs
@@ -66,7 +66,23 @@ public class PlateSolveFailureProbe(ITestOutputHelper output)
             return;
         }
 
+        // A frame can carry a perfectly good scale in its CD matrix while GetImageDim returns null,
+        // because that reads ImageMeta (PIXSCALE, else pixel size x binning x FOCALLEN) and never the
+        // WCS. Every TianWen-written master is in exactly that state. Fall back to the file's own WCS
+        // so the probe reports why MATCHING failed rather than stopping at a missing dimension, and
+        // allow an explicit override for the case where both are absent or suspect.
         var dim = image.GetImageDim();
+        if (dim is null && Environment.GetEnvironmentVariable("TIANWEN_STAR_PROBE_SCALE") is { Length: > 0 } scaleText
+            && double.TryParse(scaleText, System.Globalization.CultureInfo.InvariantCulture, out var forcedScale))
+        {
+            dim = new ImageDim(forcedScale, image.Width, image.Height);
+            output.WriteLine($"imageDim   forced to {forcedScale:F4}\"/px via TIANWEN_STAR_PROBE_SCALE");
+        }
+        else if (dim is null && fileWcs is { HasCDMatrix: true, PixelScaleArcsec: > 0 } cdWcs)
+        {
+            dim = new ImageDim(cdWcs.PixelScaleArcsec, image.Width, image.Height);
+            output.WriteLine($"imageDim   NULL from headers; using the file's own CD matrix: {cdWcs.PixelScaleArcsec:F4}\"/px");
+        }
         output.WriteLine($"file       {System.IO.Path.GetFileName(path)}");
         output.WriteLine($"imageDim   {dim}");
         output.WriteLine($"fileWcs    {(fileWcs is { } w ? $"RA={w.CenterRA:F4}h Dec={w.CenterDec:F3} hasCD={w.HasCDMatrix} scale={w.PixelScaleArcsec}" : "(none)")}");

--- a/src/TianWen.Lib.Tests/RotatedFieldSeedTests.cs
+++ b/src/TianWen.Lib.Tests/RotatedFieldSeedTests.cs
@@ -1,0 +1,205 @@
+using Shouldly;
+using System;
+using System.Collections.Generic;
+using System.Numerics;
+using TianWen.Lib;
+using TianWen.Lib.Astrometry;
+using TianWen.Lib.Astrometry.PlateSolve;
+using TianWen.Lib.Imaging;
+using Xunit;
+
+namespace TianWen.Lib.Tests
+{
+    /// <summary>
+    /// The seed's anchor pool must not assume the camera is north-up.
+    /// </summary>
+    /// <remarks>
+    /// <para>The bug this pins kept LDN 1089 -- a real 3:2 frame at an 88 degree camera angle --
+    /// from solving at all, while every existing regression stayed green, because
+    /// <c>VelaMosaicFieldTests</c> builds its pools with the test project's own
+    /// <c>VelaProjection.ProjectInFrame</c> and so never exercised
+    /// <see cref="CatalogPlateSolver.ProjectCatalogStars"/>'s in-frame policy, and every panel in
+    /// that mosaic is close to north-up regardless.</para>
+    /// <para>The field here is synthetic in exactly one respect -- the camera angle -- over the
+    /// REAL frozen Vela catalogue, which is the point: the defect is geometric (which region of
+    /// sky the pool selects), not photometric, so what matters is real star density and brightness
+    /// distribution, both of which the frozen catalogue supplies.</para>
+    /// </remarks>
+    public class RotatedFieldSeedTests(ITestOutputHelper output)
+    {
+        // A deliberately non-square frame: on a square one the rectangle and the disc very nearly
+        // agree, and the bug is invisible. 3:2 is what most sensors are.
+        private const int W = 6248, H = 4176;
+        private const double PixelScaleArcsec = 1.38;
+        private const double CameraAngleDeg = 88.0;
+
+        [Fact]
+        public void ARotatedFieldSeedsFromTheDiscPoolAndNotFromTheRectangle()
+        {
+            var catalog = VelaMosaicStarLists.Manifest.CatalogTuples();
+            catalog.Sort(static (a, b) => a.VMag.CompareTo(b.VMag));
+
+            var panel = VelaMosaicStarLists.Manifest.Panels[0];
+            var origin = new WCS(panel.Frames[0].Wcs.CenterRA, panel.Frames[0].Wcs.CenterDec);
+            var dim = new ImageDim(PixelScaleArcsec, W, H);
+            var pixelScaleRad = double.DegreesToRadians(PixelScaleArcsec / 3600.0);
+            double cx = W / 2.0, cy = H / 2.0;
+
+            // The detected field: every catalogue star the ROTATED camera actually sees. Built by
+            // rotating the north-up projection about the frame centre and keeping what lands on
+            // the sensor -- which is precisely the set the rectangle policy gets wrong.
+            var rot = double.DegreesToRadians(CameraAngleDeg);
+            var truth = new Matrix3x2(
+                (float)Math.Cos(rot), (float)Math.Sin(rot),
+                (float)-Math.Sin(rot), (float)Math.Cos(rot),
+                0f, 0f);
+            truth.M31 = (float)(cx - (cx * truth.M11 + cy * truth.M21));
+            truth.M32 = (float)(cy - (cx * truth.M12 + cy * truth.M22));
+
+            var everything = CatalogPlateSolver.ProjectCatalogStars(
+                catalog, origin, pixelScaleRad, cx, cy, dim, xSign: 1.0, marginFraction: 1.0f);
+            var detected = new List<Vector2>();
+            foreach (var s in everything)
+            {
+                var t = Vector2.Transform(new Vector2(s.Pixel.XCentroid, s.Pixel.YCentroid), truth);
+                if (t.X >= 0 && t.Y >= 0 && t.X < W && t.Y < H)
+                {
+                    detected.Add(t);
+                }
+            }
+            var detPts = detected.ToArray();
+            output.WriteLine($"{CameraAngleDeg} deg camera angle on a {W}x{H} frame: " +
+                $"{catalog.Count} catalogue stars, {detPts.Length} of them on the sensor");
+            detPts.Length.ShouldBeGreaterThan(200, "the synthetic field must be dense enough to be worth locking");
+
+            var disc = Anchors(catalog, origin, pixelScaleRad, cx, cy, dim, rotationInvariant: true);
+            var rect = Anchors(catalog, origin, pixelScaleRad, cx, cy, dim, rotationInvariant: false);
+
+            // How many anchors each policy picks that the camera cannot see. This is the defect
+            // itself, independent of whether any particular scan finds a lock.
+            output.WriteLine($"  disc pool      {disc.Length,4} anchors, {OffSensor(disc, truth),4} of them off the sensor");
+            output.WriteLine($"  rectangle pool {rect.Length,4} anchors, {OffSensor(rect, truth),4} of them off the sensor");
+            OffSensor(disc, truth).ShouldBe(0, "no disc anchor may leave the sensor under ANY camera angle -- that is what the disc IS");
+            OffSensor(rect, truth).ShouldBeGreaterThan(rect.Length / 10,
+                "the rectangle is the CONTROL: if it stops picking off-sensor anchors here, this test " +
+                "has stopped discriminating and the disc assertion above proves nothing");
+
+            var discLock = PairRansacLock.TryLock(disc, detPts, detPts, W, H, 0.03f, out var discDiag);
+            var rectLock = PairRansacLock.TryLock(rect, detPts, detPts, W, H, 0.03f, out var rectDiag);
+            output.WriteLine($"  disc:      {(discLock is null ? "NO LOCK" : $"locked {discLock.Value.Hits}/{discLock.Value.Census}")} -- {discDiag}");
+            output.WriteLine($"  rectangle: {(rectLock is null ? "NO LOCK" : $"locked {rectLock.Value.Hits}/{rectLock.Value.Census}")} -- {rectDiag}");
+
+            // Sanity check, NOT the discriminator: these detections are noiseless and complete, so
+            // the rectangle survives its 44 dead anchors and locks too (116/160 when this was
+            // written). The real frame is what separates them -- on LDN 1089 only 35% of the
+            // rectangle's 20 brightest anchors had a detection at all, which is what starved
+            // Stage 1. The OffSensor pair above is what fails if the disc policy regresses.
+            discLock.ShouldNotBeNull($"a rotated field must seed from the rotation-invariant pool; {discDiag}");
+
+            // And the recovered transform must be the one we rotated by, across the whole frame.
+            foreach (var corner in new[] { new Vector2(0, 0), new Vector2(W, 0), new Vector2(0, H), new Vector2(W, H) })
+            {
+                Vector2.Distance(Vector2.Transform(corner, truth), Vector2.Transform(corner, discLock.Value.Transform))
+                    .ShouldBeLessThan(2.0f, $"corner {corner} disagrees with the {CameraAngleDeg} deg truth");
+            }
+        }
+
+        private static Vector2[] Anchors(
+            List<(double RA, double Dec, double VMag)> catalog, WCS origin, double pixelScaleRad,
+            double cx, double cy, ImageDim dim, bool rotationInvariant)
+        {
+            var pool = CatalogPlateSolver.ProjectCatalogStars(
+                catalog, origin, pixelScaleRad, cx, cy, dim, xSign: 1.0,
+                marginFraction: 0f, rotationInvariant: rotationInvariant);
+            var n = Math.Min(160, pool.Count);
+            var pts = new Vector2[n];
+            for (var i = 0; i < n; i++)
+            {
+                pts[i] = new Vector2(pool[i].Pixel.XCentroid, pool[i].Pixel.YCentroid);
+            }
+            return pts;
+        }
+
+        private static int OffSensor(Vector2[] anchors, in Matrix3x2 truth)
+        {
+            var off = 0;
+            foreach (var a in anchors)
+            {
+                var t = Vector2.Transform(a, truth);
+                if (t.X < 0 || t.Y < 0 || t.X >= W || t.Y >= H)
+                {
+                    off++;
+                }
+            }
+            return off;
+        }
+
+        /// <summary>
+        /// The similarity fit the in-scan refinement uses. Four degrees of freedom, so unlike
+        /// <see cref="Matrix3x2Helper.FitAffineTransform"/> it cannot answer with a mirror -- which
+        /// is what keeps <c>PairRansacLock</c>'s per-parity separation intact while it refines.
+        /// </summary>
+        [Theory]
+        [InlineData(0.0, 1.0)]
+        [InlineData(88.0, 1.0)]
+        [InlineData(-33.0, 1.04)]
+        [InlineData(180.0, 0.97)]
+        public void FitSimilarityTransformRecoversRotationScaleAndTranslation(double rotDeg, double scale)
+        {
+            var rot = double.DegreesToRadians(rotDeg);
+            var expected = new Matrix3x2(
+                (float)(scale * Math.Cos(rot)), (float)(scale * Math.Sin(rot)),
+                (float)(-scale * Math.Sin(rot)), (float)(scale * Math.Cos(rot)),
+                17f, -42f);
+
+            var rng = new Random(11);
+            var src = new Vector2[40];
+            var dst = new Vector2[40];
+            for (var i = 0; i < src.Length; i++)
+            {
+                src[i] = new Vector2(rng.Next(0, 4000), rng.Next(0, 3000));
+                dst[i] = Vector2.Transform(src[i], expected);
+            }
+
+            var fit = Matrix3x2.FitSimilarityTransform(src, dst);
+            fit.ShouldNotBeNull();
+            foreach (var probe in new[] { new Vector2(0, 0), new Vector2(4000, 0), new Vector2(0, 3000), new Vector2(4000, 3000) })
+            {
+                Vector2.Distance(Vector2.Transform(probe, expected), Vector2.Transform(probe, fit.Value))
+                    .ShouldBeLessThan(0.01f);
+            }
+        }
+
+        [Fact]
+        public void FitSimilarityTransformNeverAnswersWithAMirror()
+        {
+            // A perfectly mirrored correspondence has no similarity that explains it. The fit must
+            // still return a chirality-PRESERVING matrix (positive determinant) and simply be
+            // wrong, rather than silently flipping parity.
+            var rng = new Random(5);
+            var src = new Vector2[40];
+            var dst = new Vector2[40];
+            for (var i = 0; i < src.Length; i++)
+            {
+                src[i] = new Vector2(rng.Next(0, 4000), rng.Next(0, 3000));
+                dst[i] = new Vector2(4000 - src[i].X, src[i].Y);
+            }
+
+            var fit = Matrix3x2.FitSimilarityTransform(src, dst);
+            fit.ShouldNotBeNull();
+            (fit.Value.M11 * fit.Value.M22 - fit.Value.M12 * fit.Value.M21)
+                .ShouldBeGreaterThanOrEqualTo(0f, "a similarity fit must never flip chirality");
+        }
+
+        [Fact]
+        public void FitSimilarityTransformRefusesDegenerateInput()
+        {
+            Matrix3x2.FitSimilarityTransform([new Vector2(1, 1)], [new Vector2(2, 2)]).ShouldBeNull();
+
+            // Every source point identical: nothing determines a rotation or a scale.
+            var same = new[] { new Vector2(7, 7), new Vector2(7, 7), new Vector2(7, 7) };
+            var moved = new[] { new Vector2(1, 2), new Vector2(3, 4), new Vector2(5, 6) };
+            Matrix3x2.FitSimilarityTransform(same, moved).ShouldBeNull();
+        }
+    }
+}

--- a/src/TianWen.Lib.Tests/SeedAnchorPoolProbe.cs
+++ b/src/TianWen.Lib.Tests/SeedAnchorPoolProbe.cs
@@ -1,0 +1,319 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Numerics;
+using System.Threading.Tasks;
+using TianWen.Lib;
+using TianWen.Lib.Astrometry;
+using TianWen.Lib.Astrometry.Catalogs;
+using TianWen.Lib.Astrometry.PlateSolve;
+using TianWen.Lib.Imaging;
+using Xunit;
+
+namespace TianWen.Lib.Tests
+{
+    /// <summary>
+    /// Would the pair lock's own anchor pool verify the TRUE transform?
+    /// </summary>
+    /// <remarks>
+    /// <para>A lock that reports "no seed" has two completely different causes and says the same
+    /// thing about both: the hypothesis space does not CONTAIN a correct pairing, or it contains one
+    /// the scan failed to find. <see cref="FrameWcsAgreementProbe"/> answers a question one level
+    /// further out -- do the pixels agree with the catalogue at all -- and can pass while this one
+    /// fails, because the lock does not match against the frame, it matches against a projected
+    /// ANCHOR POOL that is a small, brightness-truncated, hint-dependent subset of it.</para>
+    /// <para>So this builds the pool the seed actually uses, via the production projection rather
+    /// than a copy of it, then constructs the transform the lock is SUPPOSED to find -- from the
+    /// pool's own stars to where the frame's WCS says they are -- and counts hits under it. If the
+    /// truth verifies, the pool is fine and the scan is at fault. If the truth does not verify,
+    /// searching harder cannot help, and neither can refining: there is nothing to refine onto.</para>
+    /// <para>Gated: <c>TIANWEN_SEED_POOL_FITS</c> must name a FITS that already carries a CD matrix,
+    /// which is what supplies the truth.</para>
+    /// </remarks>
+    [Collection("Imaging")]
+    public class SeedAnchorPoolProbe(ITestOutputHelper output)
+    {
+        [Fact]
+        public async Task ReportWhetherTheTrueTransformVerifiesAgainstTheSeedPool()
+        {
+            var path = Environment.GetEnvironmentVariable("TIANWEN_SEED_POOL_FITS");
+            Assert.SkipWhen(string.IsNullOrWhiteSpace(path), "Set TIANWEN_SEED_POOL_FITS to a solved FITS");
+
+            var ct = TestContext.Current.CancellationToken;
+            Image.TryReadFitsFile(path!, out var image, out var fileWcs);
+            Assert.NotNull(image);
+            Assert.NotNull(fileWcs);
+            // A frame's OWN CD matrix is not automatically the truth -- ldn1089_n2n.fits carries one
+            // that misses its own stars by ~74 px. Prefer a solver's .wcs sidecar when there is one,
+            // and say which was used, because every number below is measured against it.
+            var truth = fileWcs!.Value;
+            var truthSource = "the frame's own CD matrix";
+            var sidecar = System.IO.Path.ChangeExtension(path!, ".wcs");
+            if (System.IO.File.Exists(sidecar))
+            {
+                using var wcsFits = new nom.tam.fits.Fits(sidecar);
+                if (WCS.FromFits(wcsFits) is { HasCDMatrix: true } solved)
+                {
+                    truth = solved;
+                    truthSource = "the .wcs sidecar";
+                }
+            }
+            Assert.True(truth.HasCDMatrix, "the probe needs a CD matrix as its ground truth");
+            output.WriteLine($"truth from {truthSource}: RA={truth.CenterRA:F5}h Dec={truth.CenterDec:F4} scale={truth.PixelScaleArcsec:F4}\"/px");
+
+            // Exactly the solver's own detection path, downsample included -- the anchor ranks
+            // depend on it, and a probe that detects differently is measuring a different pool.
+            var dim = image!.GetImageDim(truth)!.Value;
+            var detectionImage = image;
+            var detectionScale = 1;
+            var pixelScaleX10 = (int)Math.Round(dim.PixelScale * 10);
+            if (pixelScaleX10 > 0 && pixelScaleX10 < 15)
+            {
+                detectionScale = (15 + pixelScaleX10 - 1) / pixelScaleX10;
+                if (detectionScale > 1)
+                {
+                    detectionImage = image.Downsample(detectionScale);
+                }
+            }
+            var detected = (await detectionImage.FindStarsAsync(
+                detectionImage.ReferenceStarChannel, snrMin: 5f, maxStars: 500, minStars: 50, maxRetries: 0,
+                maxFirstPassNoiseSigma: Image.MaxFirstPassNoiseSigma, cancellationToken: ct)).ToList();
+            var halfBlock = detectionScale / 2.0f - 0.5f;
+            var detPts = detected
+                .OrderByDescending(s => s.Flux)
+                .Select(s => new Vector2(
+                    s.XCentroid * detectionScale + halfBlock,
+                    s.YCentroid * detectionScale + halfBlock))
+                .ToArray();
+
+            output.WriteLine($"{System.IO.Path.GetFileName(path)}: {image.Width}x{image.Height}, " +
+                $"{dim.PixelScale:F4}\"/px, detection bin {detectionScale}x, {detPts.Length} detections");
+
+            // Control: detections made at full resolution, so the downsample step can be ablated.
+            Vector2[] fullResPts = [];
+            if (detectionScale > 1)
+            {
+                fullResPts = (await image.FindStarsAsync(
+                    image.ReferenceStarChannel, snrMin: 5f, maxStars: 500, minStars: 50, maxRetries: 0,
+                    maxFirstPassNoiseSigma: Image.MaxFirstPassNoiseSigma, cancellationToken: ct))
+                    .Select(s => new Vector2(s.XCentroid, s.YCentroid))
+                    .ToArray();
+            }
+
+            var db2 = await SharedCatalogDB.InitAsync(ct);
+            var solver = new CatalogPlateSolver(db2, Microsoft.Extensions.Logging.Abstractions.NullLogger.Instance);
+            var origin = new WCS(truth.CenterRA, truth.CenterDec);
+            var catalogCoords = solver.QueryCatalogStarsInRegion(origin, 2.0, 0.0);
+            var pixelScaleRad = double.DegreesToRadians(dim.PixelScale / 3600.0);
+            var cx = image.Width / 2.0;
+            var cy = image.Height / 2.0;
+            output.WriteLine($"catalog in search region: {catalogCoords.Count}");
+
+            foreach (var xSign in new[] { 1.0, -1.0 })
+            {
+                foreach (var margin in new[] { 0f, 0.1f })
+                {
+                    var pool = CatalogPlateSolver.ProjectCatalogStars(
+                        catalogCoords, origin, pixelScaleRad, cx, cy, dim, xSign, margin);
+                    var anchors = pool.Take(160).ToArray();
+                    if (anchors.Length < 8)
+                    {
+                        output.WriteLine($"xSign={xSign:+0;-0} margin={margin:P0}: only {anchors.Length} anchors");
+                        continue;
+                    }
+
+                    // The transform the lock is supposed to find: anchor as PROJECTED (what the
+                    // pool holds) onto anchor as the frame's WCS PLACES it (where a detection of
+                    // it must be). Both sides are the same stars, so this is the truth by
+                    // construction -- no fitting to detections, nothing centred on the answer.
+                    var src = new List<Vector2>(anchors.Length);
+                    var dst = new List<Vector2>(anchors.Length);
+                    // catalogCoords carries RA in HOURS (QueryCatalogStarsInRegion), which is
+                    // what SkyToPixel wants -- a /15 here reads as a 1000 px projection residual.
+                    foreach (var a in anchors)
+                    {
+                        if (truth.SkyToPixel(a.RA, a.Dec) is { } px)
+                        {
+                            src.Add(new Vector2(a.Pixel.XCentroid, a.Pixel.YCentroid));
+                            dst.Add(new Vector2((float)px.X, (float)px.Y));
+                        }
+                    }
+                    if (Matrix3x2.FitSimilarityTransform(src.ToArray(), dst.ToArray()) is not { } trueM)
+                    {
+                        output.WriteLine($"xSign={xSign:+0;-0} margin={margin:P0}: truth not fittable");
+                        continue;
+                    }
+
+                    var scale = MathF.Sqrt(trueM.M11 * trueM.M22 - trueM.M12 * trueM.M21);
+                    var rotDeg = MathF.Atan2(trueM.M12, trueM.M11) * 180f / MathF.PI;
+                    var resid = src.Select((s, i) => Vector2.Distance(Vector2.Transform(s, trueM), dst[i])).ToArray();
+
+                    var grid4 = new PairRansacLock.PointGrid(detPts, image.Width, image.Height, 4f);
+                    var grid12 = new PairRansacLock.PointGrid(detPts, image.Width, image.Height, 12f);
+                    int h4 = 0, h12 = 0;
+                    foreach (var s in src)
+                    {
+                        var t = Vector2.Transform(s, trueM);
+                        if (grid4.HasWithin(t.X, t.Y)) { h4++; }
+                        if (grid12.HasWithin(t.X, t.Y)) { h12++; }
+                    }
+
+                    output.WriteLine(
+                        $"xSign={xSign:+0;-0} margin={margin:P0}: {anchors.Length} anchors, " +
+                        $"truth is scale {scale:F4} rot {rotDeg:F2} deg, " +
+                        $"projection residual median {resid.Order().ElementAt(resid.Length / 2):F2} px / max {resid.Max():F2} px");
+                    output.WriteLine(
+                        $"    the TRUE transform scores {h4}/{src.Count} at 4 px, {h12}/{src.Count} at 12 px " +
+                        $"-- accept threshold is 24");
+
+                    if (resid.Max() > 1f)
+                    {
+                        continue;   // wrong parity; the breakdown below would be meaningless
+                    }
+
+                    // WHERE in the pool the matchable stars are. The lock takes a brightness
+                    // PREFIX, so a pool that matches well overall but not at its bright end is a
+                    // pool the lock cannot use, and the two look identical from the outside.
+                    // ProjectedCatalogStar drops VMag, but the pool preserves catalogCoords'
+                    // brightest-first order, so rank IS brightness.
+                    var whole = pool
+                        .Select(a => new Vector2(a.Pixel.XCentroid, a.Pixel.YCentroid))
+                        .ToArray();
+                    foreach (var prefix in new[] { 20, 50, 160, 500, whole.Length })
+                    {
+                        var n = Math.Min(prefix, whole.Length);
+                        var hit = 0;
+                        for (var i = 0; i < n; i++)
+                        {
+                            var t = Vector2.Transform(whole[i], trueM);
+                            if (grid4.HasWithin(t.X, t.Y)) { hit++; }
+                        }
+                        output.WriteLine($"      brightest {n,5}: {hit,5} match at 4 px ({(double)hit / n:P1})");
+                    }
+
+                    // What a ROTATION-INVARIANT pool would score. The box test keeps stars whose
+                    // north-up projection is in frame; under an unknown field rotation about the
+                    // tangent point, the only region guaranteed to STAY in frame is the inscribed
+                    // disc. A subset of the box, so it can be measured without changing anything.
+                    var safeR = Math.Min(image.Width, image.Height) / 2.0;
+                    var disc = whole
+                        .Where(p => (p.X - cx) * (p.X - cx) + (p.Y - cy) * (p.Y - cy) <= safeR * safeR)
+                        .Take(160)
+                        .ToArray();
+                    var discHits = disc.Count(p =>
+                    {
+                        var t = Vector2.Transform(p, trueM);
+                        return grid4.HasWithin(t.X, t.Y);
+                    });
+                    output.WriteLine($"      ROTATION-INVARIANT disc pool: {discHits}/{disc.Length} match at 4 px " +
+                        $"({(disc.Length > 0 ? (double)discHits / disc.Length : 0):P1}) -- threshold 24");
+
+                    // Is the pool even ORDERED by brightness? TrySeedPairLock documents that it is.
+                    var mags = catalogCoords.Select(c => c.VMag).ToArray();
+                    var sortedMags = mags.Order().ToArray();
+                    output.WriteLine($"      catalogCoords VMag order: first 8 = " +
+                        $"{string.Join(", ", mags.Take(8).Select(v => v.ToString("F2")))}" +
+                        $"  (sorted would be {string.Join(", ", sortedMags.Take(8).Select(v => v.ToString("F2")))})");
+
+                    // Are the pool's coordinates the ones Tycho-2 holds? FrameWcsAgreementProbe
+                    // matches raw Tycho2StarLite against this same frame and finds most of them,
+                    // so a pool that does NOT agree with Tycho-2 is a pool in a different epoch,
+                    // frame or unit -- and the projection cannot tell, because it uses the same
+                    // numbers on both sides of the fit.
+                    var tycho = new Tycho2StarLite[db2.Tycho2StarCount];
+                    var tychoN = db2.CopyTycho2Stars(tycho);
+                    var offsets = new List<double>();
+                    foreach (var a in anchors.Take(60))
+                    {
+                        var best = double.MaxValue;
+                        for (var i = 0; i < tychoN; i++)
+                        {
+                            var dRa = (tycho[i].RaHours - a.RA) * 15.0 * Math.Cos(double.DegreesToRadians(a.Dec));
+                            var dDec = tycho[i].DecDeg - a.Dec;
+                            var d = Math.Sqrt(dRa * dRa + dDec * dDec) * 3600.0;
+                            if (d < best) { best = d; }
+                        }
+                        offsets.Add(best);
+                    }
+                    offsets.Sort();
+                    output.WriteLine($"      anchor -> nearest Tycho-2 star: p10 {offsets[6]:F2}\", " +
+                        $"p50 {offsets[30]:F2}\", p90 {offsets[54]:F2}\" " +
+                        $"({offsets.Count(o => o < 2.0)}/60 within 2\")");
+
+                    // For anchors the truth places INSIDE the frame, how far is the nearest
+                    // detection? Near zero means the pool is fine and something else is wrong;
+                    // tens of pixels means the pool's coordinates do not describe these pixels.
+                    var inFrameNearest = new List<double>();
+                    for (var i = 0; i < dst.Count; i++)
+                    {
+                        if (dst[i].X < 0 || dst[i].Y < 0 || dst[i].X >= image.Width || dst[i].Y >= image.Height)
+                        {
+                            continue;
+                        }
+                        var best = double.MaxValue;
+                        foreach (var d in detPts)
+                        {
+                            var dd = Vector2.Distance(d, dst[i]);
+                            if (dd < best) { best = dd; }
+                        }
+                        inFrameNearest.Add(best);
+                    }
+                    inFrameNearest.Sort();
+                    if (inFrameNearest.Count > 0)
+                    {
+                        output.WriteLine($"      in-frame anchors, nearest detection: " +
+                            $"p10 {inFrameNearest[inFrameNearest.Count / 10]:F1} px, " +
+                            $"p50 {inFrameNearest[inFrameNearest.Count / 2]:F1} px, " +
+                            $"p90 {inFrameNearest[inFrameNearest.Count * 9 / 10]:F1} px");
+                    }
+
+                    // The SAME question against detections made WITHOUT the solver's downsample.
+                    // If these agree, the pool is at fault; if only the binned ones miss, the
+                    // downsample-and-rescale step is displacing every centroid it produces.
+                    if (detectionScale > 1 && fullResPts is { Length: > 0 })
+                    {
+                        var fullNearest = new List<double>();
+                        for (var i = 0; i < dst.Count; i++)
+                        {
+                            if (dst[i].X < 0 || dst[i].Y < 0 || dst[i].X >= image.Width || dst[i].Y >= image.Height)
+                            {
+                                continue;
+                            }
+                            var best = double.MaxValue;
+                            foreach (var d in fullResPts)
+                            {
+                                var dd = Vector2.Distance(d, dst[i]);
+                                if (dd < best) { best = dd; }
+                            }
+                            fullNearest.Add(best);
+                        }
+                        fullNearest.Sort();
+                        output.WriteLine($"      SAME anchors vs FULL-RES detections ({fullResPts.Length}): " +
+                            $"p10 {fullNearest[fullNearest.Count / 10]:F1} px, " +
+                            $"p50 {fullNearest[fullNearest.Count / 2]:F1} px, " +
+                            $"p90 {fullNearest[fullNearest.Count * 9 / 10]:F1} px");
+                    }
+
+                    var centre = Vector2.Transform(new Vector2((float)cx, (float)cy), trueM);
+                    var dstInFrame = dst.Count(d => d.X >= 0 && d.Y >= 0 && d.X < image.Width && d.Y < image.Height);
+                    output.WriteLine($"      frame centre ({cx:F0},{cy:F0}) maps to ({centre.X:F1},{centre.Y:F1}); " +
+                        $"{dstInFrame}/{dst.Count} anchors land INSIDE the frame under the truth");
+
+                    output.WriteLine("      the 12 brightest anchors, projected -> true, and what is actually there:");
+                    for (var i = 0; i < Math.Min(12, whole.Length); i++)
+                    {
+                        var t = Vector2.Transform(whole[i], trueM);
+                        output.WriteLine($"        projected ({whole[i].X,8:F1},{whole[i].Y,8:F1})");
+                        var best = double.MaxValue;
+                        foreach (var d in detPts)
+                        {
+                            var dd = Vector2.Distance(d, t);
+                            if (dd < best) { best = dd; }
+                        }
+                        output.WriteLine($"        rank {i,3} at ({t.X,8:F1},{t.Y,8:F1})  nearest detection {best,9:F1} px");
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/TianWen.Lib.Tests/SolverAnchorQualityProbe.cs
+++ b/src/TianWen.Lib.Tests/SolverAnchorQualityProbe.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using TianWen.Lib.Imaging;
+using Xunit;
+
+namespace TianWen.Lib.Tests
+{
+    /// <summary>
+    /// Are the stars the pair-lock anchors on actually STARS?
+    /// </summary>
+    /// <remarks>
+    /// <para><c>CatalogPlateSolver</c> ranks detections by FLUX and <c>PairRansacLock</c> takes the top
+    /// 48 as its hypothesis anchors. Flux is a fine proxy for "bright star" on a star field and a poor
+    /// one on a nebula: an extended blob integrates a lot of flux without being a point source, and the
+    /// catalogue holds only point sources, so an anchor set full of blobs cannot form a correspondence
+    /// no matter how many hypotheses are tried.</para>
+    /// <para>The measurement is the ratio of an anchor's HFD to the frame's MEDIAN HFD. A star sits
+    /// near 1. A blob sits far above it, and the catalogue has nothing to match it to. Reported for
+    /// the top 48 by flux, which is exactly the set the lock uses.</para>
+    /// <para>Run against a frame that SOLVES as the control -- a difference only means something if
+    /// the working case looks different. Gated: <c>TIANWEN_ANCHOR_PROBE_FITS</c>.</para>
+    /// </remarks>
+    [Collection("Imaging")]
+    public class SolverAnchorQualityProbe(ITestOutputHelper output)
+    {
+        [Fact]
+        public async Task ReportWhetherTheBrightestDetectionsAreStars()
+        {
+            var path = Environment.GetEnvironmentVariable("TIANWEN_ANCHOR_PROBE_FITS");
+            Assert.SkipWhen(string.IsNullOrWhiteSpace(path), "Set TIANWEN_ANCHOR_PROBE_FITS");
+
+            var ct = TestContext.Current.CancellationToken;
+            Image.TryReadFitsFile(path!, out var image, out var wcs);
+            Assert.NotNull(image);
+
+            // Same detection parameters the solver uses, so the anchor set is the one it would see.
+            var stars = (await image!.FindStarsAsync(
+                image.ReferenceStarChannel, snrMin: 5f, maxStars: 500, minStars: 50, maxRetries: 0,
+                maxFirstPassNoiseSigma: Image.MaxFirstPassNoiseSigma, cancellationToken: ct)).ToArray();
+
+            var hfds = stars.Select(s => s.HFD).Order().ToArray();
+            var median = hfds[hfds.Length / 2];
+            output.WriteLine($"{System.IO.Path.GetFileName(path)}: {stars.Length} detections, HFD median {median:F2} " +
+                             $"(p5 {hfds[hfds.Length / 20]:F2}, p95 {hfds[hfds.Length * 19 / 20]:F2})");
+
+            // The 48 the lock actually anchors on.
+            const int Anchors = 48;
+            var byFlux = stars.OrderByDescending(s => s.Flux).Take(Anchors).ToArray();
+            var ratios = byFlux.Select(s => s.HFD / median).Order().ToArray();
+            output.WriteLine($"  top {byFlux.Length} by FLUX: HFD/median  min {ratios[0]:F2}  " +
+                             $"p50 {ratios[ratios.Length / 2]:F2}  max {ratios[^1]:F2}");
+            output.WriteLine($"    within 1.5x median: {byFlux.Count(s => s.HFD <= 1.5f * median),3} of {byFlux.Length}");
+            output.WriteLine($"    beyond 2.0x median: {byFlux.Count(s => s.HFD > 2.0f * median),3} of {byFlux.Length}");
+            output.WriteLine($"    mean ellipticity:   {byFlux.Average(s => s.Ellipticity):F2}");
+
+            // What a star-likeness ranking would pick instead: brightest AMONG those whose size and
+            // roundness look stellar. If the two sets are nearly identical the hypothesis is wrong.
+            var starLike = stars
+                .Where(s => s.HFD <= 1.5f * median && s.HFD >= 0.5f * median && s.Ellipticity <= 0.6f)
+                .OrderByDescending(s => s.Flux)
+                .Take(Anchors)
+                .ToArray();
+            output.WriteLine($"  top {starLike.Length} STAR-LIKE: HFD/median " +
+                             $"p50 {(starLike.Length > 0 ? starLike.OrderBy(s => s.HFD).ElementAt(starLike.Length / 2).HFD / median : 0):F2}" +
+                             $"  mean ellipticity {(starLike.Length > 0 ? starLike.Average(s => s.Ellipticity) : 0):F2}");
+
+            var overlap = byFlux.Count(a => starLike.Any(b => Math.Abs(a.XCentroid - b.XCentroid) < 0.01f
+                                                              && Math.Abs(a.YCentroid - b.YCentroid) < 0.01f));
+            output.WriteLine($"  the two anchor sets share {overlap} of {Anchors} -- a low number is the hypothesis");
+        }
+    }
+}

--- a/src/TianWen.Lib.Tests/VelaMosaicFieldTests.cs
+++ b/src/TianWen.Lib.Tests/VelaMosaicFieldTests.cs
@@ -204,15 +204,26 @@ namespace TianWen.Lib.Tests
 
         /// <summary>
         /// Pins WHY the seed tries two anchor-pool policies, so neither can be dropped as
-        /// redundant. Both cases are real and both occur in this one mosaic:
+        /// redundant:
         /// <list type="bullet">
         ///   <item>an accurate hint needs the STRICT pool -- with the matching loop's 0.1 margin,
         ///   ~31% of anchors sit outside the frame where they cannot be detected, and because the
         ///   pool is the brightest N of whatever is kept they displace genuine in-frame stars and
-        ///   starve the staged gates;</item>
-        ///   <item>a hint tens of arcmin off needs the MARGINED pool, because real stars project
-        ///   outside the frame under it.</item>
+        ///   starve the staged gates. Five panels lock only this way;</item>
+        ///   <item>a hint tens of arcmin off is what the MARGINED pool is for, because real stars
+        ///   project outside the frame under it.</item>
         /// </list>
+        /// <para><b>The margined half is no longer EXCLUSIVELY needed by anything in this mosaic,
+        /// and that is a result, not a rotted assertion.</b> It used to rescue P20.2, whose hint
+        /// is 38 arcmin off, from a strict pool that could not lock it. Refining a hypothesis
+        /// before judging it (<c>PairRansacLock.TryRefine</c>) closed that gap: a hint that bad
+        /// still leaves enough of the anchor set in frame to seed from, once a seed no longer has
+        /// to survive a tolerance only its refinement could meet. So the test asserts the strict
+        /// pool is still necessary, and that the margined pool still LOCKS the worst hint in the
+        /// set -- proving the fallback works, rather than requiring it to be the only thing that
+        /// does. Keeping it is a judgement about hints worse than this mosaic contains; deleting
+        /// it on the evidence of one dataset would be exactly the overfit this file exists to
+        /// catch.</para>
         /// </summary>
         [Fact]
         public void BothAnchorPoolPoliciesAreNecessary()
@@ -220,6 +231,9 @@ namespace TianWen.Lib.Tests
             var catalog = Manifest.CatalogTuples();
             var strictOnly = new List<string>();
             var marginOnly = new List<string>();
+            var worstHintArcmin = -1.0;
+            var worstHintPanel = "";
+            var worstHintMargined = false;
 
             foreach (var panel in Manifest.Panels)
             {
@@ -251,23 +265,37 @@ namespace TianWen.Lib.Tests
                     }
                 }
 
+                var hintErrArcmin = Separation(frame.Hint, frame.Wcs) * 60;
+                if (hintErrArcmin > worstHintArcmin)
+                {
+                    worstHintArcmin = hintErrArcmin;
+                    worstHintPanel = panel.Id;
+                    worstHintMargined = margined;
+                }
+
                 if (strict && !margined)
                 {
                     strictOnly.Add(panel.Id);
                 }
                 else if (margined && !strict)
                 {
-                    marginOnly.Add($"{panel.Id} (hint off by {Separation(frame.Hint, frame.Wcs) * 60:F0} arcmin)");
+                    marginOnly.Add($"{panel.Id} (hint off by {hintErrArcmin:F0} arcmin)");
                 }
             }
 
             output.WriteLine($"strict-pool only: {string.Join(", ", strictOnly)}");
             output.WriteLine($"margined-pool only: {string.Join(", ", marginOnly)}");
+            output.WriteLine($"worst hint: {worstHintPanel} off by {worstHintArcmin:F0} arcmin, " +
+                $"margined pool {(worstHintMargined ? "locks" : "does NOT lock")} it");
 
             strictOnly.Count.ShouldBeGreaterThan(0,
                 "panels that only seed from a strictly in-frame pool are why the seed tries it first");
-            marginOnly.Count.ShouldBeGreaterThan(0,
-                "panels that only seed from the margined pool are why it remains as a fallback");
+
+            // The margined pool must still WORK on the case it exists for, even now that nothing
+            // in this mosaic needs it exclusively.
+            worstHintMargined.ShouldBeTrue(
+                $"the margined pool must lock the worst hint in the set ({worstHintPanel}, " +
+                $"{worstHintArcmin:F0} arcmin off), which is the case it exists for");
         }
 
         /// <summary>

--- a/src/TianWen.Lib.Tests/VelaMosaicStarListExport.cs
+++ b/src/TianWen.Lib.Tests/VelaMosaicStarListExport.cs
@@ -158,8 +158,14 @@ namespace TianWen.Lib.Tests
             var dtYr = epoch.Year > 1900 ? epoch.JulianYearsSinceJ2000() : 0.0;
 
             var swCat = Stopwatch.StartNew();
+            // Deliberately NOT re-sorted. This export used to sort brightest-first itself, which
+            // silently corrected a query that returned grid-scan order -- so every replay tested a
+            // brightness ranking the solver never actually had, and the frozen regression stayed
+            // green through the bug that cost LDN 1089 its solve. The freeze must record what
+            // QueryCatalogStarsInRegion RETURNS, whatever that is; if it ever stops sorting, the
+            // next re-export bakes scan order into the fixture and the Vela panels go red, which
+            // is the signal. Normalising an input is how a fixture stops being able to see it.
             var catalog = solver.QueryCatalogStarsInRegion(centre, radiusDeg, dtYr);
-            catalog.Sort(static (a, b) => a.VMag.CompareTo(b.VMag));
             output.WriteLine($"Catalog: {catalog.Count} stars within {radiusDeg:F2}° of " +
                 $"RA={centre.CenterRA:F4}h Dec={centre.CenterDec:F3}° at epoch {epoch:yyyy-MM-dd} " +
                 $"({swCat.Elapsed.TotalSeconds:F1} s)");

--- a/src/TianWen.Lib/Astrometry/Catalogs/HdHipCrossSnapshot.cs
+++ b/src/TianWen.Lib/Astrometry/Catalogs/HdHipCrossSnapshot.cs
@@ -327,9 +327,14 @@ internal static class HdHipCrossInputHasher
                 // Hash the *decompressed* content for .gs.gz so the input hash is invariant to
                 // gzip-encoder output differences across platforms / .NET versions. .lz inputs
                 // stay raw: they ship as LFS-tracked immutable bytes.
-                using Stream stream = inputSuffix.EndsWith(".gs.gz", StringComparison.Ordinal)
+                // The decompressor gets its OWN using variable rather than riding a ternary into
+                // a shared one: assigned through the conditional, CA2000 cannot see that the
+                // branch which allocates is the branch that disposes, and the other branch was
+                // double-disposing rawStream (harmless, but only by luck).
+                using var gzip = inputSuffix.EndsWith(".gs.gz", StringComparison.Ordinal)
                     ? new GZipStream(rawStream, CompressionMode.Decompress)
-                    : rawStream;
+                    : null;
+                var stream = gzip as Stream ?? rawStream;
 
                 int read;
                 while ((read = stream.Read(rentedBuf, 0, rentedBuf.Length)) > 0)

--- a/src/TianWen.Lib/Astrometry/PlateSolve/CatalogPlateSolver.cs
+++ b/src/TianWen.Lib/Astrometry/PlateSolve/CatalogPlateSolver.cs
@@ -117,7 +117,7 @@ internal sealed class CatalogPlateSolver(ICelestialObjectDB db, ILogger logger) 
     /// attached, so the matching loop can collect (detected pixel, catalog
     /// RA/Dec) pairs without a second pass over the catalog.
     /// </summary>
-    private readonly record struct ProjectedCatalogStar(ImagedStar Pixel, double RA, double Dec);
+    internal readonly record struct ProjectedCatalogStar(ImagedStar Pixel, double RA, double Dec);
 
     private int _catalogStars, _detectedStars;
 
@@ -1295,11 +1295,27 @@ internal sealed class CatalogPlateSolver(ICelestialObjectDB db, ILogger logger) 
 
     /// <summary>
     /// Queries every catalog star within <paramref name="radiusDeg"/> of <paramref name="origin"/>,
-    /// proper-motion propagated to the image epoch. <c>internal</c> rather than private so the
-    /// star-list export (see <c>VelaMosaicStarListExport</c> in the test project) freezes the
-    /// SAME catalog the solver sees -- a re-derived query in the test would silently diverge on
-    /// proper motion or the polar-cap path and turn a real regression into a data artefact.
+    /// proper-motion propagated to the image epoch, <b>brightest first</b>. <c>internal</c> rather
+    /// than private so the star-list export (see <c>VelaMosaicStarListExport</c> in the test
+    /// project) freezes the SAME catalog the solver sees -- a re-derived query in the test would
+    /// silently diverge on proper motion or the polar-cap path and turn a real regression into a
+    /// data artefact.
     /// </summary>
+    /// <remarks>
+    /// <para><b>The sort is load-bearing, and its absence is what kept LDN 1089 from solving.</b>
+    /// Both loops below accumulate in grid-scan order, RA cell major, so without a sort the list
+    /// comes back in a spatial order that has nothing to do with brightness -- on that frame the
+    /// first eight entries were V 11.66, 8.90, 11.48, 10.35, ... where the brightest eight in the
+    /// region are V 3.40 to 6.92.</para>
+    /// <para>Every downstream consumer reads this list as a brightness ranking and TRUNCATES it.
+    /// <see cref="PairRansacLock"/> keeps the first 160 as its anchor pool and probes the first 8
+    /// of those as its Stage 1 gate, so in scan order that gate asks whether an arbitrary strip of
+    /// one RA cell was detected. On LDN 1089 the first 20 anchors matched NOTHING under the true
+    /// transform while the first 160 matched 112 -- so the correct hypothesis was generated and
+    /// then discarded at Stage 1, every time, and the diagnostics could only report that nothing
+    /// correlated. Sorting is the whole fix: the pool becomes the 160 brightest, which is what a
+    /// star detector finds and what the gates were designed around.</para>
+    /// </remarks>
     internal List<(double RA, double Dec, double VMag)> QueryCatalogStarsInRegion(WCS origin, double radiusDeg, double dtJulianYears)
     {
         var result = new List<(double RA, double Dec, double VMag)>();
@@ -1357,6 +1373,7 @@ internal sealed class CatalogPlateSolver(ICelestialObjectDB db, ILogger logger) 
                 }
             }
 
+            SortBrightestFirst(result);
             return result;
         }
 
@@ -1382,18 +1399,33 @@ internal sealed class CatalogPlateSolver(ICelestialObjectDB db, ILogger logger) 
             }
         }
 
+        SortBrightestFirst(result);
         return result;
     }
 
     /// <summary>
-    /// Searches for the geometric pair-lock seed for one parity, over BOTH anchor-pool policies.
-    /// <c>internal</c> so the frozen-star-list regressions
+    /// Brightest first, with a magnitude-less star (<c>V_Mag</c> NaN, mapped to 99) sorting last
+    /// rather than first. Both query paths end here, so neither can be the one that forgets.
+    /// </summary>
+    private static void SortBrightestFirst(List<(double RA, double Dec, double VMag)> stars)
+        => stars.Sort(static (a, b) => a.VMag.CompareTo(b.VMag));
+
+    /// <summary>
+    /// Searches for the geometric pair-lock seed for one parity, over every anchor-pool policy in
+    /// <see cref="PoolPolicies"/>. <c>internal</c> so the frozen-star-list regressions
     /// (<c>VelaMosaicFieldTests</c>) drive this exact code rather than a copy of the pool policy
     /// that could silently drift from it.
     /// </summary>
     /// <remarks>
-    /// Two pools, tried in order, because the right one depends on how good the hint is and both
-    /// cases occur within one night's data.
+    /// Three pools, tried in order, because the right one depends on the camera ANGLE and on how
+    /// good the hint is, and neither is known when the pool is built.
+    /// <para>
+    /// DISC (rotation-invariant) is tried first and is the only one that does not assume the
+    /// camera is north-up; <see cref="ProjectCatalogStars"/> carries the geometry and the LDN 1089
+    /// measurements. It is first rather than last because when it differs from the rectangle it is
+    /// RIGHT, and it is cheap when it is unnecessary: a field it can lock, it locks early (LDN
+    /// 1089 seeds in 7,003 hypotheses where the rectangle exhausted a 1,000,000 budget).
+    /// </para>
     /// <para>
     /// STRICT (no margin) is the default: an anchor outside the frame cannot possibly be detected,
     /// so it can only dilute the consensus -- and worse, since the pool is the brightest N of
@@ -1406,9 +1438,13 @@ internal sealed class CatalogPlateSolver(ICelestialObjectDB db, ILogger logger) 
     /// merit, which is why raising the hypothesis cap to exhaustive coverage did not help them.
     /// </para>
     /// <para>
-    /// MARGINED is the fallback and earns its keep on a BAD hint: panel 20.2's header is 38 arcmin
-    /// off, which pushes real stars off the projected frame, and it locks only with the margin.
-    /// Neither pool alone covers the night.
+    /// MARGINED is the last fallback and earns its keep on a BAD hint: panel 20.2's header is 38
+    /// arcmin off, which pushes real stars off the projected frame. No pool alone covers the night.
+    /// </para>
+    /// <para>
+    /// All three read the pool as a brightness ranking and truncate it to
+    /// <c>PairRansacLock</c>'s 160 anchors, which is why <see cref="QueryCatalogStarsInRegion"/>
+    /// sorting is a precondition of every one of them rather than a detail of any.
     /// </para>
     /// </remarks>
     internal static PairRansacLock.LockResult? TrySeedPairLock(
@@ -1423,15 +1459,16 @@ internal sealed class CatalogPlateSolver(ICelestialObjectDB db, ILogger logger) 
         float scaleTolerance,
         ILogger? logger = null)
     {
-        foreach (var marginFraction in new[] { 0f, 0.1f })
+        foreach (var (marginFraction, rotationInvariant) in PoolPolicies)
         {
-            var seedProjected = ProjectCatalogStars(catalogCoords, origin, pixelScaleRad, cx, cy, dim, xSign, marginFraction);
+            var seedProjected = ProjectCatalogStars(catalogCoords, origin, pixelScaleRad, cx, cy, dim, xSign, marginFraction, rotationInvariant);
             if (seedProjected.Count < MinStarsForMatch)
             {
                 continue;
             }
 
-            // catalogCoords is VMag-sorted, so the projected list is brightest-first.
+            // QueryCatalogStarsInRegion sorts brightest-first, so the projected list is too --
+            // and both the 160-anchor truncation below and PairRansacLock's Stage 1 depend on it.
             var catPts = new Vector2[seedProjected.Count];
             for (var i = 0; i < seedProjected.Count; i++)
             {
@@ -1442,20 +1479,30 @@ internal sealed class CatalogPlateSolver(ICelestialObjectDB db, ILogger logger) 
                 dim.Width, dim.Height, scaleTolerance, out var lockDiagnostics);
             if (lockResult is { } locked)
             {
-                logger?.LogDebug("CatalogPlateSolver: pair-lock seed (xSign={XSign}, anchor margin {Margin:P0}) consensus {Hits}/{Census} (chance {Chance:F1}) after {Hypotheses} hypotheses",
-                    xSign, marginFraction, locked.Hits, locked.Census, locked.ExpectedChanceHits, locked.Hypotheses);
+                logger?.LogDebug("CatalogPlateSolver: pair-lock seed (xSign={XSign}, anchor pool {Pool}) consensus {Hits}/{Census} (chance {Chance:F1}) after {Hypotheses} hypotheses",
+                    xSign, PoolName(marginFraction, rotationInvariant), locked.Hits, locked.Census, locked.ExpectedChanceHits, locked.Hypotheses);
                 return locked;
             }
 
             // No seed is a legitimate outcome on a sparse field, but on a dense one it is the
             // difference between "nothing correlates" and "the scan never got there" -- and only
             // the diagnostics distinguish them.
-            logger?.LogDebug("CatalogPlateSolver: no pair-lock seed (xSign={XSign}, anchor margin {Margin:P0}): {Diagnostics}",
-                xSign, marginFraction, lockDiagnostics.ToString());
+            logger?.LogDebug("CatalogPlateSolver: no pair-lock seed (xSign={XSign}, anchor pool {Pool}): {Diagnostics}",
+                xSign, PoolName(marginFraction, rotationInvariant), lockDiagnostics.ToString());
         }
 
         return null;
     }
+
+    /// <summary>
+    /// The anchor-pool policies the seed tries, in order. See <see cref="TrySeedPairLock"/> for
+    /// why more than one is needed and <see cref="ProjectCatalogStars"/> for what each keeps.
+    /// </summary>
+    private static readonly (float MarginFraction, bool RotationInvariant)[] PoolPolicies =
+        [(0f, true), (0f, false), (0.1f, false)];
+
+    private static string PoolName(float marginFraction, bool rotationInvariant) =>
+        rotationInvariant ? "rotation-invariant disc" : $"rectangle, margin {marginFraction:P0}";
 
     /// <param name="marginFraction">
     /// How far outside the frame a projected star may fall and still be kept, as a fraction of
@@ -1463,7 +1510,25 @@ internal sealed class CatalogPlateSolver(ICelestialObjectDB db, ILogger logger) 
     /// that is still wrong by up to the hint error, so a star just off the edge may well move in
     /// as the fit converges. The pair-lock SEED wants 0 -- see <see cref="TrySeedPairLock"/>.
     /// </param>
-    private static List<ProjectedCatalogStar> ProjectCatalogStars(
+    /// <param name="rotationInvariant">
+    /// Keep only stars inside the disc that stays in frame under ANY camera angle, ignoring
+    /// <paramref name="marginFraction"/>.
+    /// <para><b>The projection here is north-up and the camera is not.</b> This routine has no
+    /// rotation to apply -- finding it is the seed's whole job -- so an in-frame test against the
+    /// frame RECTANGLE silently assumes a camera angle of zero. On a 3:2 frame at LDN 1089's
+    /// 88 degree angle, that rectangle's contents rotate mostly off the sensor: of the 160
+    /// brightest anchors it kept, only 92 were really on the frame, and the ones it dropped were
+    /// real stars sitting in the sensor's own corners. The rectangle is not a conservative
+    /// approximation of the frame, it is a DIFFERENT REGION OF SKY that merely has the same area.
+    /// </para>
+    /// <para>The largest region that is in frame at every angle is the inscribed disc, and
+    /// selecting on it costs the corners (48% of a 3:2 frame) to gain an anchor set every member
+    /// of which is genuinely observable: measured on LDN 1089, 125 of 130 disc anchors have a
+    /// detection within 4 px, against 87 of 160 for the rectangle. That ratio is what the staged
+    /// gates read -- Stage 1 asks whether 3 of the 8 brightest anchors were detected -- so it
+    /// decides whether the true hypothesis survives to be counted at all.</para>
+    /// </param>
+    internal static List<ProjectedCatalogStar> ProjectCatalogStars(
         List<(double RA, double Dec, double VMag)> catalogCoords,
         WCS origin,
         double pixelScaleRad,
@@ -1471,7 +1536,8 @@ internal sealed class CatalogPlateSolver(ICelestialObjectDB db, ILogger logger) 
         double cy,
         ImageDim dim,
         double xSign,
-        float marginFraction = 0.1f
+        float marginFraction = 0.1f,
+        bool rotationInvariant = false
     )
     {
         var projected = new List<ProjectedCatalogStar>();
@@ -1481,6 +1547,12 @@ internal sealed class CatalogPlateSolver(ICelestialObjectDB db, ILogger logger) 
 
         var marginX = dim.Width * marginFraction;
         var marginY = dim.Height * marginFraction;
+
+        // Radius of the disc that is in frame at any camera angle. The seed's projection shares
+        // its tangent point with the frame centre, so the unknown rotation is about (cx, cy) and
+        // this disc is invariant under it.
+        var safeRadius = Math.Min(dim.Width, dim.Height) / 2.0;
+        var safeRadiusSq = safeRadius * safeRadius;
 
         foreach (var (ra, dec, _) in catalogCoords)
         {
@@ -1502,8 +1574,20 @@ internal sealed class CatalogPlateSolver(ICelestialObjectDB db, ILogger logger) 
             var xPix = (float)(cx + xSign * xi / pixelScaleRad);
             var yPix = (float)(cy - eta / pixelScaleRad);
 
-            if (xPix >= -marginX && xPix <= dim.Width + marginX &&
-                yPix >= -marginY && yPix <= dim.Height + marginY)
+            bool keep;
+            if (rotationInvariant)
+            {
+                var dx = xPix - cx;
+                var dy = yPix - cy;
+                keep = dx * dx + dy * dy <= safeRadiusSq;
+            }
+            else
+            {
+                keep = xPix >= -marginX && xPix <= dim.Width + marginX &&
+                       yPix >= -marginY && yPix <= dim.Height + marginY;
+            }
+
+            if (keep)
             {
                 projected.Add(new ProjectedCatalogStar(
                     new ImagedStar(2f, 2f, 100f, 1000f, xPix, yPix, 0f), ra, dec));

--- a/src/TianWen.Lib/Astrometry/PlateSolve/CatalogPlateSolver.cs
+++ b/src/TianWen.Lib/Astrometry/PlateSolve/CatalogPlateSolver.cs
@@ -183,8 +183,13 @@ internal sealed class CatalogPlateSolver(ICelestialObjectDB db, ILogger logger) 
             return Result(empty);
         }
 
-        if ((imageDim ?? image.GetImageDim()) is not { } dim)
+        // The search origin doubles as a scale source. A frame that carries a solved CD matrix but no
+        // FOCALLEN -- which is every master TianWen writes -- otherwise fails HERE, in a few ms,
+        // before detecting a star, with its own pixel scale sitting unread in the same header.
+        if ((imageDim ?? image.GetImageDim(searchOrigin)) is not { } dim)
         {
+            _logger.LogWarning(
+                "CatalogPlateSolver: no pixel scale available -- the frame states no PIXSCALE, no FOCALLEN + pixel size, and the search origin carries no CD matrix. Pass an explicit ImageDim.");
             return Result(empty);
         }
 

--- a/src/TianWen.Lib/Astrometry/PlateSolve/IPlateSolver.cs
+++ b/src/TianWen.Lib/Astrometry/PlateSolve/IPlateSolver.cs
@@ -64,7 +64,11 @@ public interface IPlateSolver : IAsyncSupportedCheck
         try
         {
             image.WriteToFitsFile(fitsFile);
-            return await SolveFileAsync(fitsFile, imageDim ?? image.GetImageDim(), range, searchOrigin, searchRadius, cancellationToken);
+            // searchOrigin doubles as a scale source when the headers have none. This matters for every
+            // solver, not just ours: an external one is handed the field of view derived from this dim,
+            // so a frame with a solved CD matrix and no FOCALLEN would otherwise send ASTAP off to
+            // search blind for a field size it was already told.
+            return await SolveFileAsync(fitsFile, imageDim ?? image.GetImageDim(searchOrigin), range, searchOrigin, searchRadius, cancellationToken);
         }
         finally
         {

--- a/src/TianWen.Lib/Astrometry/PlateSolve/PairRansacLock.cs
+++ b/src/TianWen.Lib/Astrometry/PlateSolve/PairRansacLock.cs
@@ -23,11 +23,12 @@ namespace TianWen.Lib.Astrometry.PlateSolve;
 /// pre-sorted pair-separation index). Each candidate pairing determines a similarity transform
 /// via the complex ratio of the pair vectors: chirality-preserving by construction, so mirror
 /// parity stays cleanly separated in the caller's per-<c>xSign</c> attempts. Hypotheses are
-/// verified in stages against a uniform grid hash of ALL detected stars (cheap 8-star probe,
-/// then 32, then full census), and accepted only when the hit count beats the Poisson
-/// expectation of chance alignment by <see cref="ChanceSafetyFactor"/>; the statistic that
-/// distinguishes a genuine lock from the dense-field nearest-neighbour-noise regime where
-/// proximity matching silently fails.</para>
+/// staged against a uniform grid hash of ALL detected stars (cheap 8-star probe, then 32, then
+/// full census), then <b>refined onto their own inliers before being judged</b>
+/// (<see cref="TryRefine"/>), and accepted only when the refined transform's hit count beats
+/// the Poisson expectation of chance alignment by <see cref="ChanceSafetyFactor"/>; the
+/// statistic that distinguishes a genuine lock from the dense-field nearest-neighbour-noise
+/// regime where proximity matching silently fails.</para>
 /// </summary>
 internal static class PairRansacLock
 {
@@ -46,6 +47,41 @@ internal static class PairRansacLock
     /// <summary>Stage gates: probe hit floors at 8 and 32 catalog stars. Chance passes the
     /// first gate at ~4e-5 per hypothesis, so full verification runs only on real candidates.</summary>
     private const int Stage1Count = 8, Stage1MinHits = 3, Stage2Count = 32, Stage2MinHits = 8;
+
+    /// <summary>
+    /// Staging probes at this multiple of the verification radius, because a hypothesis cannot
+    /// be judged at the radius its refined successor is judged at.
+    /// <para>A hypothesis is derived from ONE pair, so its rotation error is the pair's centroid
+    /// error divided by its baseline, and that angular error is amplified by the distance from
+    /// the pair to wherever the hit is being counted. The baseline floor is
+    /// <see cref="MinBaselineFraction"/> of the short side and the far corner is half the
+    /// diagonal away, so the worst-case amplification is
+    /// <c>0.5 * sqrt(w^2 + h^2) / (0.2 * min(w, h))</c> -- 3.5x on a square frame, 4.2x on 4:3.
+    /// A per-star centroid error inside the verification radius therefore lands OUTSIDE it at
+    /// the corners, and the true hypothesis dies at Stage 1 having been measured against a
+    /// tolerance only its own refinement could meet.</para>
+    /// <para>Measured on LDN 1089 (835 px winning baseline, ~1.9 px centroid error, 8.6 px
+    /// corner displacement): at a 4 px radius the best hypothesis scored 12 of 160 against a
+    /// threshold of 24, and at 12 px it scored 38. Widening the ACCEPT radius does not fix that
+    /// -- chance grows as r^2, so the threshold outran the gain (24 -> 100.5). Widening only the
+    /// CAPTURE radius does: the accept decision stays at the tight radius, where chance is
+    /// unchanged, and the extra reach is spent on giving refinement something to work with.
+    /// Horsehead, whose corner displacement is 1.8 px, locks either way.</para>
+    /// </summary>
+    private const float CaptureRadiusFactor = 3f;
+
+    /// <summary>
+    /// Refinement rounds per promoted candidate. Each is a capture-and-refit (ICP) pass, and the
+    /// transform is already within a capture radius of the truth when the first one runs, so it
+    /// converges in two; the third is the margin.
+    /// </summary>
+    private const int RefineIterations = 3;
+
+    /// <summary>
+    /// Correspondences a refit needs. An affine has 6 degrees of freedom, so at 3 points it
+    /// interpolates rather than fits and any noise becomes signal.
+    /// </summary>
+    private const int MinRefineCorrespondences = 6;
 
     /// <summary>
     /// Consensus fraction that ends the scan. Plate solving has exactly ONE true transform and
@@ -109,7 +145,8 @@ internal static class PairRansacLock
         int DetectedPairsTotal,
         int BestHits,
         double AcceptThreshold,
-        double ExpectedChanceHits)
+        double ExpectedChanceHits,
+        int Refinements)
     {
         /// <summary>Fraction of bright detected pairs the scan actually got to.</summary>
         internal double Coverage => DetectedPairsTotal == 0 ? 0 : (double)DetectedPairsTried / DetectedPairsTotal;
@@ -117,6 +154,7 @@ internal static class PairRansacLock
         public override string ToString() =>
             $"{BestHits} best hits vs threshold {AcceptThreshold:F1} (chance {ExpectedChanceHits:F1}) over " +
             $"{Hypotheses} hypotheses{(HypothesisCapHit ? " (CAP HIT)" : "")}, " +
+            $"{Refinements} refined, " +
             $"{DetectedPairsTried}/{DetectedPairsTotal} bright detected pairs tried ({Coverage:P0}), " +
             $"{CatalogAnchors} catalog / {DetectedAnchors} detected anchors";
     }
@@ -140,22 +178,35 @@ internal static class PairRansacLock
     {
         var nCat = Math.Min(MaxCatalogAnchors, catalogBright.Length);
         var nDet = Math.Min(MaxDetectedAnchors, detectedBright.Length);
-        diagnostics = new LockDiagnostics(nCat, nDet, 0, false, 0, Math.Max(0, nDet * (nDet - 1) / 2), 0, 0, 0);
+        diagnostics = new LockDiagnostics(nCat, nDet, 0, false, 0, Math.Max(0, nDet * (nDet - 1) / 2), 0, 0, 0, 0);
         if (nCat < Stage1Count || nDet < 2 || detectedAll.Length < Stage1MinHits)
         {
             return null;
         }
 
-        var grid = new PointGrid(detectedAll, width, height, verifyRadiusPx);
+        // Two radii, two jobs (see CaptureRadiusFactor): staging and refinement CAPTURE at the
+        // wide one, the accept decision VERIFIES at the tight one. Chance is a property of the
+        // radius a hit is accepted at, so widening the capture radius costs candidates to refine,
+        // never a looser bar to clear.
+        var verifyGrid = new PointGrid(detectedAll, width, height, verifyRadiusPx);
+        var captureGrid = new PointGrid(detectedAll, width, height, CaptureRadiusFactor * verifyRadiusPx);
         var verifyRadiusSq = verifyRadiusPx * verifyRadiusPx;
 
         // Chance model: a transformed catalog star lands within verifyRadius of SOME detected
-        // star with probability lambda * pi * r^2 (Poisson field). The accept threshold and the
-        // stage gates both derive from this, so density can never fake a lock.
+        // star with probability lambda * pi * r^2 (Poisson field). The accept threshold derives
+        // from this, so density can never fake a lock.
         var lambda = detectedAll.Length / ((double)width * height);
         var expectedChance = nCat * lambda * Math.PI * verifyRadiusSq;
         var consensusFloor = ConsensusFloorFraction * Math.Min(nCat, detectedAll.Length);
         var acceptThreshold = Math.Max(Math.Max(MinAcceptHits, ChanceSafetyFactor * expectedChance), consensusFloor);
+
+        // Promotion floor for refinement. The same Poisson model at the capture radius says how
+        // many hits chance alone supplies there, and a candidate that cannot beat its own noise
+        // is not worth refining; Stage2MinHits floors it on a sparse field where that number is
+        // near zero. This gate is a COST control, not a correctness one -- everything promoted
+        // still has to clear acceptThreshold at the verify radius afterwards.
+        var expectedCaptureChance = expectedChance * CaptureRadiusFactor * CaptureRadiusFactor;
+        var refineFloor = Math.Max(Stage2MinHits, (int)Math.Ceiling(expectedCaptureChance));
 
         // Pair-separation index over the catalog anchors, sorted ascending so each detected
         // pair's scale-compatible window is a binary search + linear walk.
@@ -182,7 +233,13 @@ internal static class PairRansacLock
         Matrix3x2 bestM = default;
         var hypotheses = 0;
         var detectedPairsTried = 0;
+        var refinements = 0;
         var capHit = false;
+
+        // Refit scratch, allocated once: refinement runs on a small fraction of hypotheses but
+        // that is still hundreds of calls, and it is on the solve's critical path.
+        var refineSrc = new Vector2[nCat];
+        var refineDst = new Vector2[nCat];
         var earlyExitHits = Math.Max((int)Math.Ceiling(acceptThreshold), (int)(EarlyExitFraction * nCat));
 
         // Detected pairs in RANK-SUM order -- (0,1), (0,2), (1,2), (0,3), (1,3), (2,3), ...
@@ -272,24 +329,42 @@ internal static class PairRansacLock
                     var tx = detI.X - (catA.X * re - catA.Y * im);
                     var ty = detI.Y - (catA.X * im + catA.Y * re);
 
-                    // Staged consensus: cheap probes first so chance hypotheses die in
-                    // nanoseconds; only near-certain candidates pay the full census.
-                    var hits = CountHits(catalogBright, 0, Stage1Count, re, im, tx, ty, grid);
-                    if (hits < Stage1MinHits)
-                    {
-                        continue;
-                    }
-                    hits += CountHits(catalogBright, Stage1Count, Math.Min(Stage2Count, nCat), re, im, tx, ty, grid);
-                    if (hits < Stage2MinHits)
-                    {
-                        continue;
-                    }
-                    hits += CountHits(catalogBright, Math.Min(Stage2Count, nCat), nCat, re, im, tx, ty, grid);
+                    var m = new Matrix3x2(re, im, -im, re, tx, ty);
 
+                    // Staged consensus at the CAPTURE radius: cheap probes first so chance
+                    // hypotheses die in nanoseconds; only near-certain candidates pay the full
+                    // census, and only those pay refinement.
+                    var captured = CountHits(catalogBright, 0, Stage1Count, m, captureGrid);
+                    if (captured < Stage1MinHits)
+                    {
+                        continue;
+                    }
+                    captured += CountHits(catalogBright, Stage1Count, Math.Min(Stage2Count, nCat), m, captureGrid);
+                    if (captured < Stage2MinHits)
+                    {
+                        continue;
+                    }
+                    captured += CountHits(catalogBright, Math.Min(Stage2Count, nCat), nCat, m, captureGrid);
+                    if (captured < refineFloor)
+                    {
+                        continue;
+                    }
+
+                    // Refine BEFORE judging. Everything up to here is a 2-point estimate, whose
+                    // error at the frame corners is several times its error at the pair; the
+                    // refit turns it into an N-point one, and only then is it worth measuring
+                    // against a tolerance the whole frame has to meet.
+                    refinements++;
+                    if (!TryRefine(catalogBright, nCat, captureGrid, refineSrc, refineDst, scaleLoSq, scaleHiSq, ref m))
+                    {
+                        continue;
+                    }
+
+                    var hits = CountHits(catalogBright, 0, nCat, m, verifyGrid);
                     if (hits > bestHits)
                     {
                         bestHits = hits;
-                        bestM = new Matrix3x2(re, im, -im, re, tx, ty);
+                        bestM = m;
                         if (bestHits >= earlyExitHits)
                         {
                             break;
@@ -302,16 +377,16 @@ internal static class PairRansacLock
     scanDone:
         diagnostics = new LockDiagnostics(
             nCat, nDet, hypotheses, capHit, detectedPairsTried, nDet * (nDet - 1) / 2,
-            bestHits, acceptThreshold, expectedChance);
+            bestHits, acceptThreshold, expectedChance, refinements);
 
         if (bestHits < acceptThreshold)
         {
             return null;
         }
 
-        // Least-squares refit over the consensus inliers upgrades the 2-point similarity to a
-        // full affine (absorbs the small anisotropy a real optical train has). Falls back to
-        // the raw hypothesis when degenerate.
+        // Final refit, now over the TIGHT-radius inliers: refinement captured at the wide radius,
+        // so this drops whatever it swept in that the accepted transform does not actually
+        // explain. Falls back to the winning hypothesis when degenerate.
         var srcPts = new List<Vector2>(bestHits);
         var dstPts = new List<Vector2>(bestHits);
         for (var c = 0; c < nCat; c++)
@@ -319,7 +394,7 @@ internal static class PairRansacLock
             var q = catalogBright[c];
             var txp = q.X * bestM.M11 + q.Y * bestM.M21 + bestM.M31;
             var typ = q.X * bestM.M12 + q.Y * bestM.M22 + bestM.M32;
-            if (grid.TryNearest(txp, typ, out var nearest))
+            if (verifyGrid.TryNearest(txp, typ, out var nearest))
             {
                 srcPts.Add(q);
                 dstPts.Add(nearest);
@@ -334,21 +409,90 @@ internal static class PairRansacLock
 
     private static int CountHits(
         ReadOnlySpan<Vector2> catalogBright, int from, int to,
-        float re, float im, float tx, float ty,
+        in Matrix3x2 m,
         in PointGrid grid)
     {
         var hits = 0;
         for (var c = from; c < to; c++)
         {
             var q = catalogBright[c];
-            var x = q.X * re - q.Y * im + tx;
-            var y = q.X * im + q.Y * re + ty;
+            var x = q.X * m.M11 + q.Y * m.M21 + m.M31;
+            var y = q.X * m.M12 + q.Y * m.M22 + m.M32;
             if (grid.HasWithin(x, y))
             {
                 hits++;
             }
         }
         return hits;
+    }
+
+    /// <summary>
+    /// Turns a 2-point hypothesis into an N-point one: captures the nearest detected star to
+    /// each projected catalog star and refits over those correspondences, repeatedly. The
+    /// starting transform is already within a capture radius of the truth (that is what promoted
+    /// it), so this is the converging end of ICP, not a search.
+    /// <para><b>The refit is a SIMILARITY, not the affine the accepted winner is finally
+    /// upgraded to</b>, and that is what keeps the chance model honest. Refinement optimises the
+    /// very statistic the transform is then judged on, so its hits are no longer an independent
+    /// draw from the Poisson field <see cref="ChanceSafetyFactor"/> assumes -- the freer the
+    /// model, the further it can chase a dense field's own clustering. A 6-DOF affine has enough
+    /// of that freedom to matter: fitted in here it walked two UNRELATED Vela panels (P14
+    /// detected against P06's 3,774-star catalog) to exactly 24 hits -- the accept threshold,
+    /// dead on -- over 12,884 refinements, a false lock. Four degrees of freedom cannot shear or
+    /// stretch onto a random field: all 272 non-overlapping panel pairs stay clear of the
+    /// threshold, and the five the test samples fall from 18-21 back to 14-17. The affine upgrade
+    /// still happens, once, on the accepted winner, where nothing is selected on its
+    /// outcome.</para>
+    /// </summary>
+    /// <returns>
+    /// <c>false</c> when no round produced a usable fit, leaving <paramref name="m"/> untouched;
+    /// a later round failing keeps what the earlier ones achieved.
+    /// </returns>
+    private static bool TryRefine(
+        ReadOnlySpan<Vector2> catalogBright,
+        int nCat,
+        in PointGrid captureGrid,
+        Vector2[] src,
+        Vector2[] dst,
+        float scaleLoSq,
+        float scaleHiSq,
+        ref Matrix3x2 m)
+    {
+        var refined = false;
+        for (var iter = 0; iter < RefineIterations; iter++)
+        {
+            var n = 0;
+            for (var c = 0; c < nCat; c++)
+            {
+                var q = catalogBright[c];
+                var x = q.X * m.M11 + q.Y * m.M21 + m.M31;
+                var y = q.X * m.M12 + q.Y * m.M22 + m.M32;
+                if (captureGrid.TryNearest(x, y, out var nearest))
+                {
+                    src[n] = q;
+                    dst[n] = nearest;
+                    n++;
+                }
+            }
+            if (n < MinRefineCorrespondences
+                || Matrix3x2.FitSimilarityTransform(src.AsSpan(0, n), dst.AsSpan(0, n)) is not { } fit)
+            {
+                return refined;
+            }
+
+            // Scale is the one thing a similarity refit can still run away with, and it is the
+            // one the hypothesis was admitted on. Its determinant IS the scale squared, so the
+            // gate is the same window the 2-point hypothesis passed.
+            var scaleSq = fit.M11 * fit.M22 - fit.M12 * fit.M21;
+            if (scaleSq < scaleLoSq || scaleSq > scaleHiSq)
+            {
+                return refined;
+            }
+
+            m = fit;
+            refined = true;
+        }
+        return refined;
     }
 
     private static int LowerBound((float Sep, short A, short B)[] sorted, float value)

--- a/src/TianWen.Lib/Imaging/Image.cs
+++ b/src/TianWen.Lib/Imaging/Image.cs
@@ -500,6 +500,43 @@ public partial class Image(ImmutableArray<Channel> initialChannels, BitDepth bit
     }
 
     /// <summary>
+    /// As <see cref="GetImageDim()"/>, falling back to a WCS the frame already carries.
+    /// </summary>
+    /// <remarks>
+    /// <para><b>A solved CD matrix is the BEST scale a frame can state, and the header-only overload
+    /// cannot see it.</b> That overload reads <see cref="ImageMeta"/> -- <c>PIXSCALE</c>, else pixel
+    /// size x binning x <c>FOCALLEN</c> -- and returns null with neither, which is the correct answer
+    /// for what it can see and the wrong one for the frame as a whole: a plate-solved file knows its
+    /// scale to the digit, in the CD matrix, measured from the stars rather than typed by a human.</para>
+    /// <para><b>Every master TianWen writes is in exactly that state.</b> They carry a full CD matrix
+    /// and no <c>FOCALLEN</c>, so <see cref="GetImageDim()"/> answers null and a solver handed that
+    /// refuses before it starts -- measured at 3 ms on a 6248x4176 LDN 1089 master, with the scale
+    /// sitting in the same header at 1.3814 arcsec/px. It is why "cannot solve our own stacker's
+    /// output" keeps recurring.</para>
+    /// <para>Ordered last deliberately. A declared <c>PIXSCALE</c> still wins, because a frame that
+    /// states one is either repeating the same guess or reporting a solved scale; and the derived
+    /// focal-length form still beats nothing. This only fires where both are absent, and a stale WCS
+    /// is no worse a scale prior than the absent one it replaces -- the position may have drifted
+    /// (one real master's was 74 px out) while the SCALE stays right, since a translation does not
+    /// change it.</para>
+    /// </remarks>
+    /// <param name="wcs">A WCS for this frame, typically the one read from its own headers.</param>
+    public ImageDim? GetImageDim(in Astrometry.WCS? wcs)
+    {
+        if (GetImageDim() is { } fromHeaders)
+        {
+            return fromHeaders;
+        }
+
+        if (wcs is { HasCDMatrix: true } solved && solved.PixelScaleArcsec is var scale && scale > 0 && !double.IsNaN(scale))
+        {
+            return new ImageDim(scale, Width, Height);
+        }
+
+        return null;
+    }
+
+    /// <summary>
     /// Read-only indexer to get a pixel value.
     /// </summary>
     /// <param name="h"></param>

--- a/src/TianWen.Lib/Matrix3x2Helper.cs
+++ b/src/TianWen.Lib/Matrix3x2Helper.cs
@@ -95,6 +95,65 @@ public static class Matrix3x2Helper
         }
 
         /// <summary>
+        /// Fits the least-squares <b>similarity</b> (rotation + uniform scale + translation) that
+        /// maps <paramref name="source"/> onto <paramref name="dest"/>, as opposed to the full
+        /// affine <see cref="FitAffineTransform"/> fits.
+        /// <para>
+        /// Solved in the complex plane, where a similarity is the single number <c>c</c> in
+        /// <c>w = c*z + t</c>: centre both sets, then <c>c = sum(conj(u) * v) / sum(|u|^2)</c>.
+        /// The result is chirality-preserving by construction (its determinant is
+        /// <c>|c|^2 &gt;= 0</c>) and cannot shear, which is the point of choosing it: four degrees
+        /// of freedom have far less room to warp onto correspondences that do not describe one
+        /// transform than six do. Prefer it wherever a fit is being scored on how well it fits.
+        /// </para>
+        /// </summary>
+        /// <param name="source">Source (input) 2D positions.</param>
+        /// <param name="dest">Destination (output) 2D positions; must have the same count as <paramref name="source"/>.</param>
+        /// <returns>The best-fit similarity, or <c>null</c> if fewer than 2 points or the source points coincide.</returns>
+        public static Matrix3x2? FitSimilarityTransform(ReadOnlySpan<Vector2> source, ReadOnlySpan<Vector2> dest)
+        {
+            int n = source.Length;
+            if (n < 2)
+            {
+                return null;
+            }
+
+            double mx = 0, my = 0, nx = 0, ny = 0;
+            for (int i = 0; i < n; i++)
+            {
+                mx += source[i].X;
+                my += source[i].Y;
+                nx += dest[i].X;
+                ny += dest[i].Y;
+            }
+            mx /= n; my /= n; nx /= n; ny /= n;
+
+            double num = 0, cross = 0, den = 0;
+            for (int i = 0; i < n; i++)
+            {
+                double ux = source[i].X - mx, uy = source[i].Y - my;
+                double vx = dest[i].X - nx, vy = dest[i].Y - ny;
+
+                num += ux * vx + uy * vy;
+                cross += ux * vy - uy * vx;
+                den += ux * ux + uy * uy;
+            }
+
+            if (den < 1e-12)
+            {
+                return null;
+            }
+
+            double a = num / den, b = cross / den;
+            return new Matrix3x2(
+                (float)a, (float)b,
+                (float)-b, (float)a,
+                (float)(nx - (a * mx - b * my)),
+                (float)(ny - (b * mx + a * my))
+            );
+        }
+
+        /// <summary>
         /// See <seealso href="https://stackoverflow.com/a/51921217/281306"/>
         /// </summary>
         /// <returns></returns>


### PR DESCRIPTION
LDN 1089 -- a real 6248x4176 Newtonian frame at an 88 degree camera angle -- could not be solved by our own solver. It fell through to ASTAP every time, with 7,244 detections, a hint 1.6 arcmin from truth, and an exhaustive 1,000,000-hypothesis scan that scored 13 of 160 against a threshold of 24.

It now seeds in **7,003 hypotheses** at 127/132 consensus and solves at **0.67 px rms**, agreeing with ASTAP to 0.0002 deg. ASTAP is no longer reached.

## The two defects

Both are in how the seed's 160 catalogue anchors are **chosen** -- upstream of the matcher that got the blame.

**1. `QueryCatalogStarsInRegion` never sorted.** Both loops accumulate in RA-cell scan order, and every consumer reads the result as a brightness ranking and truncates it: `PairRansacLock` keeps the first 160 as anchors and probes the first 8 as its Stage 1 gate; the matching loop takes the first 50 then 100 on a dense field and penalises by rank. `TrySeedPairLock` even documented the premise -- *"catalogCoords is VMag-sorted"* -- and it was false.

On LDN the first eight anchors were V 11.66, 8.90, 11.48, ... where the region's brightest eight are V 3.40 to 6.92. Under the true transform **zero of the first 20 anchors matched a detection, while the first 160 matched 112**. The correct hypothesis was generated a million times and discarded at Stage 1 every time -- and the lock's diagnostics could only report that nothing correlated.

**2. The in-frame test assumed the camera is north-up.** `ProjectCatalogStars` has no rotation to apply -- finding it is the seed's whole job -- so testing projected positions against the frame *rectangle* silently assumes an angle of zero. At 88 degrees on a 3:2 frame that rectangle is not a conservative approximation of the sensor, it is a **different region of sky with the same area**: 44 of 160 anchors sat off the sensor entirely, and the ones it dropped were real stars in the sensor's own corners.

The largest region in frame at every angle is the inscribed disc. Selecting on it costs the corners (48% of a 3:2 frame) and buys an anchor set that is **125-of-130 detected against 87-of-160** for the rectangle.

## The fix

- Sort at the **producer** -- one shared contract, not duplicated into the two consumers that both depend on it.
- Add a **rotation-invariant disc pool**, tried first, ahead of the existing rectangle and margined policies. It is first because when it differs from the rectangle it is right, and it is cheap when it is unnecessary.

## Refine before verifying (separate commit)

A hypothesis comes from one pair, so its rotation error is centroid-error / baseline, amplified by distance to where a hit is counted -- 3.5x on a square frame, 4.2x on 4:3. A per-star error inside the 4 px radius lands **outside** it at the corners (8.6 px on LDN, 1.8 px on Horsehead). Staging and refinement now capture at 3x while the accept decision still verifies at the tight radius, so chance is unchanged and the extra reach is spent giving the refit something to work with. The LSQ refit already existed; it just ran *after* acceptance.

The in-scan refit is a **similarity, not an affine**, and that is what keeps the chance model honest: refinement optimises the very statistic the transform is judged on, so a freer model can chase a dense field's own clustering. Fitted as a 6-DOF affine it walked two unrelated Vela panels to *exactly* 24 hits -- the threshold, dead on -- over 12,884 refinements. Caught by `UnrelatedDenseFieldsMustNotLock`. Four DOF cannot shear onto a random field; all 272 non-overlapping pairs stay clear.

**This was the change I set out to make, and it is not what fixed LDN.** Implementing it is what exposed the real cause: with a correct reference in hand, the lock was scoring 3/160 where it should score 112.

## Why nothing caught this

The frozen Vela dataset **replaces** the query, and its exporter sorted the result itself -- so 24 panels replayed a brightness ranking the solver never had, and stayed green throughout. That sort is removed, so the freeze now records what the query returns; if it ever stops sorting, the next re-export bakes scan order in and the panels go red. The guard that actually fails on regression is a direct test on the query (**756 inversions** with the sort ablated).

`SeedAnchorPoolProbe` is the instrument that separated *"no correct hypothesis exists"* from *"one exists and is being discarded"*, which the lock's own diagnostics cannot distinguish.

One trap worth knowing: `ldn1089_n2n.fits` carries a CD matrix that is ~74 px off its own stars. Measured against it the pool scored 3/160 with in-frame anchors at a random-field distance; against ASTAP's `.wcs` sidecar the same pool scores 112/160 at p50 1.6 px. Same code, opposite conclusions. The probe now prefers the sidecar and prints which reference it used.

## Verification

- Full unit suite: **5048 passed, 0 failed**, 67 skipped
- Solver set (`PairRansacLock`, `PlateSolver*`, `VelaMosaicField`, `SolverScaleTolerance`, `IncrementalSolver`): **94 passed, 0 failed**
- New: `CatalogQueryOrderTests` (ablation-verified), `RotatedFieldSeedTests` (geometric assertions with the rectangle as control, plus `FitSimilarityTransform` coverage)
- `BothAnchorPoolPoliciesAreNecessary` had its premise restated rather than its assertion relaxed: refining closed the gap that made the margined pool the only thing able to lock P20.2's 38-arcmin-off hint. It now asserts the strict pool is still necessary and that the margined pool still *locks* the worst hint -- proving the fallback works rather than requiring it to be the only thing that does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
