### PR TITLE
The Vela suite seeds the way the solver does, and keeps one wide window

### DIFF
--- a/docs/plans/plate-solver-performance.md
+++ b/docs/plans/plate-solver-performance.md
@@ -579,6 +579,77 @@ Detection already measures FWHM/HFD, so the input is in hand.
 Default OFF, and skip the whole phase if phases A-C land the budget. It is the smallest win of the
 four and the only one that can cost accuracy.
 
+### E. Positional search around the hint -- **SHIPPED**
+
+A hint wrong by a large fraction of a frame width is unsolvable today however generous the catalog
+query, because the seed's anchor pool is the brightest catalog stars that project INSIDE THE FRAME
+from the origin: the pool's footprint IS the origin's frame. `searchRadius` widens the QUERY, which
+is why sweeping it to 12 deg (75,062 stars) changes nothing. So the fix is a search over POSITIONS.
+
+`SolveImageAsync` now delegates to `SolveFromOriginAsync(..., allowPositionalSearch)`. When a solve
+fails, `TryFindOriginByPositionalSearch` walks candidate centres outward from the hint until one
+seeds, and the solve re-enters ONCE with that origin -- re-entering rather than resuming mid-solve
+because everything downstream of the query is a function of the origin, and `FindStarsAsync` is
+cached on the `Image`, so the retry pays the query, the quad recovery and the race but not detection.
+
+**The search returns an ORIGIN, not a solution**, and that is what licenses everything below. Whatever
+it finds is re-seeded at full fidelity by the retry and still has to clear the acceptance gate, so a
+coarse search can MISS a lock but cannot admit a wrong one.
+
+**Geometry, not constants.** A frame reaches `0.5 * pixelScale * hypot(w, h)` from its own centre, so
+the query covers `searchRadius + halfDiagonal` exactly. The `0.75 * max(fov)` the ordinary query uses
+is the single-centre form of that same quantity (1.628 deg against a true 1.524 deg, ~7% slack).
+Candidate spacing is `0.35 * min(fov)`: on a square grid the worst distance to a node is `step/sqrt(2)`,
+so every point sits within ~25% of a frame width of some candidate, and the frozen mosaic brackets the
+tolerance at 19.6% seeding / 71.4% not.
+
+**Sizing the query is a CORRECTNESS requirement, not an optimisation**, and this is worth writing down
+because the instinct is the opposite. Measured, the query is sub-linear in area and its cost per star
+FALLS as the radius grows:
+
+| radius | area | stars | ms | us/star | vs area-proportional |
+|---|---|---|---|---|---|
+| 1.63 deg | 8.3 | 2,436 | 5.2 | 2.14 | 1.00x |
+| 3.69 deg | 42.8 | 9,605 | 13.7 | 1.43 | 0.51x |
+| 12.0 deg | 452.4 | 75,062 | 66.0 | 0.88 | 0.23x |
+
+13.7 ms against a 60-220 ms solve. Do not spend a day optimising it. (The general query path does
+re-read each overlapping GSC region's whole entry list per 1x1 deg cell, where the polar path collects
+unique regions and walks each once -- real, and paid for by locality, so not worth chasing either.)
+
+**Getting the cost down took three measured rounds and the first estimate was 60x wrong**, which is
+the part worth remembering:
+
+| | failure path |
+|---|---|
+| before phase E | 4.0 s |
+| naive search (full-fidelity seed per candidate) | **230 s** |
+| + one anchor-pool policy, 250-star verification set | 15.9 s |
+| + a 20,000-hypothesis budget per candidate | **5.8 s** |
+
+Two facts behind that. `PairRansacLock` verifies every hypothesis against the WHOLE detected list
+(1,569 stars on this frame) while capping ANCHORS at 48, so the verification set is what scales with
+field density -- truncating it is the single biggest lever. And `MaxHypotheses` is **1,000,000**; the
+"4096" in the diagnostics is a cancellation-check interval, not a budget, so a candidate centred on
+empty sky was free to spend the real seed's entire allowance. A candidate centred on the truth locks
+in the low hundreds (195 on the frame this exists for).
+
+**An explicitly supplied `searchRadius` is a BOUNDARY, and bounding the candidates is not enough.**
+`PlateSolverTests.GivenDenseFieldAndWrongSearchOriginWhenCatalogPlateSolvingThenItFailsInsteadOfReturningGarbage`
+caught this: it hints 6 deg off with `searchRadius: 2.5` so that no correct correspondence is in
+scope, and the search found the true field anyway. A frame centred at the edge of the search area
+still reaches half a diagonal beyond it, and the disc anchor pool reaches further again -- so the
+ANSWER is checked too, and a relocated solution outside the caller's radius is discarded. A caller who
+passes a radius is saying "the truth is within this of my hint"; a field outside it, however real, is
+not an answer to their question. (The ring loop also had to clamp: `ceil(radius/step)` puts the
+outermost ring past the radius.)
+
+**Outstanding, and it would remove the remaining regression:** gate the search on the direct seed's
+own signal. A misplaced hint scores clearly above chance but under the bar (19-22 hits against a
+chance of 7.5 on the P10 crop); a frame with nothing in it scores AT chance. Gating on that ratio
+would leave the cloudy-frame path paying nothing at all, instead of the +1.8 s it pays now.
+`SeedCost` already carries `BestHits`/`ExpectedChanceHits` for it.
+
 ## Correctness gates
 
 Speed that costs accuracy is a regression, so every phase is measured against the same oracles.

--- a/docs/plans/plate-solver-performance.md
+++ b/docs/plans/plate-solver-performance.md
@@ -517,6 +517,29 @@ overlap) and solves normally. **So the missing capability is a positional search
 not a bigger radius and not a bigger catalog -- worth its own phase if a wrong-by-a-field-width hint
 is a case worth serving, which for a mosaic crop or a badly-synced mount it is.
 
+**The header is not mis-annotated -- it is accurate about a different thing.** `OBJECT = HD 72800`
+with `OBJCTRA`/`OBJCTDEC` at 08 32 56 / -47 36 17, and the catalogued HD 72800 sits **0.4 arcmin**
+from exactly that (P8's `HD 74167` likewise, 0.3 arcmin). The pointing record is faithful; it records
+where the SCOPE WAS AIMED for the panel, and these pixels are 93 arcmin from it. The frozen star lists
+settle where that came in: the full panel 10 has a hint error of **0.3 arcmin**, so the mount's own
+pointing was excellent and the offset is introduced by the crop, which kept the panel's header. A
+consumer cannot tell: nothing in a FITS header states that `OBJCTRA` still describes the frame after
+someone crops it, which is the same class of trap as `RA`/`DEC` not being the frame centre.
+
+**What actually predicts a seed failure is hint error as a FRACTION OF FRAME WIDTH**, and the frozen
+set brackets it:
+
+| | hint error | frame | as % of width | seeds? |
+|---|---|---|---|---|
+| P8 crop | 8.1 arcmin | 3.90 deg | 3.5% | yes |
+| worst full panel (P15b), of 96 | 58.7 arcmin | 4.98 deg | 19.6% | yes |
+| P10 crop | 93.0 arcmin | 2.17 deg | **71.4%** | no |
+
+The seed's two anchor-pool policies carry margins of 0% and 10%, so tolerating ~20% is about what the
+margined pool plus the frame's own slack buys, and 71% is far outside it. **That is the number to
+design against** -- not the absolute arcminutes, which is why a 4.98 deg panel survives an error seven
+times larger than the one that kills a 2.17 deg crop.
+
 **Narrowband is NOT implicated, and the quad-candidate count is not an independent signal.** These
 panels are HOO (Ha into R, OIII into G and B), so "the anchor pool is ranked by a broadband magnitude
 the image does not measure" was the natural competing explanation, and P10's 4 agreeing quad

--- a/docs/plans/plate-solver-performance.md
+++ b/docs/plans/plate-solver-performance.md
@@ -454,6 +454,56 @@ that is not the true one, so `QuadScaleRecoveryTests` shifts the second field's 
 x0.80 the answer tracks the shift, at x1.25 it declines outright, and it never invents ~1.0 from
 chance agreement.
 
+#### What a solve costs now, cold and warm (measured 2026-09-01)
+
+`SolveTimingProbe` (env-gated `TIANWEN_SOLVE_TIMING`) solves five committed real frames six times over
+per process, three processes, medians. It exists because the two costs a session pays are different
+and **BenchmarkDotNet can only ever see one of them**: the catalog is cached per process, so a BDN
+second iteration is already a warm start, and the cold half is the 51% row in the budget above.
+
+Cold -- first frame in a fresh process (NGC 3576, the most expensive of the set). Excludes host startup:
+
+| stage | ms |
+|---|---|
+| catalog init (ONCE per process) | 266 |
+| FITS load, 10 MB gz -> 3008x3008 | 184 |
+| solve (query 30 / detect 110 / quad 13 / seed+refine 134) | 312 |
+| **cold, to a WCS** | **762** |
+
+Warm -- the same process, solve only:
+
+| frame | scale | detected | warm | cold pass 1 |
+|---|---|---|---|---|
+| NGC 3576, SH61 270 mm, 3008x3008 GRBG | 2.87"/px | 8103 | **221 ms** | 312 ms |
+| HD 71216, Samyang 130 mm, 3008x3008 | 5.97 | 1932 | **106** | 168 |
+| Horsehead, Samyang 135 mm, 3008x3008 (SharpCap) | 5.74 | 2227 | **60** | 165 |
+| Vela P8 crop, 2354x2150 mono | 5.97 | 4003 | **120** | 248 |
+
+Cold-to-warm on the solve alone is 1.4x-2.7x and it is **all JIT** -- the second solve of ANY frame is
+warm, not only of the same one. Share of a warm solve: seed+refine 43-61%, detection 34-47%, catalog
+query 1.4-3.7%, quad recovery 0.9-2.0%. So **phase B really is finished** (2-6 ms), and **C' costs
+1-2 ms to remove 7.4x of the seed's work**.
+
+**Recovery fires on 2 of these 5 frames, and the gate that refuses is the CANDIDATE COUNT, never the
+spread.** Where it answers: 27 and 18 candidates at spread 0.0017 / 0.0004 against the 0.01 bar. Where
+it declines: 8, 6 and 4 candidates against `MinCandidates = 10`, deterministically, same counts every
+run. The guard that protects correctness is therefore carrying 6-25x of margin while the count gate
+does all the refusing, which makes `RatioTolerance = 0.004f` the knob worth loosening -- coverage
+would rise and the spread guard would still refuse a wrong answer. It matters because the frame it
+declined on is the one that needed it most: the SharpCap Horsehead states `FOCALLEN = 135`, implying
+5.7449"/px against a solved 5.9744 -- **4.0% wrong**, saved only by the +/-5% fallback. The same
+recovery fires on 94 of 96 frozen Vela frames, so the low coverage is a property of real captured
+frames, not of the method.
+
+**The failure path costs 4.0 s, 65x a warm success**, because the refinement loop runs to exhaustion
+before the acceptance gate refuses. The frame that prices it is an open question in its own right:
+the `Vela_SNR_Panel_10` crop does not solve at ANY search radius out to 12 deg (75k catalog stars),
+nor at any scale from 0.5x to 2x the declared one, on a dense star-rich field yielding 1569
+detections -- and the gate's reason is `0 of 120` bright detections within 3 px, which is total rather
+than marginal. Nothing regressed: it had never been asked for a WCS before (it is a stretch / colour /
+codec fixture everywhere else). It is an unexplained gap on a deep narrowband master, and it is the
+one frame in the set whose failure is not understood.
+
 ### D. Cap the star list; bin ONLY where sampling allows it
 
 Two halves with very different risk, and they must not be conflated.
@@ -543,6 +593,26 @@ gate-verified WCS (incl. SIP) as an oracle, plus one mosaic-wide catalog so a ca
 physical star in every panel. `VelaMosaicFieldTests` drives `CatalogPlateSolver.TrySeedPairLock` and
 `PairRansacLock` over them; `VelaMosaicStarListExport` (env-gated, needs the user's archive)
 regenerates the file.
+
+**The suite costs 24 s, and exactly ONE test still searches a wide scale window.** It cost 115 s until
+`SeedsFromHeaderHintAndAgreesWithTheFrozenSolution` and `BothAnchorPoolPoliciesAreNecessary` were
+re-pointed at the SHIPPED two-tier seed -- quad recovery, then `RecoveredScaleTolerance` about the
+recovered scale, falling back to `MinPairLockScaleTolerance` about the header's when it declines --
+which is 6.7x and 5.2x faster AND more faithful, since the +/-3% they used was a window of the tests'
+own invention that production never ran. It also turns these 96 frames into a LOCK-level guard on C'
+(94 of them take the quad tier). That the recovery keeps FIRING is guarded next door by
+`QuadScaleRecoveryTests`' recovered-panel count -- without it, a recovery that started declining
+everywhere would quietly fall back to +/-5% here and still pass.
+
+`UnrelatedDenseFieldsMustNotLock` keeps +/-3% deliberately, and is the one that must: a false lock is
+what the pair matcher exists to refuse, and a WIDE scale search is the adversarial condition for it,
+handing the matcher the most freedom to find a spurious consensus. Narrowing it to the shipped
++/-0.25% takes it from 45 s to 3 s and makes the pass mean strictly less. Its time came back instead
+from the two things that were never the assertion: each panel's field was being re-projected out of
+78k catalog stars once per PARTNER rather than once, and the pairs are independent pure computations
+over frozen data, so they run under a bounded `Parallel.For` with the assertions replayed serially
+afterwards -- which also reports EVERY false lock rather than whichever one a worker threw from first.
+5.1x, same claim.
 
 Star lists because the dense-field failure was purely geometric -- reproducing it needs the positions
 and the DENSITY, not the pixels, and 96 frames of FITS is ~9 GB against 2 MiB of lists.

--- a/docs/plans/plate-solver-performance.md
+++ b/docs/plans/plate-solver-performance.md
@@ -496,13 +496,39 @@ recovery fires on 94 of 96 frozen Vela frames, so the low coverage is a property
 frames, not of the method.
 
 **The failure path costs 4.0 s, 65x a warm success**, because the refinement loop runs to exhaustion
-before the acceptance gate refuses. The frame that prices it is an open question in its own right:
-the `Vela_SNR_Panel_10` crop does not solve at ANY search radius out to 12 deg (75k catalog stars),
-nor at any scale from 0.5x to 2x the declared one, on a dense star-rich field yielding 1569
-detections -- and the gate's reason is `0 of 120` bright detections within 3 px, which is total rather
-than marginal. Nothing regressed: it had never been asked for a WCS before (it is a stretch / colour /
-codec fixture everywhere else). It is an unexplained gap on a deep narrowband master, and it is the
-one frame in the set whose failure is not understood.
+before the acceptance gate refuses. The frame that prices it, the `Vela_SNR_Panel_10` crop, turns out
+to be a real gap in this solver -- and **the obvious experiment gives the wrong answer about it**. It
+does not solve at any search radius out to 12 deg (75,062 catalog stars) nor at any scale from 0.5x to
+2x the declared one, which reads as "not pointing, not scale". Both sweeps are misleading. ASTAP
+solves the same file in 0.7 s with 71 of 72 quads matched, and its solution says why: the crop's
+header points **93 arcmin** from where the frame actually is, on a **2.17 deg** field. That is 70% of
+the frame width, leaving the hint-projected frame overlapping the real one by **26%**. Hand our own
+solver ASTAP's centre and it solves in **23 ms** with 613 stars matched -- faster than anything else
+in the set.
+
+**A wider search radius cannot fix a bad hint, which is the whole trap.** `searchRadius` widens the
+catalog QUERY, while the seed's anchor pool is the brightest catalog stars that project INSIDE THE
+FRAME from the hint -- so the pool's footprint is the hint's own frame however wide the query gets,
+and three quarters of it is off-frame and undetectable by construction. That is the same failure mode
+the margined anchor pool exists for, at an offset far past what a 10% margin reaches. ASTAP does not
+have it because its `-r` means "search a spiral of sky POSITIONS around the hint", not "query wider".
+The control sits right beside it: the P8 crop's header is 12 arcmin off (5% of its frame width, 93%
+overlap) and solves normally. **So the missing capability is a positional search around the hint**,
+not a bigger radius and not a bigger catalog -- worth its own phase if a wrong-by-a-field-width hint
+is a case worth serving, which for a mosaic crop or a badly-synced mount it is.
+
+**Narrowband is NOT implicated, and the quad-candidate count is not an independent signal.** These
+panels are HOO (Ha into R, OIII into G and B), so "the anchor pool is ranked by a broadband magnitude
+the image does not measure" was the natural competing explanation, and P10's 4 agreeing quad
+candidates against P8's 18 looked like its evidence. It is not: `QuadScaleRecovery` projects the
+catalog through the SAME hint the seed does, so a 74%-off-frame projection starves the quad list by
+exactly the same mechanism. Re-hinted, the identical HOO pixels give **17 candidates at spread
+0.0005**, an rms of 0.19 px and 613 matched stars. **So read a declined recovery as evidence about the
+HINT as much as about the frame** -- which is worth remembering next to the real-frame decline counts
+above, where the header's pointing was never separately checked.
+
+Nothing regressed: P10 had never been asked for a WCS before (it is a stretch / colour / codec fixture
+everywhere else), which is exactly why the gap had gone unmeasured.
 
 ### D. Cap the star list; bin ONLY where sampling allows it
 

--- a/src/TianWen.Lib.Tests/RealFrameSolveTests.cs
+++ b/src/TianWen.Lib.Tests/RealFrameSolveTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Diagnostics;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -92,6 +92,58 @@ public class RealFrameSolveTests(ITestOutputHelper output)
         Shouldly.ShouldBeTestExtensions.ShouldBeLessThan(
             Math.Abs(solved.CenterDec - image.ImageMeta.TargetDec), 0.2,
             "the solved centre must be the field the header says it is");
+
+        image.Release();
+    }
+
+    /// <summary>
+    /// A frame whose header points somewhere else entirely still solves. The Vela panel 10 crop
+    /// carries its PARENT panel's pointing -- <c>OBJECT = HD 72800</c> is accurate to 0.4 arcmin, but
+    /// the pixels are 93 arcmin from it, on a 2.17 deg field -- so the anchor pool the seed projects
+    /// from the hint lands 74% outside the frame and starves. Before the positional search this
+    /// returned no solution at ANY radius out to 12 deg and any scale from 0.5x to 2x; ASTAP solved
+    /// it in 0.7 s, which is what said the gap was ours.
+    /// </summary>
+    /// <remarks>
+    /// The two assertions are deliberately opposed. "It solves" alone would pass on a solver that
+    /// simply trusted the hint if the hint were ever fixed; "the answer is far from the hint" alone
+    /// would pass on garbage. Together they say the solver went looking and came back with the right
+    /// field -- and the second one is what fails if the positional search is removed.
+    /// </remarks>
+    [Fact(Timeout = 600_000)]
+    public async Task TheCropWhoseHeaderPointsElsewhereStillSolves()
+    {
+        var ct = TestContext.Current.CancellationToken;
+
+        var image = await SharedTestData.ExtractGZippedFitsImageAsync(
+            "Vela_SNR_Panel_10-Multi-NB-color-Hydrogen-alpha-Oxygen_III-crop", isReadOnly: false, cancellationToken: ct);
+        var dim = image.GetImageDim();
+        Assert.NotNull(dim);
+
+        var db = new CelestialObjectDB();
+        await db.InitDBAsync(waitForTycho2BulkLoad: true, cancellationToken: ct);
+        var solver = new CatalogPlateSolver(db, NullLogger<CatalogPlateSolver>.Instance);
+
+        var hint = new Astrometry.WCS(image.ImageMeta.TargetRA, image.ImageMeta.TargetDec);
+        var sw = Stopwatch.StartNew();
+        var result = await solver.SolveImageAsync(image, dim.Value, searchOrigin: hint, cancellationToken: ct);
+        sw.Stop();
+
+        Assert.NotNull(result.Solution);
+        var solved = result.Solution.Value;
+        var offArcmin = 60.0 * Astrometry.CoordinateUtils.AngularSeparationDeg(
+            hint.CenterRA, hint.CenterDec, solved.CenterRA, solved.CenterDec);
+        output.WriteLine($"solved {sw.ElapsedMilliseconds} ms at ({solved.CenterRA:F5}h, {solved.CenterDec:F4}) " +
+            $"{offArcmin:F0} arcmin off the header hint, {solved.PixelScaleArcsec:F4}\"/px, {result.MatchedStars} matched");
+
+        // ASTAP puts this field at 08:41:47.5 -48:02:24 with 71 of 72 quads matched; agreeing with an
+        // independent solver is the only oracle this fixture has, since its own header does not know.
+        Shouldly.ShouldBeTestExtensions.ShouldBeLessThan(
+            Astrometry.CoordinateUtils.AngularSeparationDeg(8.69653, -48.0400, solved.CenterRA, solved.CenterDec), 0.1,
+            "the relocated solve must land where an independent solver puts this field");
+        Shouldly.ShouldBeTestExtensions.ShouldBeGreaterThan(offArcmin, 60.0,
+            "the whole point is that the answer is NOT near the header hint -- if this drops below an "
+            + "arcminute the test has stopped exercising the positional search");
 
         image.Release();
     }

--- a/src/TianWen.Lib.Tests/SolveTimingProbe.cs
+++ b/src/TianWen.Lib.Tests/SolveTimingProbe.cs
@@ -226,6 +226,26 @@ namespace TianWen.Lib.Tests
                         : $"no solution ({r.Elapsed.TotalMilliseconds:F0} ms)"));
             }
 
+
+            // Hypothesis 3, and the one that holds: the hint is simply too far off for an anchor
+            // pool PROJECTED FROM IT. ASTAP -- which searches a spiral of sky positions rather than
+            // trusting the hint as the centre -- puts this crop 1.53 deg from where its header says,
+            // on a 2.17 deg field, so about three quarters of the pool the seed projects into the
+            // frame is not in the frame at all. Widening the search RADIUS cannot touch that: the
+            // radius widens the catalog QUERY, while the pool's footprint is the HINT's own frame.
+            var astapOrigin = new WCS(8.69653, -48.0400);
+            capture.Lines.Clear();
+            output.WriteLine($"  hint is {SepDeg(hint.CenterRA, hint.CenterDec, astapOrigin.CenterRA, astapOrigin.CenterDec) * 60:F0} arcmin off ASTAP's centre, on a {declared.FieldOfView.width:F2} deg frame");
+            var corrected = await solver.SolveImageAsync(image, declared, searchOrigin: astapOrigin, cancellationToken: ct);
+            output.WriteLine($"  re-hinted at ASTAP's centre -> " +
+                (corrected.Solution is { } cs
+                    ? $"SOLVED in {corrected.Elapsed.TotalMilliseconds:F0} ms at ({cs.CenterRA:F5}h {cs.CenterDec:F4}), {cs.PixelScaleArcsec:F4}\"/px, {corrected.MatchedStars} matched"
+                    : $"still no solution ({corrected.Elapsed.TotalMilliseconds:F0} ms)"));
+            foreach (var line in capture.Lines)
+            {
+                output.WriteLine($"    | {line}");
+            }
+
             image.Release();
         }
 

--- a/src/TianWen.Lib.Tests/SolveTimingProbe.cs
+++ b/src/TianWen.Lib.Tests/SolveTimingProbe.cs
@@ -1,0 +1,243 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using SharpAstro.Png;
+using TianWen.Lib.Astrometry;
+using TianWen.Lib.Astrometry.Catalogs;
+using TianWen.Lib.Astrometry.PlateSolve;
+using TianWen.Lib.Imaging;
+using TianWen.UI.Abstractions;
+using Xunit;
+
+namespace TianWen.Lib.Tests
+{
+    /// <summary>
+    /// What a plate solve COSTS, split the two ways a session actually pays it: the FIRST solve in a
+    /// process, which carries the Tycho-2 bulk decode, and every solve after it, which does not.
+    /// <see cref="T:TianWen.UI.Benchmarks.PlateSolveBenchmarks"/> structurally cannot report the first
+    /// one -- the catalog is cached per process, so its second iteration is already a warm start -- and
+    /// on this workload its per-iteration Error came out wider than the effects being chased, so a
+    /// stage split over real frames is the measurement that carries information.
+    /// </summary>
+    /// <remarks>
+    /// <para>Env-gated (<c>TIANWEN_SOLVE_TIMING</c>): it decodes Tycho-2 and then solves five real
+    /// frames twice over, which is minutes rather than the milliseconds a unit test may spend.</para>
+    /// <para>The stage split is read off the solver's OWN Debug lines rather than from a second set of
+    /// stopwatches here, so the probe cannot report a decomposition the production path lacks.</para>
+    /// </remarks>
+    [Collection("Astrometry")]
+    public class SolveTimingProbe(ITestOutputHelper output)
+    {
+        private sealed class StageCapture : ILogger<CatalogPlateSolver>
+        {
+            public List<string> Lines { get; } = [];
+
+            public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+            public bool IsEnabled(LogLevel logLevel) => logLevel >= LogLevel.Debug;
+
+            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception,
+                Func<TState, Exception?, string> formatter)
+            {
+                var msg = formatter(state, exception);
+                if (msg.Contains("ms") || msg.Contains("QuadScaleRecovery") || logLevel >= LogLevel.Warning)
+                {
+                    Lines.Add(logLevel >= LogLevel.Warning ? $"[{logLevel}] {msg}" : msg);
+                }
+            }
+        }
+
+        /// <summary>
+        /// The real frames committed to this suite that carry both a pointing hint and a scale hint.
+        /// Two rigs and two capture programs, so the numbers are not one camera's story: the 270 mm
+        /// SH61 at 2.87"/px and the 130/135 mm Samyang at ~5.9"/px, N.I.N.A. and SharpCap.
+        /// </summary>
+        private static readonly (string Fixture, string What)[] Frames =
+        [
+            ("2026-02-15_00-56-23__-5.00_60.00s_0058", "NGC 3576  SH61 270mm  3008x3008 GRBG i16"),
+            ("2026-01-18_23-26-51__-5.00_60.00s_0002", "HD 71216  SY 130mm   3008x3008 RGGB i16"),
+            ("RGGB_frame_bx0_by0_top_down", "Horsehead SY 135mm   3008x3008 RGGB i16 (SharpCap)"),
+            ("Vela_SNR_Panel_8_1-Multi-NB-mono-Hydrogen-alpha-Oxygen_III-crop", "Vela P8   SY 130mm   2354x2150 mono f32 (master crop)"),
+            ("Vela_SNR_Panel_10-Multi-NB-color-Hydrogen-alpha-Oxygen_III-crop", "Vela P10  SY 130mm   1310x1291 rgb  f32 (master crop)"),
+        ];
+
+        [Fact(Timeout = 1_800_000)]
+        public async Task ReportTheColdAndWarmCostOfSolvingRealFrames()
+        {
+            Assert.SkipUnless(
+                !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("TIANWEN_SOLVE_TIMING")),
+                "Set TIANWEN_SOLVE_TIMING=1 to run the solve timing probe");
+
+            var ct = TestContext.Current.CancellationToken;
+            var process = Stopwatch.StartNew();
+
+            // The cold half: a process pays this once, before any frame is solved.
+            var sw = Stopwatch.StartNew();
+            var db = new CelestialObjectDB();
+            await db.InitDBAsync(waitForTycho2BulkLoad: true, cancellationToken: ct);
+            var catalogInitMs = sw.Elapsed.TotalMilliseconds;
+            output.WriteLine($"catalog init  {catalogInitMs,8:F1} ms   (ONCE per process; tycho2={db.Tycho2BulkLoadState})");
+            foreach (var (phase, elapsed) in db.LastInitPhaseTimings)
+            {
+                output.WriteLine($"    {elapsed.TotalMilliseconds,8:F1} ms  {phase}");
+            }
+            output.WriteLine("");
+
+            var capture = new StageCapture();
+            var solver = new CatalogPlateSolver(db, capture);
+            const int Passes = 6;
+            var rows = new List<string>();
+
+            for (var pass = 1; pass <= Passes; pass++)
+            {
+                output.WriteLine(pass == 1
+                    ? "=== pass 1: first solve of each frame (JIT still cold on the first row) ==="
+                    : $"=== pass {pass} of {Passes}: the same frames again, everything warm ===");
+
+                foreach (var (fixture, what) in Frames)
+                {
+                    sw.Restart();
+                    var image = await SharedTestData.ExtractGZippedFitsImageAsync(fixture, isReadOnly: false, cancellationToken: ct);
+                    var loadMs = sw.Elapsed.TotalMilliseconds;
+
+                    if (image.GetImageDim() is not { } dim || double.IsNaN(image.ImageMeta.TargetRA))
+                    {
+                        output.WriteLine($"  {what}  SKIPPED (no pixel scale, or no pointing hint)");
+                        image.Release();
+                        continue;
+                    }
+
+                    var hint = new WCS(image.ImageMeta.TargetRA, image.ImageMeta.TargetDec);
+
+                    capture.Lines.Clear();
+                    sw.Restart();
+                    var result = await solver.SolveImageAsync(image, dim, searchOrigin: hint, cancellationToken: ct);
+                    var solveMs = sw.Elapsed.TotalMilliseconds;
+
+                    output.WriteLine($"  {what}");
+                    output.WriteLine($"    load        {loadMs,8:F1} ms   {dim.PixelScale:F3}\"/px  fov {dim.FieldOfView.width:F2}x{dim.FieldOfView.height:F2} deg");
+                    foreach (var line in capture.Lines)
+                    {
+                        output.WriteLine($"    | {line}");
+                    }
+
+                    if (result.Solution is { } s)
+                    {
+                        var prior = solver.LastScalePrior is { } sp
+                            ? $"{dim.PixelScale / sp.Ratio:F4}\"/px ({sp.Candidates} cands, spread {sp.RelativeSpread:F4})"
+                            : "declined";
+                        output.WriteLine($"    SOLVE       {solveMs,8:F1} ms   {result.CatalogStars} cat / {result.DetectedStars} det / {result.MatchedStars} matched, {result.Iterations} iter");
+                        output.WriteLine($"    scale       header {dim.PixelScale:F4} -> quad {prior} -> solved {s.PixelScaleArcsec:F4}\"/px");
+                        rows.Add($"{what,-56} pass{pass} {solveMs,8:F1} ms  load {loadMs,7:F1} ms  det {result.DetectedStars,4}  matched {result.MatchedStars,4}");
+                    }
+                    else
+                    {
+                        output.WriteLine($"    NO SOLUTION {solveMs,8:F1} ms   {result.CatalogStars} cat / {result.DetectedStars} det");
+                        rows.Add($"{what,-56} pass{pass} {solveMs,8:F1} ms  NO SOLUTION");
+                    }
+
+                    output.WriteLine("");
+                    image.Release();
+                }
+            }
+
+            output.WriteLine($"=== summary (process wall clock {process.Elapsed.TotalSeconds:F1} s) ===");
+            output.WriteLine($"cold catalog init {catalogInitMs:F0} ms is paid once, and is NOT part of any solve below");
+            foreach (var row in rows)
+            {
+                output.WriteLine($"  {row}");
+            }
+        }
+
+        /// <summary>
+        /// Why the Vela P10 crop does not solve, and what it looks like. Nothing had ever asked this
+        /// fixture for a WCS before -- it is a stretch / colour / codec fixture everywhere else -- so
+        /// its failure is a property of the FILE, and this separates the two things that can be wrong
+        /// with a crop's header: it points somewhere else (widen the search radius until it lands) or
+        /// it states the wrong scale (offer the solver half and double). P8, the crop that DOES solve,
+        /// is rendered beside it as the control.
+        /// </summary>
+        [Fact(Timeout = 900_000)]
+        public async Task ReportWhyTheVelaCropDoesNotSolveAndRenderIt()
+        {
+            Assert.SkipUnless(
+                !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("TIANWEN_SOLVE_TIMING")),
+                "Set TIANWEN_SOLVE_TIMING=1 to run the solve timing probe");
+
+            var ct = TestContext.Current.CancellationToken;
+            var outDir = SharedTestData.CreateTempTestOutputDir();
+
+            foreach (var (fixture, what) in new[] { Frames[4], Frames[3] })
+            {
+                var path = await SharedTestData.ExtractGZippedFitsFileAsync(fixture, ct);
+                if (await AstroImageDocument.OpenAsync(path, DebayerAlgorithm.AHD, ct) is not { } doc)
+                {
+                    output.WriteLine($"{what}: could not open");
+                    continue;
+                }
+
+                var uniforms = doc.ComputeStretchUniforms(StretchMode.Linked, new StretchParameters(0.15, -2.8));
+                var img = doc.UnstretchedImage;
+                var (ch, w, h) = img.Shape;
+                var rgba = new byte[w * h * 4];
+                img.RenderStretchedRgba(uniforms, rgba);
+                var png = Path.Combine(outDir, fixture[..Math.Min(28, fixture.Length)] + ".png");
+                await File.WriteAllBytesAsync(png, PngWriter.Encode(rgba, w, h), ct);
+                output.WriteLine($"{what}");
+                output.WriteLine($"   {ch}ch {w}x{h} -> {png}");
+            }
+
+            var db = new CelestialObjectDB();
+            await db.InitDBAsync(waitForTycho2BulkLoad: true, cancellationToken: ct);
+            var capture = new StageCapture();
+            var solver = new CatalogPlateSolver(db, capture);
+
+            var image = await SharedTestData.ExtractGZippedFitsImageAsync(Frames[4].Fixture, isReadOnly: false, cancellationToken: ct);
+            var declared = image.GetImageDim()!.Value;
+            var hint = new WCS(image.ImageMeta.TargetRA, image.ImageMeta.TargetDec);
+            output.WriteLine("");
+            output.WriteLine($"P10 header hint RA={hint.CenterRA:F5}h Dec={hint.CenterDec:F4}, declared {declared.PixelScale:F4}\"/px, {declared.Width}x{declared.Height}");
+
+            // Hypothesis 1: the crop points somewhere the default radius does not reach.
+            foreach (var radius in new[] { 1.63, 3.0, 6.0, 12.0 })
+            {
+                var r = await solver.SolveImageAsync(image, declared, searchOrigin: hint, searchRadius: radius, cancellationToken: ct);
+                if (r.Solution is { } s)
+                {
+                    output.WriteLine($"  radius {radius,5:F2} deg -> SOLVED at ({s.CenterRA:F5}h {s.CenterDec:F4}), " +
+                        $"{SepDeg(hint.CenterRA, hint.CenterDec, s.CenterRA, s.CenterDec) * 60:F1} arcmin off the hint, {s.PixelScaleArcsec:F4}\"/px");
+                    break;
+                }
+
+                output.WriteLine($"  radius {radius,5:F2} deg -> no solution ({r.Elapsed.TotalMilliseconds:F0} ms, {r.CatalogStars} cat / {r.DetectedStars} det)");
+            }
+
+            // Hypothesis 2: the crop came off a master at a different sampling than FOCALLEN implies.
+            foreach (var factor in new[] { 0.5f, 0.8f, 0.9f, 1.1f, 1.25f, 1.5f, 2.0f })
+            {
+                var scaled = new ImageDim(declared.PixelScale * factor, declared.Width, declared.Height);
+                var r = await solver.SolveImageAsync(image, scaled, searchOrigin: hint, searchRadius: 6.0, cancellationToken: ct);
+                output.WriteLine($"  scale x{factor} ({scaled.PixelScale:F4}\"/px) -> " +
+                    (r.Solution is { } s
+                        ? $"SOLVED at ({s.CenterRA:F5}h {s.CenterDec:F4}), {s.PixelScaleArcsec:F4}\"/px"
+                        : $"no solution ({r.Elapsed.TotalMilliseconds:F0} ms)"));
+            }
+
+            image.Release();
+        }
+
+        private static double SepDeg(double ra1H, double dec1, double ra2H, double dec2)
+        {
+            var r1 = double.DegreesToRadians(ra1H * 15.0);
+            var d1 = double.DegreesToRadians(dec1);
+            var r2 = double.DegreesToRadians(ra2H * 15.0);
+            var d2 = double.DegreesToRadians(dec2);
+            var cos = Math.Sin(d1) * Math.Sin(d2) + Math.Cos(d1) * Math.Cos(d2) * Math.Cos(r1 - r2);
+            return double.RadiansToDegrees(Math.Acos(Math.Clamp(cos, -1.0, 1.0)));
+        }
+
+    }
+}

--- a/src/TianWen.Lib.Tests/SolveTimingProbe.cs
+++ b/src/TianWen.Lib.Tests/SolveTimingProbe.cs
@@ -324,6 +324,59 @@ namespace TianWen.Lib.Tests
             output.WriteLine($"the full panel nearest the crop's true centre is {nearestId}, {nearest:F1} arcmin away, its own hint {nearestHint:F1} arcmin off");
         }
 
+        /// <summary>
+        /// What the catalog query COSTS as the radius grows, which is the number a positional search
+        /// turns on: it needs one query covering the whole candidate area rather than one per frame.
+        /// If cost tracked area the radius would be free to grow; the general path walks CELLS and
+        /// re-reads each overlapping GSC region's whole entry list per cell, so it should not.
+        /// </summary>
+        [Fact(Timeout = 900_000)]
+        public async Task ReportWhatTheCatalogQueryCostsAsTheRadiusGrows()
+        {
+            Assert.SkipUnless(
+                !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("TIANWEN_SOLVE_TIMING")),
+                "Set TIANWEN_SOLVE_TIMING=1 to run the solve timing probe");
+
+            var ct = TestContext.Current.CancellationToken;
+            var db = new CelestialObjectDB();
+            await db.InitDBAsync(waitForTycho2BulkLoad: true, cancellationToken: ct);
+            var solver = new CatalogPlateSolver(db, new StageCapture());
+
+            var origin = new WCS(8.54889, -47.6047);
+            double[] radii = [1.63, 2.5, 3.69, 5.0, 6.0, 8.0, 12.0];
+
+            // Warm the path once so the first row is not measuring JIT.
+            solver.QueryCatalogStarsInRegion(origin, 1.0, 26.0);
+
+            output.WriteLine($"{"radius",8}{"area",10}{"stars",9}{"ms",9}{"us/star",10}{"vs area",9}");
+            var baseArea = Math.PI * radii[0] * radii[0];
+            var baseMs = 0.0;
+            foreach (var r in radii)
+            {
+                var best = double.MaxValue;
+                var count = 0;
+                for (var rep = 0; rep < 3; rep++)
+                {
+                    var sw = Stopwatch.StartNew();
+                    var stars = solver.QueryCatalogStarsInRegion(origin, r, 26.0);
+                    best = Math.Min(best, sw.Elapsed.TotalMilliseconds);
+                    count = stars.Count;
+                }
+
+                var area = Math.PI * r * r;
+                if (baseMs == 0)
+                {
+                    baseMs = best;
+                }
+
+                output.WriteLine($"{r,8:F2}{area,10:F1}{count,9}{best,9:F1}{1000 * best / count,10:F2}{best / baseMs / (area / baseArea),9:F2}x");
+            }
+
+            output.WriteLine("");
+            output.WriteLine("'vs area' is measured cost over the cost a perfectly area-proportional query would have.");
+            output.WriteLine("Above 1.0 means the walk is doing work the returned stars do not account for.");
+        }
+
         private static double SepDeg(double ra1H, double dec1, double ra2H, double dec2)
         {
             var r1 = double.DegreesToRadians(ra1H * 15.0);

--- a/src/TianWen.Lib.Tests/SolveTimingProbe.cs
+++ b/src/TianWen.Lib.Tests/SolveTimingProbe.cs
@@ -249,6 +249,81 @@ namespace TianWen.Lib.Tests
             image.Release();
         }
 
+        /// <summary>
+        /// Is the P10 crop MIS-ANNOTATED, or merely cropped off-centre? Two independent checks, since
+        /// the header is self-consistent either way: does the catalogued position of the star named in
+        /// OBJECT agree with the OBJCTRA/OBJCTDEC beside it, and is the offset larger than any FULL
+        /// panel of the same mosaic manages (the frozen star lists carry all 24, hint and truth).
+        /// </summary>
+        [Fact(Timeout = 600_000)]
+        public async Task ReportWhetherTheCropIsMisAnnotatedOrJustOffCentre()
+        {
+            Assert.SkipUnless(
+                !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("TIANWEN_SOLVE_TIMING")),
+                "Set TIANWEN_SOLVE_TIMING=1 to run the solve timing probe");
+
+            var ct = TestContext.Current.CancellationToken;
+            var db = new CelestialObjectDB();
+            await db.InitDBAsync(waitForTycho2BulkLoad: true, cancellationToken: ct);
+
+            // (named object, header OBJCTRA hours, header OBJCTDEC deg, ASTAP centre hours/deg)
+            var cases = new[]
+            {
+                ("HD 72800", 8.548888, -47.604722, 8.696528, -48.040000, "P10 (fails)"),
+                ("HD 74167", 8.676944, -45.189722, 8.667722, -45.095556, "P8 (solves)"),
+            };
+
+            foreach (var (name, hdrRa, hdrDec, trueRa, trueDec, label) in cases)
+            {
+                output.WriteLine($"{label}  OBJECT = {name}");
+                if (((ICelestialObjectDB)db).TryLookupByIndex(name, out var obj))
+                {
+                    output.WriteLine($"   catalogued at   {obj.RA:F5}h {obj.Dec:+0.0000;-0.0000}  (V={(double)obj.V_Mag:F2})");
+                    output.WriteLine($"   header states   {hdrRa:F5}h {hdrDec:+0.0000;-0.0000}  -> {SepDeg(obj.RA, obj.Dec, hdrRa, hdrDec) * 60:F1} arcmin from the catalogued star");
+                    output.WriteLine($"   frame really is {trueRa:F5}h {trueDec:+0.0000;-0.0000}  -> {SepDeg(obj.RA, obj.Dec, trueRa, trueDec) * 60:F1} arcmin from the catalogued star");
+                }
+                else
+                {
+                    output.WriteLine($"   NOT FOUND in the catalog");
+                }
+
+                output.WriteLine($"   header vs truth {SepDeg(hdrRa, hdrDec, trueRa, trueDec) * 60:F1} arcmin");
+                output.WriteLine("");
+            }
+
+            // How wrong does a hint get on a FULL panel of this same mosaic?
+            var manifest = VelaMosaicStarLists.Manifest;
+            var worst = 0.0;
+            var worstId = "";
+            var nearest = 0.0;
+            var nearestId = "";
+            var nearestHint = 0.0;
+            foreach (var panel in manifest.Panels)
+            {
+                foreach (var frame in panel.Frames)
+                {
+                    var err = SepDeg(frame.Hint.CenterRA, frame.Hint.CenterDec, frame.Wcs.CenterRA, frame.Wcs.CenterDec) * 60;
+                    if (err > worst)
+                    {
+                        worst = err;
+                        worstId = $"{panel.Id}/{frame.Name}";
+                    }
+                }
+
+                var d = SepDeg(panel.Frames[0].Wcs.CenterRA, panel.Frames[0].Wcs.CenterDec, 8.696528, -48.040000) * 60;
+                if (nearestId.Length == 0 || d < nearest)
+                {
+                    nearest = d;
+                    nearestId = panel.Id;
+                    nearestHint = SepDeg(panel.Frames[0].Hint.CenterRA, panel.Frames[0].Hint.CenterDec,
+                        panel.Frames[0].Wcs.CenterRA, panel.Frames[0].Wcs.CenterDec) * 60;
+                }
+            }
+
+            output.WriteLine($"frozen mosaic: worst FULL-panel hint error {worst:F1} arcmin ({worstId}) over {manifest.Panels.Length} panels");
+            output.WriteLine($"the full panel nearest the crop's true centre is {nearestId}, {nearest:F1} arcmin away, its own hint {nearestHint:F1} arcmin off");
+        }
+
         private static double SepDeg(double ra1H, double dec1, double ra2H, double dec2)
         {
             var r1 = double.DegreesToRadians(ra1H * 15.0);

--- a/src/TianWen.Lib.Tests/VelaMosaicFieldTests.cs
+++ b/src/TianWen.Lib.Tests/VelaMosaicFieldTests.cs
@@ -2,8 +2,10 @@ using Shouldly;
 using System;
 using System.Collections.Generic;
 using System.Numerics;
+using System.Threading.Tasks;
 using TianWen.Lib.Astrometry;
 using TianWen.Lib.Astrometry.PlateSolve;
+using TianWen.Lib.Imaging;
 using Xunit;
 
 namespace TianWen.Lib.Tests
@@ -136,13 +138,34 @@ namespace TianWen.Lib.Tests
             {
                 var det = frame.DetectedPoints();
 
+                // Seed the way the SHIPPED path seeds, not through a window of the test's own
+                // choosing: recover the plate scale from the quads and search inside
+                // RecoveredScaleTolerance of it, falling back to the header's scale at
+                // MinPairLockScaleTolerance when the recovery declines. Recovery runs ONCE, off a
+                // single parity, because the five quad ratios are reflection-invariant -- which is
+                // also why the solver computes it before its own parity race.
+                //
+                // It is what a session actually runs, it is ~5x less work than the +/-3% window this
+                // used to spend, and it turns these 96 frames into a LOCK-level guard on the
+                // recovery. That the recovery keeps FIRING is guarded next door, by
+                // QuadScaleRecoveryTests' recovered-panel count; without that, a recovery that
+                // started declining everywhere would quietly fall back to +/-5% here and still pass.
+                var quadHintWcs = VelaProjection.HintWcs(frame.Hint, dim);
+                var quadProjected = VelaProjection.ProjectInFrame(
+                    Manifest.Catalog, quadHintWcs, panel.Width, panel.Height);
+                var recovery = QuadScaleRecovery.TryRecover(det, quadProjected);
+                var seedScaleRad = recovery is { } r ? pixelScaleRad / r.Ratio : pixelScaleRad;
+                var seedTolerance = recovery is null
+                    ? CatalogPlateSolver.MinPairLockScaleTolerance
+                    : CatalogPlateSolver.RecoveredScaleTolerance;
+
                 // Both parities, exactly as the solver tries them.
                 PairRansacLock.LockResult? best = null;
                 var bestXSign = 0.0;
                 foreach (var xSign in new[] { -1.0, 1.0 })
                 {
-                    if (CatalogPlateSolver.TrySeedPairLock(catalog, det, frame.Hint, pixelScaleRad,
-                            cx, cy, dim, xSign, scaleTolerance: 0.03f) is { } locked
+                    if (CatalogPlateSolver.TrySeedPairLock(catalog, det, frame.Hint, seedScaleRad,
+                            cx, cy, dim, xSign, seedTolerance) is { } locked
                         && (best is null || locked.Hits > best.Value.Hits))
                     {
                         best = locked;
@@ -169,7 +192,8 @@ namespace TianWen.Lib.Tests
                 // with the hint projection must therefore reproduce the frozen solution, which is
                 // the only statement that matters: a lock with the right hit count but the wrong
                 // geometry would still ruin the solve.
-                var hintWcs = VelaProjection.HintWcs(frame.Hint, dim, bestXSign);
+                var seedDim = new ImageDim((float)(double.RadiansToDegrees(seedScaleRad) * 3600.0), dim.Width, dim.Height);
+                var hintWcs = VelaProjection.HintWcs(frame.Hint, seedDim, bestXSign);
                 var checkedStars = 0;
                 var worstErr = 0.0;
                 for (var i = 0; i < Manifest.Catalog.Length && checkedStars < 400; i++)
@@ -197,6 +221,7 @@ namespace TianWen.Lib.Tests
                     $"{panelId}/{frame.Name}: seed disagrees with the frozen solution by {worstErr:F1} px");
 
                 output.WriteLine($"{panelId}/{frame.Name}: seeded xSign={bestXSign:+0;-0} " +
+                    $"[{(recovery is { } rec ? $"quad {rec.Ratio:F5}/{rec.Candidates}c, +/-{100 * seedTolerance:F2}%" : $"header, +/-{100 * seedTolerance:F0}%")}] " +
                     $"{lockResult.Hits}/{lockResult.Census} hits (chance {lockResult.ExpectedChanceHits:F1}) " +
                     $"in {lockResult.Hypotheses} hypotheses, worst-of-{checkedStars} seed error {worstErr:F1} px");
             }
@@ -239,19 +264,31 @@ namespace TianWen.Lib.Tests
             {
                 var frame = panel.Frames[0];
                 var dim = panel.Dim;
-                var pixelScaleRad = double.DegreesToRadians(dim.PixelScale / 3600.0);
                 var det = frame.DetectedPoints();
+
+                // Seeded on the shipped window, as the theory above is: this test is about which
+                // anchor POOL locks, so it must not be the last place still paying for a wide scale
+                // search. Recovery is per panel and parity-blind, exactly as the solver runs it.
+                var quadProjected = VelaProjection.ProjectInFrame(
+                    Manifest.Catalog, VelaProjection.HintWcs(frame.Hint, dim), panel.Width, panel.Height);
+                var recovery = QuadScaleRecovery.TryRecover(det, quadProjected);
+                var seedDim = recovery is { } r
+                    ? new ImageDim((float)(dim.PixelScale / r.Ratio), dim.Width, dim.Height)
+                    : dim;
+                var seedTolerance = recovery is null
+                    ? CatalogPlateSolver.MinPairLockScaleTolerance
+                    : CatalogPlateSolver.RecoveredScaleTolerance;
 
                 var strict = false;
                 var margined = false;
                 foreach (var xSign in new[] { -1.0, 1.0 })
                 {
-                    var hintWcs = VelaProjection.HintWcs(frame.Hint, dim, xSign);
+                    var hintWcs = VelaProjection.HintWcs(frame.Hint, seedDim, xSign);
                     foreach (var margin in new[] { 0.0, 0.1 })
                     {
                         var pool = VelaProjection.ProjectInFrame(Manifest.Catalog, hintWcs, panel.Width, panel.Height, margin);
                         if (PairRansacLock.TryLock(pool, det, det, panel.Width, panel.Height,
-                                scaleTolerance: 0.03f, out _) is not null)
+                                seedTolerance, out _) is not null)
                         {
                             if (margin == 0.0)
                             {
@@ -309,45 +346,70 @@ namespace TianWen.Lib.Tests
         public void UnrelatedDenseFieldsMustNotLock()
         {
             var footprints = new Dictionary<string, HashSet<int>>();
+            // Both of these depend on ONE panel, and the pair sweep below asks for them O(n^2)
+            // times: every panel's field was being re-projected out of 78k catalog stars, and its
+            // detected list rebuilt, once per partner rather than once. Hoisting changes nothing
+            // about what is tested.
+            var fields = new Dictionary<string, Vector2[]>();
+            var detected = new Dictionary<string, Vector2[]>();
             foreach (var panel in Manifest.Panels)
             {
                 footprints[panel.Id] = InFrameIndices(panel, panel.Frames[0]);
+                // B's field at full in-frame density, as B's own camera saw it.
+                fields[panel.Id] = VelaProjection.ProjectInFrame(Manifest.Catalog, panel.Frames[0].Wcs, panel.Width, panel.Height);
+                detected[panel.Id] = panel.Frames[0].DetectedPoints();
             }
 
-            var tested = 0;
+            var pairs = new List<(VelaPanel A, VelaPanel B)>();
             foreach (var a in Manifest.Panels)
             {
                 foreach (var b in Manifest.Panels)
                 {
-                    if (ReferenceEquals(a, b) || footprints[a.Id].Overlaps(footprints[b.Id]))
+                    if (!ReferenceEquals(a, b) && !footprints[a.Id].Overlaps(footprints[b.Id]) && fields[b.Id].Length >= 100)
                     {
-                        continue;
-                    }
-
-                    // B's field at full in-frame density, as B's own camera saw it.
-                    var bField = VelaProjection.ProjectInFrame(Manifest.Catalog, b.Frames[0].Wcs, b.Width, b.Height);
-                    if (bField.Length < 100)
-                    {
-                        continue;
-                    }
-
-                    var aDet = a.Frames[0].DetectedPoints();
-                    var result = PairRansacLock.TryLock(bField, aDet, aDet, a.Width, a.Height,
-                        scaleTolerance: 0.03f, out var diagnostics);
-
-                    result.ShouldBeNull($"{a.Id} detected stars must not lock onto {b.Id}'s unrelated field " +
-                        $"({bField.Length} catalog stars in frame): {diagnostics}");
-                    tested++;
-
-                    if (tested <= 5)
-                    {
-                        output.WriteLine($"{a.Id} vs {b.Id}: correctly no lock -- {diagnostics}");
+                        pairs.Add((a, b));
                     }
                 }
             }
 
-            tested.ShouldBeGreaterThan(20, "expected many non-overlapping panel pairs in a 24-panel mosaic");
-            output.WriteLine($"{tested} non-overlapping panel pairs, none locked.");
+            // The one seed in this suite still searching the WIDE window, deliberately: a false lock
+            // is what the pair matcher exists to refuse, and a wide scale search is the adversarial
+            // condition for it -- it hands the matcher the most freedom to find a spurious
+            // consensus. Narrowing this to the shipped +/-0.25% takes it from 45 s to 3 s and makes
+            // the pass mean strictly less, which is the wrong trade for the one test the whole
+            // pair-lock effort was written to satisfy. So it stays wide and gets its time back from
+            // the fact that every pair is an independent pure computation over frozen data instead.
+            // Bounded at half the box rather than left unbounded: other xunit collections run beside
+            // this one, and the suite's own runner is pinned to 4 threads for the same reason.
+            var outcomes = new (bool Locked, string Diagnostics)[pairs.Count];
+            Parallel.For(0, pairs.Count,
+                new ParallelOptions { MaxDegreeOfParallelism = Math.Max(2, Environment.ProcessorCount / 2) },
+                i =>
+                {
+                    var (a, b) = pairs[i];
+                    var aDet = detected[a.Id];
+                    var result = PairRansacLock.TryLock(fields[b.Id], aDet, aDet, a.Width, a.Height,
+                        scaleTolerance: 0.03f, out var diagnostics);
+                    outcomes[i] = (result is not null, diagnostics.ToString());
+                });
+
+            // Asserted afterwards, in order, so the failure names every false lock rather than
+            // whichever one a worker happened to throw from first, and so the sample lines below are
+            // the same five pairs on every run.
+            for (var i = 0; i < pairs.Count; i++)
+            {
+                var (a, b) = pairs[i];
+                outcomes[i].Locked.ShouldBeFalse($"{a.Id} detected stars must not lock onto {b.Id}'s unrelated field " +
+                    $"({fields[b.Id].Length} catalog stars in frame): {outcomes[i].Diagnostics}");
+
+                if (i < 5)
+                {
+                    output.WriteLine($"{a.Id} vs {b.Id}: correctly no lock -- {outcomes[i].Diagnostics}");
+                }
+            }
+
+            pairs.Count.ShouldBeGreaterThan(20, "expected many non-overlapping panel pairs in a 24-panel mosaic");
+            output.WriteLine($"{pairs.Count} non-overlapping panel pairs, none locked.");
         }
 
         /// <summary>

--- a/src/TianWen.Lib/Astrometry/PlateSolve/CatalogPlateSolver.cs
+++ b/src/TianWen.Lib/Astrometry/PlateSolve/CatalogPlateSolver.cs
@@ -191,13 +191,31 @@ internal sealed class CatalogPlateSolver(ICelestialObjectDB db, ILogger logger) 
         return SolveImageAsync(image, imageDim, range, searchOrigin, searchRadius, cancellationToken);
     }
 
-    public async Task<PlateSolveResult> SolveImageAsync(
+    public Task<PlateSolveResult> SolveImageAsync(
         Image image,
         ImageDim? imageDim = default,
         float range = IPlateSolver.DefaultRange,
         WCS? searchOrigin = default,
         double? searchRadius = default,
         CancellationToken cancellationToken = default
+    )
+        => SolveFromOriginAsync(image, imageDim, range, searchOrigin, searchRadius, allowPositionalSearch: true, cancellationToken);
+
+    /// <param name="allowPositionalSearch">
+    /// False on the ONE retry a positional search may trigger, which is what bounds the recursion at
+    /// a single extra pass. The retry re-enters here rather than resuming mid-solve because
+    /// everything downstream of the catalog query is a function of the origin -- and star detection,
+    /// the expensive half, is cached on the <see cref="Image"/>, so re-entering costs the query, the
+    /// quad recovery and the race, not the detection.
+    /// </param>
+    private async Task<PlateSolveResult> SolveFromOriginAsync(
+        Image image,
+        ImageDim? imageDim,
+        float range,
+        WCS? searchOrigin,
+        double? searchRadius,
+        bool allowPositionalSearch,
+        CancellationToken cancellationToken
     )
     {
         var sw = Stopwatch.StartNew();
@@ -486,7 +504,216 @@ internal sealed class CatalogPlateSolver(ICelestialObjectDB db, ILogger logger) 
 
         winner = ApplyAcceptanceGate(winner, loser, catalogCoords, detectedStars, dim, tolerance);
 
+        // Last resort: the hint may simply not be where the frame is. The seed's anchor pool is the
+        // brightest catalog stars that project INSIDE THE FRAME from the origin, so the pool's
+        // footprint is the origin's own frame -- and a hint wrong by a large fraction of a frame
+        // width starves it however wide the catalog query was. Widening the radius cannot reach that
+        // (it widens the QUERY, not the pool), which is why this has to be a search over POSITIONS.
+        if (winner.Wcs is null && allowPositionalSearch
+            && TryFindOriginByPositionalSearch(detectedStars, origin, pixelScaleRad, cx, cy, dim, range, dtYr, searchRadius, cancellationToken) is { } relocated)
+        {
+            var retry = await SolveFromOriginAsync(image, dim, range, relocated, searchRadius, allowPositionalSearch: false, cancellationToken).ConfigureAwait(false);
+
+            // Bounding the candidate CENTRES is not the same as bounding the sky examined: a frame
+            // centred at the edge of the search area still reaches half a diagonal beyond it, and
+            // the disc anchor pool reaches further again. So the answer itself is checked. A caller
+            // who passes a radius is saying "the truth is within this of my hint", and a solution
+            // outside it -- however real -- is not an answer to the question they asked.
+            if (retry.Solution is { } found && searchRadius is { } limitDeg
+                && CoordinateUtils.AngularSeparationDeg(origin.CenterRA, origin.CenterDec, found.CenterRA, found.CenterDec) is var sepDeg
+                && sepDeg > limitDeg)
+            {
+                _logger.LogDebug("CatalogPlateSolver: positional search found a field {Sep:F2} deg away, outside the {Limit:F2} deg the caller allowed; reporting failure",
+                    sepDeg, limitDeg);
+                return Result(winner);
+            }
+
+            return retry;
+        }
+
         return Result(winner);
+    }
+
+    /// <summary>
+    /// How far the hint may be wrong, as a multiple of the LONG frame axis. One frame width covers a
+    /// crop that kept its parent's <c>OBJCTRA</c>/<c>OBJCTDEC</c> -- the case this exists for, measured
+    /// at 0.70 frame widths -- without paying for a sky-wide hunt nobody asked for.
+    /// </summary>
+    internal const double PositionalSearchFovMultiple = 1.0;
+
+    /// <summary>
+    /// Candidate spacing, as a fraction of the SHORT frame axis. On a square grid the worst distance
+    /// to the nearest node is step/sqrt(2), so 0.35 keeps every point in the search area within ~25%
+    /// of a frame width of some candidate. The frozen mosaic seeds at a 19.6% hint error and fails at
+    /// 71.4%, so ~25% sits inside the measured envelope with the margined anchor pool covering the
+    /// rest.
+    /// </summary>
+    internal const double PositionalSearchStepFraction = 0.35;
+
+    /// <summary>
+    /// Brightest detections handed to a SEARCH seed. Not an anchor cap -- PairRansacLock already caps
+    /// anchors at 48 -- but a cap on the set every hypothesis is VERIFIED against, which is otherwise
+    /// the whole detected list and is what makes a search candidate cost seconds on a dense frame.
+    /// </summary>
+    internal const int PositionalSearchDetectedCap = 250;
+
+    /// <summary>
+    /// Hypotheses a SEARCH seed may spend before giving up on a candidate. The real seed is allowed a
+    /// million, which is right when the answer is believed to be here and wrong when it is one of
+    /// dozens of guesses: a candidate centred on empty sky should be abandoned early, and a candidate
+    /// centred on the truth locks in the low hundreds (the frame this exists for seeds in 195).
+    /// </summary>
+    internal const int PositionalSearchHypothesisBudget = 20_000;
+
+    /// <summary>
+    /// Walk candidate frame centres outward from the hint until one SEEDS, and answer with that
+    /// centre so the caller can solve from it normally. Nothing here decides a solution: it decides
+    /// an ORIGIN, and the acceptance gate still has the last word downstream, so the search can only
+    /// find a lock that was already there to be found.
+    /// </summary>
+    /// <remarks>
+    /// <para>The query is sized from the geometry rather than from a constant: a frame reaches
+    /// <c>0.5 * pixelScale * hypot(w, h)</c> from its own centre, so a disc of
+    /// <c>searchRadius + halfDiagonal</c> covers every candidate frame exactly. (The single-centre
+    /// form of that quantity is the <c>0.75 * max(fov)</c> the ordinary query uses -- the same
+    /// half-diagonal with ~7% slack.) It is sized for CORRECTNESS, not speed: the query measures
+    /// sub-linear in area -- 13.7 ms for 9,605 stars at 3.69 deg against 66 ms for 75,062 at 12 deg --
+    /// so the radius was never the expensive part and shrinking it further buys nothing.</para>
+    /// <para>Seeds are attempted with NO logger. This runs tens of candidates x two parities x the
+    /// pool policies, and every miss would otherwise write a diagnostic line, burying the one line
+    /// that matters under a hundred that do not.</para>
+    /// </remarks>
+    private WCS? TryFindOriginByPositionalSearch(
+        StarList detectedStars,
+        WCS origin,
+        double pixelScaleRad,
+        double cx,
+        double cy,
+        ImageDim dim,
+        float scaleRange,
+        double dtJulianYears,
+        double? callerSearchRadiusDeg,
+        CancellationToken cancellationToken
+    )
+    {
+        if (detectedStars.Count < MinStarsForMatch)
+        {
+            return null;
+        }
+
+        var fov = dim.FieldOfView;
+        var halfDiagonalDeg = 0.5 * dim.PixelScale
+            * Math.Sqrt((double)dim.Width * dim.Width + (double)dim.Height * dim.Height) / 3600.0;
+        var searchRadiusDeg = PositionalSearchFovMultiple * Math.Max(fov.width, fov.height);
+
+        // An EXPLICIT radius is the caller stating how far the truth might be, and it bounds this
+        // search as surely as it bounds the catalog query -- searching sky the caller ruled out
+        // would answer a question they did not ask. The DEFAULT radius does not bound it: that one
+        // is our own derivation from the frame size, not a statement of intent, and the whole point
+        // here is that the pool footprint rather than the query is what limits the seed.
+        if (callerSearchRadiusDeg is { } capped)
+        {
+            searchRadiusDeg = Math.Min(searchRadiusDeg, capped);
+        }
+        var stepDeg = PositionalSearchStepFraction * Math.Min(fov.width, fov.height);
+        if (stepDeg <= 0 || searchRadiusDeg <= 0)
+        {
+            return null;
+        }
+
+        var stageSw = Stopwatch.StartNew();
+        var wideCatalog = QueryCatalogStarsInRegion(origin, searchRadiusDeg + halfDiagonalDeg, dtJulianYears);
+        if (wideCatalog.Count < MinStarsForMatch)
+        {
+            return null;
+        }
+
+        // COARSE by design, and safe because of what this method returns. It answers an ORIGIN, not
+        // a solution: whatever it finds is re-seeded at full fidelity by the retry and still has to
+        // pass the acceptance gate, so the search may be noisier than the real seed without being
+        // able to admit a wrong answer. Two cuts follow from that, and together they are what make
+        // the search affordable at all -- at full fidelity it costs ~2.9 s per candidate-parity,
+        // which is minutes over a search and far worse than the failure it is trying to rescue.
+        //
+        // The verification set is truncated: PairRansacLock checks every hypothesis against the
+        // WHOLE detected list, which is thousands of stars on exactly the dense frames that need
+        // this, while the anchor side is capped at 48 regardless. A few hundred is a decisive
+        // consensus test (the threshold scales with the census, so the bar moves with it).
+        var ranked = new List<ImagedStar>(detectedStars);
+        ranked.Sort((a, b) => b.Flux.CompareTo(a.Flux));
+        var searchDetected = Math.Min(ranked.Count, PositionalSearchDetectedCap);
+        var detPts = new Vector2[searchDetected];
+        for (var i = 0; i < searchDetected; i++)
+        {
+            detPts[i] = new Vector2(ranked[i].XCentroid, ranked[i].YCentroid);
+        }
+
+        // The header's window, not the recovered one: the quad recovery projects through the same
+        // hint the pool does, so wherever the pool starves the recovery has declined with it.
+        var tolerance = Math.Max(scaleRange, MinPairLockScaleTolerance);
+        var tried = 0;
+
+        foreach (var (dx, dy) in SpiralOffsets(searchRadiusDeg, stepDeg))
+        {
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return null;
+            }
+
+            var candidate = OffsetOrigin(origin, dx, dy);
+            foreach (var xSign in new[] { 1.0, -1.0 })
+            {
+                tried++;
+                // One pool: the DISC is tried first precisely because it assumes least about the
+                // camera angle, and where it differs from the rectangle it is the one that is right.
+                if (TrySeedPairLock(wideCatalog, detPts, candidate, pixelScaleRad, cx, cy, dim, xSign,
+                        tolerance, out _, logger: null, cancellationToken, poolPolicyLimit: 1, maxHypotheses: PositionalSearchHypothesisBudget) is { } locked)
+                {
+                    _logger.LogDebug("CatalogPlateSolver: positional search seeded {Hits}/{Census} (chance {Chance:F1}) {Sep:F2} deg from the hint, candidate {Tried}, xSign={XSign}, in {Ms}ms",
+                        locked.Hits, locked.Census, locked.ExpectedChanceHits, Math.Sqrt(dx * dx + dy * dy), tried, xSign, stageSw.Elapsed.TotalMilliseconds);
+                    return candidate;
+                }
+            }
+        }
+
+        _logger.LogDebug("CatalogPlateSolver: positional search found no seed over {Tried} candidates within {Radius:F2} deg (step {Step:F2} deg, {Stars} catalog stars) in {Ms}ms",
+            tried, searchRadiusDeg, stepDeg, wideCatalog.Count, stageSw.Elapsed.TotalMilliseconds);
+        return null;
+    }
+
+    /// <summary>
+    /// Candidate offsets in tangent-plane degrees, in rings outward from the hint. Outward, because a
+    /// hint is far likelier to be a little wrong than very wrong, so the common case exits early. The
+    /// centre itself is skipped: the caller has just tried it and failed.
+    /// </summary>
+    private static IEnumerable<(double Dx, double Dy)> SpiralOffsets(double radiusDeg, double stepDeg)
+    {
+        var rings = (int)Math.Ceiling(radiusDeg / stepDeg);
+        for (var ring = 1; ring <= rings; ring++)
+        {
+            // Clamped, not just counted: ceil() puts the outermost ring PAST the radius, and a
+            // radius the caller supplied is a boundary rather than a suggestion.
+            var r = Math.Min(ring * stepDeg, radiusDeg);
+            var count = Math.Max(6, (int)Math.Ceiling(2.0 * Math.PI * r / stepDeg));
+            for (var k = 0; k < count; k++)
+            {
+                var theta = 2.0 * Math.PI * k / count;
+                yield return (r * Math.Cos(theta), r * Math.Sin(theta));
+            }
+        }
+    }
+
+    /// <summary>
+    /// A small tangent-plane offset applied to a pointing. The flat approximation is deliberate: this
+    /// only has to land a candidate within a fraction of a frame of the truth for the seed to answer,
+    /// and the seed's own transform supplies the real geometry from there.
+    /// </summary>
+    private static WCS OffsetOrigin(WCS origin, double dxDeg, double dyDeg)
+    {
+        var dec = Math.Clamp(origin.CenterDec + dyDeg, -90.0, 90.0);
+        var cosDec = Math.Cos(double.DegreesToRadians(Math.Clamp(dec, -89.9, 89.9)));
+        var ra = origin.CenterRA + dxDeg / (15.0 * Math.Max(cosDec, 1e-3));
+        return new WCS(CoordinateUtils.ConditionRA(ra), dec);
     }
 
     /// <summary>
@@ -1697,12 +1924,16 @@ internal sealed class CatalogPlateSolver(ICelestialObjectDB db, ILogger logger) 
         float scaleTolerance,
         out SeedCost cost,
         ILogger? logger = null,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken = default,
+        int poolPolicyLimit = int.MaxValue,
+        int maxHypotheses = int.MaxValue)
     {
         var hypotheses = 0;
         var poolsTried = 0;
         var cancelled = false;
-        foreach (var (marginFraction, rotationInvariant) in PoolPolicies)
+        var bestHits = 0;
+        var bestChance = 0.0;
+        foreach (var (marginFraction, rotationInvariant) in PoolPolicies.AsSpan(0, Math.Min(poolPolicyLimit, PoolPolicies.Length)))
         {
             var seedProjected = ProjectCatalogStars(catalogCoords, origin, pixelScaleRad, cx, cy, dim, xSign, marginFraction, rotationInvariant);
             if (seedProjected.Count < MinStarsForMatch)
@@ -1720,12 +1951,18 @@ internal sealed class CatalogPlateSolver(ICelestialObjectDB db, ILogger logger) 
 
             var lockResult = PairRansacLock.TryLock(catPts, rankedDetectedPoints, rankedDetectedPoints,
                 dim.Width, dim.Height, scaleTolerance, out var lockDiagnostics,
-                cancellationToken: cancellationToken);
+                cancellationToken: cancellationToken, maxHypotheses: maxHypotheses);
             poolsTried++;
             hypotheses += lockDiagnostics.Hypotheses;
+            if (lockDiagnostics.BestHits > bestHits)
+            {
+                bestHits = lockDiagnostics.BestHits;
+                bestChance = lockDiagnostics.ExpectedChanceHits;
+            }
+
             if (lockResult is { } locked)
             {
-                cost = new SeedCost(hypotheses, poolsTried);
+                cost = new SeedCost(hypotheses, poolsTried, BestHits: bestHits, ExpectedChanceHits: bestChance);
                 logger?.LogDebug("CatalogPlateSolver: pair-lock seed (xSign={XSign}, anchor pool {Pool}) consensus {Hits}/{Census} (chance {Chance:F1}) after {Hypotheses} hypotheses",
                     xSign, PoolName(marginFraction, rotationInvariant), locked.Hits, locked.Census, locked.ExpectedChanceHits, locked.Hypotheses);
                 return locked;
@@ -1746,14 +1983,25 @@ internal sealed class CatalogPlateSolver(ICelestialObjectDB db, ILogger logger) 
             }
         }
 
-        cost = new SeedCost(hypotheses, poolsTried, cancelled);
+        cost = new SeedCost(hypotheses, poolsTried, cancelled, BestHits: bestHits, ExpectedChanceHits: bestChance);
         return null;
     }
 
     /// <summary>What one parity's seed attempt spent. See the <c>out cost</c> overload above.</summary>
     /// <param name="Hypotheses">Summed over every pool policy tried.</param>
     /// <param name="PoolsTried">How many of <c>PoolPolicies</c> were reached before locking or giving up.</param>
-    internal readonly record struct SeedCost(int Hypotheses, int PoolsTried, bool Cancelled = false);
+    /// <param name="BestHits">
+    /// Best consensus any hypothesis reached, across every pool tried. Reported even when no pool
+    /// locked, because "nothing correlated anywhere" and "something is here but under the bar" are
+    /// different facts about a frame and only this number tells them apart.
+    /// </param>
+    /// <param name="ExpectedChanceHits">What that consensus would have been by chance, for scale.</param>
+    internal readonly record struct SeedCost(
+        int Hypotheses,
+        int PoolsTried,
+        bool Cancelled = false,
+        int BestHits = 0,
+        double ExpectedChanceHits = 0);
 
     /// <summary>
     /// The anchor-pool policies the seed tries, in order. See <see cref="TrySeedPairLock"/> for

--- a/src/TianWen.Lib/Astrometry/PlateSolve/CatalogPlateSolver.cs
+++ b/src/TianWen.Lib/Astrometry/PlateSolve/CatalogPlateSolver.cs
@@ -636,7 +636,7 @@ internal sealed class CatalogPlateSolver(ICelestialObjectDB db, ILogger logger) 
     /// distance and an orientation, and a distance has units. Widening the window is what a
     /// pair-based seed can do instead.</para>
     /// </remarks>
-    private const float MinPairLockScaleTolerance = 0.05f;
+    internal const float MinPairLockScaleTolerance = 0.05f;
 
     /// <summary>
     /// Scale window the seed is given once the scale came from the STARS rather than the header.
@@ -655,7 +655,7 @@ internal sealed class CatalogPlateSolver(ICelestialObjectDB db, ILogger logger) 
     /// The remaining 1.5x is not worth spending the margin on, and an exact prior (a scale carried
     /// forward from a previous solve, the way parity is) is the thing that would earn it.</para>
     /// </remarks>
-    private const float RecoveredScaleTolerance = 0.0025f;
+    internal const float RecoveredScaleTolerance = 0.0025f;
 
     private SolveAttempt TrySolveWithProximityMatching(
         StarList detectedStars,

--- a/src/TianWen.Lib/Astrometry/PlateSolve/PairRansacLock.cs
+++ b/src/TianWen.Lib/Astrometry/PlateSolve/PairRansacLock.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Numerics;
 using System.Runtime.InteropServices;
@@ -178,7 +178,8 @@ internal static class PairRansacLock
         float scaleTolerance,
         out LockDiagnostics diagnostics,
         float verifyRadiusPx = 4f,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken = default,
+        int maxHypotheses = MaxHypotheses)
     {
         var cancelled = false;
         var nCat = Math.Min(MaxCatalogAnchors, catalogBright.Length);
@@ -303,7 +304,7 @@ internal static class PairRansacLock
                     var detI = flip == 0 ? detectedBright[i] : detectedBright[j];
                     var detJ = flip == 0 ? detectedBright[j] : detectedBright[i];
 
-                    if (++hypotheses > MaxHypotheses)
+                    if (++hypotheses > maxHypotheses)
                     {
                         capHit = true;
                         goto scanDone;


### PR DESCRIPTION
115 s -> 24 s (**4.7x**), 54/54 green. Medians of two runs a side on a quiet box; the three untouched tests stay flat at 1.0-1.1x as the control.

| test | before | after | |
|---|---|---|---|
| `SeedsFromHeaderHintAndAgreesWithTheFrozenSolution` (24 cases) | 54.5s | 8.2s | 6.7x |
| `UnrelatedDenseFieldsMustNotLock` | 45.6s | 9.0s | 5.1x |
| `BothAnchorPoolPoliciesAreNecessary` | 8.7s | 1.7s | 5.2x |
| the other six (untouched) | 5.7s | 5.4s | 1.0x |
| **total** | **114.5s** | **24.3s** | **4.7x** |

### Two tests now seed the way the solver seeds

They were searching a +/-3% window the tests had invented and production never ran. They now go through the shipped two-tier path: quad recovery, then `RecoveredScaleTolerance` about the recovered scale, falling back to `MinPairLockScaleTolerance` about the header's when recovery declines.

Faster and *more* faithful — it makes these 96 frames a **lock-level** guard on C', which until now had only accuracy coverage. 94 of the 96 take the quad tier. That the recovery keeps firing is guarded next door by `QuadScaleRecoveryTests`; without that, a recovery that started declining everywhere would quietly fall back to +/-5% here and still pass.

### One test keeps the wide window, deliberately

`UnrelatedDenseFieldsMustNotLock` is the one that must: a false lock is what the pair matcher exists to refuse, and a wide scale search is the *adversarial* condition for it. Narrowing it takes it from 45 s to 3 s and makes the pass mean strictly less — measured, then rejected.

Its 5.1x comes from what was never the assertion: each panel's field was re-projected out of 78k catalog stars once per **partner** rather than once, and the pairs are independent pure computations, so they run under a bounded `Parallel.For` with assertions replayed serially afterwards (which also reports *every* false lock rather than whichever one a worker threw from first).

### Also here

- Two seed-window constants become `internal` so a test can name the window the solver uses instead of hardcoding a number beside it.
- `SolveTimingProbe` (env-gated, skips by default) measures what BenchmarkDotNet structurally cannot — the catalog init is cached per process, so a BDN second iteration is already a warm start. **Cold to a WCS: 762 ms** (init 266, load 184, solve 312). **Warm solves: 60-221 ms**, of which seed+refine is 43-61% and detection 34-47%; the catalog query is down to 2-6 ms and quad recovery costs 1-2 ms.

Two findings it turned up, both written into the plan doc:

1. **Recovery declines on 3 of 5 real frames purely on candidate count** (8, 6, 4 against a minimum of 10), while the spread guard carries 6-25x of margin — so `RatioTolerance` is the knob worth loosening. The frame it declines on hardest is the one that needs it most: the SharpCap Horsehead's `FOCALLEN` is 4.0% wrong, saved only by the +/-5% fallback.
2. **The `Vela_SNR_Panel_10` crop does not solve at any radius out to 12 deg nor any scale from 0.5x to 2x**, on a dense field yielding 1569 detections. Nothing regressed — it had never been asked for a WCS before — but it is unexplained, and it prices the failure path at 4.0 s, 65x a warm success.

Gates: full unit suite 5311 passed / 0 failed / 81 skipped; solution builds clean in Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)