### PR TITLE
refactor(skywatcher): make the guide-rate bound a type, not a comment

### DIFF
--- a/src/TianWen.Lib.Tests/SkywatcherGuideRateTests.cs
+++ b/src/TianWen.Lib.Tests/SkywatcherGuideRateTests.cs
@@ -1,0 +1,131 @@
+using System;
+using Shouldly;
+using TianWen.Lib.Devices.Skywatcher;
+using Xunit;
+
+namespace TianWen.Lib.Tests;
+
+/// <summary>
+/// Pins the bound that makes live-<c>:I</c> RA pulse guiding correct.
+/// </summary>
+/// <remarks>
+/// An RA pulse offsets the sidereal tracking rate rather than replacing it, and changes only the step
+/// period (<c>:I</c>) while the axis keeps running. <c>:I</c> sets MAGNITUDE; DIRECTION lives in the
+/// motion mode (<c>:G</c>), which a live pulse does not touch. So if an East pulse's combined rate ever
+/// went negative the axis would need to reverse, and we would be commanding the right speed in the
+/// wrong direction -- which is the bug GSServer fixed in "Fix RA pulse guiding for GEM mounts" (#89) by
+/// stopping the axis, re-issuing <c>:G</c> with a flipped direction bit and restarting.
+/// <para>We do not need that fix because <c>Fraction &lt;= 1.0</c> holds across the whole enum. That is
+/// only a guarantee if it is checked over the whole enum, which is what these tests do -- a property of
+/// a closed set, not a comment about an <c>int</c>.</para>
+/// </remarks>
+public class SkywatcherGuideRateTests
+{
+    /// <summary>
+    /// The wire indices rather than the enum itself: <c>SkywatcherGuideRate</c> is internal to the
+    /// driver and an xUnit theory signature has to be public. The index IS the enum value, so nothing
+    /// is lost and the cast in each theory is total over the declared set.
+    /// </summary>
+    public static TheoryData<int> AllRates()
+    {
+        var data = new TheoryData<int>();
+        foreach (var rate in SkywatcherGuideRateEx.All)
+        {
+            data.Add((int)rate);
+        }
+        return data;
+    }
+
+    [Fact]
+    public void AllCoversEveryDeclaredMember()
+    {
+        // Or the theories below silently stop covering a member somebody added.
+        SkywatcherGuideRateEx.All.ShouldBe(Enum.GetValues<SkywatcherGuideRate>(), ignoreOrder: true);
+    }
+
+    [Theory]
+    [MemberData(nameof(AllRates))]
+    public void FractionIsBoundedToUnitInterval(int wireIndex)
+    {
+        var rate = (SkywatcherGuideRate)wireIndex;
+        rate.Fraction.ShouldBeGreaterThan(0.0);
+        rate.Fraction.ShouldBeLessThanOrEqualTo(1.0);
+    }
+
+    [Theory]
+    [MemberData(nameof(AllRates))]
+    public void AnEastPulseNeverReversesTheAxis(int wireIndex)
+    {
+        var rate = (SkywatcherGuideRate)wireIndex;
+        // THE invariant. A negative factor means the axis must turn the other way, which a live :I
+        // cannot express.
+        rate.EastRateFactor.ShouldBeGreaterThanOrEqualTo(0.0);
+        rate.WestRateFactor.ShouldBeGreaterThan(1.0);
+    }
+
+    [Theory]
+    [MemberData(nameof(AllRates))]
+    public void OnlyTheFullSiderealRateHaltsTheAxisOnAnEastPulse(int wireIndex)
+    {
+        var rate = (SkywatcherGuideRate)wireIndex;
+        var halts = rate.EastPulseHaltsTheAxis;
+        halts.ShouldBe(rate == SkywatcherGuideRate.Sidereal1_0);
+
+        // The flag and the factor must agree, or the call site picks the sidereal/1000 branch for a
+        // rate that actually wanted a real one (or the reverse, commanding an unencodable zero period).
+        halts.ShouldBe(rate.EastRateFactor <= 0.0);
+    }
+
+    [Theory]
+    [MemberData(nameof(AllRates))]
+    public void WireIndexRoundTripsToTheEnumValue(int wireIndex)
+    {
+        var rate = (SkywatcherGuideRate)wireIndex;
+        // The :P payload IS the enum value; a mismatch sets the mount's ST-4 port to a different rate
+        // than the one we pulse at, which only shows up as guiding that disagrees with itself.
+        rate.WireIndex.ShouldBe(((int)rate).ToString(System.Globalization.CultureInfo.InvariantCulture));
+    }
+
+    [Fact]
+    public void AnUndeclaredValueThrowsRatherThanGuessing()
+    {
+        // The previous lookup answered 0.5x for any out-of-range index, which guides at the wrong rate
+        // and presents as poor seeing rather than as a fault.
+        Should.Throw<ArgumentOutOfRangeException>(() => ((SkywatcherGuideRate)99).Fraction);
+    }
+
+    [Theory]
+    [InlineData(1.0, (int)/*Sidereal1_0*/ 0)]
+    [InlineData(0.9, (int)/*Sidereal1_0*/ 0)]
+    [InlineData(0.75, (int)/*Sidereal0_75*/ 1)]
+    [InlineData(0.5, (int)/*Sidereal0_5*/ 2)]
+    [InlineData(0.25, (int)/*Sidereal0_25*/ 3)]
+    [InlineData(0.125, (int)/*Sidereal0_125*/ 4)]
+    [InlineData(0.0, (int)/*Sidereal0_125*/ 4)]
+    public void NearestSnapsToTheFirmwaresOwnFiveRates(double fraction, int expectedWireIndex)
+        => ((int)SkywatcherGuideRate.Nearest(fraction)).ShouldBe(expectedWireIndex);
+
+    [Theory]
+    [InlineData(2.0)]
+    [InlineData(1.5)]
+    [InlineData(1.1)]
+    public void ARateAboveSiderealSnapsDownAndIsNeverAllowedToReverse(double fraction)
+    {
+        // ASCOM lets a client ask for this; no Synta board can encode it. Snapping is what keeps
+        // EastRateFactor non-negative for a rate that, taken literally, would demand a reversal.
+        var snapped = SkywatcherGuideRate.Nearest(fraction);
+
+        ((int)snapped).ShouldBe((int)SkywatcherGuideRate.Sidereal1_0);
+        snapped.EastRateFactor.ShouldBeGreaterThanOrEqualTo(0.0);
+        SkywatcherGuideRate.WasSnapped(fraction, snapped).ShouldBeTrue("the client must be told it did not get what it asked for");
+    }
+
+    [Theory]
+    [InlineData(1.0)]
+    [InlineData(0.75)]
+    [InlineData(0.5)]
+    [InlineData(0.25)]
+    [InlineData(0.125)]
+    public void AnExactlyEncodableRateIsNotReportedAsSnapped(double fraction)
+        => SkywatcherGuideRate.WasSnapped(fraction, SkywatcherGuideRate.Nearest(fraction)).ShouldBeFalse();
+}

--- a/src/TianWen.Lib.Tests/SkywatcherProtocolTests.cs
+++ b/src/TianWen.Lib.Tests/SkywatcherProtocolTests.cs
@@ -356,9 +356,13 @@ public class SkywatcherProtocolTests
     [InlineData(2, 0.5)]
     [InlineData(3, 0.25)]
     [InlineData(4, 0.125)]
-    public void GuideSpeedFraction_ReturnsExpected(int index, double expected)
+    public void GuideSpeedFraction_ReturnsExpected(int wireIndex, double expected)
     {
-        SkywatcherProtocol.GuideSpeedFraction(index).ShouldBe(expected);
+        // Moved off SkywatcherProtocol onto the SkywatcherGuideRate enum, whose value IS this wire
+        // index. The bound that makes a live-:I RA pulse correct (Fraction <= 1, so an East pulse never
+        // reverses the axis) is pinned across the whole enum by SkywatcherGuideRateTests; this keeps
+        // the per-index values themselves nailed down where the rest of the protocol constants live.
+        ((SkywatcherGuideRate)wireIndex).Fraction.ShouldBe(expected);
     }
 
     #endregion

--- a/src/TianWen.Lib/Devices/Skywatcher/SkywatcherGuideRate.cs
+++ b/src/TianWen.Lib/Devices/Skywatcher/SkywatcherGuideRate.cs
@@ -1,0 +1,140 @@
+using System;
+
+namespace TianWen.Lib.Devices.Skywatcher;
+
+/// <summary>
+/// The five guide rates a Synta motor board accepts, as the <c>:P</c> index it is sent as.
+/// </summary>
+/// <remarks>
+/// <para>The enum value IS the wire index, so <c>((int)rate)</c> is what <c>:P</c> carries. The set is
+/// closed by the firmware, not by us: the hand controller offers exactly these five and there is no
+/// encoding for anything between them.</para>
+///
+/// <para><b>Why this is a type and not an <c>int</c> plus a lookup.</b> RA pulse guiding OFFSETS the
+/// sidereal tracking rate rather than replacing it, so a pulse commands <c>(1 +/- f) x sidereal</c> and
+/// changes only the step period (<c>:I</c>) while the axis keeps running. <c>:I</c> sets the MAGNITUDE
+/// of the rate; the DIRECTION lives in the motion mode (<c>:G</c>), which a live pulse deliberately does
+/// not touch. So an East pulse whose combined rate went negative would need the axis to reverse, and
+/// sending <c>:I</c> alone would run it at the right speed in the WRONG direction.
+/// <see cref="SkywatcherGuideRateEx.EastRateFactor"/> can never be negative because
+/// <see cref="SkywatcherGuideRateEx.Fraction"/> is bounded above by 1.0 across the whole enum, which is
+/// what makes the live-<c>:I</c> pulse correct rather than merely lucky -- and the bound is a property
+/// of a closed set of five members, checkable by enumerating them, instead of a comment about an
+/// <c>int</c>.</para>
+///
+/// <para>GSServer carries the reversing case because its rate is an arbitrary <c>double</c> from ASCOM;
+/// it fixed the resulting wrong-direction pulse in "Fix RA pulse guiding for GEM mounts" (#89) by
+/// stopping the axis, re-issuing <c>:G</c> with a flipped direction bit and restarting. We do not need
+/// that, and this type is the reason. <b>Reintroducing an unbounded rate reintroduces the bug</b>, which
+/// is why <see cref="SkywatcherGuideRateEx.Nearest"/> is the only way in from a <c>double</c>.</para>
+/// </remarks>
+internal enum SkywatcherGuideRate
+{
+    /// <summary>1.0x sidereal. An East pulse cancels tracking exactly; see
+    /// <see cref="SkywatcherGuideRateEx.EastPulseHaltsTheAxis"/>.</summary>
+    Sidereal1_0 = 0,
+
+    /// <summary>0.75x sidereal.</summary>
+    Sidereal0_75 = 1,
+
+    /// <summary>0.5x sidereal. The power-on default, and what the hand controller ships with.</summary>
+    Sidereal0_5 = 2,
+
+    /// <summary>0.25x sidereal.</summary>
+    Sidereal0_25 = 3,
+
+    /// <summary>0.125x sidereal.</summary>
+    Sidereal0_125 = 4,
+}
+
+internal static class SkywatcherGuideRateEx
+{
+    /// <summary>Every member, for tests that need to assert a property holds across the whole set.</summary>
+    internal static readonly SkywatcherGuideRate[] All =
+    [
+        SkywatcherGuideRate.Sidereal1_0,
+        SkywatcherGuideRate.Sidereal0_75,
+        SkywatcherGuideRate.Sidereal0_5,
+        SkywatcherGuideRate.Sidereal0_25,
+        SkywatcherGuideRate.Sidereal0_125,
+    ];
+
+    extension(SkywatcherGuideRate rate)
+    {
+        /// <summary>
+        /// The rate as a fraction of sidereal, in <c>(0, 1]</c>.
+        /// </summary>
+        /// <exception cref="ArgumentOutOfRangeException">The value is not one of the five the firmware
+        /// defines. Deliberately a throw rather than a silent default: the previous
+        /// <c>_ =&gt; 0.5</c> turned any out-of-range index into a plausible-looking half-sidereal
+        /// pulse, which guides at the wrong rate and looks like poor seeing.</exception>
+        public double Fraction => rate switch
+        {
+            SkywatcherGuideRate.Sidereal1_0 => 1.0,
+            SkywatcherGuideRate.Sidereal0_75 => 0.75,
+            SkywatcherGuideRate.Sidereal0_5 => 0.5,
+            SkywatcherGuideRate.Sidereal0_25 => 0.25,
+            SkywatcherGuideRate.Sidereal0_125 => 0.125,
+            _ => throw new ArgumentOutOfRangeException(nameof(rate), rate, "not a Synta guide-rate index")
+        };
+
+        /// <summary>
+        /// Multiplier on sidereal for a WEST pulse, <c>1 + Fraction</c>: the axis runs faster than
+        /// tracking, in the tracking direction. Range <c>[1.125, 2.0]</c>.
+        /// </summary>
+        public double WestRateFactor => 1.0 + rate.Fraction;
+
+        /// <summary>
+        /// Multiplier on sidereal for an EAST pulse, <c>1 - Fraction</c>: the axis runs SLOWER than
+        /// tracking, still in the tracking direction. Range <c>[0, 0.875]</c> -- <b>never negative, which
+        /// is the whole point of this type</b> (see the remarks on <see cref="SkywatcherGuideRate"/>).
+        /// </summary>
+        public double EastRateFactor => 1.0 - rate.Fraction;
+
+        /// <summary>
+        /// True for <see cref="SkywatcherGuideRate.Sidereal1_0"/> alone, where an East pulse cancels
+        /// tracking exactly and <see cref="EastRateFactor"/> is 0.
+        /// </summary>
+        /// <remarks>
+        /// The motor boards cannot encode a zero step period, so this case commands sidereal/1000 --
+        /// the axis looks stopped without the decel/accel transient a real stop would cost. Named rather
+        /// than expressed as a <c>Math.Max(factor, 1e-3)</c> clamp at the call site, because a clamp
+        /// reads as defence against negatives and would go on silently "working" if the bound above
+        /// were ever lifted, which is exactly the failure this type exists to prevent.
+        /// </remarks>
+        public bool EastPulseHaltsTheAxis => rate.Fraction >= 1.0;
+
+        /// <summary>The <c>:P</c> payload for this rate.</summary>
+        public string WireIndex => ((int)rate).ToString(System.Globalization.CultureInfo.InvariantCulture);
+    }
+
+    extension(SkywatcherGuideRate)
+    {
+        /// <summary>
+        /// The firmware rate nearest <paramref name="fractionOfSidereal"/>, snapping at the midpoints.
+        /// The only way in from a caller-supplied rate.
+        /// </summary>
+        /// <remarks>
+        /// ASCOM lets a client set <c>GuideRateRightAscension</c> to anything, including rates above
+        /// sidereal that no Synta board can encode. Snapping is therefore mandatory, and the caller is
+        /// entitled to know it happened: <see cref="WasSnapped"/> answers that so the driver can log it
+        /// rather than quietly guiding at a rate nobody asked for.
+        /// </remarks>
+        public static SkywatcherGuideRate Nearest(double fractionOfSidereal) => fractionOfSidereal switch
+        {
+            >= 0.875 => SkywatcherGuideRate.Sidereal1_0,
+            >= 0.625 => SkywatcherGuideRate.Sidereal0_75,
+            >= 0.375 => SkywatcherGuideRate.Sidereal0_5,
+            >= 0.1875 => SkywatcherGuideRate.Sidereal0_25,
+            _ => SkywatcherGuideRate.Sidereal0_125
+        };
+
+        /// <summary>
+        /// Whether <see cref="Nearest"/> had to move <paramref name="fractionOfSidereal"/> by more than
+        /// a thousandth of sidereal to reach <paramref name="snapped"/> -- i.e. whether the client asked
+        /// for something the mount cannot do.
+        /// </summary>
+        public static bool WasSnapped(double fractionOfSidereal, SkywatcherGuideRate snapped)
+            => Math.Abs(fractionOfSidereal - snapped.Fraction) > 0.001;
+    }
+}

--- a/src/TianWen.Lib/Devices/Skywatcher/SkywatcherMountDriverBase.cs
+++ b/src/TianWen.Lib/Devices/Skywatcher/SkywatcherMountDriverBase.cs
@@ -69,7 +69,7 @@ internal abstract class SkywatcherMountDriverBase<TDevice>(TDevice device, IServ
     internal ISerialConnection? SerialConnection => _deviceInfo.SerialDevice;
 
     // Guide state
-    private int _guideSpeedIndex = 2; // default 0.5x sidereal
+    private SkywatcherGuideRate _guideRate = SkywatcherGuideRate.Sidereal0_5;
 
     /// <summary>
     /// Opt-in (<c>?decPulseGoto=true</c> on the mount URI, advanced setting): Dec pulses
@@ -620,7 +620,7 @@ internal abstract class SkywatcherMountDriverBase<TDevice>(TDevice device, IServ
 
     private async ValueTask PulseGuideCoreAsync(GuideDirection direction, TimeSpan duration, CancellationToken cancellationToken)
     {
-        var guideFraction = SkywatcherProtocol.GuideSpeedFraction(_guideSpeedIndex);
+        var guideRate = _guideRate;
         var siderealDegPerSec = SIDEREAL_RATE / 3600.0;
 
         if (direction is GuideDirection.East or GuideDirection.West)
@@ -632,11 +632,19 @@ internal abstract class SkywatcherMountDriverBase<TDevice>(TDevice device, IServ
             // relative to the sky: a West pulse ran the axis slower than sidereal (-f
             // relative) and an East pulse reversed it (-(1+f) relative), with a (1+f)/f
             // gain asymmetry between the two directions.
-            var rateFactor = direction is GuideDirection.West ? 1.0 + guideFraction : 1.0 - guideFraction;
-            // East at guide fraction 1.0x gives a combined rate of 0; the motor boards
-            // cannot encode a zero step period, so command sidereal/1000 instead; the
-            // axis "looks stopped" without a stop/start transient (GSS does the same).
-            var guideSpeed = siderealDegPerSec * Math.Max(rateFactor, 1e-3);
+            // Never negative for East: SkywatcherGuideRate bounds Fraction at 1.0, so the axis
+            // never has to reverse and a live :I (which sets magnitude only, direction living in :G)
+            // is the correct command. That bound is the type's whole purpose -- see its remarks, and
+            // GSServer's #89, which had to stop/re-:G/restart precisely because its rate is unbounded.
+            var rateFactor = direction is GuideDirection.West
+                ? guideRate.WestRateFactor
+                : guideRate.EastRateFactor;
+            // At 1.0x an East pulse cancels tracking exactly, and the boards cannot encode a zero step
+            // period -- command sidereal/1000 so the axis looks stopped without a stop/start transient
+            // (GSS does the same). Named on the type rather than a Math.Max clamp here: a clamp reads
+            // as defence against negatives and would keep silently "working" if the bound were lifted.
+            var guideSpeed = siderealDegPerSec *
+                (direction is GuideDirection.East && guideRate.EastPulseHaltsTheAxis ? 1e-3 : rateFactor);
             var t1Pulse = SkywatcherProtocol.EncodeUInt24(
                 SkywatcherProtocol.ComputeT1Preset(_tmrFreq, _cprRa, guideSpeed, false, _highSpeedRatio));
 
@@ -693,7 +701,7 @@ internal abstract class SkywatcherMountDriverBase<TDevice>(TDevice device, IServ
                 GuideDirection.South => false, // Dec reverse
                 _ => throw new ArgumentException($"Unknown guide direction {direction}", nameof(direction))
             };
-            var guideSpeed = siderealDegPerSec * guideFraction;
+            var guideSpeed = siderealDegPerSec * guideRate.Fraction;
 
             if (_decPulseGoTo)
             {
@@ -777,25 +785,27 @@ internal abstract class SkywatcherMountDriverBase<TDevice>(TDevice device, IServ
 
     public ValueTask<double> GetGuideRateRightAscensionAsync(CancellationToken cancellationToken)
     {
-        var fraction = SkywatcherProtocol.GuideSpeedFraction(_guideSpeedIndex);
-        return ValueTask.FromResult(fraction * SIDEREAL_RATE / 3600.0);
+        // Reports what the mount is ACTUALLY set to, derived from the snapped rate rather than from
+        // whatever was last requested -- ASCOM's contract is that a getter reflects the hardware.
+        return ValueTask.FromResult(_guideRate.Fraction * SIDEREAL_RATE / 3600.0);
     }
 
     public async ValueTask SetGuideRateRightAscensionAsync(double value, CancellationToken cancellationToken)
     {
-        // Map to nearest guide speed index (0-4)
+        // The firmware offers five rates and nothing between them, so an ASCOM client's arbitrary
+        // double must snap. SAY SO when it moves materially: guiding at a rate nobody asked for looks
+        // like poor seeing or a mis-tuned aggressiveness, and silence there costs a night to diagnose.
         var siderealDegPerSec = SIDEREAL_RATE / 3600.0;
         var fraction = value / siderealDegPerSec;
-        _guideSpeedIndex = fraction switch
+        _guideRate = SkywatcherGuideRate.Nearest(fraction);
+        if (SkywatcherGuideRate.WasSnapped(fraction, _guideRate))
         {
-            >= 0.875 => 0,   // 1.0x
-            >= 0.625 => 1,   // 0.75x
-            >= 0.375 => 2,   // 0.5x
-            >= 0.1875 => 3,  // 0.25x
-            _ => 4            // 0.125x
-        };
+            Logger.LogInformation(
+                "{MountName}: guide rate {Requested:F3}x sidereal is not encodable; using {Applied:F3}x.",
+                Name, fraction, _guideRate.Fraction);
+        }
         // Send :P to set the ST-4 autoguide port speed on the mount hardware
-        await SendCommandAsync('P', '1', _guideSpeedIndex.ToString(), cancellationToken);
+        await SendCommandAsync('P', '1', _guideRate.WireIndex, cancellationToken);
     }
 
     public ValueTask<double> GetGuideRateDeclinationAsync(CancellationToken cancellationToken)
@@ -804,9 +814,9 @@ internal abstract class SkywatcherMountDriverBase<TDevice>(TDevice device, IServ
     public async ValueTask SetGuideRateDeclinationAsync(double value, CancellationToken cancellationToken)
     {
         await SetGuideRateRightAscensionAsync(value, cancellationToken);
-        // RA setter already updates _guideSpeedIndex and sends :P to axis 1;
+        // RA setter already snapped the rate and sent :P to axis 1;
         // also send to axis 2 for the Dec ST-4 port
-        await SendCommandAsync('P', '2', _guideSpeedIndex.ToString(), cancellationToken);
+        await SendCommandAsync('P', '2', _guideRate.WireIndex, cancellationToken);
     }
 
     #endregion
@@ -1123,9 +1133,9 @@ internal abstract class SkywatcherMountDriverBase<TDevice>(TDevice device, IServ
             // Initialize both axes
             await SendCommandAsync('F', '3', null, cancellationToken);
 
-            // Set ST-4 autoguide port speed to match our guide speed index
-            await SendCommandAsync('P', '1', _guideSpeedIndex.ToString(), cancellationToken);
-            await SendCommandAsync('P', '2', _guideSpeedIndex.ToString(), cancellationToken);
+            // Set ST-4 autoguide port speed to match our guide rate
+            await SendCommandAsync('P', '1', _guideRate.WireIndex, cancellationToken);
+            await SendCommandAsync('P', '2', _guideRate.WireIndex, cancellationToken);
 
             // Read site coordinates from URI
             await GetSiteLatitudeAsync(cancellationToken);

--- a/src/TianWen.Lib/Devices/Skywatcher/SkywatcherProtocol.cs
+++ b/src/TianWen.Lib/Devices/Skywatcher/SkywatcherProtocol.cs
@@ -337,20 +337,6 @@ internal static class SkywatcherProtocol
         _ => rawCpr
     };
 
-    /// <summary>
-    /// Guide speed fraction for index 0-4.
-    /// 0=1.0x, 1=0.75x, 2=0.5x, 3=0.25x, 4=0.125x sidereal.
-    /// </summary>
-    internal static double GuideSpeedFraction(int index) => index switch
-    {
-        0 => 1.0,
-        1 => 0.75,
-        2 => 0.5,
-        3 => 0.25,
-        4 => 0.125,
-        _ => 0.5
-    };
-
     internal static int ParseHexNibble(char c) => c switch
     {
         >= '0' and <= '9' => c - '0',


### PR DESCRIPTION
## The invariant, and why a comment was not enough

An RA pulse **offsets** the sidereal tracking rate rather than replacing it: a pulse commands `(1 +/- f) x sidereal` and changes only the step period (`:I`) while the axis keeps running. `:I` sets the **magnitude**; the **direction** lives in the motion mode (`:G`), which a live pulse deliberately does not touch.

So an East pulse whose combined rate went negative would need the axis to reverse, and sending `:I` alone would run it at the right speed in the **wrong direction**. That is GSServer's #89 ("Fix RA pulse guiding for GEM mounts"), which it fixed by stopping the axis, re-issuing `:G` with a flipped direction bit and restarting. We never needed that fix, because our rate is bounded at `1.0x`.

The bound lived in a five-entry `int` lookup plus a comment, defended at the call site by `Math.Max(rateFactor, 1e-3)`. Both were fragile the same way: the clamp *reads* as protection against negatives, and would go on silently commanding a near-zero rate if the bound were ever lifted. A different wrong answer than GSS's, safer, but equally silent.

## What changed

`SkywatcherGuideRate` is an enum whose value **is** the `:P` wire index, with the invariant expressed on the type:

```csharp
public double WestRateFactor      => 1.0 + rate.Fraction;   // [1.125, 2.0]
public double EastRateFactor      => 1.0 - rate.Fraction;   // [0, 0.875] -- never negative
public bool   EastPulseHaltsTheAxis => rate.Fraction >= 1.0;
```

- `Math.Max(rateFactor, 1e-3)` is gone. The `1.0x` case the clamp used to absorb is now **named**, so it is a stated case rather than a bound quietly doing double duty.
- `Nearest()` is the only way in from a caller-supplied `double`, so reintroducing an unbounded rate means deleting a documented gate rather than assigning a field.
- The invariant is **checked across the whole enum** (`SkywatcherGuideRateEx.All`), with a test that the enumeration itself stays complete, so a member added later cannot slip past the theories.

## Two defects fixed on the way

- **`GuideSpeedFraction` answered `0.5x` for any out-of-range index.** Guiding at half the requested rate presents as poor seeing rather than as a fault. It throws now.
- **`SetGuideRateRightAscension` snapped silently.** The getter already derives from the stored index, so the value it reports was honest (ASCOM's contract holds); the **silence** was the defect. Ask for `2x`, get `1x`, nothing says so. It logs when the request moves materially.

## Verification

- **Sabotage-verified**: setting one member to `1.5x` turns `FractionIsBoundedToUnitInterval`, `AnEastPulseNeverReversesTheAxis`, `AnExactlyEncodableRateIsNotReportedAsSnapped` and all three `ARateAboveSiderealSnapsDownAndIsNeverAllowedToReverse` cases red. Restored and re-confirmed green.
- `TianWen.Lib.Tests --filter "~Skywatcher"`: **169 passed, 0 failed**.
- `TianWen.Lib.Tests.Functional --filter "~Skywatcher|~Mount|~Guide"`: **201 passed, 0 failed**.

The existing `GuideSpeedFraction_ReturnsExpected` theory is kept, retargeted at the enum.

Part of the standing goal to port GSS fixes/ideas/limits and generalize where possible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
