### PR TITLE
perf(solve): a rig that has solved once already knows its parity and scale

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -487,6 +487,17 @@ synthetic suite**, because a synthetic field is built from a transform the test 
 dataset rationale, both measurements above, and what real density covers that synthetic fields cannot:
 [docs/plans/plate-solver-performance.md](docs/plans/plate-solver-performance.md).
 
+**A remembered parity is a hypothesis BUDGET for the other half, never a skip; and it is keyed on the
+LIGHT PATH.** `SolveHintCache` learns each rig's plate scale and parity from an accepted solve.
+Skipping the doubted parity is the tempting form and it inverts the goal: with one half gone, a frame
+that seeds on neither runs them in SERIES (the believed one, then the gate's re-run), where today they
+overlap -- twice the wall clock on the doomed path to save half the CPU. Capped and still parallel it
+is 1.6x fewer hypotheses on the P10 crop. The key is `(Telescope, Instrument, RowOrder, Bin)`: an OAG
+guide camera is the OPPOSITE parity to the main camera on the same rig at the same instant, so per-rig
+is wrong, and per-camera gets a body moved between an SCT and a refractor backwards. The parity rides
+on `SolveAttempt.IsStd` rather than beside the race, because the acceptance gate can overturn the pick
+and the cache must learn the half that actually answered.
+
 **DI registration uses a factory lambda** (`AstrometryServiceCollectionExtensions.cs`):
 
 ```csharp

--- a/docs/plans/plate-solver-performance.md
+++ b/docs/plans/plate-solver-performance.md
@@ -199,6 +199,55 @@ hypothesis count, which is deterministic and machine-independent; converting tha
 proves the cancellation FIRES end to end (and fails when it is disabled -- the solved WCS is
 byte-identical either way, so nothing else could).
 
+#### The cache half -- **SHIPPED 2026-09-01**, and it is a BUDGET, not a skip
+
+`SolveHintCache` remembers, per light path, what an ACCEPTED solve answered: the plate scale (as the
+header-over-solved RATIO, the same quantity `QuadScaleRecovery.Recovery` carries, so it consumes
+through the existing two-tier seed with no new path) and the parity. Keyed
+`(Telescope, Instrument, RowOrder, BinX, BinY)` -- the pair as argued above, plus row order because it
+is a parity determinant in its own right and belongs in the key rather than being learned, plus
+binning because the same camera at 1x1 and 2x2 is two plate scales. In-memory on the solver, which is
+a DI singleton, so a session's second and later solves benefit; persisting it the way
+`BacklashHistory` is persisted would extend that to the first solve of a night and is not done here.
+
+**A remembered parity SHRINKS the doubted half's hypothesis budget; it never skips it.** Skipping is
+the obvious form and it is wrong in exactly the place this is meant to help. With one parity gone, a
+frame that seeds on neither runs the two halves in SERIES -- the believed one, then the gate's re-run
+of the other -- where today they overlap. The doomed path would get twice as long in wall clock to
+save half the CPU, which is the opposite of the goal. Capped and still parallel, the wall time stays
+the believed half's while the doubted half stops early. When the cache is stale the capped half simply
+finds nothing, and it is marked abandoned, so the gate's existing re-run picks it up uncapped -- the
+same fallback an abandoned parity has always used. `DoubtedParityHypothesisBudget = 100_000` is sized
+off what a real lock costs (Vela panels 235-567, P10's relocated solve 749, phase A's own frame
+32,179), not off what a scan can afford.
+
+**Measured on the P10 crop, second solve on the same solver: 9,165,717 -> 5,813,171 hypotheses, 1.6x.**
+Two things that measurement says, both worth keeping:
+
+- **The saving is the PARITY half only, on a frame that fails.** A remembered scale cannot help a
+  doomed pass by construction: the narrow tier is tried first, does not lock, and falls through to the
+  header's +/-5% window, which is the expensive scan it was meant to avoid. That fallback is what
+  stops a stale scale from turning a solvable frame into a failure, so the ordering stays.
+- **The scale half is a net NEGATIVE on a doomed frame, at +13.6%** (9,165,717 -> 10,418,023 with the
+  parity cap disabled): the narrow tier's own pass is pure addition when nothing can lock. The parity
+  cap more than pays for it, and the scale's win lands on a frame that SOLVES while its quad recovery
+  declines -- a real combination (2 of 5 archive frames decline) that no committed fixture reproduces,
+  so it is deliberately not asserted. Worth revisiting: bounding the *cached-scale* tier the same way
+  the doubted parity is bounded would make its failure cost negligible while keeping its win, since
+  the wide-window fallback already covers a narrow scan cut short.
+
+**The parity travels ON `SolveAttempt` (`IsStd`), not beside it.** The consumer that matters reads it
+AFTER the acceptance gate, and the gate is the one place the pick gets overturned -- so a flag tracked
+alongside the race would teach the cache the wrong half in exactly the case the gate exists to catch.
+It also keeps phase A's own bug fixed for the same reason it was a bug: which half won has to be DATA,
+never `ReferenceEquals` on a record struct.
+
+Guarded by `SolveHintCacheTests` (learning, light-path separation, and that an unidentified frame or a
+non-positive ratio teaches nothing) plus the second solve in
+`RealFrameSolveTests.TheCropWhoseHeaderPointsElsewhereStillSolves`, which asserts on
+`CatalogPlateSolver.LastSeedHypotheses` -- deterministic, unlike wall clock -- and was seen to FAIL
+with the cap disabled.
+
 ### B. Tycho-2 pre-baked region index -- **OBSOLETE, the work is already done**
 
 **Measured 2026-08-31 and it invalidates this phase.** The Tycho-2 bulk load, budgeted here at
@@ -644,11 +693,92 @@ passes a radius is saying "the truth is within this of my hint"; a field outside
 not an answer to their question. (The ring loop also had to clamp: `ceil(radius/step)` puts the
 outermost ring past the radius.)
 
-**Outstanding, and it would remove the remaining regression:** gate the search on the direct seed's
-own signal. A misplaced hint scores clearly above chance but under the bar (19-22 hits against a
-chance of 7.5 on the P10 crop); a frame with nothing in it scores AT chance. Gating on that ratio
-would leave the cloudy-frame path paying nothing at all, instead of the +1.8 s it pays now.
-`SeedCost` already carries `BestHits`/`ExpectedChanceHits` for it.
+### Gating the search on the seed's signal: TRIED, and the premise is wrong
+
+The obvious way to remove the remaining +1.8 s was to gate the search on the direct seed's own
+signal -- "a misplaced hint scores above chance, a frame with nothing in it scores AT chance, so
+read `SeedCost.BestHits`/`ExpectedChanceHits`". It was built (threaded up through `SolveAttempt` to
+the gate) and then **reverted, because measurement refuted every leg of it.** Three findings, and
+the third one is the one that settles it.
+
+**1. The populations do not separate, under any normalisation.** Three frames, the seed's best
+consensus at the hint, against both the chance rate and against `PairRansacLock`'s own accept bar
+(which is `max(max(10, 5 x chance), 0.15 x census)`):
+
+| frame | detected | best hits | chance | bar | vs chance | vs bar |
+|---|---|---|---|---|---|---|
+| P10 crop -- hint 71% of a frame off, RELOCATABLE | 1,569 | 32 | 7.5 | 37.3 | 4.3x | **0.86** |
+| dense field solved 6 deg off -- real sky, elsewhere | 3,250 | 22 | 2.9 | 24.0 | 7.6x | **0.92** |
+| random 48-star field -- NO sky in it at all | 48 | 8 | 0.0 | 10.0 | 8.0x | **0.80** |
+
+By chance ratio the frame with no sky in it scores the **highest** of the three: the model assumes an
+independent field, so a real one clusters above it, and a sparse one drives chance to ~0 where 8 hits
+is an enormous multiple of nothing. Against the bar -- the composite that stays meaningful in both
+regimes, which is why the lock uses it -- the no-sky frame lands at 0.80 against the 0.86 of the case
+that must never be refused. There is no threshold in that gap worth a shipped capability.
+
+**2. The middle row is not noise, it is the shape of the problem.** A real star field scores high
+whether or not it is *this frame's* field, because the seed measures "do these detections correlate
+with a star field" and not "is that field mine". So a gate tight enough to refuse the 6-deg-off case
+would refuse relocation too. That case is also the one where the search is *right* to run: there is a
+field, it simply is not within the radius the caller allowed, and the radius check is what refuses it.
+
+**3. The case it was written for never reaches the gate.** A cloudy frame mid-session has a GOOD
+hint, so it does not fail the way the premise assumed. Measured on `FakeCameraDriver`'s cloud model at
+the correct pointing: 0%, 70%, 85%, 93% and 97% coverage all **solve**, in 168-334 ms, still finding
+90-130 stars through the worst of them. A frame with too few stars to seed exits before the race on
+`detectedStars < MinStarsForMatch`, which is also before the search. The +1.8 s is paid only by a
+solve that genuinely fails with a real field on the sensor -- which is the case that deserves it.
+
+So **the regression is narrower than it looked, and the seed cannot be the discriminant.** What
+remains available, in order of how much it would buy:
+
+- **Bound the cost rather than predicting the outcome.** The failure path spends 4.0 s in proximity
+  refinement before the acceptance gate refuses it, which is 2.2x what the search costs on top.
+- **Let the caller state its pointing uncertainty.** An explicit `searchRadius` already clamps the
+  candidate walk, and today exactly one production caller passes one at all (`Session.Focus.cs:882`,
+  at 10 deg); polar alignment, `MasterPostProcessor` and the viewer pass none, so every session solve
+  searches the full frame width. A session that has just slewed knows better than that.
+
+**One thing the attempt did find, worth keeping:** on the random 48-star field the positional search
+**seeded** -- it returned an origin for a frame with no sky in it, and only the acceptance gate on the
+retry refused the result. That is the "returns an ORIGIN, not a solution" design being load-bearing
+rather than decorative, and it is an argument against ever letting a search result skip the gate.
+
+### Where a doomed solve actually spends its time -- it is the SEED, not the refinement
+
+Measured 2026-09-01 off the solver's own stage logs (Debug build, so read the SHARES, not the
+absolute times):
+
+| stage | P10 crop, doomed pass at the header hint | dense field, hint 6 deg off |
+|---|---|---|
+| catalog query + detect + quad recovery | 195 ms | 377 ms |
+| **seed + refine** (the one stage log) | **20,483 ms (98%)** | **8,669 ms (91%)** |
+| positional search | 54 ms (0.3%) | 423 ms (4.5%) |
+| relocated retry, whole solve | ~60 ms | n/a |
+
+**Two attributions in this plan were wrong, and both pointed at the wrong lever.**
+
+**The refinement loop does not run to exhaustion.** Both doomed frames exit it after **3** iterations
+on each parity (P10: std 534 matches / 3 iters, mirror 518 / 3; the dense one: 2,652 / 3). The
+divergence and convergence breaks already work. What fills that stage is the pair-lock SEED: with no
+lock to be had it runs all three anchor-pool policies on both parities to 100% pair coverage --
+1.39M-1.62M hypotheses per pool-parity, ~9.2M in total on P10. Nothing cancels, because the parity
+race only cancels the loser when the winner seeds clear of chance, and on a doomed frame neither does.
+
+**The positional search is not the +1.8 s regression it was recorded as**, at 54 ms on P10 (it seeded
+at candidate 2) and 423 ms walking all 34 candidates on the dense one. Whatever produced the 4.0 s ->
+5.8 s delta above does not reproduce here; the search is 0.3-4.5% of a failure path that is ~95% seed.
+So the thing task #25 was written to remove was ~2% of the cost, and the thing to remove is the seed's
+doomed scan.
+
+**Which does NOT mean lowering `MaxHypotheses`.** The counter-evidence is already in this file: 400k
+"stopped at 37-41% of pairs on real Vela frames and found no seed on fields that do have one". A hard
+frame can need deep coverage, so the budget is load-bearing for exactly the frames it looks wasteful
+on. The lever that survives is **phase A's unshipped half, the per-(OTA, camera) parity cache**: the
+parity is a property of the optical train, not of the frame, so a rig that solved once has already
+answered it. Caching it halves the doomed path outright -- and it is the doomed path that needs it,
+since a successful solve already cancels its loser mid-seed.
 
 ## Correctness gates
 

--- a/docs/plans/plate-solver-performance.md
+++ b/docs/plans/plate-solver-performance.md
@@ -777,8 +777,10 @@ doomed scan.
 frame can need deep coverage, so the budget is load-bearing for exactly the frames it looks wasteful
 on. The lever that survives is **phase A's unshipped half, the per-(OTA, camera) parity cache**: the
 parity is a property of the optical train, not of the frame, so a rig that solved once has already
-answered it. Caching it halves the doomed path outright -- and it is the doomed path that needs it,
-since a successful solve already cancels its loser mid-seed.
+answered it -- and it is the doomed path that needs it, since a successful solve already cancels its
+loser mid-seed. **Shipped, and it came in at 1.6x rather than the 2x this predicted** (the doubted
+half is capped, not skipped, and the retry after a relocation runs a race of its own): see the cache
+subsection under phase A.
 
 ## Correctness gates
 

--- a/src/TianWen.Lib.Tests/RealFrameSolveTests.cs
+++ b/src/TianWen.Lib.Tests/RealFrameSolveTests.cs
@@ -145,6 +145,36 @@ public class RealFrameSolveTests(ITestOutputHelper output)
             "the whole point is that the answer is NOT near the header hint -- if this drops below an "
             + "arcminute the test has stopped exercising the positional search");
 
+        // And now the SAME rig again, on the same solver, which is what a session does all night.
+        //
+        // What moves is the PARITY half of the cache, and only that: measured 9,165,717 -> 5,813,171
+        // hypotheses, 1.6x. The remembered SCALE cannot help a frame that fails, by construction --
+        // the narrow tier is tried first and falls through to the header's +/-5% window when it does
+        // not lock, so a doomed pass pays the wide scan either way. That fallback is what keeps a
+        // stale scale from turning a solvable frame into a failure, so the ordering is deliberate.
+        // The scale's own win lands on a frame that SOLVES while its quad recovery declines, which
+        // is a real combination (2 of 5 archive frames decline) but not one any committed fixture
+        // reproduces, so it is not asserted here.
+        var firstHypotheses = solver.LastSeedHypotheses;
+        var swSecond = Stopwatch.StartNew();
+        var again = await solver.SolveImageAsync(image, dim.Value, searchOrigin: hint, cancellationToken: ct);
+        swSecond.Stop();
+        var secondHypotheses = solver.LastSeedHypotheses;
+        output.WriteLine($"second solve {swSecond.ElapsedMilliseconds} ms, seed hypotheses {firstHypotheses:N0} -> {secondHypotheses:N0} "
+            + $"({(firstHypotheses > 0 ? (double)firstHypotheses / Math.Max(1, secondHypotheses) : 0):F1}x fewer)");
+
+        Assert.NotNull(again.Solution);
+        var solvedAgain = again.Solution.Value;
+        Shouldly.ShouldBeTestExtensions.ShouldBeLessThan(
+            Astrometry.CoordinateUtils.AngularSeparationDeg(
+                solved.CenterRA, solved.CenterDec, solvedAgain.CenterRA, solvedAgain.CenterDec),
+            1.0 / 3600.0,
+            "a remembered scale and parity may make the solve cheaper, never different");
+        Shouldly.ShouldBeTestExtensions.ShouldBeLessThan(secondHypotheses, (int)(firstHypotheses * 0.75),
+            $"the second solve on a known light path must cost materially less than the first "
+            + $"({firstHypotheses:N0} -> {secondHypotheses:N0} hypotheses; measured 1.6x, and the bar "
+            + "is set at 1.33x so an unrelated seed change cannot fail this by a few percent)");
+
         image.Release();
     }
 

--- a/src/TianWen.Lib.Tests/SolveHintCacheTests.cs
+++ b/src/TianWen.Lib.Tests/SolveHintCacheTests.cs
@@ -1,0 +1,171 @@
+﻿using Microsoft.Extensions.Logging.Abstractions;
+using Shouldly;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using TianWen.Lib.Astrometry;
+using TianWen.Lib.Astrometry.Catalogs;
+using TianWen.Lib.Astrometry.PlateSolve;
+using TianWen.Lib.Devices;
+using TianWen.Lib.Devices.Fake;
+using TianWen.Lib.Imaging;
+using Xunit;
+
+namespace TianWen.Lib.Tests;
+
+/// <summary>
+/// The plate scale and the parity are properties of the LIGHT PATH, not of the frame, so a rig that
+/// has solved once has already answered both. These pin that the second solve is measurably cheaper
+/// and that a wrong answer is never the price.
+/// </summary>
+/// <remarks>
+/// Asserted on <see cref="CatalogPlateSolver.LastSeedHypotheses"/>, because the cache's entire effect
+/// is work that does not happen: the emitted WCS is identical with it and without it, so nothing an
+/// ordinary assertion can reach would move if it were deleted. Hypotheses rather than milliseconds --
+/// they are deterministic for a given input, so the same numbers hold on CI and in Debug.
+/// </remarks>
+[Collection("Astrometry")]
+public class SolveHintCacheTests(ITestOutputHelper output)
+{
+    private const double TargetRA = 8.468;
+    private const double TargetDec = -41.24;
+
+    private static async Task<(Image Image, ImageDim Dim)> RenderFieldAsync(
+        ITestOutputHelper output, ICelestialObjectDB db, CancellationToken ct, string? telescope = null)
+    {
+        var timeProvider = new FakeTimeProviderWrapper(new DateTimeOffset(2026, 1, 1, 14, 0, 0, TimeSpan.Zero));
+        var external = new FakeExternal(output, timeProvider);
+        var camera = new FakeCameraDriver(new FakeDevice(DeviceType.Camera, 2), external.BuildServiceProvider());
+        await camera.ConnectAsync(ct);
+        camera.TrueBestFocus = 1000;
+        camera.FocusPosition = 1000;
+        camera.FocalLength = 130;
+        camera.Target = new Target(TargetRA, TargetDec, "COO71", null);
+        camera.CelestialObjectDB = db;
+
+        // The light path's identity is the (OTA, camera) pair, so a test that needs a DIFFERENT rig
+        // renames the telescope rather than building a second camera.
+        if (telescope is not null)
+        {
+            camera.Telescope = telescope;
+        }
+
+        var pixelScaleArcsec = 206264.806 * camera.PixelSizeX * 1e-3 / camera.FocalLength;
+        var dim = new ImageDim(pixelScaleArcsec, camera.CameraXSize - 1, camera.CameraYSize - 1);
+
+        await camera.StartExposureAsync(TimeSpan.FromSeconds(60), cancellationToken: ct);
+        await timeProvider.SleepAsync(TimeSpan.FromSeconds(60), ct);
+        (await camera.GetImageReadyAsync(ct)).ShouldBeTrue();
+        ICameraDriver cameraDriver = camera;
+        var image = await cameraDriver.GetImageAsync(ct);
+        image.ShouldNotBeNull();
+
+        return (image, dim);
+    }
+
+    /// <summary>
+    /// An accepted solve teaches the light path, and the next solve on it answers identically.
+    /// </summary>
+    /// <remarks>
+    /// It deliberately does NOT assert a saving, because on this frame there is none to assert and a
+    /// test that claimed one would be measuring noise: an easy field seeds in 8,937 hypotheses across
+    /// the whole race, phase A's cancellation has already stopped the loser, and the quad recovery
+    /// answers from the frame's own stars so the remembered scale is never consulted. The saving
+    /// lands where the seed is expensive, and is measured there --
+    /// <see cref="RealFrameSolveTests.TheCropWhoseHeaderPointsElsewhereStillSolves"/>, 1.6x.
+    /// What matters here is the other half of the contract: the hints are HINTS, so the answer must
+    /// not move.
+    /// </remarks>
+    [Fact(Timeout = 300_000)]
+    public async Task AnAcceptedSolveTeachesTheLightPathAndTheNextAnswerIsIdentical()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var db = await SharedCatalogDB.InitAsync(ct);
+        var (image, dim) = await RenderFieldAsync(output, db, ct);
+
+        var solver = new CatalogPlateSolver(db, NullLogger.Instance);
+        var hint = new WCS(TargetRA, TargetDec);
+
+        var first = await solver.SolveImageAsync(image, dim, searchOrigin: hint, searchRadius: 3d, cancellationToken: ct);
+        var firstHypotheses = solver.LastSeedHypotheses;
+        first.Solution.ShouldNotBeNull("the premise is a frame that solves");
+        solver.Hints.Count.ShouldBe(1, "an accepted solve teaches the light path it came from");
+
+        var second = await solver.SolveImageAsync(image, dim, searchOrigin: hint, searchRadius: 3d, cancellationToken: ct);
+        var secondHypotheses = solver.LastSeedHypotheses;
+        second.Solution.ShouldNotBeNull();
+
+        output.WriteLine($"seed hypotheses: first {firstHypotheses:N0}, second {secondHypotheses:N0} "
+            + $"({(firstHypotheses > 0 ? (double)secondHypotheses / firstHypotheses : 0):P1} of the first)");
+
+        // The answer must not move -- the whole design rests on the hints being hints.
+        var a = first.Solution.Value;
+        var b = second.Solution.Value;
+        CoordinateUtils.AngularSeparationDeg(a.CenterRA, a.CenterDec, b.CenterRA, b.CenterDec)
+            .ShouldBeLessThan(1.0 / 3600.0, "a remembered scale and parity may make the solve cheaper, never different");
+
+        secondHypotheses.ShouldBeLessThanOrEqualTo(firstHypotheses,
+            "a light path's remembered scale and parity may never make its own field COSTLIER to "
+            + "solve than it was with no history at all");
+    }
+
+    [Fact(Timeout = 300_000)]
+    public async Task ADifferentLightPathLearnsNothingFromTheFirst()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var db = await SharedCatalogDB.InitAsync(ct);
+        var (imageA, dim) = await RenderFieldAsync(output, db, ct, telescope: "Refractor A");
+        var (imageB, _) = await RenderFieldAsync(output, db, ct, telescope: "SCT B, with a diagonal");
+
+        var solver = new CatalogPlateSolver(db, NullLogger.Instance);
+        var hint = new WCS(TargetRA, TargetDec);
+
+        (await solver.SolveImageAsync(imageA, dim, searchOrigin: hint, searchRadius: 3d, cancellationToken: ct))
+            .Solution.ShouldNotBeNull();
+        var learned = solver.LastSeedHypotheses;
+
+        var other = await solver.SolveImageAsync(imageB, dim, searchOrigin: hint, searchRadius: 3d, cancellationToken: ct);
+        other.Solution.ShouldNotBeNull();
+
+        output.WriteLine($"rig A first solve {learned:N0} hypotheses; rig B (no history) {solver.LastSeedHypotheses:N0}");
+
+        // Parity is set by the reflections between sky and sensor, so an SCT with a diagonal is not
+        // entitled to a refractor's answer even with the same camera on the same night. The cost of
+        // getting this wrong is low BY DESIGN, but a key that is wrong by construction would be wrong
+        // for a whole class of rigs forever.
+        solver.Hints.Count.ShouldBe(2, "the two rigs are two light paths, not one");
+    }
+
+    [Fact]
+    public void AnUnidentifiedFrameIsNotALightPath()
+    {
+        var cache = new SolveHintCache();
+        var anonymous = new ImageMeta();
+
+        cache.Store(anonymous, scaleRatio: 1.01f, winnerIsStd: true);
+
+        cache.Count.ShouldBe(0,
+            "a frame naming neither telescope nor camera is not a rig, it is every frame that omits "
+            + "the keywords -- one entry shared by all of them would hand a synthetic frame's answer "
+            + "to a real rig");
+        cache.TryGet(anonymous).ShouldBeNull();
+    }
+
+    [Fact]
+    public void ARejectedSolveTeachesNothing()
+    {
+        var cache = new SolveHintCache();
+        var meta = new ImageMeta() with { Telescope = "SH61 EDPH", Instrument = "SV605CC" };
+
+        cache.Store(meta, scaleRatio: float.NaN, winnerIsStd: true);
+        cache.Store(meta, scaleRatio: 0f, winnerIsStd: true);
+
+        cache.Count.ShouldBe(0, "a ratio that is not a positive number is not a measurement");
+
+        cache.Store(meta, scaleRatio: 1.0019f, winnerIsStd: false);
+        var hint = cache.TryGet(meta);
+        hint.ShouldNotBeNull();
+        hint.Value.ScaleRatio.ShouldBe(1.0019f);
+        hint.Value.WinnerIsStd.ShouldBeFalse();
+    }
+}

--- a/src/TianWen.Lib/Astrometry/PlateSolve/CatalogPlateSolver.cs
+++ b/src/TianWen.Lib/Astrometry/PlateSolve/CatalogPlateSolver.cs
@@ -120,7 +120,16 @@ internal sealed class CatalogPlateSolver(ICelestialObjectDB db, ILogger logger) 
 
     public float Priority => 0.99f;
 
-    private readonly record struct SolveAttempt(WCS? Wcs, int ProjectedStars, int MatchedStars, int Iterations, double RmsResidual, double AffineDeterminant);
+    /// <param name="IsStd">
+    /// Which parity produced this attempt (<c>xSign = +1</c>). Stamped by the attempt itself rather
+    /// than tracked beside it, because the ONE consumer that reads it after the acceptance gate is
+    /// asking about the half that actually answered, and the gate can hand back the other one.
+    /// <para>It is also how the phase-A bug stays fixed: <see cref="SolveAttempt"/> is a
+    /// <c>readonly record struct</c>, so <c>ReferenceEquals(loser, std)</c> boxes and is
+    /// unconditionally false. Which half won has to travel as DATA. It compiled, ran, and picked the
+    /// wrong half of the time.</para>
+    /// </param>
+    private readonly record struct SolveAttempt(WCS? Wcs, int ProjectedStars, int MatchedStars, int Iterations, double RmsResidual, double AffineDeterminant, bool IsStd = false);
 
     /// <summary>
     /// Test seam: what the parity race did on the most recent solve. Phase A's whole effect is work
@@ -134,6 +143,9 @@ internal sealed class CatalogPlateSolver(ICelestialObjectDB db, ILogger logger) 
     /// it declined. Reported for the same reason as <see cref="LastParityRace"/> -- the effect is a
     /// narrower search, so the WCS is identical whether the recovery fired or not and no output can
     /// show that it did.
+    /// <para>It reports the RECOVERY, not the prior the seed ran with: when this declines,
+    /// <see cref="SolveHintCache"/> can still supply one from a previous solve on the same light
+    /// path. The two are kept apart deliberately, since one measures THIS frame's stars.</para>
     /// </summary>
     internal QuadScaleRecovery.Recovery? LastScalePrior { get; private set; }
 
@@ -155,6 +167,45 @@ internal sealed class CatalogPlateSolver(ICelestialObjectDB db, ILogger logger) 
     internal readonly record struct ProjectedCatalogStar(ImagedStar Pixel, double RA, double Dec);
 
     private int _catalogStars, _detectedStars;
+
+    /// <summary>
+    /// What previous accepted solves on each light path answered about scale and parity. Per solver
+    /// instance, which is per process: the solver is a DI singleton, so a session's second and later
+    /// solves are the ones that benefit -- and a session solves on every recentre, every autofocus
+    /// check and every polar-align rung.
+    /// </summary>
+    private readonly SolveHintCache _hints = new SolveHintCache();
+
+    /// <summary>Test seam: what the solver has learned about the rigs it has solved for.</summary>
+    internal SolveHintCache Hints => _hints;
+
+    private int _seedHypotheses;
+
+    /// <summary>
+    /// Test seam: hypotheses the pair-lock seed spent on the most recent solve, summed over both
+    /// parities, every anchor pool and the relocation retry.
+    /// </summary>
+    /// <remarks>
+    /// The measure the cache has to be judged on, for the same reason phase A was: its entire effect
+    /// is work that DOES NOT HAPPEN, so the emitted WCS is identical with it and without it and only
+    /// the cost moves. Hypotheses rather than milliseconds because they are deterministic for a given
+    /// input, so they compare across machines, across builds and between a Debug and a Release run.
+    /// </remarks>
+    internal int LastSeedHypotheses => _seedHypotheses;
+
+    /// <summary>
+    /// Hypotheses per anchor pool allowed to the parity a remembered solve says is the WRONG one.
+    /// </summary>
+    /// <remarks>
+    /// Sized off what a real lock costs, not off what a scan can afford: the frozen Vela panels seed
+    /// at 235-567 hypotheses, the P10 crop's relocated solve at 749, and phase A's own frame at
+    /// 32,179 -- so 100,000 clears the worst observed lock by 3x while cutting ~93% of the 1.4M-1.6M
+    /// per pool a doomed scan spends. It bounds only the DOUBTED half, so the frames this could bite
+    /// are the ones where the cache is stale, and there the capped half finds nothing and the gate
+    /// re-runs it uncapped. That is why this may be far tighter than <c>PairRansacLock</c>'s own
+    /// 1,000,000, which bounds the only scan there is and was measured to lose real fields at 400k.
+    /// </remarks>
+    internal const int DoubtedParityHypothesisBudget = 100_000;
 
     public ValueTask<bool> CheckSupportAsync(CancellationToken cancellationToken = default)
         => ValueTask.FromResult(true);
@@ -228,6 +279,13 @@ internal sealed class CatalogPlateSolver(ICelestialObjectDB db, ILogger logger) 
             MatchedStars = a.MatchedStars,
             Iterations = a.Iterations
         };
+
+        if (allowPositionalSearch)
+        {
+            // Per SOLVE, not per call: the relocation retry re-enters here and its seed is part of
+            // what this solve cost.
+            _seedHypotheses = 0;
+        }
 
         var empty = new SolveAttempt(null, 0, 0, 0, 0, 0);
 
@@ -396,6 +454,20 @@ internal sealed class CatalogPlateSolver(ICelestialObjectDB db, ILogger logger) 
                 : "declined",
             stageSw.Elapsed.TotalMilliseconds);
 
+        // What this rig already answered, for the two questions the seed is most expensive without.
+        // Read BEFORE the race so both parities see the same hints, and never overriding the quad
+        // recovery: that one measured THIS frame's stars, where the cache only remembers a previous
+        // frame's, so it is the fallback for a decline rather than a competitor. The decline is the
+        // case worth serving -- the recovery needs 10 agreeing quad candidates and answers on 2 of 5
+        // real frames, and it declines through the same starved projection that makes the seed hard.
+        var cachedHint = _hints.TryGet(image.ImageMeta);
+        if (scalePrior is null && cachedHint is { } cached)
+        {
+            scalePrior = new QuadScaleRecovery.Recovery(cached.ScaleRatio, Candidates: 0, RelativeSpread: 0f);
+            _logger.LogDebug("CatalogPlateSolver: no quad recovery, using the scale this light path solved at before -- ratio {Ratio:F5} (implied {Implied:F4}\"/px against the header's {Header:F4})",
+                cached.ScaleRatio, dim.PixelScale / cached.ScaleRatio, dim.PixelScale);
+        }
+
         // Try both orientations in parallel; pick the one with lower re-projection error.
         //
         // Exactly one of the two is real work: measured over the 96 frozen Vela frames, one parity
@@ -425,14 +497,37 @@ internal sealed class CatalogPlateSolver(ICelestialObjectDB db, ILogger logger) 
             }
         };
 
-        var stdTask = Task.Run(() => TrySolveWithProximityMatching(detectedStars, catalogCoords, origin, pixelScaleRad, cx, cy, dim, xSign: 1.0, range, scalePrior, ClaimAgainst(mirrorCts), stdCts.Token), cancellationToken);
-        var mirrorTask = Task.Run(() => TrySolveWithProximityMatching(detectedStars, catalogCoords, origin, pixelScaleRad, cx, cy, dim, xSign: -1.0, range, scalePrior, ClaimAgainst(stdCts), mirrorCts.Token), cancellationToken);
+        // A remembered parity SHRINKS the doubted half's budget; it never skips it. Skipping is the
+        // tempting form and it is wrong in the one place this is meant to help: with one parity gone,
+        // a frame that seeds on neither runs the two halves in SERIES -- the believed one, then the
+        // gate's re-run of the other -- where today they overlap, so the doomed path would get twice
+        // as long in wall clock to save half the CPU. Capped and still parallel, the wall time stays
+        // the believed half's and the doubted half stops early, which is the saving without the
+        // trade. And when the cache is wrong, the capped half simply finds nothing and the gate's
+        // existing re-run picks it up uncapped -- the same fallback an abandoned parity already uses.
+        var believedIsStd = cachedHint?.WinnerIsStd;
+        var stdBudget = believedIsStd is false ? DoubtedParityHypothesisBudget : int.MaxValue;
+        var mirrorBudget = believedIsStd is true ? DoubtedParityHypothesisBudget : int.MaxValue;
+        if (believedIsStd is { } believed)
+        {
+            _logger.LogDebug("CatalogPlateSolver: this light path last solved on the {Parity} parity, so the other half is capped at {Budget} hypotheses per pool",
+                believed ? "standard" : "mirror", DoubtedParityHypothesisBudget);
+        }
+
+        var stdTask = Task.Run(() => TrySolveWithProximityMatching(detectedStars, catalogCoords, origin, pixelScaleRad, cx, cy, dim, xSign: 1.0, range, scalePrior, ClaimAgainst(mirrorCts), stdBudget, stdCts.Token), cancellationToken);
+        var mirrorTask = Task.Run(() => TrySolveWithProximityMatching(detectedStars, catalogCoords, origin, pixelScaleRad, cx, cy, dim, xSign: -1.0, range, scalePrior, ClaimAgainst(stdCts), mirrorBudget, mirrorCts.Token), cancellationToken);
         await Task.WhenAll(stdTask, mirrorTask);
 
         var std = stdTask.Result;
         var mirror = mirrorTask.Result;
-        var stdAbandoned = stdCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested;
-        var mirrorAbandoned = mirrorCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested;
+        // "Abandoned" means the scan STOPPED SHORT, so its empty hands are not evidence -- which is
+        // equally true of a half the cache told us to cap as of one the sibling cancelled. Both feed
+        // the same re-run below, which is what makes a stale cached parity cost one extra pass
+        // instead of a failed solve.
+        var stdAbandoned = (stdCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+            || (stdBudget != int.MaxValue && std.Wcs is null);
+        var mirrorAbandoned = (mirrorCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+            || (mirrorBudget != int.MaxValue && mirror.Wcs is null);
         _logger.LogDebug("CatalogPlateSolver: matching iterations std={StdMatched}/{StdIter} (rms {StdRms:F2}px) mirror={MirrorMatched}/{MirrorIter} (rms {MirRms:F2}px) in {Ms}ms",
             std.MatchedStars, std.Iterations, std.RmsResidual, mirror.MatchedStars, mirror.Iterations, mirror.RmsResidual, stageSw.Elapsed.TotalMilliseconds);
 
@@ -450,17 +545,17 @@ internal sealed class CatalogPlateSolver(ICelestialObjectDB db, ILogger logger) 
         // bright catalog candidates almost always hits *some* nearby detected
         // star). That used to flip the parity at Dec near -90 deg, picking
         // std=3-matched garbage over mirror=30-matched correct.
-        // Which of the two won is tracked as a FLAG, never by reference identity: SolveAttempt is a
-        // readonly record struct, so ReferenceEquals against it boxes and is unconditionally false.
+        // Which of the two won is read off the ATTEMPT (see SolveAttempt.IsStd), never by reference
+        // identity: it is a readonly record struct, so ReferenceEquals against it boxes and is
+        // unconditionally false.
         SolveAttempt winner, loser;
-        bool winnerIsStd;
         if (std.MatchedStars >= 2 * Math.Max(mirror.MatchedStars, 1))
         {
-            (winner, loser, winnerIsStd) = (std, mirror, true);
+            (winner, loser) = (std, mirror);
         }
         else if (mirror.MatchedStars >= 2 * Math.Max(std.MatchedStars, 1))
         {
-            (winner, loser, winnerIsStd) = (mirror, std, false);
+            (winner, loser) = (mirror, std);
         }
         else
         {
@@ -469,9 +564,10 @@ internal sealed class CatalogPlateSolver(ICelestialObjectDB db, ILogger logger) 
             // projects bright catalog stars onto detected stars.
             var stdError = std.Wcs is { } ws ? ReProjectionError(ws, catalogCoords, detectedStars) : double.MaxValue;
             var mirrorError = mirror.Wcs is { } wm ? ReProjectionError(wm, catalogCoords, detectedStars) : double.MaxValue;
-            winnerIsStd = stdError <= mirrorError;
-            (winner, loser) = winnerIsStd ? (std, mirror) : (mirror, std);
+            (winner, loser) = stdError <= mirrorError ? (std, mirror) : (mirror, std);
         }
+
+        var winnerIsStd = winner.IsStd;
 
         // Chance-aware acceptance gate. In a dense field the proximity loop can hand back a
         // full complement of matches that are pure nearest-neighbour noise -- observed on a
@@ -498,11 +594,22 @@ internal sealed class CatalogPlateSolver(ICelestialObjectDB db, ILogger logger) 
             _logger.LogDebug("CatalogPlateSolver: winner failed the acceptance gate and the other parity was abandoned mid-seed; re-running it before reporting failure");
             var loserXSign = winnerIsStd ? -1.0 : 1.0;
             loser = TrySolveWithProximityMatching(detectedStars, catalogCoords, origin, pixelScaleRad,
-                cx, cy, dim, loserXSign, range, scalePrior, onSeedClearOfChance: null, cancellationToken);
+                cx, cy, dim, loserXSign, range, scalePrior, onSeedClearOfChance: null, seedHypothesisBudget: int.MaxValue, cancellationToken);
             LastParityRace = LastParityRace with { ReRanAbandonedParity = true };
         }
 
         winner = ApplyAcceptanceGate(winner, loser, catalogCoords, detectedStars, dim, tolerance);
+
+        // Learn from an ACCEPTED solve only. A rejected one's parity and scale are whatever noise it
+        // latched onto, and caching those would aim the next solve at a window with nothing in it --
+        // the cache would then be slower than having none, which is the failure mode to avoid in a
+        // structure whose whole justification is that a miss is cheap. The parity is read off the
+        // attempt that answered rather than off the pick, because the gate above is exactly where
+        // those two part company.
+        if (winner.Wcs is { } accepted && accepted.PixelScaleArcsec > 0)
+        {
+            _hints.Store(image.ImageMeta, (float)(dim.PixelScale / accepted.PixelScaleArcsec), winner.IsStd);
+        }
 
         // Last resort: the hint may simply not be where the frame is. The seed's anchor pool is the
         // brightest catalog stars that project INSIDE THE FRAME from the origin, so the pool's
@@ -741,6 +848,11 @@ internal sealed class CatalogPlateSolver(ICelestialObjectDB db, ILogger logger) 
     /// Verifies the picked parity against the chance model; falls back to the losing parity
     /// when it verifies instead, and strips the WCS entirely when neither does.
     /// </summary>
+    /// <remarks>
+    /// The returned attempt carries its own <see cref="SolveAttempt.IsStd"/>, so a caller learning
+    /// the light path's parity from an accepted solve reads the half that actually answered -- which
+    /// is not always the pick, since this is the one place the pick gets overturned.
+    /// </remarks>
     private SolveAttempt ApplyAcceptanceGate(
         SolveAttempt winner,
         SolveAttempt loser,
@@ -896,6 +1008,7 @@ internal sealed class CatalogPlateSolver(ICelestialObjectDB db, ILogger logger) 
         float scaleRange,
         QuadScaleRecovery.Recovery? scalePrior,
         Action? onSeedClearOfChance,
+        int seedHypothesisBudget,
         CancellationToken cancellationToken
     )
     {
@@ -915,7 +1028,7 @@ internal sealed class CatalogPlateSolver(ICelestialObjectDB db, ILogger logger) 
         int projectedCount = 0, matchedCount = 0, iterCount = 0;
         double rmsResidual = 0, affineDet = 0;
 
-        SolveAttempt MakeResult(WCS? wcs) => new SolveAttempt(wcs, projectedCount, matchedCount, iterCount, rmsResidual, affineDet);
+        SolveAttempt MakeResult(WCS? wcs) => new SolveAttempt(wcs, projectedCount, matchedCount, iterCount, rmsResidual, affineDet, IsStd: xSign > 0);
 
         // Rank detected stars by flux once (brightest first); the geometric seed and every
         // matching iteration below consume this ordering.
@@ -954,7 +1067,8 @@ internal sealed class CatalogPlateSolver(ICelestialObjectDB db, ILogger logger) 
             {
                 var recoveredPixelScaleRad = hintPixelScaleRad / recovery.Ratio;
                 seedLock = TrySeedPairLock(catalogCoords, detPts, currentOrigin, recoveredPixelScaleRad,
-                    cx, cy, dim, xSign, RecoveredScaleTolerance, out _, _logger, cancellationToken);
+                    cx, cy, dim, xSign, RecoveredScaleTolerance, out var recoveredCost, _logger, cancellationToken, maxHypotheses: seedHypothesisBudget);
+                Interlocked.Add(ref _seedHypotheses, recoveredCost.Hypotheses);
                 if (seedLock is not null)
                 {
                     pixelScaleRad = recoveredPixelScaleRad;
@@ -971,8 +1085,12 @@ internal sealed class CatalogPlateSolver(ICelestialObjectDB db, ILogger logger) 
             // narrow window safe to try at all: a stale, mis-measured or simply unlucky scale costs
             // one extra pass that is cheap by construction (2.2M hypotheses against 24.9M) and can
             // never turn a solvable frame into a failure.
-            seedLock ??= TrySeedPairLock(catalogCoords, detPts, currentOrigin, pixelScaleRad, cx, cy,
-                dim, xSign, Math.Max(scaleRange, MinPairLockScaleTolerance), out _, _logger, cancellationToken);
+            if (seedLock is null)
+            {
+                seedLock = TrySeedPairLock(catalogCoords, detPts, currentOrigin, pixelScaleRad, cx, cy,
+                    dim, xSign, Math.Max(scaleRange, MinPairLockScaleTolerance), out var headerCost, _logger, cancellationToken, maxHypotheses: seedHypothesisBudget);
+                Interlocked.Add(ref _seedHypotheses, headerCost.Hypotheses);
+            }
 
             // A seed this far clear of chance settles the parity, so tell the sibling to stop --
             // deliberately BEFORE the invert/project below, because a lock is evidence about the

--- a/src/TianWen.Lib/Astrometry/PlateSolve/SolveHintCache.cs
+++ b/src/TianWen.Lib/Astrometry/PlateSolve/SolveHintCache.cs
@@ -1,0 +1,104 @@
+using System.Collections.Concurrent;
+using TianWen.Lib.Imaging;
+
+namespace TianWen.Lib.Astrometry.PlateSolve
+{
+    /// <summary>
+    /// What a previous successful solve on the same light path already answered, so the next solve
+    /// does not rediscover it: the plate SCALE the stars actually have, and which PARITY the optics
+    /// present.
+    /// </summary>
+    /// <remarks>
+    /// <para>Both are properties of the rig rather than of the frame, which is what makes them
+    /// cacheable at all. They are also the two inputs the seed is most expensive without: the scale
+    /// sets the width of the window every hypothesis draws its candidate pairs from (a star-recovered
+    /// scale is 7.4x fewer hypotheses than a typed <c>FOCALLEN</c>), and the parity decides which half
+    /// of the race is pure waste (97% of the seed's hypotheses, measured over 96 frozen Vela frames).
+    /// </para>
+    /// <para><b>Everything here is a HINT and nothing is a constraint.</b> A stale entry -- someone
+    /// added a diagonal, moved the camera to the OAG port, swapped a reducer, changed capture software
+    /// -- must never turn a solvable frame into a failure. So the scale is offered as the narrow tier
+    /// of a fallback chain that already exists, and the parity only shrinks the OTHER half's
+    /// hypothesis budget rather than skipping it, which keeps both halves running and leaves the
+    /// acceptance gate's re-run as the backstop. A miss costs one wider pass and corrects itself on
+    /// the next successful solve.</para>
+    /// <para>Process-lifetime and in-memory: a session solves dozens of frames on one rig, so the
+    /// first solve pays and the rest do not. Persisting it across restarts the way
+    /// <c>BacklashHistory</c> is persisted would extend that to the first solve of a night, and is
+    /// deliberately left out of this change -- it needs a path, a serializer context and an
+    /// <c>IExternal</c> the solver does not currently take.</para>
+    /// </remarks>
+    internal sealed class SolveHintCache
+    {
+        /// <summary>
+        /// The LIGHT PATH, which is what parity and scale are properties of -- never the rig, and
+        /// never either half alone.
+        /// </summary>
+        /// <remarks>
+        /// <para>Parity is set by the number of reflections between sky and sensor plus the sensor's
+        /// own row-order convention, and those live on different objects. An off-axis guider's
+        /// pick-off prism is one reflection before the imaging plane, so a refractor + OAG has an
+        /// even-parity main camera and an ODD-parity guide camera at the same instant on the same rig
+        /// -- and the polar-align loop solves guider frames while the session solves imaging frames,
+        /// so one answer per rig is actively wrong for one of them. Equally it is not per camera:
+        /// moving one body from a refractor to an SCT with a diagonal changes its parity, while
+        /// swapping bodies on one scope changes nothing.</para>
+        /// <para><see cref="RowOrder"/> is in the key rather than left to be learned because it is a
+        /// parity determinant in its own right -- a <c>BOTTOM-UP</c> frame read as <c>TOP-DOWN</c> is
+        /// a vertical flip with no mirror anywhere in the optics -- and capture software differs. In
+        /// the key it can never mispredict; learned, it would cost a fallback every time it changed.
+        /// </para>
+        /// <para>Binning is in the key for the SCALE's sake, not parity's: the same camera at 1x1 and
+        /// 2x2 is two different plate scales, and a ratio learned at one would be a wrong prior at the
+        /// other.</para>
+        /// </remarks>
+        internal readonly record struct LightPath(string Telescope, string Instrument, RowOrder RowOrder, int BinX, int BinY)
+        {
+            internal static LightPath From(in ImageMeta meta)
+                => new LightPath(meta.Telescope ?? "", meta.Instrument ?? "", meta.RowOrder, meta.BinX, meta.BinY);
+
+            /// <summary>
+            /// Whether this frame says enough about its own optics to be worth remembering. An
+            /// unnamed telescope AND camera is not a light path, it is every frame that omits the
+            /// keywords -- and collapsing those into one entry would hand a synthetic frame's answer
+            /// to a real rig.
+            /// </summary>
+            internal bool IsIdentified => Telescope.Length > 0 || Instrument.Length > 0;
+        }
+
+        /// <param name="ScaleRatio">
+        /// Header-implied plate scale divided by the solved one, i.e. the same quantity
+        /// <see cref="QuadScaleRecovery.Recovery.Ratio"/> carries, and consumed through the same path.
+        /// A RATIO rather than an absolute scale so it stays meaningful when the header's own numbers
+        /// move: it records how wrong the typed focal length is, which is the part that persists.
+        /// </param>
+        /// <param name="WinnerIsStd">Which parity the accepted solve came from.</param>
+        internal readonly record struct Hint(float ScaleRatio, bool WinnerIsStd);
+
+        private readonly ConcurrentDictionary<LightPath, Hint> _hints = new();
+
+        /// <summary>What a previous accepted solve on this light path answered, if there was one.</summary>
+        internal Hint? TryGet(in ImageMeta meta)
+        {
+            var key = LightPath.From(meta);
+            return key.IsIdentified && _hints.TryGetValue(key, out var hint) ? hint : null;
+        }
+
+        /// <summary>
+        /// Records what an ACCEPTED solve answered. Only ever called for a WCS that cleared the
+        /// acceptance gate: a rejected solve's parity and scale are whatever noise it latched onto,
+        /// and caching those would make the next solve slower AND point it at the wrong window.
+        /// </summary>
+        internal void Store(in ImageMeta meta, float scaleRatio, bool winnerIsStd)
+        {
+            var key = LightPath.From(meta);
+            if (key.IsIdentified && float.IsFinite(scaleRatio) && scaleRatio > 0)
+            {
+                _hints[key] = new Hint(scaleRatio, winnerIsStd);
+            }
+        }
+
+        /// <summary>Test seam: how many light paths have been learned.</summary>
+        internal int Count => _hints.Count;
+    }
+}

--- a/src/TianWen.Lib/Devices/Fake/FakeGuider.cs
+++ b/src/TianWen.Lib/Devices/Fake/FakeGuider.cs
@@ -320,8 +320,14 @@ internal class FakeGuider(FakeDevice fakeDevice, IServiceProvider serviceProvide
         // If not already looping, start the capture loop now
         if (_camera is { Connected: true } camera && _mount is { Connected: true } mount && _loopCts is null)
         {
-            _loopCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-            _loopTask = Task.Run(() => RunCaptureLoopAsync(camera, mount, _loopCts.Token), _loopCts.Token);
+            // The lambda reads the LOCAL, never the field. StopCaptureAsync cancels and then nulls
+            // _loopCts, and the thread pool may not have started this delegate yet -- so a field read
+            // here is a NullReferenceException thrown inside the loop task and surfaced, confusingly,
+            // at the awaiting StopCaptureAsync. It needs a busy pool to happen at all, which is why
+            // it shows up as a CI-only failure that passes every time it is run on its own.
+            var loopCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            _loopCts = loopCts;
+            _loopTask = Task.Run(() => RunCaptureLoopAsync(camera, mount, loopCts.Token), loopCts.Token);
         }
 
         return ValueTask.CompletedTask;
@@ -419,9 +425,12 @@ internal class FakeGuider(FakeDevice fakeDevice, IServiceProvider serviceProvide
                 var exposureTime = TimeSpan.FromSeconds(2);
                 LastLoopFrame = await BuiltInGuiderDriver.CaptureGuideFrameAsync(camera, exposureTime, TimeProvider, External.ImageReadyPollInterval, cancellationToken);
 
-                // Start the unified capture loop in background
-                _loopCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-                _loopTask = Task.Run(() => RunCaptureLoopAsync(camera, _mount!, _loopCts.Token), _loopCts.Token);
+                // Start the unified capture loop in background, on a LOCAL token source -- see the
+                // note at the other start site: the field is nulled by StopCaptureAsync and the
+                // delegate may not have run yet.
+                var loopCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                _loopCts = loopCts;
+                _loopTask = Task.Run(() => RunCaptureLoopAsync(camera, _mount!, loopCts.Token), loopCts.Token);
             }
         }
 


### PR DESCRIPTION
## What

`SolveHintCache` remembers, per **light path**, what an ACCEPTED solve answered: the plate scale (as the header-over-solved ratio, so it consumes through the seed's existing two-tier chain with no new path) and the parity.

The key is `(Telescope, Instrument, RowOrder, BinX, BinY)`:

- the **(OTA, camera) pair**, never the rig and never either half alone — an OAG guide camera is the *opposite* parity to the main camera on the same rig at the same instant, and the polar-align loop solves guider frames while the session solves imaging frames;
- **row order**, because a `BOTTOM-UP` frame read as `TOP-DOWN` is a parity change with no mirror anywhere in the optics;
- **binning**, because one camera at 1x1 and 2x2 is two different plate scales.

## The design decision that matters

**A remembered parity shrinks the doubted half's hypothesis budget; it never skips it.** Skipping is the obvious form and it inverts the goal: with one half gone, a frame that seeds on neither runs them in SERIES — the believed one, then the acceptance gate's re-run — where today they overlap. The doomed path would take twice as long in wall clock to save half the CPU. Capped and still parallel, the wall time stays the believed half's while the doubted half stops early.

A stale entry (a diagonal added, a camera moved to the OAG port, capture software changed) leaves the capped half empty-handed, which marks it abandoned and routes it into the gate's **existing** uncapped re-run. Everything here is a hint; nothing is a constraint.

The parity travels on `SolveAttempt.IsStd` rather than beside the race, because the gate is the one place the pick gets overturned — a flag tracked alongside would teach the cache the wrong half in exactly the case the gate exists to catch.

## Measured

P10 crop, second solve on the same solver: **9,165,717 -> 5,813,171 seed hypotheses (1.6x)**, and the assertion was seen to FAIL with the cap disabled.

Asserted on a new `LastSeedHypotheses` seam, because the cache's entire effect is work that does not happen — the emitted WCS is identical with it and without it, and hypotheses are deterministic where wall clock is not.

Two things that measurement says, both recorded in the plan doc:

- the saving is the **parity half only**. A remembered scale cannot help a frame that fails: the narrow tier does not lock and falls through to the header's +/-5% window. That fallback is what stops a stale scale breaking a solvable frame, so the ordering stays.
- taken alone the scale half is **-13.6% on a doomed frame** (9,165,717 -> 10,418,023 with the cap off). The cap more than pays for it, and the scale's win lands on a frame that SOLVES while its quad recovery declines — a real combination (2 of 5 archive frames decline) that no committed fixture reproduces, so it is deliberately not asserted.

## Also in the plan doc: two investigations that ended in refutations

- **The positional search cannot be gated on the seed's signal.** Built, measured, reverted. A frame with no sky in it scores 8.0x chance against a relocatable frame's 4.3x (sparse, so chance falls to ~0), and 0.80 of the lock's own bar against 0.86. And the cloudy frame it was written for never reaches the gate: at 0/70/85/93/97% cloud with a good hint, all five solve in 168-334 ms.
- **A doomed solve is ~95% seed, not refinement.** The refinement loop exits after 3 iterations, not 10; the positional search costs 54-423 ms, so the +1.8 s regression it was recorded as does not reproduce.

## Not done, deliberately

Persistence across restarts (the `BacklashHistory` shape). It would extend the win to the first solve of a night, but needs a path, a serializer context and an `IExternal` the solver does not currently take.

## Tests

`SolveHintCacheTests` (learning, light-path separation, and that an unidentified frame or a non-positive ratio teaches nothing) plus the second solve in `RealFrameSolveTests.TheCropWhoseHeaderPointsElsewhereStillSolves`. Full unit suite green: 5321 passed, 0 failed, 78 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GMutiVoF4wdm6z96TmKPo6
