### PR TITLE
docs(gss-audit): close the rollover question - GSS does nothing either

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -172,10 +172,18 @@
   **A test for it must assert on fake time traversed per guide frame** -- `GuideLoopTests` builds
   `FakeMountDriver` so it never blocks, and where the blocking driver is driven the fake clock
   auto-advances `SleepAsync`, so the stall is real and costs no wall time.
-  **Still unanswered:** 24-bit position-counter rollover -- decide whether we track the wrap or
-  re-home. And decide whether to regenerate `gss-oracle-transcripts.json` against `origin/master`:
-  it currently pins GSS's PRE-fix behaviour, and regenerating may legitimately turn
-  `SkywatcherGssOracleTests` red.
+  **24-bit rollover: CLOSED, no action.** GSS does nothing about it either -- its pointing path is
+  the same three stateless lines ours is, and `6e6dba9` turned out to be a scripting-API diagnostic
+  (only internal caller feeds PLOTTING), not machinery. +/-0x800000 is +/-0.93 rev from home at an
+  EQ6's CPR, so a GEM meets its pier or cable wrap first: the real protection is the mount safety
+  limits, not wrap tracking. Tracking it would need persistent per-axis revolution state that goes
+  stale the instant anyone touches the hand controller, which mis-points by a whole turn and looks
+  like a sync bug -- worse than the raw discontinuity it replaces.
+  **Still unanswered:** whether to regenerate `gss-oracle-transcripts.json` against `origin/master`.
+  It currently pins GSS's PRE-fix behaviour, and regenerating may legitimately turn
+  `SkywatcherGssOracleTests` red. Note while answering the rollover question we found a probable
+  copy-paste bug in upstream `SkyServer.GetRawStepsDt` (different command type per axis) -- GSS is a
+  reference, not a specification.
 - [ ] **Astro Photo Viewer, next release (P11-P21, from the user's notes 2026-08-22 and 2026-08-27)**.
   **Shipped:** the version now leads `--help` (plus `--version`, and the same line in the in-app `?`
   panel beside the AI-enhancer discovery status, which reports which backend resolved, which RC

--- a/docs/plans/gss-parity-audit.md
+++ b/docs/plans/gss-parity-audit.md
@@ -23,7 +23,7 @@ horizon limit", which is wrong on current upstream. Every verdict below is again
 | `765bd26` | Pulse duration loops | **No** - we never had the latency compensation |
 | `7441ccd` (#76) | Pulse guide async dual axis | **YES - finding 1** |
 | `fb6e682` (#109) | Slewing race condition | **Partly - see finding 2** |
-| `6e6dba9` | Rollover / rollunder test support | **No** as a fix; raises a question we should answer |
+| `6e6dba9` | Rollover / rollunder test support | **No** - a test affordance, not a fix; question now answered, no action |
 | `f70d821` (#116) | Queue race condition | **No** - we have no command queue |
 
 ### #89 - RA pulse guiding on GEM mounts. Not applicable.
@@ -74,7 +74,7 @@ deleted the compensation and now waits the full `duration`.
 We already wait the full duration from after the write. **Do not add latency compensation**:
 it buys a few ms of accuracy and costs a silent no-op pulse whenever the measurement is off.
 
-### `6e6dba9` - rollover/rollunder. Not a fix, but check the question it asks.
+### `6e6dba9` - rollover/rollunder. Not a fix, and CLOSED: no action, by design.
 
 This adds a `raw` flag to the position read and a `SetAxisPositionCounter` so a test can PLACE
 an axis near the 24-bit wrap. Note GSS's setter has `//steps += 0x800000;` commented out while
@@ -82,12 +82,42 @@ its getter subtracts the offset by default - asymmetric, which is presumably wha
 was built to explore.
 
 Ours is symmetric (`EncodePosition` adds `POSITION_OFFSET`, `DecodePosition` subtracts it), so
-the specific asymmetry does not exist here. **Open question we have not answered:** what our
-`j`/`E` pair does when an axis genuinely crosses the 24-bit boundary. `DecodePosition` returns
-`[-0x800000, 0x7FFFFF]`, so a crossing decodes as a +/-16777216-step jump. At an EQ6's ~9.02M
-steps/rev the counter holds about +/-0.93 revolution from home, which a long unattended session
-can plausibly reach. Filed, not fixed - it needs a decision about whether we track the wrap or
-re-home.
+the specific asymmetry does not exist here. That left the question of what our `j`/`E` pair does
+when an axis genuinely crosses the boundary. `DecodePosition` returns `[-0x800000, 0x7FFFFF]`, so
+a crossing decodes as a +/-16777216-step jump.
+
+**Answered by reading upstream: GSS does nothing about it, and its behaviour is identical to
+ours.** The pointing path, `Commands.GetAxisPosition` (`GS.SkyWatcher/Commands.cs:678` on
+`origin/master`), is three stateless lines - read `j`, subtract `0x00800000`, convert to an angle.
+No accumulator, no revolution count, no discontinuity check. The only `Unwrap*` in the whole
+repository is DSP phase unwrapping for PEC analysis, which is unrelated.
+
+**And `6e6dba9` is a diagnostic affordance, not machinery.** The `raw` flag and
+`SetAxisPositionCounter` are surfaced on `GS.SkyApi/Sky.cs`, the scripting / COM API for external
+users; the only internal caller is `SkyServer.GetRawSteps`, which feeds **plotting** (the call
+sites in `SkyWatcher.cs` are commented `// read for plotting`). The commented-out offset in the
+setter is deliberate rather than a slip: that setter is *meant* to write raw counter values, which
+is the whole point of being able to park an axis next to the wrap and watch.
+
+**Why neither of us has been bitten is mechanical, not clever.** At an EQ6's ~9.02M steps/rev,
++/-0x800000 is **+/-0.93 revolution from home**, and a GEM's RA axis meets a pier or a cable wrap
+long before it turns 335 degrees. So the thing that actually protects against rollover is
+[`mount-safety-limits.md`](mount-safety-limits.md), which is an argument for finishing that wiring
+rather than for building wrap tracking.
+
+**Why tracking the wrap would be worse than the problem.** It means persistent per-axis revolution
+state carried across restarts, and that state is wrong the moment anybody moves the mount by hand
+or with the hand controller - neither of which we can observe. A silently wrong revolution count
+mis-points by a whole turn and looks like a sync problem; a raw wrap at least presents as an
+obvious +/-16.7M-step discontinuity. Re-homing has the same flaw in a different costume: it needs a
+home sensor (`CanHomeSensors` is optional on Synta hardware) and it is motion across a path nothing
+has checked, which is exactly the objection that made parking opt-in for the safety limits.
+
+**One caution about the oracle, found while answering this.** `SkyServer.GetRawStepsDt` (around
+line 3960) issues `SkyGetAxisPositionDate` for axis 0 and `SkyGetAxisPositionCounter` for axis 1 -
+two different command types for the two axes of one accessor. That looks like a copy-paste bug in
+upstream, and it sits in precisely the area this entry was reading. **GSS is a reference, not a
+specification**; verify anything ported out of it rather than assuming intent.
 
 ### `f70d821` - queue race. Not applicable.
 


### PR DESCRIPTION
Docs only. Closes the last open question from the GSServer parity audit's verdict table.

**The question was:** when an axis crosses the 24-bit encoder boundary, do we track the wrap or
re-home? `DecodePosition` returns `[-0x800000, 0x7FFFFF]`, so a crossing decodes as a ±16.7M-step
jump.

**Answered by reading upstream rather than reasoning about it.** GSS's pointing path,
`Commands.GetAxisPosition`, is three stateless lines — read `j`, subtract `0x00800000`, convert to
an angle. No accumulator, no revolution count, no discontinuity check. Identical to ours. The only
`Unwrap*` in the entire repository is DSP phase unwrapping for PEC analysis.

`6e6dba9` turned out to be a diagnostic affordance, not machinery: the `raw` flag and
`SetAxisPositionCounter` live on `GS.SkyApi` (the scripting/COM surface for external users), and the
only internal caller feeds **plotting**.

**Closed as no action, for two reasons now written down:**

- **Mechanical.** ±`0x800000` is **±0.93 revolution from home** at an EQ6's CPR, and a GEM's RA axis
  meets its pier or cable wrap long before it turns 335°. The real protection is `MountLimits` —
  which is an argument for finishing that wiring, not for building wrap tracking.
- **A fix would be worse than the defect.** Tracking the wrap needs persistent per-axis revolution
  state that goes stale the moment anyone moves the mount by hand or with the hand controller. A
  silently wrong revolution count mis-points by a whole turn and reads as a sync problem, where a
  raw wrap at least presents as an obvious discontinuity. Re-homing fails the same way, plus needs
  an optional sensor and motion across an unchecked path.

**One caution recorded on the way:** `SkyServer.GetRawStepsDt` issues `SkyGetAxisPositionDate` for
axis 0 and `SkyGetAxisPositionCounter` for axis 1 — two different command types for the two axes of
one accessor. Looks like a copy-paste bug upstream, sitting in exactly the area this entry was
reading. GSS is a reference, not a specification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)