### PR TITLE
Plate-solve benchmark harness, and the frame's premise asserted

### DIFF
--- a/docs/plans/plate-solver-performance.md
+++ b/docs/plans/plate-solver-performance.md
@@ -102,13 +102,26 @@ orientation is discarded. A header hint carries no CD matrix (the probe prints `
 this pays off only where a caller feeds back a previous solve, which `IncrementalSolver` and the
 polar-align loop already do.
 
-**Cache it per CAMERA, never per rig or per OTA.** Parity is set by the number of reflections in
-that camera's own light path, and an off-axis guider inserts one: its pick-off prism is a single
-reflection before the imaging plane, so on a refractor + OAG the main camera is even-parity and the
-guide camera is ODD -- opposite parity, same rig, at the same time. This is not hypothetical here:
-the polar-align loop solves GUIDER frames while the session solves IMAGING frames, so one cached
-parity per rig would be actively wrong for one of them. Key it by camera device id, the way
-per-focuser backlash is keyed in `Profiles/BacklashHistory/`.
+**Key it by the LIGHT PATH: the (OTA, camera) pair. Never by rig, and neither half alone.** Parity
+is set by the number of reflections between sky and sensor, plus the sensor's own row-order
+convention -- and those two facts live on different objects, which is why neither is a sufficient key.
+
+- **Not per rig.** An off-axis guider's pick-off prism is a single reflection before the imaging
+  plane, so on a refractor + OAG the main camera is even-parity and the guide camera is ODD --
+  opposite parity, same rig, at the same time. Not hypothetical: the polar-align loop solves GUIDER
+  frames while the session solves IMAGING frames, so one parity per rig is actively wrong for one of
+  them.
+- **Not per OTA alone**, for the same reason -- that OAG guide camera is on the same OTA as the main
+  camera and must not share its answer.
+- **Not per camera alone.** The optical train is the OTA's, not the camera's: swapping a camera body
+  onto the same scope changes no reflection, while moving one camera from a refractor to an SCT with
+  a diagonal changes parity for that same camera. A camera-only key gets both of those backwards.
+
+So the key is the pair. The cost of getting it slightly wrong is deliberately low -- parity stays a
+HINT, so a miss costs one unnecessary both-parity solve and self-corrects -- but a key that is wrong
+by CONSTRUCTION would be wrong on a whole class of rigs forever, which is a different thing.
+
+Store it the way per-focuser backlash is stored in `Profiles/BacklashHistory/`, keyed on the pair.
 
 **Do not try to infer parity from the declared optical train.** Counting reflections is
 insufficient even in principle, because FITS ROW ORDER contributes: a `BOTTOM-UP` frame read as
@@ -239,9 +252,40 @@ Speed that costs accuracy is a regression, so every phase is measured against th
    27.75 px fit rather than emit a wrong WCS. Nothing here may loosen `GateTolerancePx` or the
    chance threshold to make a number look better.
 
-Add `PlateSolveBenchmarks` to `TianWen.UI.Benchmarks` so these figures stop being hand-timed wall
-clock. Everything above was measured by hand: fine for deciding what to do, not fine for detecting
-a regression.
+**`PlateSolveBenchmarks` SHIPPED** (2026-08-31), so these figures are no longer hand-timed. Frame:
+NGC 3576, SVBONY SV605CC / IMX533 3008x3008, SH61 EDPH 270 mm f/4.5, 60 s, N.I.N.A. -- already
+committed for `FindStarsBenchmarks`. Solved as a raw GRBG mosaic, which is the shipped path
+(`FindStarsAsync` debayers to mono internally); `SensorType.RGGB` means only "this is a CFA mosaic",
+the pattern riding in the Bayer offsets.
+
+Warm-catalog baseline, Release, medians (see below on why the median):
+
+| | median |
+|---|---|
+| full hinted solve | **331 ms** |
+| detect stars (incl. mono debayer) | 36-48 ms |
+| catalog region query | 7.1 ms |
+
+Plus, from `RealFrameSolveTests`, the two things BDN cannot report: **catalog cold start ~530-690 ms**
+(51% of the budget, all of phase B -- once per process and cached after, so a second BDN iteration of
+it is a warm start) and the scale the stars recover, **2.8669"/px against the 2.8724"/px `FOCALLEN`
+implies**. That 0.19% gap is this plan's own point about the header scale being a hint: 270 mm was
+typed in, the optics are ~269.5 mm, and the solver found it without being told.
+
+**Two traps this harness hit, both worth knowing before writing another one.**
+
+`Image` caches its `StarList` in a single slot keyed on the detection parameters, so the first version
+measured a cache-key comparison: **50.87 ns to find 1,377 stars in a 9 MP frame**, and the "full
+solve" silently stopped including detection from its second iteration. `[IterationSetup]` invalidating
+the cache fixes it and is also the honest model, since a session solves a different frame every time.
+A benchmark that measures nothing is worse than no benchmark, because someone will optimise against
+it.
+
+And **read the median, on a quiet box.** One invocation per iteration (forced by `[IterationSetup]`)
+on work this long is high-variance: medians repeated to within ~3% across runs while the means moved
+12%, and the detect benchmark under `ShortRunJob` reported an Error larger than its own mean. Hence
+`RunStrategy.Monitoring` with 12 iterations. The resolution is right for what the phases target
+(2-4x), not for calling a 10% delta.
 
 ## Explicitly not in scope
 

--- a/src/TianWen.Lib.Tests/RealFrameSolveTests.cs
+++ b/src/TianWen.Lib.Tests/RealFrameSolveTests.cs
@@ -1,0 +1,99 @@
+using System;
+using System.Diagnostics;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging.Abstractions;
+using TianWen.Lib.Astrometry.Catalogs;
+using TianWen.Lib.Astrometry.PlateSolve;
+using TianWen.Lib.Imaging;
+using Xunit;
+
+namespace TianWen.Lib.Tests;
+
+/// <summary>
+/// The committed real frame solves from nothing but its own header, and this says so -- the premise
+/// <see cref="T:TianWen.UI.Benchmarks.PlateSolveBenchmarks"/> rests on. A harness whose frame stopped
+/// solving would measure the FAILURE path at a completely different cost and look like a win, so the
+/// premise is asserted here rather than assumed there.
+///
+/// <para>It also reports the stage split, including the catalog COLD START that BenchmarkDotNet
+/// structurally cannot measure: it happens once per process and is cached after, so a second BDN
+/// iteration of it is a warm start. That stage is 51% of the plan's budget and all of phase B, which
+/// is why it is worth having a number for it somewhere.</para>
+///
+/// <para>The frame: NGC 3576 (Statue of Liberty Nebula), SVBONY SV605CC / IMX533 3008x3008, SH61
+/// EDPH 270 mm f/4.5, 60 s, N.I.N.A. It is a raw GRBG mosaic -- <c>SensorType.RGGB</c> means only
+/// "this is a CFA mosaic", the pattern itself riding in the Bayer offsets -- and is deliberately
+/// solved as one, because <see cref="Image.FindStarsAsync"/> debayers to mono internally and that is
+/// the path a session actually takes.</para>
+/// </summary>
+[Collection("Astrometry")]
+public class RealFrameSolveTests(ITestOutputHelper output)
+{
+    private const string FixtureName = "2026-02-15_00-56-23__-5.00_60.00s_0058";
+
+    [Fact(Timeout = 600_000)]
+    public async Task TheRealFrameSolvesFromItsOwnHeaderAndRecoversItsScale()
+    {
+        var ct = TestContext.Current.CancellationToken;
+
+        var sw = Stopwatch.StartNew();
+        var image = await SharedTestData.ExtractGZippedFitsImageAsync(FixtureName, isReadOnly: false, cancellationToken: ct);
+        output.WriteLine($"load          {sw.ElapsedMilliseconds} ms  {image.Width}x{image.Height} {image.ImageMeta.SensorType} bayer=({image.ImageMeta.BayerOffsetX},{image.ImageMeta.BayerOffsetY}) channels={image.ChannelCount}");
+
+        var dim = image.GetImageDim();
+        output.WriteLine($"implied dim   {(dim is { } d ? $"{d.PixelScale:F4}\"/px {d.Width}x{d.Height} -> {d.Width * d.PixelScale / 3600.0:F2} deg" : "NONE")}");
+        output.WriteLine($"header hint   RA={image.ImageMeta.TargetRA:F5}h Dec={image.ImageMeta.TargetDec:F4} (focallen={image.ImageMeta.FocalLength}mm pix={image.ImageMeta.PixelSizeX}um)");
+
+        Assert.NotNull(dim);
+
+        sw.Restart();
+        var db = new CelestialObjectDB();
+        await db.InitDBAsync(waitForTycho2BulkLoad: true, cancellationToken: ct);
+        output.WriteLine($"catalog init  {sw.ElapsedMilliseconds} ms  <- phase B targets this");
+
+        sw.Restart();
+        var stars = await image.FindStarsAsync(channel: 0, snrMin: 10f, cancellationToken: ct);
+        output.WriteLine($"detect        {sw.ElapsedMilliseconds} ms  {stars.Count} stars at snrMin=10");
+
+        var solver = new CatalogPlateSolver(db, NullLogger<CatalogPlateSolver>.Instance);
+        var hint = double.IsNaN(image.ImageMeta.TargetRA)
+            ? null
+            : (Astrometry.WCS?)new Astrometry.WCS(image.ImageMeta.TargetRA, image.ImageMeta.TargetDec);
+
+        foreach (var (label, origin) in new[] { ("hinted", hint), ("blind", null) })
+        {
+            sw.Restart();
+            var result = await solver.SolveImageAsync(image, dim.Value, searchOrigin: origin, cancellationToken: ct);
+            sw.Stop();
+            if (result.Solution is { } s)
+            {
+                output.WriteLine($"{label,-8} SOLVED {sw.ElapsedMilliseconds,6} ms  centre=({s.CenterRA:F5}h, {s.CenterDec:F4}) rot={s.RotationDeg:F2} scale={s.PixelScaleArcsec:F4}\"/px  CD=[{s.CD1_1:E3} {s.CD1_2:E3}; {s.CD2_1:E3} {s.CD2_2:E3}] det={(s.CD1_1 * s.CD2_2 - s.CD1_2 * s.CD2_1):E3}  race: abandoned={solver.LastParityRace.AbandonedAParity} winnerIsStd={solver.LastParityRace.WinnerIsStd} reRan={solver.LastParityRace.ReRanAbandonedParity}");
+            }
+            else
+            {
+                output.WriteLine($"{label,-8} NO SOLUTION after {sw.ElapsedMilliseconds} ms");
+            }
+        }
+
+        // Assertions, not just output: this is the benchmark's premise and a solver regression guard.
+        var solved = await _AssertSolves(solver, image, dim.Value, hint, ct);
+        Shouldly.ShouldBeTestExtensions.ShouldBeLessThan(
+            Math.Abs(solved.PixelScaleArcsec - dim.Value.PixelScale) / dim.Value.PixelScale, 0.01,
+            $"the scale recovered from the stars ({solved.PixelScaleArcsec:F4}) must agree with the one FOCALLEN implies "
+            + $"({dim.Value.PixelScale:F4}) to within 1% -- FOCALLEN is a hint, but not a wrong one");
+        Shouldly.ShouldBeTestExtensions.ShouldBeLessThan(
+            Math.Abs(solved.CenterDec - image.ImageMeta.TargetDec), 0.2,
+            "the solved centre must be the field the header says it is");
+
+        image.Release();
+    }
+
+    private static async Task<Astrometry.WCS> _AssertSolves(
+        CatalogPlateSolver solver, Image image, ImageDim dim,
+        Astrometry.WCS? hint, System.Threading.CancellationToken ct)
+    {
+        var result = await solver.SolveImageAsync(image, dim, searchOrigin: hint, cancellationToken: ct);
+        Assert.NotNull(result.Solution);
+        return result.Solution.Value;
+    }
+}

--- a/src/TianWen.UI.Benchmarks/PlateSolveBenchmarks.cs
+++ b/src/TianWen.UI.Benchmarks/PlateSolveBenchmarks.cs
@@ -1,0 +1,166 @@
+using System;
+using System.IO;
+using System.IO.Compression;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Engines;
+using BenchmarkDotNet.Jobs;
+using TianWen.Lib.Astrometry;
+using TianWen.Lib.Astrometry.Catalogs;
+using TianWen.Lib.Astrometry.PlateSolve;
+using TianWen.Lib.Imaging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace TianWen.UI.Benchmarks;
+
+/// <summary>
+/// The wall-clock budget behind <c>docs/plans/plate-solver-performance.md</c>, on a real frame.
+/// Every figure in that plan was hand-timed with a stopwatch and a fresh process -- good enough to
+/// decide what to optimise, useless for noticing that an optimisation regressed. This is the
+/// harness the plan asks for.
+///
+/// <para><b>The frame:</b> NGC 3576 (Statue of Liberty Nebula), SVBONY SV605CC / IMX533 at
+/// 3008x3008, SH61 EDPH 270 mm f/4.5, 60 s, written by N.I.N.A. Already committed and already
+/// linked into this project for <see cref="FindStarsBenchmarks"/>. It solves from nothing but its
+/// own header -- 2.87"/px implied by <c>FOCALLEN</c> x pixel size over a 2.40 degree field, hint
+/// from <c>OBJCTRA</c>/<c>OBJCTDEC</c> -- which is the premise the whole harness rests on, so it is
+/// asserted in <see cref="GlobalSetup"/> rather than assumed. A frame that does not solve would
+/// measure the failure path, at a completely different cost, and look like a win.</para>
+///
+/// <para><b>It is a Bayer mosaic and that is deliberate.</b> <c>SensorType.RGGB</c> means only "this
+/// is a CFA mosaic"; the pattern itself rides in the Bayer offsets, which this file's <c>GRBG</c>
+/// maps to (1, 0). <see cref="Image.FindStarsAsync"/> debayers to mono internally for such a frame
+/// and corrects the half-pixel grid offset a 2x2 box debayer introduces, so solving the mosaic
+/// directly is the real shipped path -- pre-debayering here would measure something the session
+/// never does.</para>
+///
+/// <para><b>Read the MEDIAN, on a quiet box.</b> One invocation per iteration (forced by
+/// <c>[IterationSetup]</c>) on work this long is inherently high-variance, and a machine doing
+/// anything else widens it further -- measured medians repeated to within ~3% across runs while the
+/// means moved 12%. That resolution is fine for what this harness is for: phases B and C target
+/// 2-4x, not 10%. Do not read a 10% delta here as a regression.</para>
+///
+/// <para><b>What is NOT here, and why:</b> the ~590 ms catalog cold start, which is 51% of the
+/// budget and all of phase B. It happens once per process and is cached thereafter, so it is
+/// structurally not a BenchmarkDotNet job: BDN wants many iterations of a repeatable thing, and the
+/// second iteration of a cold start is a warm start. Measure it the way the plan did -- whole-process
+/// wall clock, fresh process per rep -- or with <c>RealFrameSolveProbe</c>, which reports it once.
+/// Everything here runs with the catalog already warm, which is also what the second and subsequent
+/// solves of a real session see.</para>
+/// </summary>
+[MemoryDiagnoser]
+// RunStrategy.Monitoring, not the default throughput job. Two reasons, both forced by what is being
+// measured: [IterationSetup] pins BDN to one invocation per iteration, and these operations run for
+// tens to hundreds of milliseconds -- so the pilot/warmup machinery a throughput job runs buys
+// nothing and ShortRunJob's three iterations cannot stabilise it (the detect benchmark reported an
+// Error LARGER than its own mean). Monitoring plus more iterations gives a usable median.
+[SimpleJob(RunStrategy.Monitoring, warmupCount: 1, iterationCount: 12)]
+public class PlateSolveBenchmarks
+{
+    private Image _frame = null!;
+    private ImageDim _dim;
+    private WCS _headerHint;
+    private CelestialObjectDB _db = null!;
+    private CatalogPlateSolver _solver = null!;
+    private double _searchRadiusDeg;
+    private double _dtJulianYears;
+
+    [GlobalSetup]
+    public async Task GlobalSetup()
+    {
+        _frame = LoadRealFrame();
+
+        _dim = _frame.GetImageDim()
+            ?? throw new InvalidOperationException("the frame must imply a pixel scale (PIXSCALE, or pixel size x focal length)");
+
+        var meta = _frame.ImageMeta;
+        if (double.IsNaN(meta.TargetRA) || double.IsNaN(meta.TargetDec))
+        {
+            throw new InvalidOperationException("the frame must carry a pointing hint (OBJCTRA/OBJCTDEC)");
+        }
+        _headerHint = new WCS(meta.TargetRA, meta.TargetDec);
+
+        // Mirrors SolveImageAsync: 0.75 of the longer field edge, and proper motion referred to the
+        // exposure epoch (0 for a file with no plausible date, rather than a ~2000-year shift).
+        _searchRadiusDeg = Math.Max(_dim.Width, _dim.Height) * _dim.PixelScale / 3600.0 * 0.75;
+        _dtJulianYears = meta.ExposureStartTime.Year > 1900 ? meta.ExposureStartTime.JulianYearsSinceJ2000() : 0.0;
+
+        _db = new CelestialObjectDB();
+        await _db.InitDBAsync(waitForTycho2BulkLoad: true);
+        _solver = new CatalogPlateSolver(_db, NullLogger<CatalogPlateSolver>.Instance);
+
+        // Assert the premise ONCE, here, where it is free: every number below is meaningless if
+        // this frame does not actually solve.
+        var probe = await _solver.SolveImageAsync(_frame, _dim, searchOrigin: _headerHint);
+        if (probe.Solution is null)
+        {
+            throw new InvalidOperationException(
+                "the benchmark frame no longer solves from its header -- fix that before reading any timing below");
+        }
+    }
+
+    /// <summary>
+    /// Detection results are CACHED on the <see cref="Image"/> (a single slot keyed on the detection
+    /// parameters), so without this every iteration after the first measures a cache-key comparison
+    /// instead of the work. It is not a small distortion: the detect benchmark reported <b>50.87 ns</b>
+    /// for finding 1,377 stars in a 9 MP frame, and the "full solve" quietly stopped including
+    /// detection at all from its second iteration. A benchmark that measures nothing is worse than no
+    /// benchmark, because someone will optimise against it.
+    /// <para>Invalidating per iteration is also the honest model: a session solves a DIFFERENT frame
+    /// every time, and so pays detection every time.</para>
+    /// </summary>
+    [IterationSetup]
+    public void IterationSetup() => _frame.InvalidateStarListCache();
+
+    /// <summary>
+    /// The headline: a full hinted solve on a warm catalog. This is what phases A, C and D move.
+    /// </summary>
+    [Benchmark(Baseline = true, Description = "Full hinted solve (warm catalog)")]
+    public async Task<double> HintedSolve()
+    {
+        var result = await _solver.SolveImageAsync(_frame, _dim, searchOrigin: _headerHint);
+        return result.Solution?.PixelScaleArcsec ?? double.NaN;
+    }
+
+    /// <summary>
+    /// Star detection alone -- 7% of the plan's budget, and the input phase D would cap. Includes
+    /// the internal mono debayer, because that is what detecting on a mosaic costs.
+    /// </summary>
+    [Benchmark(Description = "Detect stars (incl. mono debayer)")]
+    public async Task<int> DetectStars()
+    {
+        var stars = await _frame.FindStarsAsync(channel: 0, snrMin: 10f);
+        return stars.Count;
+    }
+
+    /// <summary>
+    /// The catalog region query alone -- 5% of the budget, and the read phase B makes cheap. Warm,
+    /// so this is the query, not the load.
+    /// </summary>
+    [Benchmark(Description = "Catalog region query (warm)")]
+    public int CatalogQuery()
+        // The solver's own query, with the radius and proper-motion epoch it derives internally, so
+        // this measures the shipped call rather than a lookalike written beside it.
+        => _solver.QueryCatalogStarsInRegion(_headerHint, _searchRadiusDeg, _dtJulianYears).Count;
+
+    [GlobalCleanup]
+    public void GlobalCleanup() => _frame?.Release();
+
+    private static Image LoadRealFrame()
+    {
+        var path = Path.Combine(AppContext.BaseDirectory, "Fixtures", "FITS", "imx533_sv605cc_60s_real.fits.gz");
+        var tempPath = Path.Combine(Path.GetTempPath(), "TianWen.UI.Benchmarks_platesolve_real.fits");
+        if (!File.Exists(tempPath) || new FileInfo(tempPath).Length == 0)
+        {
+            using var fileStream = File.OpenRead(path);
+            using var gz = new GZipStream(fileStream, CompressionMode.Decompress);
+            using var outStream = File.Create(tempPath);
+            gz.CopyTo(outStream);
+        }
+
+        // Deliberately NOT debayered: see the class remarks.
+        return Image.TryReadFitsFile(tempPath, out var raw)
+            ? raw
+            : throw new InvalidDataException($"Failed to parse FITS at {tempPath}");
+    }
+}


### PR DESCRIPTION
The plan's own next step, and the precondition for phases B and C: *"Everything above was measured by hand: fine for deciding what to do, not fine for detecting a regression."*

## Baseline (warm catalog, Release, medians)

| | median |
|---|---|
| full hinted solve | **331 ms** |
| detect stars (incl. mono debayer) | 36–48 ms |
| catalog region query | 7.1 ms |

Plus, from `RealFrameSolveTests`, the two things BenchmarkDotNet structurally cannot report: **catalog cold start ~530–690 ms** (51% of the budget, all of phase B — once per process and cached after, so a second BDN iteration is a warm start), and the scale the stars recover: **2.8669″/px against the 2.8724″/px `FOCALLEN` implies.** That 0.19% is the plan's own point — 270 mm was typed in, the optics are ~269.5 mm, and the solver found it unaided.

## The frame

NGC 3576 (Statue of Liberty Nebula), SVBONY SV605CC / IMX533 3008², SH61 EDPH 270 mm f/4.5, 60 s, N.I.N.A. Already committed and linked for `FindStarsBenchmarks`.

Solved as a **raw GRBG mosaic**, deliberately: `SensorType.RGGB` means only "this is a CFA mosaic" — the pattern rides in the Bayer offsets, `(1,0)` here — and `FindStarsAsync` debayers to mono internally, correcting the half-pixel offset a 2×2 box debayer introduces. Pre-debayering would measure something no session does.

## Two traps, both hit while building this

- **`Image` caches its `StarList`** in one slot keyed on the detection parameters, so the first version measured a cache-key comparison: **50.87 ns to find 1,377 stars in 9 MP**, with the "full solve" silently dropping detection from its second iteration. `[IterationSetup]` invalidates it — also the honest model, since a session solves a different frame every time. A benchmark that measures nothing is worse than none, because someone will optimise against it.
- **Read the median, on a quiet box.** One invocation per iteration on work this long is high-variance: medians repeated within ~3% across runs while means moved 12%, and under `ShortRunJob` detect reported an `Error` larger than its own mean. Hence `RunStrategy.Monitoring` with 12 iterations. Right for the 2–4× the phases target, not for calling a 10% delta.

## Parity-cache keying corrected

The plan prescribed "per CAMERA, never per rig or per OTA". The optical train is the OTA's — swapping a camera body onto the same scope changes no reflection, while moving one camera to an SCT with a diagonal flips parity. But an OAG guide camera shares an OTA with the main camera at *opposite* parity, so OTA alone collides them. The key is the **(OTA, camera) pair** — the light path a given camera actually sees.

🤖 Generated with [Claude Code](https://claude.com/claude-code)