### PR TITLE
fix(session): Finalise stops tracking instead of only checking whether it has

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2,6 +2,25 @@
 
 ## High Priority
 
+- [x] **Finalise never stopped tracking; it only checked** (SHIPPED 2026-08-29). The step logged
+  "Finalise: stopping tracking..." and then read `IsTracking` -- `SetTrackingAsync(false)` was called
+  nowhere in the shutdown path, the only such call in `Session` being the sky-flat routine's.
+  **It was invisible on any mount that can park**, because ASCOM's `Park` stops tracking by definition
+  and `SkywatcherMountDriverBase.ParkAsync` halts both axes on its way home, so the motor did come to
+  rest and the shutdown report's "Tracking stopped" line happened to be true by the end. On a mount
+  with `CanPark == false` -- the iOptron SkyGuider Pro is the one in the shipped device list -- nothing
+  in the whole finaliser ever stopped the motor, so a completed session left it tracking until the
+  battery died or the payload reached the tripod.
+  Now it commands the stop when the mount has a tracking switch and then reports **what the mount
+  says**, so a tracker that cannot be commanded is never credited with a stop it did not make; that
+  case logs a warning naming the mount and telling the operator to stop it at the hand controller.
+  **The test needs `CanPark = false` to mean anything** (`FakeMountDriver.CanPark` became settable for
+  it): with park available the fake's own `ParkAsync` clears the flag and the test passes with the bug
+  still in place. Seen to fail against the original expression before being committed.
+  Still open from the same review: **there are no hour-angle or altitude safety limits anywhere** --
+  grep finds no `HALimit` / `LimitReached` / `SafetyLimit` -- so a failed flip has no backstop that
+  stops a mount tracking into the pier. That is a feature, not this fix, and wants its own entry.
+
 - [x] **Keep the measurement frames, and stamp each light with how well it was guided**
   (SHIPPED 2026-08-29). Two changes from one conversation about where paired blurry/sharp training
   data could come from.

--- a/src/TianWen.Lib.Tests.Functional/SessionLifecycleTests.cs
+++ b/src/TianWen.Lib.Tests.Functional/SessionLifecycleTests.cs
@@ -211,6 +211,47 @@ public class SessionLifecycleTests(ITestOutputHelper output)
 
     // --- Finalise ---
 
+    /// <summary>
+    /// Finalise must COMMAND the mount to stop tracking, not merely observe that it has.
+    /// </summary>
+    /// <remarks>
+    /// The step logged "Finalise: stopping tracking..." and then only read <c>IsTracking</c>;
+    /// <c>SetTrackingAsync(false)</c> was called nowhere in the shutdown path. It was invisible on any
+    /// mount that can park, because ASCOM's <c>Park</c> stops tracking by definition and the SkyWatcher
+    /// driver halts both axes on the way home -- so the motor did stop and the report's line happened to
+    /// come out true. On a mount with <c>CanPark == false</c> (the iOptron SkyGuider Pro) nothing in the
+    /// finaliser ever stopped it, and a finished session left the mount tracking until the battery died
+    /// or the payload met the tripod.
+    /// <para>Hence <c>CanPark = false</c> here: with park available the fake's own <c>ParkAsync</c> clears
+    /// the flag and this test passes with the bug still in place.</para>
+    /// </remarks>
+    [Fact(Timeout = 120_000)]
+    public async Task GivenAMountThatCannotParkWhenFinaliseThenTrackingIsStillStopped()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await using var ctx = await SessionTestHelper.CreateSessionAsync(output, now: WinterNight, cancellationToken: ct);
+
+        var mount = (FakeMountDriver)ctx.Mount;
+        mount.CanPark = false;
+        mount.CanSetTracking.ShouldBeTrue("the mount must be able to stop tracking for this to be its job");
+
+        await ((IMountDriver)mount).EnsureTrackingAsync(cancellationToken: ct);
+        (await mount.IsTrackingAsync(ct)).ShouldBeTrue("mount should be tracking before finalise");
+
+        var finaliseTask = ctx.Track(Task.Run(async () => await ctx.Session.Finalise(ctx.Token), ctx.Token));
+        while (!finaliseTask.IsCompleted && !ct.IsCancellationRequested)
+        {
+            await ctx.TimeProvider.SleepAsync(TimeSpan.FromSeconds(1), ct);
+            await Task.Delay(10, ct);
+        }
+
+        finaliseTask.IsCompleted.ShouldBeTrue("Finalise should complete within timeout");
+        await finaliseTask;
+
+        (await mount.AtParkAsync(ct)).ShouldBeFalse("precondition: this mount cannot park, so park cannot be what stopped it");
+        (await mount.IsTrackingAsync(ct)).ShouldBeFalse("Finalise must stop tracking on a mount that cannot be parked");
+    }
+
     [Fact(Timeout = 120_000)]
     public async Task GivenActiveSessionWhenFinaliseThenShutdownCompletes()
     {

--- a/src/TianWen.Lib/Devices/Fake/FakeMountDriver.cs
+++ b/src/TianWen.Lib/Devices/Fake/FakeMountDriver.cs
@@ -200,7 +200,14 @@ internal sealed class FakeMountDriver(FakeDevice fakeDevice, IServiceProvider se
     public bool CanSetDeclinationRate { get; } = false;
     public bool CanSetGuideRates { get; } = true;
     public bool CanPulseGuide { get; } = true;
-    public bool CanPark { get; } = true;
+    /// <summary>
+    /// Settable so a test can model a mount that cannot park -- a star tracker such as the iOptron
+    /// SkyGuider Pro, whose driver reports <c>CanPark = false</c>. It matters because
+    /// <see cref="ParkAsync"/> stops tracking as a side effect, which MASKS a finaliser that fails to
+    /// stop it: on a parkable mount the motor comes to rest either way, so the no-park configuration is
+    /// the only one where "did the finaliser actually command the stop?" is observable at all.
+    /// </summary>
+    public bool CanPark { get; set; } = true;
     public bool CanSetPark { get; } = false;
     public bool CanUnpark { get; } = true;
     public bool CanSlew { get; } = true;

--- a/src/TianWen.Lib/Sequencing/Session.Lifecycle.cs
+++ b/src/TianWen.Lib/Sequencing/Session.Lifecycle.cs
@@ -136,7 +136,34 @@ internal partial record Session
 
         _currentActivity = "Stopping tracking\u2026";
         _logger.LogInformation("Finalise: stopping tracking...");
-        var trackingStopped = await CatchAsync(async cancellationToken => mount.Driver.CanSetTracking && !await mount.Driver.IsTrackingAsync(cancellationToken), cancellationToken).ConfigureAwait(false);
+        // ACTUALLY stop it. This step read the tracking state and never commanded it for a long time,
+        // which was invisible on any mount that can park: ASCOM's Park stops tracking by definition and
+        // the SkyWatcher driver halts both axes on its way home, so the motor did come to rest and the
+        // report's "Tracking stopped" line happened to be true by the end. On a mount with
+        // CanPark == false -- the iOptron SkyGuider Pro is the one in the device list -- nothing in the
+        // whole finaliser ever stopped the motor, so a finished session left it tracking until the
+        // battery died or the payload reached the tripod.
+        //
+        // Reported honestly either way: command the stop when the mount has a tracking switch, then
+        // report what the mount SAYS, so a tracker that cannot be commanded is not credited with a stop
+        // it never made.
+        var trackingStopped = await CatchAsync(async cancellationToken =>
+        {
+            if (mount.Driver.CanSetTracking)
+            {
+                await mount.Driver.SetTrackingAsync(false, cancellationToken).ConfigureAwait(false);
+            }
+
+            return !await mount.Driver.IsTrackingAsync(cancellationToken).ConfigureAwait(false);
+        }, cancellationToken).ConfigureAwait(false);
+
+        if (!trackingStopped)
+        {
+            _logger.LogWarning(
+                "Finalise: {MountName} is still tracking (CanSetTracking={CanSetTracking}). A mount that "
+                + "cannot be parked or commanded to stop will keep running; stop it at the hand controller.",
+                mount.Driver.Name, Catch(() => mount.Driver.CanSetTracking));
+        }
 
         if (trackingStopped)
         {


### PR DESCRIPTION
`Finalise` logged **"Finalise: stopping tracking..."** and then only read `IsTracking`. `SetTrackingAsync(false)` was called nowhere in the shutdown path — the only such call anywhere in `Session` is the sky-flat routine's.

```csharp
// before
var trackingStopped = await CatchAsync(async ct =>
    mount.Driver.CanSetTracking && !await mount.Driver.IsTrackingAsync(ct), ct);
```

## Why it went unnoticed

It is invisible on any mount that can park. ASCOM's `Park` stops tracking by definition, and `SkywatcherMountDriverBase.ParkAsync` halts both axes on its way home — so the motor did come to rest, and the shutdown report's "Tracking stopped" line happened to be true by the end.

On a mount with `CanPark == false` — the **iOptron SkyGuider Pro**, which is in the shipped device list — nothing in the whole finaliser ever stopped the motor. A completed session left it tracking until the battery died or the payload reached the tripod.

## The fix

Command the stop when the mount has a tracking switch, then report **what the mount says**, so a tracker that cannot be commanded is never credited with a stop it did not make. That case logs a warning naming the mount and telling the operator to stop it at the hand controller, which is the only thing left to do.

## The test needs `CanPark = false` to mean anything

`FakeMountDriver.CanPark` became settable for it. With park available the fake's own `ParkAsync` clears the tracking flag and the test passes **with the bug still in place** — the no-park configuration is the only one where "did the finaliser actually command the stop?" is observable at all.

Seen to fail against the original expression, on exactly that assertion, before commit:

```
Failed GivenAMountThatCannotParkWhenFinaliseThenTrackingIsStillStopped
  Finalise must stop tracking on a mount that cannot be parked
```

`SessionLifecycleTests` 19 passed locally.

## Deliberately not in here

There are **no hour-angle or altitude safety limits anywhere** in the codebase — no `HALimit`, `LimitReached` or `SafetyLimit` — so a failed meridian flip has no backstop that stops a mount tracking into the pier. That is a feature rather than a bug fix and wants its own change; it is recorded in `TODO.md` beside this entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
