### PR TITLE
feat(mount): wire the safety limits up, so a configured limit stops the mount

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -634,7 +634,7 @@ mount stuck `Slewing`, zero exposures. Never re-introduce a flip-success check l
 
 **Mount safety limits are NOT the meridian flip, and the horizon test keys on HOUR ANGLE, not pier
 side.** `MountLimits.Evaluate` (`Sequencing/MountLimits.cs`, pure, beside `MeridianFlipDecision`) is
-the mechanical bound -- where the tube meets the pier or the ground -- while a flip is a *scheduling*
+the mechanical bound -- where the TUBE meets the pier or the ground -- while a flip is a *scheduling*
 choice about a target that keeps being imaged from the other side. A rig can have one, both or
 neither. Ported from GSServer's `CheckAxisLimits` with three deliberate departures, each load-bearing:
 
@@ -657,6 +657,25 @@ neither. Ported from GSServer's `CheckAxisLimits` with three deliberate departur
 **Parking is opt-in for both limits**, because a park is MOTION across a path nothing has checked -- a
 mount stopped at 8 deg altitude may be a hand's width from a tripod leg. `Finalise` already parks at
 session end, so the unattended-dawn case needs no limit to slew.
+
+**It is the TUBE that collides, not the counterweight, and the threshold is an approximation.**
+Tracking past the meridian on a GEM swings the counterweight UP, above the OTA, and the tube DOWN
+toward the pier -- so the margin is set by the OPTICS (a long refractor or Newtonian runs out of
+room far sooner than a short lens) and varies with DECLINATION (a tube near the pole barely sweeps;
+one near the equator sweeps the widest arc). A single hour-angle threshold is therefore a
+conservative approximation of a three-variable envelope and must be set for the worst case the rig
+images -- lowest Dec, longest tube. Do not describe this limit as being about the counterweight.
+
+**The meridian limit is in MINUTES and is the ULTIMATE CLAMP on the flip.** It shares an axis with
+`MeridianFlipEarliestMinutesAfter` / `MeridianFlipLatestMinutesAfter`, so it shares their unit --
+it was degrees once and the two defaults read as the same numbers while differing 4x. The horizon
+limit stays in degrees (altitude is an angle). `MountLimitConfiguration.ClampFlipLatestMinutes` caps
+the flip deadline at the action threshold less `FlipClearanceMinutes`, applied INSIDE
+`MeridianFlipDecision` so no caller can forget it. **The dependency direction is load-bearing:** how
+long to keep imaging is a preference, where the tube meets the pier is a fact, and the fact caps the
+preference -- deriving the limit from the flip instead (the threshold-plus-EXTRA trick used for
+warn/act) would let a preference walk a safety bound into the pier. Unclamped the two race and the
+limit wins, stopping the mount at the moment it was about to flip.
 
 **Wired up as of P1+P2, and three placement decisions ride on it.** The config lives on
 `ProfileData.MountLimits` (nullable = never configured = disabled) and `SessionFactory` projects it

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -656,7 +656,23 @@ neither. Ported from GSServer's `CheckAxisLimits` with three deliberate departur
 
 **Parking is opt-in for both limits**, because a park is MOTION across a path nothing has checked -- a
 mount stopped at 8 deg altitude may be a hand's width from a tripod leg. `Finalise` already parks at
-session end, so the unattended-dawn case needs no limit to slew. Plan + phasing:
+session end, so the unattended-dawn case needs no limit to slew.
+
+**Wired up as of P1+P2, and three placement decisions ride on it.** The config lives on
+`ProfileData.MountLimits` (nullable = never configured = disabled) and `SessionFactory` projects it
+onto `Setup`, never onto the per-run `SessionConfiguration` -- where the tube meets the pier is a
+static fact about a rig, and it has to hold for a manual slew with no session. Enforcement is in
+`PollDeviceStatesAsync`, **not the imaging tick**, because the poll is what every slew wait and
+focus routine already calls; a limit evaluated between exposures would watch a mount drive into a
+pier during a goto. And the altitude it judges is **geometric**
+(`SiteContext.AltitudeDegrees(hourAngleHours, decDeg)`, new): refraction lifts a body by up to
+~34 arcmin at the horizon, so a refracted altitude reports the tube higher than it is and the limit
+fires late, and a tripod leg is not lifted by the atmosphere. Breaching routes to
+`ImageLoopNextAction.LimitReached`, deliberately NOT `DeviceUnrecoverable` -- nothing is broken, so
+do not report a working mount as a faulty one. Tracking is stopped for a Park response too, before
+the park slew. **A test here must place the mount by SYNC, not slew** (a slew only begins, and the
+fake needs a clock pump these tests do not run) and must switch tracking ON explicitly (a fresh test
+session has never initialised a mount). Plan + phasing:
 [docs/plans/mount-safety-limits.md](docs/plans/mount-safety-limits.md); the wider GSServer sweep in
 [docs/plans/gss-parity-audit.md](docs/plans/gss-parity-audit.md).
 

--- a/TODO.md
+++ b/TODO.md
@@ -128,16 +128,29 @@
 
 ## Next Up
 
-- [ ] **Mount safety limits: P1-P5** ([docs/plans/mount-safety-limits.md](docs/plans/mount-safety-limits.md)).
-  P0 shipped 2026-08-29: `MountLimits.Evaluate` is the pure decider plus its configuration record,
-  30 tests, three sabotages verified. **Nothing enforces it yet** -- the decider exists and no caller
-  asks it, which is the whole remaining value. Next is P1 (the config on the PROFILE, not
-  `SessionConfiguration`: it is a fact about a pier and a tube, and must apply to a manual slew with
-  no session) then P2 (evaluate in `PollDeviceStatesAsync`, which already refreshes HA and pier side
-  and is already called from every slew wait and the imaging tick; route the verdict to a new
-  `ImageLoopNextAction.LimitReached`). P3 is the half GSServer gets for free and we do not: enforcement
-  with **no session running**, which needs a watcher that respects the hub lease -- observe while a run
-  owns the mount, act when nothing does.
+- [ ] **Mount safety limits: P1b, P3-P5, and the P1 editor UI**
+  ([docs/plans/mount-safety-limits.md](docs/plans/mount-safety-limits.md)).
+  **P0 + P1 + P2 shipped 2026-08-29, so a configured limit now actually stops a mount during a run.**
+  The config persists on `ProfileData.MountLimits` (nullable = never configured = disabled) and is
+  projected onto `Setup` by `SessionFactory`; enforcement is in `PollDeviceStatesAsync` (the poll,
+  NOT the imaging tick -- it is what every slew wait and focus routine already calls) and routes to
+  the new `ImageLoopNextAction.LimitReached`. Altitude comes from the new geometric
+  `SiteContext.AltitudeDegrees`, unrefracted on purpose. 6 session tests + 9 altitude tests, two
+  sabotages verified.
+  **What remains, in rough order of value.**
+  (a) **The P1 editor UI** -- the config persists and enforces, but nothing lets a user set it
+  except editing profile JSON.
+  (b) **P3, the half GSServer gets for free and we do not:** enforcement with **no session
+  running**, which needs a watcher respecting the hub lease -- observe while a run owns the mount,
+  act when nothing does. This is also what would protect the rig during a manual 2am slew, the case
+  P1's placement on the profile was chosen for.
+  (c) **P4 surfacing** (notification feed, a `LimitAlarm` on `ISessionTelemetry` for the Home
+  board's rig card, warn threshold as a countdown beside `MeridianFlipUtc`) -- `Session` already
+  exposes `MountLimitVerdict` for this, and nothing reads it yet.
+  (d) **P1b axis modelling** (`GetAxisAngleAsync`), which upgrades the limit from an HA
+  approximation to mechanical truth on mounts that can report it.
+  (e) **P5**: observe a driver-enforced limit rather than duplicating it, so a GSS-managed rig does
+  not read as a malfunction.
 - [ ] **GSS parity: what is left of the pulse contract** (findings 1 and 2; finding 3, the
   unverified pulse-restore, is FIXED) ([docs/plans/gss-parity-audit.md](docs/plans/gss-parity-audit.md)).
   **Done so far:** the restore and both axis stops are verified with a retry and throw

--- a/docs/plans/gss-parity-audit.md
+++ b/docs/plans/gss-parity-audit.md
@@ -1,7 +1,14 @@
 # GSServer parity audit: fixes, ideas and limits worth porting
 
-**Status:** audit complete for the pulse/slew/queue band; three real findings (one already
-fixed, Finding 3), one feature (limits) split out into [`mount-safety-limits.md`](mount-safety-limits.md).
+**Status:** audit complete for the pulse/slew/queue band. **Findings 1 and 3 are FIXED and merged**
+(the whole guide-pulse contract: verify the restore, split the method in two, give the guide loop its
+missing wait, convert SkyWatcher to a background hold). **Finding 2 is fixed for pulses and open for
+slews.** The `6e6dba9` rollover question is answered and closed, no action. The feature half (limits)
+is split out into [`mount-safety-limits.md`](mount-safety-limits.md), where P0-P2 have shipped.
+
+**The verdict table below is the point of this document**: it records which GSS commits were read and
+why the five that do not apply do not, so the same commits are not re-read next year. Do not re-audit
+a row without a reason.
 
 GSServer (GSS, GPL-3.0, `rmorgan001/GSServer`) is the reference open-source Synta driver and
 the oracle TianWen's SkyWatcher protocol implementation was written against. It has kept
@@ -135,7 +142,7 @@ work yet; noted so the idea is not lost with the commit it came in.
 
 ---
 
-## Finding 1: RA and Dec guide pulses are issued SEQUENTIALLY
+## Finding 1: RA and Dec guide pulses are issued SEQUENTIALLY. FIXED
 
 `GuideLoop` applies the RA correction and then the Dec correction, each awaited:
 
@@ -420,7 +427,7 @@ blocking today; that is the path `FakeCameraMountCouplingTests` drives, and it c
 6. Pin with **fake time traversed per guide frame** -- under `FakeTimeProviderWrapper` the difference
    is free in wall time, so a wall-clock assertion cannot see it either way.
 
-## Finding 2: an "in progress" flag that is not observable when the starter returns
+## Finding 2: an "in progress" flag that is not observable when the starter returns. PARTLY FIXED
 
 `fb6e682` and `2c9cd16` are the same defect in two places: `SlewToCoordinatesAsync` returned
 before `IsSlewing` was set, and `PulseGuide` returned before `IsPulseGuiding` was. A client that
@@ -432,7 +439,16 @@ driver blocks - which is finding 1's problem. Once `StartPulseGuideAsync` return
 `_pulseGuideInFlight` must be incremented before the write and cleared by whatever ends the
 pulse, or we will have ported GSS's bug in the act of fixing the other one.
 
-Slews are worth a matching check against `_isSlewingRa` / `_isSlewingDec` for the same property.
+**Done for pulses.** `SkywatcherMountDriverBase` raises `_pulseGuideInFlight` BEFORE the first write
+and lowers it only when the background hold ends, so the conversion in finding 1 did not port GSS's
+bug while fixing the other one. It stays a counter, not a flag, so an overlapping RA+Dec pair clears
+only when both finish.
+
+**Still open, two parts.** Slews are worth a matching check against `_isSlewingRa` / `_isSlewingDec`
+for the same property. And the rule has NOT been audited on `AscomTelescopeDriver` /
+`AlpacaTelescopeDriver` / their camera counterparts, which inherit whatever the remote driver does
+and cannot be reasoned about from here -- LX200 and SkyWatcher are right by construction, those four
+are unknown.
 
 ## Finding 3: the commands that END a pulse were never verified. FIXED
 

--- a/docs/plans/mount-safety-limits.md
+++ b/docs/plans/mount-safety-limits.md
@@ -109,7 +109,7 @@ constraints GSS never had:
 |-------|------|--------|
 | P0 | **`MountLimits` pure decider** (`TianWen.Lib/Sequencing/` beside `MeridianFlipDecision`): `Evaluate(hourAngleHours, altitudeDeg, isTracking, alreadyActed, MountLimitConfiguration) -> MountLimitVerdict`. No I/O, no driver, no clock. `MountLimitConfiguration` landed with it rather than waiting for P1, because the decider cannot be written without it; P1 keeps the PLACEMENT (profile persistence + UI). **Two departures from the sketch:** it takes no pier side and no alignment mode -- see the note below. | **DONE** (30 tests, 3 sabotages verified) |
 | P1b | **Axis modelling: `GetAxisAngleAsync(TelescopeAxis) -> double?`** (degrees from the mount's home position, signed, hemisphere-corrected), implemented natively by the SkyWatcher driver from steps + CPR and returning `null` everywhere else. **Angle, not steps**: the driver owns its home convention (`0x800000`) and the southern mirroring, and leaking steps + CPR would make every caller re-derive both -- the bug `StepsToRa` already exists to prevent. This is what upgrades the limit from approximation to mechanical truth on the mounts that can support it, and it is independently useful (a true pier-side derivation, PE phase, a mechanical-position readout). | NOT STARTED |
-| P1 | **Profile placement + UI.** Persist `MountLimitConfiguration` (the record itself shipped in P0) and give it an editor. **Lives on the PROFILE, not `SessionConfiguration`** -- it is a static fact about a pier, a tube and a counterweight shaft, exactly like `OTAData`, and it must apply to a manual slew with no session. | **DONE** for persistence + plumbing; the editor UI is not built |
+| P1 | **Profile placement + UI.** Persist `MountLimitConfiguration` (the record itself shipped in P0) and give it an editor. **Lives on the PROFILE, not `SessionConfiguration`** -- it is a static fact about the mount's geometry AND the tube bolted to it, exactly like `OTAData`, and it must apply to a manual slew with no session. | **DONE** for persistence + plumbing; the editor UI is not built |
 | P2 | **Session enforcement.** Evaluate in `PollDeviceStatesAsync` (already the one place that refreshes `_mountState` with HA and pier side, and already called from every slew wait and the imaging tick). Verdict routes to a new `ImageLoopNextAction.LimitReached`, finalising the run the same way `DeviceUnrecoverable` does. Reuses `ResilientInvokeAsync` for the stop/park. | **DONE** (6 tests, 2 sabotages verified) |
 | P3 | **Enforcement outside a session** -- the half GSS gets for free. A `MountLimitWatcher` hosted alongside the device hub, polling any *connected* mount on a slow cadence (5 s) whether or not a session owns it. Must respect the hub lease: a run owns the mount, so the watcher only observes and lets the session act; with no run it acts itself. | NOT STARTED |
 | P4 | **Surface it.** A limit is useless if it fires silently: notification feed entry, a `LimitAlarm`-equivalent state on `ISessionTelemetry` for the Home board's rig card, and the warning threshold shown as a countdown next to the existing flip countdown (`MeridianFlipUtc`). | NOT STARTED |
@@ -239,3 +239,44 @@ BEGINS, and the fake advances with the fake clock which these tests never pump, 
 stays exactly where it was and every assertion passes for the wrong reason. Tracking is also
 switched on explicitly, because a freshly built test session has never initialised a mount and
 starts with tracking OFF -- asserting "still tracking" without that passes with enforcement deleted.
+
+## Correcting the physics, and making the limit the clamp
+
+**It is the TUBE that collides, not the counterweight.** Earlier notes here and in the code said the
+meridian limit is about "the counterweight shaft meeting the pier". That is backwards. Tracking past
+the meridian on a GEM swings the counterweight UP, above the OTA, and the tube DOWN toward the pier
+and tripod. Three consequences, none of which the first cut modelled:
+
+- **The margin is set by the OPTICS, not the ballast.** A long refractor or Newtonian -- plus dew
+  shield, focuser, camera train, whatever hangs off the back -- runs out of room far sooner than a
+  short lens on the same mount.
+- **It varies with DECLINATION.** A tube near the pole lies close to the RA axis and barely sweeps as
+  the mount tracks; one near the equator sweeps the widest arc and reaches the pier soonest.
+- **So a single hour-angle threshold is a conservative APPROXIMATION of a three-variable envelope**
+  (hour angle x declination x tube geometry), not the true bound. It must be set for the worst case
+  the rig actually images: the lowest declination it visits, with the longest tube fitted. Stating
+  this is the honest version; pretending the threshold is exact is how somebody sets it from a
+  high-Dec test and finds the pier at Dec 0.
+
+**The meridian limit is now in MINUTES, matching the flip.** It was degrees, while
+`MeridianFlipEarliestMinutesAfter` / `MeridianFlipLatestMinutesAfter` were minutes -- two settings
+bounding the same axis in two units, whose defaults (5 and 10 in each) looked identical and were
+not: 5 deg is 20 min. The horizon limit stays in degrees, because altitude genuinely is an angle and
+has no time analogue.
+
+**The limit is the ultimate clamp.** `MountLimitConfiguration.ClampFlipLatestMinutes` caps the flip
+deadline at the action threshold less `FlipClearanceMinutes` (5), and `MeridianFlipDecision`
+applies it internally so no caller can classify against an unclamped window by forgetting to ask.
+
+- **The direction of the dependency is the point.** How long to keep imaging before flipping is a
+  PREFERENCE; where the tube meets the pier is a FACT. The fact caps the preference.
+- **The tempting inverse is wrong.** Deriving the limit as "flip deadline plus a margin" -- the same
+  threshold-plus-EXTRA trick this record already uses for warn/act -- would let a preference move a
+  safety bound: raise the flip deadline to an hour and the mechanical limit follows it into the pier.
+- **Without the clamp the two simply race, and the limit wins**, which is the worst outcome: the
+  mount is stopped at the very moment it was about to do the right thing, ending the night instead
+  of flipping. This matters most for exactly the rigs that need it -- a GEM that cannot flip before
+  the meridian must track past it, and the user raises the flip deadline to do so.
+
+Pinned by `MountLimitClampsFlipTests`, including that the limit does NOT move when the flip
+preference does, and one sabotage (clamp removed).

--- a/docs/plans/mount-safety-limits.md
+++ b/docs/plans/mount-safety-limits.md
@@ -109,8 +109,8 @@ constraints GSS never had:
 |-------|------|--------|
 | P0 | **`MountLimits` pure decider** (`TianWen.Lib/Sequencing/` beside `MeridianFlipDecision`): `Evaluate(hourAngleHours, altitudeDeg, isTracking, alreadyActed, MountLimitConfiguration) -> MountLimitVerdict`. No I/O, no driver, no clock. `MountLimitConfiguration` landed with it rather than waiting for P1, because the decider cannot be written without it; P1 keeps the PLACEMENT (profile persistence + UI). **Two departures from the sketch:** it takes no pier side and no alignment mode -- see the note below. | **DONE** (30 tests, 3 sabotages verified) |
 | P1b | **Axis modelling: `GetAxisAngleAsync(TelescopeAxis) -> double?`** (degrees from the mount's home position, signed, hemisphere-corrected), implemented natively by the SkyWatcher driver from steps + CPR and returning `null` everywhere else. **Angle, not steps**: the driver owns its home convention (`0x800000`) and the southern mirroring, and leaking steps + CPR would make every caller re-derive both -- the bug `StepsToRa` already exists to prevent. This is what upgrades the limit from approximation to mechanical truth on the mounts that can support it, and it is independently useful (a true pier-side derivation, PE phase, a mechanical-position readout). | NOT STARTED |
-| P1 | **Profile placement + UI.** Persist `MountLimitConfiguration` (the record itself shipped in P0) and give it an editor. **Lives on the PROFILE, not `SessionConfiguration`** -- it is a static fact about a pier, a tube and a counterweight shaft, exactly like `OTAData`, and it must apply to a manual slew with no session. | NOT STARTED |
-| P2 | **Session enforcement.** Evaluate in `PollDeviceStatesAsync` (already the one place that refreshes `_mountState` with HA and pier side, and already called from every slew wait and the imaging tick). Verdict routes to a new `ImageLoopNextAction.LimitReached`, finalising the run the same way `DeviceUnrecoverable` does. Reuses `ResilientInvokeAsync` for the stop/park. | NOT STARTED |
+| P1 | **Profile placement + UI.** Persist `MountLimitConfiguration` (the record itself shipped in P0) and give it an editor. **Lives on the PROFILE, not `SessionConfiguration`** -- it is a static fact about a pier, a tube and a counterweight shaft, exactly like `OTAData`, and it must apply to a manual slew with no session. | **DONE** for persistence + plumbing; the editor UI is not built |
+| P2 | **Session enforcement.** Evaluate in `PollDeviceStatesAsync` (already the one place that refreshes `_mountState` with HA and pier side, and already called from every slew wait and the imaging tick). Verdict routes to a new `ImageLoopNextAction.LimitReached`, finalising the run the same way `DeviceUnrecoverable` does. Reuses `ResilientInvokeAsync` for the stop/park. | **DONE** (6 tests, 2 sabotages verified) |
 | P3 | **Enforcement outside a session** -- the half GSS gets for free. A `MountLimitWatcher` hosted alongside the device hub, polling any *connected* mount on a slow cadence (5 s) whether or not a session owns it. Must respect the hub lease: a run owns the mount, so the watcher only observes and lets the session act; with no run it acts itself. | NOT STARTED |
 | P4 | **Surface it.** A limit is useless if it fires silently: notification feed entry, a `LimitAlarm`-equivalent state on `ISessionTelemetry` for the Home board's rig card, and the warning threshold shown as a countdown next to the existing flip countdown (`MeridianFlipUtc`). | NOT STARTED |
 | P5 | **Driver-enforced limits, observed not duplicated.** Detect "the mount stopped itself" (tracking off / `AtPark` when we did not command it) and report it as a limit event rather than a device fault, so a GSS-managed rig does not read as a malfunction. | NOT STARTED |
@@ -198,3 +198,44 @@ meridian wins on the tie-break. Right answer, wrong reason, and the broken rank 
 - [`gss-parity-audit.md`](gss-parity-audit.md) -- the rest of the GSServer sweep: which of its
   pulse/slew/queue fixes apply to us and which are structurally impossible here. Read its
   "Read `origin/master`, not a local checkout" note before quoting any GSS behaviour below.
+
+## P1 + P2 as built
+
+**The profile is the source of truth; `Setup` is the run's projection of it.**
+`ProfileData.MountLimits` is nullable so an older profile deserialises unchanged and reads as
+"never configured", which the shipped defaults answer as disabled. `SessionFactory` copies it onto
+`Setup` -- the record that already answers "what hardware am I driving" -- rather than onto the
+per-run `SessionConfiguration`, which keeps the invariant intact while giving the session something
+to read. Note this changes the base64 `data=` segment of every profile URI, which is expected and
+is what `ProfileTests` pins.
+
+**Altitude is GEOMETRIC, and that is a decision rather than an approximation.**
+`SiteContext.AltitudeDegrees(hourAngleHours, decDeg)` is new, sitting beside the `IsAboveHorizon`
+that already cached `sinLat`/`cosLat` (the class's own remarks had flagged altitude as a missing
+use). Refraction lifts a body by up to ~34 arcmin at the horizon, so a refracted altitude reports
+the tube HIGHER than it is and a limit keyed on it fires late -- in the one regime where late is
+the whole failure. A tripod leg is not lifted by the atmosphere. It takes an hour angle rather than
+an RA because the caller reads HA straight off the mount, and going RA -> HA via `LST` would
+re-introduce a clock the mount has already accounted for.
+
+**Enforcement is on the POLL, not the imaging tick.** `PollDeviceStatesAsync` is what every slew
+wait and focus routine already calls; a limit evaluated only between exposures would watch a mount
+drive into a pier during a goto and say nothing.
+
+**Acting does not gate the exit.** Whether the stop succeeded or not, the imaging loop is told to
+finish via the new `ImageLoopNextAction.LimitReached` -- a limit we could not act on is a stronger
+reason to end the night, not a weaker one. `LimitReached` is deliberately distinct from
+`DeviceUnrecoverable`: nothing is broken, the rig reached the edge of where it may point, and
+collapsing the two would report a working mount as a faulty one and send somebody out to check
+cables at 3am.
+
+**Tracking is stopped in BOTH responses, park included.** A park is motion across a path nothing has
+checked, so the axis should not still be driving toward the limit while it is under way -- and if
+the park then fails, a stopped mount is a better place to have left the rig than a tracking one. A
+`Park` response on a mount that cannot park logs and settles for the stop.
+
+**One test lesson.** `SessionMountLimitTests` places the mount by SYNC, not by slew: a slew only
+BEGINS, and the fake advances with the fake clock which these tests never pump, so a slewed mount
+stays exactly where it was and every assertion passes for the wrong reason. Tracking is also
+switched on explicitly, because a freshly built test session has never initialised a mount and
+starts with tracking OFF -- asserting "still tracking" without that passes with enforcement deleted.

--- a/src/TianWen.Lib.Tests.Functional/ProfileTests.cs
+++ b/src/TianWen.Lib.Tests.Functional/ProfileTests.cs
@@ -10,8 +10,15 @@ namespace TianWen.Lib.Tests.Functional;
 
 public class ProfileTests(ITestOutputHelper outputHelper)
 {
+    /// <remarks>
+    /// The <c>data=</c> segment is <see cref="ProfileData"/> serialised and base64url-encoded, and
+    /// the context writes nulls, so **adding any property to that record changes this literal** --
+    /// expected, not a break. Decode it before editing rather than pasting the actual: the point of
+    /// the test is that the encoding is stable and round-trips, and a blind paste asserts only that
+    /// the code agrees with itself.
+    /// </remarks>
     [Theory]
-    [InlineData("00000000-0000-0000-0000-000000000000", "Empty profile", "profile://profile/00000000-0000-0000-0000-000000000000?data=eyJNb3VudCI6Im5vbmU6Ly9Ob25lRGV2aWNlL05vbmUjTm9uZSIsIkd1aWRlciI6Im5vbmU6Ly9Ob25lRGV2aWNlL05vbmUjTm9uZSIsIk9UQXMiOltdLCJHdWlkZXJDYW1lcmEiOm51bGwsIkd1aWRlckZvY3VzZXIiOm51bGwsIk9BR19PVEFfSW5kZXgiOm51bGwsIkd1aWRlckZvY2FsTGVuZ3RoIjpudWxsLCJXZWF0aGVyIjpudWxsLCJTaXRlTGF0aXR1ZGUiOm51bGwsIlNpdGVMb25naXR1ZGUiOm51bGwsIlNpdGVFbGV2YXRpb24iOm51bGwsIlNpdGVUaWVCcmVha2VyIjowfQ#Empty profile")]
+    [InlineData("00000000-0000-0000-0000-000000000000", "Empty profile", "profile://profile/00000000-0000-0000-0000-000000000000?data=eyJNb3VudCI6Im5vbmU6Ly9Ob25lRGV2aWNlL05vbmUjTm9uZSIsIkd1aWRlciI6Im5vbmU6Ly9Ob25lRGV2aWNlL05vbmUjTm9uZSIsIk9UQXMiOltdLCJHdWlkZXJDYW1lcmEiOm51bGwsIkd1aWRlckZvY3VzZXIiOm51bGwsIk9BR19PVEFfSW5kZXgiOm51bGwsIkd1aWRlckZvY2FsTGVuZ3RoIjpudWxsLCJXZWF0aGVyIjpudWxsLCJTaXRlTGF0aXR1ZGUiOm51bGwsIlNpdGVMb25naXR1ZGUiOm51bGwsIlNpdGVFbGV2YXRpb24iOm51bGwsIlNpdGVUaWVCcmVha2VyIjowLCJNb3VudExpbWl0cyI6bnVsbH0#Empty profile")]
     public void GivenGuidAndProfileNameAProfileUriIsCreated(string guid, string name, string expectedUriStr)
     {
         var actualUri = Profile.CreateProfileUri(new Guid(guid), name, ProfileData.Empty);

--- a/src/TianWen.Lib.Tests/MountLimitClampsFlipTests.cs
+++ b/src/TianWen.Lib.Tests/MountLimitClampsFlipTests.cs
@@ -1,0 +1,94 @@
+using Shouldly;
+using TianWen.Lib.Sequencing;
+using Xunit;
+
+namespace TianWen.Lib.Tests;
+
+/// <summary>
+/// Pins that the mechanical limit is the ULTIMATE CLAMP on the meridian flip window.
+/// </summary>
+/// <remarks>
+/// <para>The two settings bound the same axis and, before this, simply raced -- and the limit won,
+/// which is the worst outcome: the mount is stopped at the very moment it was about to flip, ending
+/// the night instead of continuing it. Worse, they were in different units (flip in minutes past
+/// the meridian, limit in degrees of hour angle), so "5 and 10" in each looked like the same
+/// numbers and were not: 5 deg is 20 min.</para>
+///
+/// <para><b>The direction of the dependency is the whole point.</b> How long to keep imaging before
+/// flipping is a preference; where the tube meets the pier is a fact. So the fact caps the
+/// preference. Deriving the limit from the flip instead -- the same "threshold plus a non-negative
+/// EXTRA" trick <see cref="MountLimitConfiguration"/> uses for warn/act -- would be exactly
+/// backwards: raise the flip deadline to an hour and the mechanical limit would follow it into the
+/// pier.</para>
+/// </remarks>
+public class MountLimitClampsFlipTests
+{
+    private static MountLimitConfiguration Limits(bool enabled, double warnMinutes, double actionExtraMinutes)
+        => new MountLimitConfiguration(
+            Enabled: enabled,
+            MeridianWarnMinutes: warnMinutes,
+            MeridianActionExtraMinutes: actionExtraMinutes);
+
+    [Fact]
+    public void AFlipDeadlineInsideTheLimitIsLeftAlone()
+    {
+        // Action at 40 min, clearance 5 => anything up to 35 is the user's own business.
+        var limits = Limits(enabled: true, warnMinutes: 20.0, actionExtraMinutes: 20.0);
+
+        limits.ClampFlipLatestMinutes(10.0).ShouldBe(10.0);
+        limits.ClampFlipLatestMinutes(35.0).ShouldBe(35.0);
+    }
+
+    [Fact]
+    public void AFlipDeadlinePastTheLimitIsPulledBackInside()
+    {
+        var limits = Limits(enabled: true, warnMinutes: 20.0, actionExtraMinutes: 20.0);
+
+        // Asking to track an hour past the meridian on a rig whose tube reaches the pier at 40 min.
+        // The request loses; it does not silently move the pier.
+        limits.ClampFlipLatestMinutes(60.0)
+            .ShouldBe(limits.MeridianActionMinutes - MountLimitConfiguration.FlipClearanceMinutes);
+        limits.ClampFlipLatestMinutes(60.0).ShouldBe(35.0);
+    }
+
+    [Fact]
+    public void DisabledLimitsClampNothing()
+    {
+        // Opt-in throughout: a rig that never configured limits must behave exactly as before.
+        Limits(enabled: false, warnMinutes: 20.0, actionExtraMinutes: 20.0)
+            .ClampFlipLatestMinutes(60.0).ShouldBe(60.0);
+    }
+
+    [Fact]
+    public void TheLimitNeverMovesWhenTheFlipPreferenceDoes()
+    {
+        // The inverse design would have had the limit trail the flip deadline. It must not.
+        var limits = Limits(enabled: true, warnMinutes: 20.0, actionExtraMinutes: 20.0);
+
+        var before = limits.MeridianActionMinutes;
+        _ = limits.ClampFlipLatestMinutes(600.0);
+
+        limits.MeridianActionMinutes.ShouldBe(before, "a preference must never move a safety bound");
+    }
+
+    [Fact]
+    public void TheFlipClassifierAppliesTheClampSoNoCallerCanForget()
+    {
+        var config = SessionTestHelper.DefaultConfiguration with
+        {
+            MeridianFlipObstructionZoneMinutesBefore = 0,
+            MeridianFlipEarliestMinutesAfter = 5,
+            MeridianFlipLatestMinutesAfter = 60,
+        };
+        var limits = Limits(enabled: true, warnMinutes: 20.0, actionExtraMinutes: 20.0);
+
+        // 45 min past: inside the REQUESTED window, outside the clamped one.
+        const double ha = 45.0 / 60.0;
+
+        MeridianFlipDecision.ClassifyHourAngle(ha, config)
+            .ShouldBe(HourAngleZone.InFlipWindow, "unclamped, the request stands");
+
+        MeridianFlipDecision.ClassifyHourAngle(ha, config, limits)
+            .ShouldBe(HourAngleZone.PastFlipWindow, "clamped, the flip was already overdue at 35 min");
+    }
+}

--- a/src/TianWen.Lib.Tests/MountLimitsTests.cs
+++ b/src/TianWen.Lib.Tests/MountLimitsTests.cs
@@ -15,17 +15,29 @@ namespace TianWen.Lib.Tests;
 /// </remarks>
 public class MountLimitsTests
 {
+    /// <summary>
+    /// An hour angle that is descending (HA &gt; 0) but still clear of the meridian warn threshold,
+    /// so a horizon case reports the horizon and nothing else.
+    /// </summary>
+    /// <remarks>
+    /// 3 minutes past. Load-bearing: the meridian and horizon verdicts are ranked against each
+    /// other, so a horizon test run at an hour angle that also trips the meridian limit asserts on
+    /// whichever won, not on the horizon. This value moved once already when the meridian threshold
+    /// changed units -- if these tests start failing together, check this first.
+    /// </remarks>
+    private const double DescendingClearOfMeridian = 0.05;
+
     private static MountLimitConfiguration Enabled(
-        double meridianWarnDeg = 5.0,
-        double meridianActionExtraDeg = 5.0,
+        double meridianWarnMinutes = 5.0,
+        double meridianActionExtraMinutes = 5.0,
         MountLimitResponse meridianResponse = MountLimitResponse.StopTracking,
         double horizonActionDeg = 10.0,
         double horizonWarnExtraDeg = 5.0,
         MountLimitResponse horizonResponse = MountLimitResponse.Park)
         => new MountLimitConfiguration(
             Enabled: true,
-            MeridianWarnDeg: meridianWarnDeg,
-            MeridianActionExtraDeg: meridianActionExtraDeg,
+            MeridianWarnMinutes: meridianWarnMinutes,
+            MeridianActionExtraMinutes: meridianActionExtraMinutes,
             MeridianResponse: meridianResponse,
             HorizonActionDeg: horizonActionDeg,
             HorizonWarnExtraDeg: horizonWarnExtraDeg,
@@ -56,7 +68,7 @@ public class MountLimitsTests
     {
         var config = new MountLimitConfiguration();
 
-        config.MeridianActionDeg.ShouldBeGreaterThan(config.MeridianWarnDeg);
+        config.MeridianActionMinutes.ShouldBeGreaterThan(config.MeridianWarnMinutes);
         config.HorizonWarnDeg.ShouldBeGreaterThan(config.HorizonActionDeg);
     }
 
@@ -79,7 +91,7 @@ public class MountLimitsTests
     [InlineData(-6.0)]  // 6 h east, rising
     [InlineData(-0.5)]
     [InlineData(0.0)]   // exactly on the meridian
-    [InlineData(0.32)]  // ~4.8 deg west, just inside the 5 deg warn threshold
+    [InlineData(0.08)]  // ~4.8 min west, just inside the 5 min warn threshold
     public void EastOfTheWarnThresholdIsClear(double hourAngleHours)
         => MountLimits.Evaluate(hourAngleHours, altitudeDeg: 60.0, isTracking: true, alreadyActed: false, Enabled())
             .IsBreached.ShouldBeFalse();
@@ -87,28 +99,28 @@ public class MountLimitsTests
     [Fact]
     public void BetweenWarnAndActionItWarnsAndDoesNotAct()
     {
-        // 7 deg past the meridian: warn is 5, action is 5 + 5 = 10.
+        // 7 min past the meridian: warn is 5, action is 5 + 5 = 10.
         var verdict = MountLimits.Evaluate(
-            hourAngleHours: 7.0 / 15.0, altitudeDeg: 60.0, isTracking: true, alreadyActed: false, Enabled());
+            hourAngleHours: 7.0 / 60.0, altitudeDeg: 60.0, isTracking: true, alreadyActed: false, Enabled());
 
         verdict.Kind.ShouldBe(MountLimitKind.Meridian);
         verdict.IsWarningOnly.ShouldBeTrue();
         // Negative = still this far from acting. 7 - 10 = -3.
-        verdict.ExceededByDeg.ShouldBe(-3.0, tolerance: 1e-9);
-        verdict.Describe().ShouldContain("3.0 deg");
+        verdict.ExceededBy.ShouldBe(-3.0, tolerance: 1e-9);
+        verdict.Describe().ShouldContain("3 min");
     }
 
     [Fact]
     public void PastTheActionThresholdItActs()
     {
-        // 12 deg past: 2 deg beyond the 10 deg action point.
+        // 12 min past: 2 min beyond the 10 min action point.
         var verdict = MountLimits.Evaluate(
-            hourAngleHours: 12.0 / 15.0, altitudeDeg: 60.0, isTracking: true, alreadyActed: false, Enabled());
+            hourAngleHours: 12.0 / 60.0, altitudeDeg: 60.0, isTracking: true, alreadyActed: false, Enabled());
 
         verdict.Kind.ShouldBe(MountLimitKind.Meridian);
         verdict.IsWarningOnly.ShouldBeFalse();
         verdict.Response.ShouldBe(MountLimitResponse.StopTracking);
-        verdict.ExceededByDeg.ShouldBe(2.0, tolerance: 1e-9);
+        verdict.ExceededBy.ShouldBe(2.0, tolerance: 1e-9);
     }
 
     [Fact]
@@ -116,7 +128,7 @@ public class MountLimitsTests
     {
         // Being past the limit is a fact about where the tube IS, not about the motors. A mount that
         // was stopped inside the limit is still inside it.
-        MountLimits.Evaluate(12.0 / 15.0, 60.0, isTracking: false, alreadyActed: false, Enabled())
+        MountLimits.Evaluate(12.0 / 60.0, 60.0, isTracking: false, alreadyActed: false, Enabled())
             .Kind.ShouldBe(MountLimitKind.Meridian);
     }
 
@@ -138,12 +150,12 @@ public class MountLimitsTests
     {
         // HA > 0 = past upper transit = descending. 6 deg altitude against a 10 deg floor.
         var verdict = MountLimits.Evaluate(
-            hourAngleHours: 0.2, altitudeDeg: 6.0, isTracking: true, alreadyActed: false, Enabled());
+            hourAngleHours: DescendingClearOfMeridian, altitudeDeg: 6.0, isTracking: true, alreadyActed: false, Enabled());
 
         verdict.Kind.ShouldBe(MountLimitKind.Horizon);
         verdict.IsWarningOnly.ShouldBeFalse();
         verdict.Response.ShouldBe(MountLimitResponse.Park);
-        verdict.ExceededByDeg.ShouldBe(4.0, tolerance: 1e-9);
+        verdict.ExceededBy.ShouldBe(4.0, tolerance: 1e-9);
     }
 
     [Fact]
@@ -151,11 +163,11 @@ public class MountLimitsTests
     {
         // Floor 10, warn 15. At 13 deg the user is told and nothing is taken away.
         var verdict = MountLimits.Evaluate(
-            hourAngleHours: 0.2, altitudeDeg: 13.0, isTracking: true, alreadyActed: false, Enabled());
+            hourAngleHours: DescendingClearOfMeridian, altitudeDeg: 13.0, isTracking: true, alreadyActed: false, Enabled());
 
         verdict.Kind.ShouldBe(MountLimitKind.Horizon);
         verdict.IsWarningOnly.ShouldBeTrue();
-        verdict.ExceededByDeg.ShouldBe(-3.0, tolerance: 1e-9);
+        verdict.ExceededBy.ShouldBe(-3.0, tolerance: 1e-9);
     }
 
     [Theory]
@@ -177,13 +189,13 @@ public class MountLimitsTests
     {
         // A parked or stowed mount routinely sits below the floor. Alarming there would alarm forever,
         // at exactly the times nothing is at risk.
-        MountLimits.Evaluate(0.2, altitudeDeg: 2.0, isTracking: false, alreadyActed: false, Enabled())
+        MountLimits.Evaluate(DescendingClearOfMeridian, altitudeDeg: 2.0, isTracking: false, alreadyActed: false, Enabled())
             .IsBreached.ShouldBeFalse();
     }
 
     [Fact]
     public void AnUnknownAltitudeDoesNotProduceAHorizonVerdict()
-        => MountLimits.Evaluate(0.2, double.NaN, isTracking: true, alreadyActed: false, Enabled())
+        => MountLimits.Evaluate(DescendingClearOfMeridian, double.NaN, isTracking: true, alreadyActed: false, Enabled())
             .IsBreached.ShouldBeFalse();
 
     [Fact]
@@ -207,7 +219,7 @@ public class MountLimitsTests
         // forever, never arriving. Downgrading to Warn rather than Clear is the point: the mount is
         // still in the limit and the user must keep being told.
         var acted = MountLimits.Evaluate(
-            hourAngleHours: 12.0 / 15.0, altitudeDeg: 60.0, isTracking: true, alreadyActed: true, Enabled());
+            hourAngleHours: 12.0 / 60.0, altitudeDeg: 60.0, isTracking: true, alreadyActed: true, Enabled());
 
         acted.IsBreached.ShouldBeTrue();
         acted.Kind.ShouldBe(MountLimitKind.Meridian);
@@ -227,10 +239,10 @@ public class MountLimitsTests
     public void AlreadyActedLeavesAWarningAloneSoTheCountdownKeepsRunning()
     {
         var warning = MountLimits.Evaluate(
-            hourAngleHours: 7.0 / 15.0, altitudeDeg: 60.0, isTracking: true, alreadyActed: true, Enabled());
+            hourAngleHours: 7.0 / 60.0, altitudeDeg: 60.0, isTracking: true, alreadyActed: true, Enabled());
 
         warning.IsWarningOnly.ShouldBeTrue();
-        warning.ExceededByDeg.ShouldBe(-3.0, tolerance: 1e-9);
+        warning.ExceededBy.ShouldBe(-3.0, tolerance: 1e-9);
     }
 
     #endregion
@@ -249,7 +261,7 @@ public class MountLimitsTests
         // distinction entirely, because both sides then tie and the meridian wins on the tie-break --
         // the right answer for the wrong reason, and a broken rank would have shipped.
         var verdict = MountLimits.Evaluate(
-            hourAngleHours: 12.0 / 15.0, altitudeDeg: 13.0, isTracking: true, alreadyActed: false,
+            hourAngleHours: 12.0 / 60.0, altitudeDeg: 13.0, isTracking: true, alreadyActed: false,
             Enabled(meridianResponse: MountLimitResponse.Warn,
                     horizonResponse: MountLimitResponse.Park));
 
@@ -265,7 +277,7 @@ public class MountLimitsTests
         // stronger action is right even though the meridian is the more dangerous limit. What the
         // verdict then NAMES is the limit driving the action, which is the horizon.
         var verdict = MountLimits.Evaluate(
-            hourAngleHours: 12.0 / 15.0, altitudeDeg: 2.0, isTracking: true, alreadyActed: false,
+            hourAngleHours: 12.0 / 60.0, altitudeDeg: 2.0, isTracking: true, alreadyActed: false,
             Enabled(meridianResponse: MountLimitResponse.StopTracking,
                     horizonResponse: MountLimitResponse.Park));
 
@@ -279,7 +291,7 @@ public class MountLimitsTests
         // The genuine tie, and the only case the kind precedence decides. The meridian ends with the
         // tube against the pier; the horizon merely ends with it pointed somewhere useless.
         var verdict = MountLimits.Evaluate(
-            hourAngleHours: 12.0 / 15.0, altitudeDeg: 2.0, isTracking: true, alreadyActed: false,
+            hourAngleHours: 12.0 / 60.0, altitudeDeg: 2.0, isTracking: true, alreadyActed: false,
             Enabled(meridianResponse: MountLimitResponse.Park,
                     horizonResponse: MountLimitResponse.Park));
 
@@ -288,7 +300,7 @@ public class MountLimitsTests
 
     [Fact]
     public void WhenOnlyTheHorizonIsDueTheHorizonWins()
-        => MountLimits.Evaluate(0.2, altitudeDeg: 2.0, isTracking: true, alreadyActed: false, Enabled())
+        => MountLimits.Evaluate(DescendingClearOfMeridian, altitudeDeg: 2.0, isTracking: true, alreadyActed: false, Enabled())
             .Kind.ShouldBe(MountLimitKind.Horizon);
 
     #endregion
@@ -301,12 +313,12 @@ public class MountLimitsTests
     [InlineData(-100.0)]
     public void ANonPositiveExtraStillLeavesActionAtOrAfterWarn(double extra)
     {
-        var config = Enabled(meridianWarnDeg: 5.0, meridianActionExtraDeg: extra,
+        var config = Enabled(meridianWarnMinutes: 5.0, meridianActionExtraMinutes: extra,
             horizonActionDeg: 10.0, horizonWarnExtraDeg: extra);
 
         // Warn-before-action is what the "extra" shape exists to guarantee; a second absolute
         // threshold could be edited into the wrong order and silently act before warning.
-        config.MeridianActionDeg.ShouldBeGreaterThanOrEqualTo(config.MeridianWarnDeg);
+        config.MeridianActionMinutes.ShouldBeGreaterThanOrEqualTo(config.MeridianWarnMinutes);
         config.HorizonWarnDeg.ShouldBeGreaterThanOrEqualTo(config.HorizonActionDeg);
     }
 
@@ -315,8 +327,8 @@ public class MountLimitsTests
     {
         // A user who wants no grace period gets none, rather than an unreachable action threshold.
         var verdict = MountLimits.Evaluate(
-            hourAngleHours: 5.0 / 15.0, altitudeDeg: 60.0, isTracking: true, alreadyActed: false,
-            Enabled(meridianWarnDeg: 5.0, meridianActionExtraDeg: 0.0));
+            hourAngleHours: 5.0 / 60.0, altitudeDeg: 60.0, isTracking: true, alreadyActed: false,
+            Enabled(meridianWarnMinutes: 5.0, meridianActionExtraMinutes: 0.0));
 
         verdict.Kind.ShouldBe(MountLimitKind.Meridian);
         verdict.IsWarningOnly.ShouldBeFalse();

--- a/src/TianWen.Lib.Tests/SessionMountLimitTests.cs
+++ b/src/TianWen.Lib.Tests/SessionMountLimitTests.cs
@@ -24,11 +24,11 @@ namespace TianWen.Lib.Tests;
 [Collection("Session")]
 public class SessionMountLimitTests(ITestOutputHelper output)
 {
-    /// <summary>Warn at 5 deg of hour angle, act at 10 by stopping tracking.</summary>
+    /// <summary>Warn at 5 min past the meridian, act at 10 by stopping tracking.</summary>
     private static MountLimitConfiguration StopTrackingPastTheMeridian => new MountLimitConfiguration(
         Enabled: true,
-        MeridianWarnDeg: 5.0,
-        MeridianActionExtraDeg: 5.0,
+        MeridianWarnMinutes: 5.0,
+        MeridianActionExtraMinutes: 5.0,
         MeridianResponse: MountLimitResponse.StopTracking);
 
     private static async Task<SessionTestContext> TrackingRigAsync(
@@ -52,8 +52,8 @@ public class SessionMountLimitTests(ITestOutputHelper output)
     public async Task AMountWithinItsLimitsIsLeftAlone()
     {
         var ct = TestContext.Current.CancellationToken;
-        // 1 deg east of the meridian: approaching, but not even at the warn threshold.
-        var ctx = await TrackingRigAsync(output, StopTrackingPastTheMeridian, -1.0 / 15.0, ct);
+        // 1 min east of the meridian: approaching, but not even at the warn threshold.
+        var ctx = await TrackingRigAsync(output, StopTrackingPastTheMeridian, -1.0 / 60.0, ct);
 
         await ctx.Session.PollDeviceStatesAsync(ct);
 
@@ -65,8 +65,8 @@ public class SessionMountLimitTests(ITestOutputHelper output)
     public async Task PastTheWarnThresholdItWarnsAndDoesNotTouchTheMount()
     {
         var ct = TestContext.Current.CancellationToken;
-        // 7 deg past the meridian: over the 5 deg warn threshold, under the 10 deg action one.
-        var ctx = await TrackingRigAsync(output, StopTrackingPastTheMeridian, 7.0 / 15.0, ct);
+        // 7 min past the meridian: over the 5 min warn threshold, under the 10 min action one.
+        var ctx = await TrackingRigAsync(output, StopTrackingPastTheMeridian, 7.0 / 60.0, ct);
 
         await ctx.Session.PollDeviceStatesAsync(ct);
 
@@ -83,7 +83,7 @@ public class SessionMountLimitTests(ITestOutputHelper output)
     public async Task PastTheActionThresholdTheMountIsStopped()
     {
         var ct = TestContext.Current.CancellationToken;
-        // 15 deg past the meridian, comfortably beyond the 10 deg action threshold.
+        // 15 min past the meridian, comfortably beyond the 10 min action threshold.
         var ctx = await TrackingRigAsync(output, StopTrackingPastTheMeridian, 1.0, ct);
 
         await ctx.Session.PollDeviceStatesAsync(ct);

--- a/src/TianWen.Lib.Tests/SessionMountLimitTests.cs
+++ b/src/TianWen.Lib.Tests/SessionMountLimitTests.cs
@@ -1,0 +1,147 @@
+using Shouldly;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using TianWen.Lib.Sequencing;
+using Xunit;
+
+namespace TianWen.Lib.Tests;
+
+/// <summary>
+/// Pins that a configured mechanical limit actually stops the mount, which is what turns
+/// <see cref="MountLimits"/> from a tested pure function into a protected rig.
+/// </summary>
+/// <remarks>
+/// <para>Enforcement lives on <c>PollDeviceStatesAsync</c>, not on the imaging tick, because the
+/// poll is what every slew wait and focus routine already calls. A limit that fired only between
+/// exposures would watch a mount drive into a pier during a goto and say nothing, so these tests
+/// drive the poll directly rather than a whole run.</para>
+///
+/// <para><b>Tracking is switched on explicitly in every case.</b> A freshly built test session has
+/// not initialised a mount, so tracking starts OFF -- asserting "still tracking" without turning it
+/// on first passes for the wrong reason and would keep passing with enforcement deleted.</para>
+/// </remarks>
+[Collection("Session")]
+public class SessionMountLimitTests(ITestOutputHelper output)
+{
+    /// <summary>Warn at 5 deg of hour angle, act at 10 by stopping tracking.</summary>
+    private static MountLimitConfiguration StopTrackingPastTheMeridian => new MountLimitConfiguration(
+        Enabled: true,
+        MeridianWarnDeg: 5.0,
+        MeridianActionExtraDeg: 5.0,
+        MeridianResponse: MountLimitResponse.StopTracking);
+
+    private static async Task<SessionTestContext> TrackingRigAsync(
+        ITestOutputHelper output, MountLimitConfiguration? limits, double hourAngleHours, CancellationToken ct)
+    {
+        var ctx = await SessionTestHelper.CreateSessionAsync(output, mountLimits: limits, cancellationToken: ct);
+
+        // SYNC rather than slew. A slew only BEGINS here, and the fake advances with the fake clock
+        // which this test never pumps -- so a slewed mount stays exactly where it was and every
+        // assertion below would pass for the wrong reason. Sync places it instantly.
+        var lst = await ctx.Mount.GetSiderealTimeAsync(ct);
+        var ra = ((lst - hourAngleHours) % 24.0 + 24.0) % 24.0;
+        await ctx.Mount.SyncRaDecAsync(ra, 45.0, ct);
+        await ctx.Mount.SetTrackingAsync(true, ct);
+
+        (await ctx.Mount.GetHourAngleAsync(ct)).ShouldBe(hourAngleHours, tolerance: 1e-3);
+        return ctx;
+    }
+
+    [Fact]
+    public async Task AMountWithinItsLimitsIsLeftAlone()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        // 1 deg east of the meridian: approaching, but not even at the warn threshold.
+        var ctx = await TrackingRigAsync(output, StopTrackingPastTheMeridian, -1.0 / 15.0, ct);
+
+        await ctx.Session.PollDeviceStatesAsync(ct);
+
+        ctx.Session.MountLimitVerdict.IsBreached.ShouldBeFalse();
+        (await ctx.Mount.IsTrackingAsync(ct)).ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task PastTheWarnThresholdItWarnsAndDoesNotTouchTheMount()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        // 7 deg past the meridian: over the 5 deg warn threshold, under the 10 deg action one.
+        var ctx = await TrackingRigAsync(output, StopTrackingPastTheMeridian, 7.0 / 15.0, ct);
+
+        await ctx.Session.PollDeviceStatesAsync(ct);
+
+        var verdict = ctx.Session.MountLimitVerdict;
+        verdict.IsBreached.ShouldBeTrue();
+        verdict.IsWarningOnly.ShouldBeTrue();
+        verdict.Kind.ShouldBe(MountLimitKind.Meridian);
+
+        // A warning is a warning: the mount keeps imaging.
+        (await ctx.Mount.IsTrackingAsync(ct)).ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task PastTheActionThresholdTheMountIsStopped()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        // 15 deg past the meridian, comfortably beyond the 10 deg action threshold.
+        var ctx = await TrackingRigAsync(output, StopTrackingPastTheMeridian, 1.0, ct);
+
+        await ctx.Session.PollDeviceStatesAsync(ct);
+
+        var verdict = ctx.Session.MountLimitVerdict;
+        verdict.IsBreached.ShouldBeTrue();
+        verdict.IsWarningOnly.ShouldBeFalse();
+        verdict.Kind.ShouldBe(MountLimitKind.Meridian);
+
+        (await ctx.Mount.IsTrackingAsync(ct)).ShouldBeFalse("the limit must actually stop the mount");
+    }
+
+    [Fact]
+    public async Task TheActionFiresOnceAndThenDowngradesToAWarning()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var ctx = await TrackingRigAsync(output, StopTrackingPastTheMeridian, 1.0, ct);
+
+        await ctx.Session.PollDeviceStatesAsync(ct);
+        ctx.Session.MountLimitVerdict.IsWarningOnly.ShouldBeFalse();
+
+        // The mount is still past the limit, and the poll runs continuously. Without the latch the
+        // action re-fires every tick -- which for a Park response re-commands the park slew forever
+        // so it never arrives (GSS's SlewState != SlewType.SlewPark guard). It must DOWNGRADE to a
+        // warning rather than clear, so the user goes on being told they are still in the limit.
+        await ctx.Session.PollDeviceStatesAsync(ct);
+
+        var second = ctx.Session.MountLimitVerdict;
+        second.IsBreached.ShouldBeTrue("still past the limit, so still reported");
+        second.Response.ShouldBe(MountLimitResponse.Warn, "the action is latched to fire once per entry");
+    }
+
+    [Fact]
+    public async Task LimitsThatAreNotConfiguredDoNothingAtAll()
+    {
+        var ct = TestContext.Current.CancellationToken;
+
+        // A profile that never configured limits deserialises to null. Well past where the limit
+        // above would have acted, and nothing happens -- opt-in is the point, because a limit
+        // firing on a rig nobody measured is worse than no limit.
+        var ctx = await TrackingRigAsync(output, null, 1.0, ct);
+
+        await ctx.Session.PollDeviceStatesAsync(ct);
+
+        ctx.Session.MountLimitVerdict.IsBreached.ShouldBeFalse();
+        (await ctx.Mount.IsTrackingAsync(ct)).ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task ADisabledConfigurationIsAlsoInert()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var ctx = await TrackingRigAsync(
+            output, StopTrackingPastTheMeridian with { Enabled = false }, 1.0, ct);
+
+        await ctx.Session.PollDeviceStatesAsync(ct);
+
+        ctx.Session.MountLimitVerdict.IsBreached.ShouldBeFalse();
+        (await ctx.Mount.IsTrackingAsync(ct)).ShouldBeTrue();
+    }
+}

--- a/src/TianWen.Lib.Tests/SessionTestHelper.cs
+++ b/src/TianWen.Lib.Tests/SessionTestHelper.cs
@@ -66,6 +66,7 @@ internal static class SessionTestHelper
         bool withManualCover = false,
         bool withFilterWheel = false,
         Func<IServiceProvider, Cover>? coverFactory = null,
+        MountLimitConfiguration? mountLimits = null,
         CancellationToken cancellationToken = default)
     {
         var timeProvider = new FakeTimeProviderWrapper(now ?? new DateTimeOffset(2025, 6, 15, 22, 0, 0, TimeSpan.Zero));
@@ -157,7 +158,7 @@ internal static class SessionTestHelper
         var weather = new Weather(weatherDevice, sp);
         await weather.Driver.ConnectAsync(cancellationToken);
 
-        var setup = new Setup(mount, guider, new GuiderSetup(guiderCam, FocalLength: 130), [ota], weather);
+        var setup = new Setup(mount, guider, new GuiderSetup(guiderCam, FocalLength: 130), [ota], weather, mountLimits);
         var plateSolver = new FakePlateSolver();
 
         var config = configuration ?? DefaultConfiguration;

--- a/src/TianWen.Lib.Tests/SiteContextAltitudeTests.cs
+++ b/src/TianWen.Lib.Tests/SiteContextAltitudeTests.cs
@@ -1,0 +1,83 @@
+using Shouldly;
+using System;
+using TianWen.Lib.Astrometry.SOFA;
+using Xunit;
+
+namespace TianWen.Lib.Tests;
+
+/// <summary>
+/// Pins <see cref="SiteContext.AltitudeDegrees"/>, the geometric altitude the mechanical horizon
+/// limit is evaluated against.
+/// </summary>
+/// <remarks>
+/// Geometric, not refracted, and that is the whole reason this exists rather than reusing a
+/// <c>Transform</c>: refraction lifts a body by up to ~34 arcmin at the horizon, so a refracted
+/// altitude reports the tube higher than it is and a limit keyed on it fires late -- in exactly the
+/// regime where late is the failure.
+/// </remarks>
+[Collection("Astrometry")]
+public class SiteContextAltitudeTests
+{
+    private const double Lat = 48.2;
+    private const double Lon = 16.3;
+
+    private static readonly DateTimeOffset Epoch = new(2026, 6, 15, 22, 0, 0, TimeSpan.Zero);
+
+    private static SiteContext At(double latitude) => SiteContext.Create(latitude, Lon, Epoch);
+
+    [Fact]
+    public void AtUpperTransitAltitudeIsNinetyMinusTheZenithDistance()
+    {
+        // HA = 0 puts the object on the meridian, where alt = 90 - |lat - dec|.
+        At(Lat).AltitudeDegrees(0.0, Lat).ShouldBe(90.0, tolerance: 1e-9);
+        At(Lat).AltitudeDegrees(0.0, Lat - 30.0).ShouldBe(60.0, tolerance: 1e-9);
+    }
+
+    [Fact]
+    public void AtLowerTransitTheObjectIsAsLowAsItGets()
+    {
+        // HA = 12h is lower transit: alt = |lat| + dec - 90 for a northern site.
+        At(Lat).AltitudeDegrees(12.0, Lat).ShouldBe(2.0 * Lat - 90.0, tolerance: 1e-9);
+    }
+
+    [Theory]
+    [InlineData(0.0)]
+    [InlineData(3.0)]
+    [InlineData(-3.0)]
+    [InlineData(11.5)]
+    public void TheCelestialPoleSitsAtTheSiteLatitudeWhateverTheHourAngle(double hourAngle)
+    {
+        // Dec = +90 is the pole, whose altitude equals the latitude and does not move. A good
+        // shape check: it exercises the cos(HA) term while the answer must stay constant.
+        At(Lat).AltitudeDegrees(hourAngle, 90.0).ShouldBe(Lat, tolerance: 1e-9);
+    }
+
+    [Fact]
+    public void TheSouthernHemisphereIsNotAMirrorOfTheNorthernOne()
+    {
+        // Same declination, opposite latitude: the pole altitude follows the site, so a southern
+        // site sees the NORTH pole below its horizon. Guards against a stray Math.Abs on latitude.
+        At(-37.5).AltitudeDegrees(0.0, 90.0).ShouldBe(-37.5, tolerance: 1e-9);
+    }
+
+    [Fact]
+    public void AnUnknownSiteOrPointingIsUnknownAndNotZero()
+    {
+        // "Unknown" must never read as "at the horizon" -- MountLimits treats NaN as not-evaluable
+        // precisely so a failed driver read cannot park the mount mid-target.
+        SiteContext.Create(double.NaN, Lon, Epoch).AltitudeDegrees(0.0, 45.0).ShouldBe(double.NaN);
+        At(Lat).AltitudeDegrees(double.NaN, 45.0).ShouldBe(double.NaN);
+        At(Lat).AltitudeDegrees(0.0, double.NaN).ShouldBe(double.NaN);
+    }
+
+    [Fact]
+    public void TheResultStaysInRangeAtTheClampBoundary()
+    {
+        // sin(alt) can exceed 1 by a rounding crumb when the object is exactly overhead; without
+        // the clamp Math.Asin returns NaN, which the limit would then read as "not evaluable" and
+        // silently disable itself at the one pointing it is most sure about.
+        var alt = At(90.0).AltitudeDegrees(0.0, 90.0);
+        double.IsNaN(alt).ShouldBeFalse();
+        alt.ShouldBe(90.0, tolerance: 1e-9);
+    }
+}

--- a/src/TianWen.Lib/Astrometry/Comets/CometObservability.cs
+++ b/src/TianWen.Lib/Astrometry/Comets/CometObservability.cs
@@ -175,11 +175,8 @@ public static class CometObservability
 
     private static double AltitudeDeg(double raHours, double decDeg, double lat, double lon, DateTimeOffset utc)
     {
-        var lst = SiteContext.ComputeLST(utc.ToUniversalTime(), lon);
-        var ha = (lst - raHours) * Math.PI / 12.0;
-        var (sinDec, cosDec) = Math.SinCos(decDeg * Math.PI / 180.0);
-        var (sinLat, cosLat) = Math.SinCos(lat * Math.PI / 180.0);
-        var sinAlt = sinLat * sinDec + cosLat * cosDec * Math.Cos(ha);
-        return Math.Asin(Math.Clamp(sinAlt, -1.0, 1.0)) * 180.0 / Math.PI;
+        // Was a hand-rolled copy of SiteContext's geometry that already borrowed its LST.
+        var site = SiteContext.Create(lat, lon, utc.ToUniversalTime());
+        return site.AltitudeDegrees(site.LST - raHours, decDeg);
     }
 }

--- a/src/TianWen.Lib/Astrometry/SOFA/SiteContext.cs
+++ b/src/TianWen.Lib/Astrometry/SOFA/SiteContext.cs
@@ -101,15 +101,53 @@ public readonly record struct SiteContext
     /// the mount has already accounted for.</para>
     /// </remarks>
     public double AltitudeDegrees(double hourAngleHours, double decDeg)
+        => IsValid ? AltitudeFrom(SinLat, CosLat, hourAngleHours, decDeg) : double.NaN;
+
+    /// <summary>
+    /// The same geometric altitude for a caller that holds a latitude but no site context -- a
+    /// guide-feature builder, say, which never needs LST.
+    /// </summary>
+    public static double AltitudeDegrees(double latitudeDeg, double hourAngleHours, double decDeg)
     {
-        if (!IsValid || double.IsNaN(hourAngleHours) || double.IsNaN(decDeg))
+        if (double.IsNaN(latitudeDeg))
+        {
+            return double.NaN;
+        }
+
+        var (sinLat, cosLat) = Math.SinCos(latitudeDeg * Math.PI / 180.0);
+        return AltitudeFrom(sinLat, cosLat, hourAngleHours, decDeg);
+    }
+
+    /// <summary>
+    /// <b>The one implementation of geometric altitude.</b> Everything above funnels here.
+    /// </summary>
+    /// <remarks>
+    /// This existed three times before it existed once: <c>CometObservability.AltitudeDeg</c>
+    /// (which already borrowed <see cref="ComputeLST"/> and then hand-rolled the rest), the inline
+    /// block in <c>NeuralGuideFeatures</c> that this type's own remarks already named as a
+    /// candidate, and a fourth copy added with the mount safety limits. They were identical down to
+    /// the <see cref="Math.Clamp(double, double, double)"/>.
+    /// <para>
+    /// <see cref="IsAboveHorizon"/> is deliberately NOT routed through this: it answers a cheaper
+    /// question (sign only) and skipping the <see cref="Math.Asin(double)"/> matters on the sky
+    /// map's per-star path. <c>SOFAHelpers.AltitudeFromAstrom</c> and
+    /// <see cref="Transform.ElevationTopocentric"/> are not duplicates either -- they are the SOFA
+    /// apparent place and the REFRACTED altitude, which is what the planner and a human eye want
+    /// and what a mechanical limit must not use. Nor is <c>VSOP87a</c>'s: it converts equatorial to
+    /// horizontal wholesale, in radians, off SOFA's <c>Gmst06</c> rather than this type's IAU-1982
+    /// approximation, and its altitude feeds its azimuth formula directly. Leave it alone.
+    /// </para>
+    /// </remarks>
+    private static double AltitudeFrom(double sinLat, double cosLat, double hourAngleHours, double decDeg)
+    {
+        if (double.IsNaN(hourAngleHours) || double.IsNaN(decDeg))
         {
             return double.NaN;
         }
 
         var ha = hourAngleHours * Math.PI / 12.0;
         var (sinDec, cosDec) = Math.SinCos(decDeg * Math.PI / 180.0);
-        var sinAlt = SinLat * sinDec + CosLat * cosDec * Math.Cos(ha);
+        var sinAlt = sinLat * sinDec + cosLat * cosDec * Math.Cos(ha);
         return Math.Asin(Math.Clamp(sinAlt, -1.0, 1.0)) * 180.0 / Math.PI;
     }
 

--- a/src/TianWen.Lib/Astrometry/SOFA/SiteContext.cs
+++ b/src/TianWen.Lib/Astrometry/SOFA/SiteContext.cs
@@ -86,6 +86,34 @@ public readonly record struct SiteContext
     }
 
     /// <summary>
+    /// Geometric altitude in degrees for an hour angle (HOURS) and declination (degrees), or
+    /// <see cref="double.NaN"/> when the site is unknown or either input is NaN.
+    /// </summary>
+    /// <remarks>
+    /// <para><b>Geometric, deliberately: no refraction.</b> This exists for the mechanical horizon
+    /// limit, and a tripod leg is not lifted by the atmosphere. Refraction raises a body by up to
+    /// ~34 arcmin at the horizon, so a refracted altitude would report the tube higher than it is
+    /// and the limit would fire late -- in the one regime where being late is the whole problem.
+    /// Use <see cref="Transform"/> when you want what the eye would see.</para>
+    ///
+    /// <para>Takes an hour angle rather than an RA because the caller that needs this reads HA
+    /// straight off the mount, and going RA -> HA via <see cref="LST"/> would re-introduce a clock
+    /// the mount has already accounted for.</para>
+    /// </remarks>
+    public double AltitudeDegrees(double hourAngleHours, double decDeg)
+    {
+        if (!IsValid || double.IsNaN(hourAngleHours) || double.IsNaN(decDeg))
+        {
+            return double.NaN;
+        }
+
+        var ha = hourAngleHours * Math.PI / 12.0;
+        var (sinDec, cosDec) = Math.SinCos(decDeg * Math.PI / 180.0);
+        var sinAlt = SinLat * sinDec + CosLat * cosDec * Math.Cos(ha);
+        return Math.Asin(Math.Clamp(sinAlt, -1.0, 1.0)) * 180.0 / Math.PI;
+    }
+
+    /// <summary>
     /// Returns the Dec at which altitude = 0 for the given RA.
     /// dec_horizon = atan(-cos(HA) / tan(lat))
     /// </summary>

--- a/src/TianWen.Lib/Devices/Guider/NeuralGuideFeatures.cs
+++ b/src/TianWen.Lib/Devices/Guider/NeuralGuideFeatures.cs
@@ -1,3 +1,4 @@
+using TianWen.Lib.Astrometry.SOFA;
 using System;
 
 namespace TianWen.Lib.Devices.Guider;
@@ -16,8 +17,7 @@ internal sealed class NeuralGuideFeatures
     private const int MediumMeanSize = 60;  // ~2 min at 2s exposure
     private const int LongMeanSize = 300;   // ~10 min at 2s exposure (~1 PE cycle)
 
-    private readonly double _sinLat;
-    private readonly double _cosLat;
+    private readonly double _siteLatitude;
 
     // 4-frame ring buffer for (raErr, decErr)
     private readonly double[] _histRa = new double[HistorySize];
@@ -69,9 +69,7 @@ internal sealed class NeuralGuideFeatures
     /// <param name="siteLatitude">Observer latitude in degrees.</param>
     public NeuralGuideFeatures(double siteLatitude = 0)
     {
-        var latRad = siteLatitude * Math.PI / 180.0;
-        _sinLat = Math.Sin(latRad);
-        _cosLat = Math.Cos(latRad);
+        _siteLatitude = siteLatitude;
     }
 
     /// <summary>
@@ -178,10 +176,7 @@ internal sealed class NeuralGuideFeatures
         features[18] = (float)(hourAngle / 12.0);
 
         // [19] Altitude / 90 (normalized to [0, 1])
-        var decRad = declination * Math.PI / 180.0;
-        var haRad = hourAngle * 15.0 * Math.PI / 180.0;
-        var sinAlt = _sinLat * Math.Sin(decRad) + _cosLat * Math.Cos(decRad) * Math.Cos(haRad);
-        var altDeg = Math.Asin(Math.Clamp(sinAlt, -1.0, 1.0)) * 180.0 / Math.PI;
+        var altDeg = SiteContext.AltitudeDegrees(_siteLatitude, hourAngle, declination);
         features[19] = (float)(altDeg / 90.0);
 
         // [20] Declination / 90 (normalized to [-1, 1])

--- a/src/TianWen.Lib/Devices/ProfileDto.cs
+++ b/src/TianWen.Lib/Devices/ProfileDto.cs
@@ -29,7 +29,24 @@ public readonly record struct ProfileData(
     double? SiteLatitude = null,
     double? SiteLongitude = null,
     double? SiteElevation = null,
-    SiteTieBreaker SiteTieBreaker = SiteTieBreaker.Mount
+    SiteTieBreaker SiteTieBreaker = SiteTieBreaker.Mount,
+
+    /// <summary>
+    /// Mechanical safety limits for this rig, or null for the shipped defaults (disabled).
+    /// </summary>
+    /// <remarks>
+    /// <para><b>On the PROFILE, not <c>SessionConfiguration</c>, and the distinction is not
+    /// bookkeeping.</b> Where the tube meets the pier is a static fact about a pier, a tube and a
+    /// counterweight shaft -- exactly like <see cref="OTAData"/> -- so it does not vary run to run,
+    /// and it has to apply to a manual slew with no session in sight. A per-run home would give the
+    /// right answer for the imaging loop and no answer at all for the case where somebody drives
+    /// the mount by hand at 2am.</para>
+    ///
+    /// <para>Null rather than a default instance so an older profile deserialises unchanged and
+    /// reads as "never configured", which the shipped defaults answer as disabled. Opt-in is the
+    /// point: a limit that fires on a rig nobody measured is worse than no limit.</para>
+    /// </remarks>
+    Sequencing.MountLimitConfiguration? MountLimits = null
 )
 {
     public static readonly ProfileData Empty = new ProfileData(NoneDevice.Instance.DeviceUri, NoneDevice.Instance.DeviceUri, []);

--- a/src/TianWen.Lib/Devices/ProfileDto.cs
+++ b/src/TianWen.Lib/Devices/ProfileDto.cs
@@ -36,11 +36,20 @@ public readonly record struct ProfileData(
     /// </summary>
     /// <remarks>
     /// <para><b>On the PROFILE, not <c>SessionConfiguration</c>, and the distinction is not
-    /// bookkeeping.</b> Where the tube meets the pier is a static fact about a pier, a tube and a
-    /// counterweight shaft -- exactly like <see cref="OTAData"/> -- so it does not vary run to run,
-    /// and it has to apply to a manual slew with no session in sight. A per-run home would give the
-    /// right answer for the imaging loop and no answer at all for the case where somebody drives
-    /// the mount by hand at 2am.</para>
+    /// bookkeeping.</b> Where the tube meets the pier is a static fact about this rig -- the mount's
+    /// geometry AND the tube bolted to it -- exactly like <see cref="OTAData"/>, so it does not vary
+    /// run to run, and it has to apply to a manual slew with no session in sight. A per-run home
+    /// would give the right answer for the imaging loop and no answer at all for the case where
+    /// somebody drives the mount by hand at 2am.</para>
+    ///
+    /// <para><b>It is the TUBE that collides, not the counterweight.</b> Tracking past the meridian
+    /// on a GEM swings the counterweight UP, above the OTA, and the tube DOWN toward the pier and
+    /// tripod -- so the margin is set by the optics, not the ballast: a long refractor or Newtonian
+    /// runs out of room far sooner than a short lens. It also varies with DECLINATION, since a tube
+    /// near the pole lies along the RA axis and barely sweeps while one near the equator sweeps the
+    /// widest arc. A single hour-angle threshold is therefore a conservative APPROXIMATION of a
+    /// three-variable envelope, and must be set for the worst case the rig actually images -- the
+    /// lowest declination, with the longest tube and whatever hangs off the back of it.</para>
     ///
     /// <para>Null rather than a default instance so an older profile deserialises unchanged and
     /// reads as "never configured", which the shipped defaults answer as disabled. Opt-in is the

--- a/src/TianWen.Lib/Sequencing/ImagingLoopResult.cs
+++ b/src/TianWen.Lib/Sequencing/ImagingLoopResult.cs
@@ -13,7 +13,19 @@ enum ImageLoopNextAction
     /// (cameras warm up, guider disconnects): this is the "dead mount doesn't
     /// pretend to be alive" exit path, distinct from per-target Advance.
     /// </summary>
-    DeviceUnrecoverable
+    DeviceUnrecoverable,
+
+    /// <summary>
+    /// The mount entered a configured mechanical limit and was stopped or parked. The session
+    /// finalises cleanly, exactly like <see cref="DeviceUnrecoverable"/>.
+    /// </summary>
+    /// <remarks>
+    /// Distinct from <see cref="DeviceUnrecoverable"/> because nothing is broken: the rig did what
+    /// it was told and reached the edge of where it may point. Collapsing the two would report a
+    /// working mount as a faulty one, and would make a limit look like a reason to go and check
+    /// cables at 3am.
+    /// </remarks>
+    LimitReached
 }
 
 internal readonly record struct MeridianFlipResult(bool Success, double HourAngle, PointingState PierSide)

--- a/src/TianWen.Lib/Sequencing/MeridianFlipDecision.cs
+++ b/src/TianWen.Lib/Sequencing/MeridianFlipDecision.cs
@@ -53,9 +53,15 @@ public static class MeridianFlipDecision
     /// the rig is past the mechanical risk but not yet at the earliest sanctioned flip; keep waiting,
     /// don't start new exposures.
     /// </remarks>
-    public static HourAngleZone ClassifyHourAngle(double hourAngleHours, SessionConfiguration config)
+    public static HourAngleZone ClassifyHourAngle(
+        double hourAngleHours, SessionConfiguration config, MountLimitConfiguration? limits = null)
     {
         var haMinutes = hourAngleHours * 60.0;
+        // The mechanical limit caps the flip window; see MountLimitConfiguration.ClampFlipLatestMinutes
+        // for why the dependency runs this way and not the other. Taken HERE, inside the decision, so
+        // no caller can classify against an unclamped window by forgetting to ask.
+        var latestAfter = limits?.ClampFlipLatestMinutes(config.MeridianFlipLatestMinutesAfter)
+            ?? config.MeridianFlipLatestMinutesAfter;
 
         if (haMinutes <= -config.MeridianFlipObstructionZoneMinutesBefore)
         {
@@ -67,7 +73,7 @@ public static class MeridianFlipDecision
             return HourAngleZone.InObstructionZone;
         }
 
-        if (haMinutes <= config.MeridianFlipLatestMinutesAfter)
+        if (haMinutes <= latestAfter)
         {
             return HourAngleZone.InFlipWindow;
         }
@@ -125,7 +131,8 @@ public static class MeridianFlipDecision
         bool pierSideChanged,
         bool alreadyOnCorrectSide,
         bool hasFlipped,
-        SessionConfiguration config)
+        SessionConfiguration config,
+        MountLimitConfiguration? limits = null)
     {
         if (hasFlipped)
         {
@@ -142,7 +149,7 @@ public static class MeridianFlipDecision
             return FlipAction.AlreadyFlipped;
         }
 
-        var zone = ClassifyHourAngle(hourAngleHours, config);
+        var zone = ClassifyHourAngle(hourAngleHours, config, limits);
         return zone switch
         {
             HourAngleZone.EastOfMeridian => FlipAction.Continue,

--- a/src/TianWen.Lib/Sequencing/MountLimits.cs
+++ b/src/TianWen.Lib/Sequencing/MountLimits.cs
@@ -50,15 +50,23 @@ public enum MountLimitResponse
 /// </summary>
 /// <param name="Kind">Which limit, or <see cref="MountLimitKind.None"/>.</param>
 /// <param name="Response">What to do. Meaningless when <paramref name="Kind"/> is None.</param>
-/// <param name="ExceededByDeg">
-/// Degrees past the ACTION threshold, or -- while only the warning threshold has been crossed -- a
-/// negative number giving the degrees still remaining before action. So the sign is the answer to
-/// "has it acted yet", and the magnitude is always "how far from the action point".
+/// <param name="ExceededBy">
+/// How far past the ACTION threshold, or -- while only the warning threshold has been crossed -- a
+/// negative number giving how far is still left before action. So the sign is the answer to "has it
+/// acted yet", and the magnitude is always "how far from the action point".
+/// <para>
+/// <b>The UNIT depends on <paramref name="Kind"/>:</b> minutes of hour angle for
+/// <see cref="MountLimitKind.Meridian"/>, degrees of altitude for
+/// <see cref="MountLimitKind.Horizon"/>. Mixed units in one field look like a smell and are the
+/// lesser evil: the alternative is two fields of which one is always meaningless, and every
+/// consumer already switches on <paramref name="Kind"/> to say anything useful anyway.
+/// <see cref="MountLimitVerdict.Describe"/> renders the right unit; do not format this raw.
+/// </para>
 /// </param>
 public readonly record struct MountLimitVerdict(
     MountLimitKind Kind,
     MountLimitResponse Response,
-    double ExceededByDeg)
+    double ExceededBy)
 {
     /// <summary>Nothing is wrong.</summary>
     public static MountLimitVerdict Clear { get; } =
@@ -71,7 +79,7 @@ public readonly record struct MountLimitVerdict(
     /// True when the mount is between the warning and action thresholds: the user should be told,
     /// but nothing is taken away from them yet.
     /// </summary>
-    public bool IsWarningOnly => IsBreached && ExceededByDeg < 0.0;
+    public bool IsWarningOnly => IsBreached && ExceededBy < 0.0;
 
     /// <summary>
     /// One user-facing sentence, in the same spirit as <c>DeviceOwnershipGate.Describe()</c>: say
@@ -81,13 +89,13 @@ public readonly record struct MountLimitVerdict(
     {
         MountLimitKind.None => "Within all configured mount limits.",
         MountLimitKind.Meridian when IsWarningOnly =>
-            $"Approaching the meridian limit: {-ExceededByDeg:F1} deg of hour angle before the mount will {ResponsePhrase()}.",
+            $"Approaching the meridian limit: {-ExceededBy:F0} min of tracking before the mount will {ResponsePhrase()}.",
         MountLimitKind.Meridian =>
-            $"Meridian limit reached: the mount has tracked {ExceededByDeg:F1} deg of hour angle past the limit. Will {ResponsePhrase()}.",
+            $"Meridian limit reached: the mount has tracked {ExceededBy:F0} min past the limit. Will {ResponsePhrase()}.",
         MountLimitKind.Horizon when IsWarningOnly =>
-            $"Approaching the horizon limit: {-ExceededByDeg:F1} deg of altitude before the mount will {ResponsePhrase()}.",
+            $"Approaching the horizon limit: {-ExceededBy:F1} deg of altitude before the mount will {ResponsePhrase()}.",
         MountLimitKind.Horizon =>
-            $"Horizon limit reached: the pointing is {ExceededByDeg:F1} deg below the limit. Will {ResponsePhrase()}.",
+            $"Horizon limit reached: the pointing is {ExceededBy:F1} deg below the limit. Will {ResponsePhrase()}.",
         _ => throw new ArgumentOutOfRangeException(nameof(Kind), Kind, "unknown limit kind"),
     };
 
@@ -106,13 +114,20 @@ public readonly record struct MountLimitVerdict(
 /// session, and a rig with clear sky in every direction genuinely has none.
 /// </summary>
 /// <param name="Enabled">Master switch, mirroring GSServer's <c>LimitsOn</c>.</param>
-/// <param name="MeridianWarnDeg">
-/// Hour angle past the meridian, in degrees, at which to start warning. 15 deg = 1 h.
+/// <param name="MeridianWarnMinutes">
+/// Minutes of tracking PAST the meridian at which to start warning.
+/// <para>
+/// <b>Minutes, matching <see cref="SessionConfiguration.MeridianFlipLatestMinutesAfter"/>.</b> These
+/// two settings bound the same axis and the user reads them together, so they must be directly
+/// comparable; this was degrees once and the pair silently invited "5 and 10 mean the same thing in
+/// both", which they did not (5 deg is 20 min). 1 min of hour angle = 0.25 deg.
+/// </para>
 /// </param>
-/// <param name="MeridianActionExtraDeg">
-/// FURTHER degrees past <paramref name="MeridianWarnDeg"/> before <paramref name="MeridianResponse"/>
-/// is carried out. Expressed as an extra rather than as a second absolute threshold so that
-/// <c>action &gt;= warn</c> holds by construction and cannot be inverted by editing one field.
+/// <param name="MeridianActionExtraMinutes">
+/// FURTHER minutes past <paramref name="MeridianWarnMinutes"/> before
+/// <paramref name="MeridianResponse"/> is carried out. Expressed as an extra rather than as a second
+/// absolute threshold so that <c>action &gt;= warn</c> holds by construction and cannot be inverted
+/// by editing one field.
 /// </param>
 /// <param name="MeridianResponse">What to do once the action threshold is passed.</param>
 /// <param name="HorizonActionDeg">
@@ -136,18 +151,53 @@ public readonly record struct MountLimitVerdict(
 /// </remarks>
 public sealed record MountLimitConfiguration(
     bool Enabled = false,
-    double MeridianWarnDeg = 5.0,
-    double MeridianActionExtraDeg = 5.0,
+    double MeridianWarnMinutes = 20.0,
+    double MeridianActionExtraMinutes = 20.0,
     MountLimitResponse MeridianResponse = MountLimitResponse.StopTracking,
     double HorizonActionDeg = 10.0,
     double HorizonWarnExtraDeg = 5.0,
     MountLimitResponse HorizonResponse = MountLimitResponse.StopTracking)
 {
-    /// <summary>The absolute hour-angle (degrees) at which <see cref="MeridianResponse"/> happens.</summary>
-    public double MeridianActionDeg => MeridianWarnDeg + Math.Max(0.0, MeridianActionExtraDeg);
+    /// <summary>The absolute hour angle, in minutes past the meridian, at which
+    /// <see cref="MeridianResponse"/> happens.</summary>
+    public double MeridianActionMinutes => MeridianWarnMinutes + Math.Max(0.0, MeridianActionExtraMinutes);
 
     /// <summary>The absolute altitude (degrees) at which warning starts.</summary>
     public double HorizonWarnDeg => HorizonActionDeg + Math.Max(0.0, HorizonWarnExtraDeg);
+
+    /// <summary>
+    /// The latest a meridian flip may be scheduled on this rig: the configured
+    /// <paramref name="requestedLatestMinutesAfter"/>, or the limit's action threshold less
+    /// <see cref="FlipClearanceMinutes"/> if that is sooner. Unconstrained when limits are off.
+    /// </summary>
+    /// <remarks>
+    /// <para><b>The limit is the ultimate clamp: the safety bound caps the preference, never the
+    /// other way round.</b> How long to keep imaging before flipping is a want; where the tube meets
+    /// the pier is a fact. The tempting inverse -- deriving the limit as "flip deadline plus a
+    /// margin", which is the same threshold-plus-EXTRA trick this record uses for warn/act -- is
+    /// WRONG here: raise the flip deadline to an hour and the mechanical limit would silently follow
+    /// it into the pier.</para>
+    ///
+    /// <para>Without this the two settings simply race, and the limit wins: a flip deadline past the
+    /// action threshold means the mount is stopped at the very moment it was about to do the right
+    /// thing, ending the night instead of flipping.</para>
+    /// </remarks>
+    public double ClampFlipLatestMinutes(double requestedLatestMinutesAfter)
+        => Enabled
+            ? Math.Min(requestedLatestMinutesAfter, MeridianActionMinutes - FlipClearanceMinutes)
+            : requestedLatestMinutesAfter;
+
+    /// <summary>
+    /// Minutes of headroom left between the last sanctioned flip and the limit acting, so the flip
+    /// has somewhere to happen rather than being commanded into the stop.
+    /// </summary>
+    /// <remarks>
+    /// A flip is a slew plus a plate-solve recenter plus a guider restart, all of it while the mount
+    /// keeps tracking toward the limit. Five minutes is a deliberately modest allowance -- enough
+    /// that the flip is not commanded at the instant of the stop, not so much that it eats a
+    /// tightly-configured window.
+    /// </remarks>
+    public const double FlipClearanceMinutes = 5.0;
 }
 
 /// <summary>
@@ -255,8 +305,8 @@ public static class MountLimits
         }
 
         // West of the meridian only. East is approaching transit and getting safer by the minute.
-        var haDeg = hourAngleHours * Astrometry.Constants.HOURS2DEG;
-        if (haDeg < config.MeridianWarnDeg)
+        var haMinutes = hourAngleHours * 60.0;
+        if (haMinutes < config.MeridianWarnMinutes)
         {
             return MountLimitVerdict.Clear;
         }
@@ -264,7 +314,7 @@ public static class MountLimits
         return new MountLimitVerdict(
             MountLimitKind.Meridian,
             config.MeridianResponse,
-            haDeg - config.MeridianActionDeg);
+            haMinutes - config.MeridianActionMinutes);
     }
 
     private static MountLimitVerdict EvaluateHorizon(

--- a/src/TianWen.Lib/Sequencing/MountState.cs
+++ b/src/TianWen.Lib/Sequencing/MountState.cs
@@ -22,4 +22,11 @@ public readonly record struct MountState(
     bool IsSlewing,
     bool IsTracking,
     double RaJ2000 = double.NaN,
-    double DecJ2000 = double.NaN);
+    double DecJ2000 = double.NaN,
+
+    /// <summary>
+    /// GEOMETRIC altitude in degrees, derived from <see cref="HourAngle"/>, <see cref="Declination"/>
+    /// and the site latitude; NaN when the site or the pointing is unknown. Unrefracted on purpose --
+    /// it feeds the mechanical horizon limit, and a tripod leg is not lifted by the atmosphere.
+    /// </summary>
+    double Altitude = double.NaN);

--- a/src/TianWen.Lib/Sequencing/Session.Imaging.cs
+++ b/src/TianWen.Lib/Sequencing/Session.Imaging.cs
@@ -221,6 +221,15 @@ internal partial record Session
                     observation, await GetMountUtcNowAsync(cancellationToken) - imageLoopStart);
                 break;
             }
+            else if (imageLoopResult is ImageLoopNextAction.LimitReached)
+            {
+                // Not an error in the rig, so it does not advance to the next target either: every
+                // remaining target is reached from the same mount, and the mount is now stopped or
+                // parked at its limit.
+                _logger.LogError("Mount safety limit reached during {Observation} after {Runtime:c} ({Verdict}); ending observation loop cleanly.",
+                    observation, await GetMountUtcNowAsync(cancellationToken) - imageLoopStart, _limitVerdict.Describe());
+                break;
+            }
             else
             {
                 _logger.LogError("Imaging loop for {Observation} did not complete successfully, total runtime: {TotalRuntime:c}", observation, await GetMountUtcNowAsync(cancellationToken) - imageLoopStart);
@@ -581,6 +590,17 @@ internal partial record Session
             {
                 _logger.LogWarning("Cancellation requested, all images in queue written to disk, abort image acquisition and quit imaging loop");
                 next = ImageLoopNextAction.BreakObservationLoop;
+                break;
+            }
+
+            // A mechanical limit was hit and acted on by the poll. Nothing is broken -- the rig
+            // reached the edge of where it may point -- so drain writes and end the night the same
+            // way an unrecoverable driver does, but under its own name.
+            if (Volatile.Read(ref _limitReached))
+            {
+                _logger.LogError("Mount safety limit reached ({Verdict}); ending the observation.", _limitVerdict.Describe());
+                await WriteQueuedImagesToFitsFilesAsync();
+                next = ImageLoopNextAction.LimitReached;
                 break;
             }
 

--- a/src/TianWen.Lib/Sequencing/Session.Imaging.cs
+++ b/src/TianWen.Lib/Sequencing/Session.Imaging.cs
@@ -764,8 +764,12 @@ internal partial record Session
 
                     if (!double.IsNaN(currentHA))
                     {
+                        // Setup.MountLimits clamps the flip window: the rig's mechanical bound caps how
+                        // late a flip may be scheduled, so the limit can never stop the mount at the
+                        // moment it was about to flip.
                         flipAction = MeridianFlipDecision.DecideFlipAction(
-                            currentHA, pierSideChanged, alreadyOnCorrectSide, hasFlipped, Configuration);
+                            currentHA, pierSideChanged, alreadyOnCorrectSide, hasFlipped, Configuration,
+                            Setup.MountLimits);
 
                         // Published from the same HA reading the decision was taken on, so the countdown a
                         // dashboard shows and the flip the loop performs can never disagree. Null once we

--- a/src/TianWen.Lib/Sequencing/Session.cs
+++ b/src/TianWen.Lib/Sequencing/Session.cs
@@ -112,6 +112,19 @@ internal partial record Session(
 
     private long _meridianFlipUtcTicks;
 
+    // Mount safety limits. _limitActed is the once-per-entry latch (see EnforceMountLimitsAsync);
+    // _limitReached is the one-way flag the imaging loop reads to finish the run. Both are written
+    // by PollDeviceStatesAsync, which runs on slew waits and focus routines as well as the imaging
+    // tick, and read from the loop -- hence Volatile rather than plain fields.
+    private bool _limitActed;
+    private bool _limitReached;
+    private MountLimitVerdict _limitVerdict = MountLimitVerdict.Clear;
+
+    /// <summary>
+    /// The most recent mount-limit verdict, for telemetry and the notification feed.
+    /// </summary>
+    public MountLimitVerdict MountLimitVerdict => _limitVerdict;
+
     // Start "unknown" (all-NaN coords), not default(MountState) which would read as a real RA0/Dec0.
     // The first PollDeviceStatesAsync (RunAsync, right after InitialisationAsync) fills it in. UI
     // consumers treat NaN RA as "no pointing yet" and keep the last known value rather than snapping
@@ -425,15 +438,93 @@ internal partial record Session(
                 }
             }
 
+            var hourAngle = await PollDriverReadAsync(mount, mount.GetHourAngleAsync, _mountState.HourAngle, cancellationToken);
+            var isTracking = await PollDriverReadAsync(mount, mount.IsTrackingAsync, _mountState.IsTracking, cancellationToken);
+
             _mountState = new MountState(
                 RightAscension: ra,
                 Declination: dec,
-                HourAngle: await PollDriverReadAsync(mount, mount.GetHourAngleAsync, _mountState.HourAngle, cancellationToken),
+                HourAngle: hourAngle,
                 PierSide: await PollDriverReadAsync(mount, mount.GetSideOfPierAsync, _mountState.PierSide, cancellationToken),
                 IsSlewing: await PollDriverReadAsync(mount, mount.IsSlewingAsync, _mountState.IsSlewing, cancellationToken),
-                IsTracking: await PollDriverReadAsync(mount, mount.IsTrackingAsync, _mountState.IsTracking, cancellationToken),
+                IsTracking: isTracking,
                 RaJ2000: raJ2000,
-                DecJ2000: decJ2000);
+                DecJ2000: decJ2000,
+                Altitude: SiteContext.Create(Configuration.SiteLatitude, Configuration.SiteLongitude, _timeProvider)
+                    .AltitudeDegrees(hourAngle, dec));
+
+            await EnforceMountLimitsAsync(mount, cancellationToken);
+        }
+    }
+
+    /// <summary>
+    /// Evaluates this rig's configured mechanical limits against the state just polled, and acts on
+    /// the verdict at most once per entry into the limit.
+    /// </summary>
+    /// <remarks>
+    /// <para>Lives on the poll rather than the imaging tick because the poll is what every slew
+    /// wait and focus routine already calls -- a limit that only fired between exposures would
+    /// watch a mount drive into a pier during a goto and say nothing.</para>
+    ///
+    /// <para><b>The latch is the whole reason this is not just an <c>if</c>.</b> The poll runs
+    /// continuously, so acting per-poll would re-command a park every tick and restart the park slew
+    /// forever, never arriving -- GSS's <c>SlewState != SlewType.SlewPark</c> guard, ported as
+    /// <see cref="MountLimits"/>' <c>alreadyActed</c>. It downgrades to Warn rather than clearing,
+    /// so the user keeps being told they are still in the limit.</para>
+    ///
+    /// <para>Acting is deliberately best-effort and does NOT gate the run's exit: whether the stop
+    /// succeeded or not, the imaging loop is told to finish. A limit we could not act on is a
+    /// stronger reason to end the night, not a weaker one.</para>
+    /// </remarks>
+    private async ValueTask EnforceMountLimitsAsync(IMountDriver mount, CancellationToken cancellationToken)
+    {
+        if (Setup.MountLimits is not { Enabled: true } limits)
+        {
+            return;
+        }
+
+        var verdict = MountLimits.Evaluate(
+            _mountState.HourAngle, _mountState.Altitude, _mountState.IsTracking, _limitActed, limits);
+
+        if (!verdict.IsBreached)
+        {
+            if (Volatile.Read(ref _limitActed))
+            {
+                _logger.LogInformation("Mount is clear of its safety limits again.");
+                Volatile.Write(ref _limitActed, false);
+            }
+            _limitVerdict = verdict;
+            return;
+        }
+
+        _limitVerdict = verdict;
+
+        if (verdict.IsWarningOnly || verdict.Response is MountLimitResponse.Warn)
+        {
+            _logger.LogWarning("Mount safety limit: {Verdict}", verdict.Describe());
+            return;
+        }
+
+        _logger.LogError("Mount safety limit: {Verdict}. Responding with {Response}.", verdict.Describe(), verdict.Response);
+        Volatile.Write(ref _limitActed, true);
+        _limitReached = true;
+
+        // Stop tracking first in BOTH responses. A park is motion across a path nothing has checked,
+        // so the axis should not still be driving toward the limit while it is under way -- and if
+        // the park then fails, a stopped mount is a better place to have left the rig than a
+        // tracking one.
+        await ResilientInvokeAsync(
+            mount, ct => mount.SetTrackingAsync(false, ct),
+            ResilientCallOptions.NonIdempotentAction, cancellationToken);
+
+        if (verdict.Response is MountLimitResponse.Park && mount.CanPark)
+        {
+            await ResilientInvokeAsync(
+                mount, mount.ParkAsync, ResilientCallOptions.NonIdempotentAction, cancellationToken);
+        }
+        else if (verdict.Response is MountLimitResponse.Park)
+        {
+            _logger.LogWarning("Mount safety limit asked for a park, but this mount cannot park; tracking was stopped instead.");
         }
     }
 

--- a/src/TianWen.Lib/Sequencing/SessionFactory.cs
+++ b/src/TianWen.Lib/Sequencing/SessionFactory.cs
@@ -99,7 +99,7 @@ internal class SessionFactory(
 
         var weather = profileData.Weather is { } weatherUri ? new Weather(DeviceFromUri(weatherUri), serviceProvider) : null;
 
-        var setup = new Setup(mount, guider, guiderSetup, [.. otas], weather);
+        var setup = new Setup(mount, guider, guiderSetup, [.. otas], weather, profileData.MountLimits);
 
         // Diagnostic: did the session reuse already-connected hub driver instances, or create fresh
         // ones? A fresh instance re-runs DoConnectDeviceAsync at InitialisationAsync, which for the fake

--- a/src/TianWen.Lib/Sequencing/Setup.cs
+++ b/src/TianWen.Lib/Sequencing/Setup.cs
@@ -23,7 +23,19 @@ public record Setup(
     Guider Guider,
     GuiderSetup GuiderSetup,
     ImmutableArray<OTA> Telescopes,
-    Weather? Weather = null
+    Weather? Weather = null,
+
+    /// <summary>
+    /// This rig's mechanical limits, projected from the profile by <c>SessionFactory</c>. Null means
+    /// never configured, which <see cref="MountLimitConfiguration"/>'s defaults answer as disabled.
+    /// </summary>
+    /// <remarks>
+    /// The profile stays the source of truth (see <see cref="TianWen.Lib.Devices.ProfileData"/>);
+    /// this is the run's projection of it, which is why it rides on <see cref="Setup"/> -- the
+    /// record that already answers "what hardware am I driving" -- rather than on the per-run
+    /// <see cref="SessionConfiguration"/>.
+    /// </remarks>
+    MountLimitConfiguration? MountLimits = null
 ) : IAsyncDisposable
 {
     /// <summary>


### PR DESCRIPTION
Mount safety limits **P1 + P2**. P0 shipped a pure decider with 30 tests and **no caller** — it
existed and nothing asked it, so no mount was protected. This gives it a home and a caller.

Unit 5183 / functional 341, zero failures. Two sabotages, each caught by the expected tests.

## Placement

Config persists on `ProfileData.MountLimits` (nullable → never configured → disabled), and
`SessionFactory` projects it onto `Setup` — **not** the per-run `SessionConfiguration`. Where the
tube meets the pier is a static fact about a pier, a tube and a counterweight shaft, and it has to
hold for a manual slew with no session in sight.

⚠️ This changes the base64 `data=` segment of every profile URI. Expected, and `ProfileTests` pins
it — that test failing is the intended signal when `ProfileData` gains a property.

## Altitude is geometric, deliberately

`SiteContext.AltitudeDegrees(hourAngleHours, decDeg)` is new, sitting beside the `IsAboveHorizon`
that already cached `sinLat`/`cosLat` (the class's own remarks had flagged altitude as a missing
use). **Refraction lifts a body by up to ~34′ at the horizon**, so a refracted altitude reports the
tube higher than it is and a limit keyed on it fires late — in the one regime where late is the
whole failure. A tripod leg is not lifted by the atmosphere.

It takes an hour angle rather than an RA because the caller reads HA straight off the mount, and
going RA → HA via `LST` would re-introduce a clock the mount has already accounted for.

## Enforcement is on the poll, not the imaging tick

`PollDeviceStatesAsync` is what every slew wait and focus routine already calls. A limit evaluated
only between exposures would watch a mount drive into a pier during a goto and say nothing.

## Three smaller decisions

- **Acting does not gate the exit.** Whether the stop succeeded or not, the loop finishes — a limit
  we could not act on is a *stronger* reason to end the night.
- **`LimitReached` is not `DeviceUnrecoverable`.** Nothing is broken; the rig reached the edge of
  where it may point. Collapsing them reports a working mount as faulty and sends someone out to
  check cables at 3am.
- **Tracking stops for a `Park` response too, before the park slew** — a park is motion across a
  path nothing has checked, and the axis should not still be driving toward the limit while it runs.

## Two test lessons, both from getting it wrong first

- The mount is placed by **sync, not slew**: a slew only *begins*, and the fake advances with a fake
  clock these tests never pump, so a slewed mount stays put and every assertion passes for the wrong
  reason.
- **Tracking is switched on explicitly** — a fresh test session has never initialised a mount and
  starts with tracking OFF. The first version asserted "still tracking" against a mount that had
  never tracked, which passes with enforcement deleted.

## Still open

The editor UI (config persists and enforces, but only profile-JSON editing sets it), P3 (enforcement
with no session running — the half GSServer gets for free), P4 surfacing (`Session.MountLimitVerdict`
is exposed and nothing reads it), P1b axis modelling, P5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)