### PR TITLE
perf(solve): cap the star list, and let the stars veto a bin

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -487,6 +487,17 @@ synthetic suite**, because a synthetic field is built from a transform the test 
 dataset rationale, both measurements above, and what real density covers that synthetic fields cannot:
 [docs/plans/plate-solver-performance.md](docs/plans/plate-solver-performance.md).
 
+**Binning before detection is PROPOSED by the plate scale and VETOED by the measured star width.**
+What a bin spends is sampling -- seeing over scale -- and a scale gate cannot see seeing, so the shipped
+"downsample to ~1.5"/px" rule put the binned FWHM under 2 px for any seeing better than 3", i.e. most
+usable nights. `MinSampledFwhmPx` (2.0) re-detects at full resolution when the binned median `StarFWHM`
+lands under it. **It only ever un-does a bin**: the cost is one wasted pass on the cheap raster, against
+a fit built on aliased centroids. Do not try to infer the unbinned width by multiplying back -- measured
+FWHM floors near 1.2 px (2.15 px at bin 1 reads 1.85 at bin 2, not 1.08). Binning's real cost is the star
+COUNT (roughly half), and it can drop a frame under `MinStarsForMatch` outright. **No committed fixture is
+oversampled**, so the gate proposes 1 on all of them and the polar-preview case is reasoned, not measured
+(hardware-validation item 25).
+
 **A remembered parity is a hypothesis BUDGET for the other half, never a skip; and it is keyed on the
 LIGHT PATH.** `SolveHintCache` learns each rig's plate scale and parity from an accepted solve.
 Skipping the doubted parity is the tempting form and it inverts the goal: with one half gone, a frame

--- a/docs/plans/plate-solver-performance.md
+++ b/docs/plans/plate-solver-performance.md
@@ -1,4 +1,4 @@
-# Plate-solver performance: closing the gap to ASTAP
+﻿# Plate-solver performance: closing the gap to ASTAP
 
 Status: **PHASE A SHIPPED**; B-D planned. The correctness work was already done; everything below is
 performance only.
@@ -90,7 +90,7 @@ Ordered by return per unit of risk; each independently shippable and measurable.
 | B | ~~Tycho-2 pre-baked region index~~ -- **OBSOLETE: already done, worth 0.3 ms** | ~~500 ms~~ 0 | n/a | n/a |
 | C | ~~Quad-descriptor matching replacing the refinement loop~~ -- **MEASURED DEAD: 15.8% of quads are shared even under a perfect prior** | ~~300 ms~~ 0 | n/a | n/a |
 | C' | Quads for the SCALE only: recover it with no prior, narrow the seed's window 5% -> 0.25% -- **SHIPPED** | 7.4x fewer seed hypotheses | nothing, and it *removes* our reliance on `FOCALLEN` | low |
-| D | Cap the star list to ~500 -> yes; bin -> **no** | ~60 ms | binning does, so it is gated on measured FWHM and default off | low |
+| D | Cap the star list to ~500 -- **SHIPPED**; bin -> only on MEASURED FWHM, not on frame size or plate scale | ~60 ms | binning can, so it is gated on measured FWHM and default off | low |
 
 Target after A-C: **~260 ms**, against ASTAP's 162 ms -- **written before B was measured to be
 already done.** With B worth 0 and the warm solve now benchmarked at 331 ms, the reachable target is
@@ -606,27 +606,66 @@ everywhere else), which is exactly why the gap had gone unmeasured.
 
 Two halves with very different risk, and they must not be conflated.
 
-**Cap the star list: do it.** Carry ~500 brightest into matching instead of 1600. This costs no
-accuracy at all -- the discarded stars are the faintest, they are not what a fit is anchored on, and
-ASTAP solves this field from 527. Phase C makes this mostly moot anyway, since quad matching is
-driven off the top-K.
+**Cap the star list -- SHIPPED 2026-09-01.** `MaxStarsCarriedIntoMatching = 500`, applied in
+`SolveFromOriginAsync` once detection and the binned-centroid rescale are done. The number is not new:
+the detection call has passed `maxStars: 500` all along, and `FindStarsAsync` documents that parameter
+as "**Caps nothing**" -- its only effect is to supply the default for `minStars` -- so a dense frame
+has been handing the solver everything it found. 8,103 stars on the NGC 3576 frame, where ASTAP solves
+the same field from 527.
 
-**Bin before detection: NO, not on this class of frame, and not on ASTAP's rule.**
-`report_binning` gates on image HEIGHT (> 2500 px -> bin 2). Height is the wrong variable: it is a
-proxy for "big sensor, therefore probably oversampled", and this rig breaks the proxy. Measured on
-frame 0018, median star **FWHM = 2.15 px** (10.16" at 4.7172"/px; HFD 2.65 px, from
-`solve --export-stars`). That is already AT critical sampling, so binning 2x lands at 1.08 px FWHM
--- below Nyquist. The cost is not a slightly softer centroid, it is aliasing, and a 1 px FWHM star
-stops being reliably separable from a hot pixel. Our unbinned SIP rms is 0.11 px (0.52"); that is
-the number downstream consumers are relying on.
+The faint tail is not what a fit is anchored on, but it is not inert either: it is the verification
+census every hypothesis is scored against, the population the proximity loop re-matches each
+iteration, and the density `PairRansacLock` derives its Poisson chance rate from.
 
-So if this is done at all, gate it on MEASURED sampling rather than on frame size: bin only while
-the binned FWHM stays comfortably above Nyquist, i.e. roughly FWHM >= 4 px before binning. A
-0.5"/px setup in 3" seeing (FWHM ~6 px) can bin to 3 px for free; this field cannot bin at all.
-Detection already measures FWHM/HFD, so the input is in hand.
+**That last one is the risk, and it is the one worth stating precisely: truncating the list LOWERS the
+accept threshold**, because the bar is `max(max(10, 5 x chance), 0.15 x census)`. A looser bar on
+dense fields is exactly where the dense-field false-lock failure mode lives, so this needed measuring
+rather than asserting. Capped against uncapped over the same 96 frozen Vela frames (1,394-1,755
+detections each, so the cap discards about two thirds of every list):
 
-Default OFF, and skip the whole phase if phases A-C land the budget. It is the smallest win of the
-four and the only one that can cost accuracy.
+| | uncapped | capped at 500 |
+|---|---|---|
+| frames that seed | 96 / 96 | **96 / 96**, none lost |
+| hits kept, vs the uncapped seed | -- | **100%** at min, median AND max |
+| false locks over 272 disjoint pairs | 0 | **0** |
+
+**Not one hit is lost anywhere**, and for a reason rather than by luck: the anchors are the brightest
+CATALOG stars, so the detections a true hypothesis lands on are the bright ones the cap keeps.
+
+**What the frozen set does NOT cover, stated so nobody reads it as more than it is.** At Vela
+densities the accept bar is the `0.15 x census` floor (24, from 160 anchors) and not the chance term,
+so the cap cannot move it there. The bar only falls on a frame dense enough for `5 x chance` to exceed
+that floor -- 8,103 detections against these panels' ~1,500 -- and in that regime the spurious hits
+thin out with the population they are drawn from. The guard is
+`GivenDenseFieldAndWrongSearchOriginWhenCatalogPlateSolvingThenItFailsInsteadOfReturningGarbage`,
+which refuses at 22 hits against a threshold of 24 on 3,250 detections: a two-hit margin, so it is the
+test that goes red first if this ever loosens the gate.
+
+`VelaMosaicFieldTests` now seeds through the cap, since an uncapped seed there would guard a path
+production no longer takes. `UnrelatedDenseFieldsMustNotLock` deliberately stays UNCAPPED: more
+detections is more freedom to pile up a spurious consensus, so the uncapped list is the harder
+question and the one that test exists to ask.
+
+**Bin before detection: gate it on MEASURED SAMPLING, and never on frame size.** ASTAP's
+`report_binning` gates on image HEIGHT (> 2500 px -> bin 2), which is a proxy for "big sensor,
+therefore probably oversampled" -- and a proxy is the wrong shape of rule for a library that solves
+whatever optics and seeing its user has. The right gate is the physical one: bin only while the binned
+FWHM stays comfortably above Nyquist, roughly **FWHM >= 4 px before binning**. Detection already
+measures FWHM/HFD, so the input is in hand.
+
+The frame that made this concrete is one instance of the rule rather than the rule itself: on frame
+0018 the median star **FWHM is 2.15 px** (10.16" at 4.7172"/px; HFD 2.65 px, from
+`solve --export-stars`), already AT critical sampling, so binning 2x lands at 1.08 px -- below
+Nyquist. The cost there is not a softer centroid but aliasing, and a 1 px FWHM star stops being
+reliably separable from a hot pixel; the unbinned SIP rms of 0.11 px (0.52") is what downstream
+consumers rely on. A 0.5"/px setup in 3" seeing (FWHM ~6 px) bins to 3 px for free. Same rule, opposite
+answer -- which is the point.
+
+**A gate on the declared plate scale is the same mistake in a better disguise, and we already ship
+one.** `SolveFromOriginAsync` downsamples to ~1.5"/px whenever `dim.PixelScale` is finer than that.
+Scale alone says nothing about seeing: a 0.5"/px rig on a 1" night has FWHM 2 px, and that gate bins
+it to 1 px. It has not bitten because oversampled rigs usually are oversampled in the seeing they get,
+but it is a proxy standing in for a measurement the detector already makes.
 
 ### E. Positional search around the hint -- **SHIPPED**
 

--- a/docs/plans/plate-solver-performance.md
+++ b/docs/plans/plate-solver-performance.md
@@ -661,11 +661,55 @@ reliably separable from a hot pixel; the unbinned SIP rms of 0.11 px (0.52") is 
 consumers rely on. A 0.5"/px setup in 3" seeing (FWHM ~6 px) bins to 3 px for free. Same rule, opposite
 answer -- which is the point.
 
-**A gate on the declared plate scale is the same mistake in a better disguise, and we already ship
-one.** `SolveFromOriginAsync` downsamples to ~1.5"/px whenever `dim.PixelScale` is finer than that.
-Scale alone says nothing about seeing: a 0.5"/px rig on a 1" night has FWHM 2 px, and that gate bins
-it to 1 px. It has not bitten because oversampled rigs usually are oversampled in the seeing they get,
-but it is a proxy standing in for a measurement the detector already makes.
+**A gate on the declared plate scale is the same mistake in a better disguise, and we already shipped
+one -- FIXED 2026-09-01.** `SolveFromOriginAsync` downsampled to ~1.5"/px whenever `dim.PixelScale`
+was finer, on the stated grounds that 1.5"/px is "still well above seeing". That is a claim about a
+quantity the gate never looked at. Binned `FWHM_px = FWHM_arcsec / 1.5`, so the target lands **under
+two pixels per FWHM for any seeing better than 3"** -- most usable nights, not a corner case. Two rigs
+at one scale on nights an arcsecond apart want opposite answers, and scale cannot tell them apart.
+
+The fix keeps the scale as a **proposal** and makes the measurement the **verdict**, in the one
+direction that is safe: `MinSampledFwhmPx = 2.0` un-does a bin, and never imposes one. Detection runs
+on the binned raster, the median `StarFWHM` is compared against the floor, and a frame that came back
+aliased is re-detected at full resolution. Worst case is one wasted pass on the *cheap* image, in
+exactly the case whose alternative is a fit built on aliased centroids; a frame that measures nothing
+leaves the proposal standing. `LastDetectionBinning` reports `(Proposed, Used)` because `Used == 1`
+alone cannot separate "never a candidate" from "vetoed".
+
+**What the committed fixtures could and could not answer** (`SolverBinningSamplingProbe`, gated on
+`TIANWEN_BINNING_PROBE`):
+
+| frame | "/px | gate | stars @1 | FWHM @1 | stars @2 | FWHM @2 |
+|---|---|---|---|---|---|---|
+| NGC 3576 (0058) | 2.872 | 1 | 8103 | 2.15 | 3123 | 1.85 |
+| Vela panel 8_1 crop | 5.966 | 1 | 4003 | 1.75 | 2240 | 1.31 |
+| Vela panel 10 crop | 5.966 | 1 | 1569 | 1.94 | 749 | 1.37 |
+| 0002 | 5.966 | 1 | 1932 | 2.00 | 1106 | 1.80 |
+| PlateSolveTestFile | 4.250 | 1 | 11 | 3.20 | 7 | 1.72 |
+
+Three things fall out, and the third is a limit on the change rather than support for it:
+
+- **Every committed fixture is 2.87-5.97"/px, so the gate proposes 1 on all of them** and always did.
+  The shipped behaviour is unchanged on every frame in the repo, which is what makes this safe to land
+  -- and it also means **the class of frame the gate exists for is not represented here at all**.
+- **Binning's measurable cost is the star COUNT, not the width**: roughly half the detections go
+  (8103 -> 3123, 4003 -> 2240), and `PlateSolveTestFile` falls 11 -> 7 -> **3** at bin 3, under
+  `MinStarsForMatch = 6`. A bin can turn a solvable frame into a failure outright.
+- **Measured FWHM floors near 1.2 px**, so a binned width cannot be multiplied back to recover the
+  unbinned one (2.15 px at bin 1 reads 1.85 px at bin 2, not 1.08). Only the comparison against the
+  floor is sound, which is why the fallback re-measures at full resolution instead of solving for a
+  better factor.
+
+**The one open risk, stated rather than hidden.** The gate was tuned for a 0.97"/px 9576x6388 polar
+preview whose 5.5 s rung-1 budget depends on the 4x speedup. If that frame's binned stars land under
+the floor -- which they do for seeing better than ~3" -- it now re-detects unbinned and blows that
+budget. No committed fixture is oversampled and there is no such frame on the dev box, so this is
+reasoned, not measured. It is also the case where the old path was returning aliased centroids to a
+routine whose whole output is a small angular difference between two solves, so the trade is the right
+way round; the follow-up is to buy the budget back with a **central CROP at full resolution** (same
+pixel count as bin 2, same cost, sampling intact) rather than by binning. Wanted:
+[`docs/todo/hardware-validation.md`](../todo/hardware-validation.md) -- an oversampled real frame
+(<1.5"/px) with a recorded FWHM, which is the missing evidence for both halves.
 
 ### E. Positional search around the hint -- **SHIPPED**
 

--- a/docs/plans/plate-solver-performance.md
+++ b/docs/plans/plate-solver-performance.md
@@ -68,6 +68,33 @@ mapping onto one phase below.
    compares with early-out: about 110k comparisons, once.
 4. **Derive scale from the match.** The median longest-side ratio over matching quads IS the plate
    scale, with outlier rejection on that ratio. The header focal length is never trusted.
+5. **The search moves the CATALOGUE, never the image.** `bin_and_find_stars` and
+   `find_quads(starlist2, ...)` run once, BEFORE the spiral; inside it (lines 1590-1657) only
+   `read_stars` at the trial centre, `find_quads` on the database stars, and
+   `find_offset_and_rotation`. A quad descriptor does not depend on where you think you are pointing,
+   so a trial centre costs one catalogue fetch and nothing else.
+
+**Point 5 is the one that decides a wrong hint, and it is three advantages compounding.** Measured
+2026-09-01 on the Vela panel 10 crop, whose header points 93 arcmin away (Release AOT, quiet box):
+ASTAP 1537 ms against our 3170 ms.
+
+| | ASTAP | TianWen |
+|---|---|---|
+| step between trial centres | `STEP_SIZE := search_field`, a **full FOV** (2.14 deg) | `0.35 x` the short axis (0.75 deg) |
+| how coverage is bought | `oversize` inflates the DATABASE READ to up to 2x image height, so a full-FOV step still overlaps | a finer step -- **8x more centres** for the same radius (0.35^-2) |
+| centres to reach a 1.55 deg error | first square-spiral ring, <= 9 | ring 2, ~20 of 39 |
+| parities per centre | **1** | 2 |
+| work at one centre | ~500-star read + ~110k `abs` compares | a RANSAC seed, <= 20,000 hypotheses x a 250-star verify |
+
+**Parity is free for a quad matcher, and that is not a tuning choice.** The descriptor is the six
+pairwise distances SORTED and divided by the longest (lines 445-460), and a reflection preserves every
+pairwise distance -- so a mirrored field matches the same quad. ASTAP recovers parity afterwards from
+the sign of `solution_vectorX[0]*solution_vectorY[1] - solution_vectorX[1]*solution_vectorY[0]` (line
+1701) and spends it only on the CDELT/CROTA signs. We search both halves on every candidate, which is
+what the light-path parity cache exists to claw back -- against a solver that never pays it at all.
+
+So roughly 9 cheap steps against ~40 expensive ones. The measured 2.1x is if anything flattering to
+us, and it was 4.9x before phase D's cap.
 
 Ours runs a pair-RANSAC seed (up to 916k hypotheses on the parity that does not lock) and then an
 O(n^2) proximity loop of 1600 detected x ~2000 projected, ~3.2M distance computations **per
@@ -602,6 +629,39 @@ above, where the header's pointing was never separately checked.
 Nothing regressed: P10 had never been asked for a WCS before (it is a stretch / colour / codec fixture
 everywhere else), which is exactly why the gap had gone unmeasured.
 
+#### "The matching half is dead" is contradicted by an existence proof, and the difference is HOW the quads are built
+
+**ASTAP solves both Vela crops, from quads, in 0.66 s and 1.54 s** (measured 2026-09-01 against
+CLI-2025.11.19 with the D80 database, on the identical files, agreeing with us to 3.2 arcsec and to 4
+significant figures of plate scale). Our probe says quad matching against the catalog shares 2.6% of
+quads under conditions granted every confound in its favour. Both are real, so **the verdict above is
+about OUR QUAD CONSTRUCTION, not about quad matching**, and it should not be read as closing the idea.
+
+The likely mechanism, from the source rather than from theory. `find_quads` builds each quad from a
+star **plus its three nearest neighbours** (lines 380-413), deduplicated by quad centre. A
+nearest-neighbour graph is only reproducible between two star lists drawn from **comparable
+populations**: one extra faint star in the image that the catalog lacks re-points its neighbours'
+quads and the descriptor changes completely. ASTAP therefore matches the DENSITIES explicitly ---
+`nrstars_required := round(nrstars*(height2/width2))`, scaled by `oversize2^2`, with the comment "So
+the star density will be the same as in the image to solve" (line 1633) --- on top of the hard
+`max_stars` cap that keeps both sides shallow.
+
+The probe's two sides were **not** matched that way: at top-K 100 it built 1,629 image quads against
+1,217 catalog quads, and the deeper rows are further apart still. So it may have been measuring what
+happens when two nearest-neighbour graphs are cut at different depths, which is a different question
+from whether the descriptors can match.
+
+**The test that would settle it** is a rerun of `QuadCatalogFeasibilityProbe` with the catalog window
+truncated to the SAME star count as the detection list (both by brightness), reporting the shared-quad
+fraction against the count ratio. If the fraction climbs as the ratio approaches 1, the phase is alive
+and the earlier reading was an artefact of the cut; if it stays near 2.6%, the verdict stands on much
+firmer ground than it does now. **Not yet run** --- stated here so the next person does not re-derive
+it, and so the "dead" verdict is not quoted without its caveat.
+
+Worth the effort because of what point 5 above says it buys: not a constant factor, but a positional
+search whose expensive half stops depending on the trial centre, and the deletion of the parity race
+outright. The two things we measure worst at are the two things it addresses.
+
 ### D. Cap the star list; bin ONLY where sampling allows it
 
 Two halves with very different risk, and they must not be conflated.
@@ -631,6 +691,21 @@ detections each, so the cap discards about two thirds of every list):
 
 **Not one hit is lost anywhere**, and for a reason rather than by luck: the anchors are the brightest
 CATALOG stars, so the detections a true hypothesis lands on are the bright ones the cap keeps.
+
+**What it is worth in wall clock** (Release AOT `tianwen solve`, whole process including catalog init,
+median of 5 interleaved runs on a quiet box, 2026-09-01). Measure this in RELEASE: the same A/B in
+Debug reads 2.3x on the dense frame, about twice the truth.
+
+| frame | uncapped | capped | |
+|---|---|---|---|
+| NGC 3576, 8,103 detections, hint good | 839 ms | **711 ms** | 1.18x |
+| Vela panel 10 crop, hint 93 arcmin off | 6,931 ms | **3,170 ms** | **2.19x, -3.8 s** |
+
+**The cap pays in proportion to HYPOTHESES TRIED, not to detections discarded** -- which is why the
+frame with 8,103 of them barely notices while the 1,569-star crop saves 3.8 seconds. A frame that
+seeds immediately never reaches the population the cap thins; a frame that has to relocate scores
+every one of its candidates against it. Read the dense-frame row as the cost ceiling of the cap, and
+the crop row as its purpose.
 
 **What the frozen set does NOT cover, stated so nobody reads it as more than it is.** At Vela
 densities the accept bar is the `0.15 x census` floor (24, from 160 anchors) and not the chance term,

--- a/docs/todo/hardware-validation.md
+++ b/docs/todo/hardware-validation.md
@@ -138,6 +138,14 @@ under it, and the fake asserts that state by construction.
 - [ ] **24. Guider calibration slew at HA -0.5 h, Dec 0** against real obstructions: `Session.Lifecycle.cs`
       slews there before calibrating; the scout is OTA-only and runs after centering, so a tree at that
       pointing is found only by trying. (`sequencing.md` carries the "slew slightly off Dec 0" idea.)
+- [ ] **25. An OVERSAMPLED frame, for the solver's detection-binning floor**: any light finer than
+      1.5"/px (the 0.97"/px 9576x6388 polar preview is the canonical one), kept with its measured median
+      FWHM. Every committed fixture is 2.87-5.97"/px, so **no test in the repo reaches the binning gate at
+      all** and both halves of it are currently unmeasured: that a bin is proposed there, and whether
+      `MinSampledFwhmPx` then vetoes it and costs the polar ramp its 5.5 s rung-1 budget. Observe the
+      solver's `LastDetectionBinning` `(Proposed, Used)` and the wall clock of the detect stage. Validates
+      [plate-solver-performance.md](../plans/plate-solver-performance.md) phase D's sampling floor -- and
+      decides whether the budget has to be bought back with a central crop instead of a bin.
 
 ## Gated on gear but NOT validations (tracked in their own backlogs)
 

--- a/src/TianWen.Lib.Tests/SolverBinningSamplingProbe.cs
+++ b/src/TianWen.Lib.Tests/SolverBinningSamplingProbe.cs
@@ -1,0 +1,93 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using TianWen.Lib.Imaging;
+using Xunit;
+
+namespace TianWen.Lib.Tests
+{
+    /// <summary>
+    /// What does the shipped pre-detection binning gate actually do to SAMPLING?
+    /// </summary>
+    /// <remarks>
+    /// <para><c>CatalogPlateSolver</c> bins to a ~1.5"/px target whenever the declared plate scale is
+    /// finer than that, on the stated grounds that 1.5"/px is "still well above seeing". That is a
+    /// claim about a quantity the gate never looks at: binned <c>FWHM_px = FWHM_arcsec / 1.5</c>, so
+    /// the gate lands under 2 px -- below critical sampling -- for any seeing better than 3", which is
+    /// most usable nights rather than a corner case.</para>
+    /// <para>This reports the measurement the gate is missing: median star FWHM at bin 1 against the
+    /// factor the gate would pick, over every committed real frame. Gated on
+    /// <c>TIANWEN_BINNING_PROBE</c> so it stays off the suite.</para>
+    /// </remarks>
+    [Collection("Imaging")]
+    public class SolverBinningSamplingProbe(ITestOutputHelper output)
+    {
+        [Fact(Timeout = 900_000)]
+        public async Task ReportSamplingAgainstTheShippedBinningGate()
+        {
+            Assert.SkipWhen(
+                string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("TIANWEN_BINNING_PROBE")),
+                "Set TIANWEN_BINNING_PROBE=1");
+
+            var ct = TestContext.Current.CancellationToken;
+            string[] fixtures =
+            [
+                "2026-01-18_23-26-51__-5.00_60.00s_0002",
+                "2026-02-15_00-56-23__-5.00_60.00s_0058",
+                "PlateSolveTestFile",
+                "RGGB_frame_bx0_by0_top_down",
+                "Vela_SNR_Panel_10-Multi-NB-color-Hydrogen-alpha-Oxygen_III-crop",
+                "Vela_SNR_Panel_8_1-Multi-NB-mono-Hydrogen-alpha-Oxygen_III-crop",
+                "PHD2SimGuider",
+                "image_file-snr-20_stars-28_1280x960x16",
+            ];
+
+            output.WriteLine($"{"frame",-58} {"size",-11} {"\"/px",7} {"gate",4}  {"bin",3} {"stars",6} {"FWHM px",8} {"FWHM \"",8}");
+
+            foreach (var name in fixtures)
+            {
+                Image image;
+                try
+                {
+                    image = await SharedTestData.ExtractGZippedFitsImageAsync(name, isReadOnly: false, cancellationToken: ct);
+                }
+                catch (Exception ex)
+                {
+                    output.WriteLine($"{name,-58} SKIPPED: {ex.GetType().Name}");
+                    continue;
+                }
+
+                var dim = image.GetImageDim();
+                var scale = dim?.PixelScale ?? double.NaN;
+
+                // The shipped gate, reproduced exactly.
+                var gateFactor = 1;
+                var pixelScaleX10 = (int)Math.Round(scale * 10);
+                if (pixelScaleX10 > 0 && pixelScaleX10 < 15)
+                {
+                    gateFactor = (15 + pixelScaleX10 - 1) / pixelScaleX10;
+                }
+
+                foreach (var factor in new[] { 1, 2, 3, gateFactor }.Distinct().Order())
+                {
+                    var detectionImage = factor > 1 ? image.Downsample(factor) : image;
+                    var stars = await detectionImage.FindStarsAsync(
+                        detectionImage.ReferenceStarChannel, snrMin: 5f, maxStars: 500, minStars: 50,
+                        maxRetries: 0, maxFirstPassNoiseSigma: Image.MaxFirstPassNoiseSigma,
+                        cancellationToken: ct);
+
+                    var widths = stars.Where(s => s.StarFWHM > 0f).Select(s => s.StarFWHM).Order().ToArray();
+                    var medianPx = widths.Length > 0 ? widths[widths.Length / 2] : float.NaN;
+                    var arcsec = medianPx * scale * factor;
+                    var mark = factor == gateFactor ? " <- the gate picks this" : "";
+                    output.WriteLine(
+                        $"{(factor == 1 ? name : ""),-58} {(factor == 1 ? $"{image.Width}x{image.Height}" : ""),-11} "
+                        + $"{(factor == 1 ? $"{scale,7:F3}" : new string(' ', 7))} {(factor == 1 ? $"{gateFactor,4}" : new string(' ', 4))}  "
+                        + $"{factor,3} {stars.Count,6} {medianPx,8:F2} {arcsec,8:F2}{mark}");
+                }
+
+                image.Release();
+            }
+        }
+    }
+}

--- a/src/TianWen.Lib.Tests/SolverSamplingFloorTests.cs
+++ b/src/TianWen.Lib.Tests/SolverSamplingFloorTests.cs
@@ -1,0 +1,100 @@
+using System.Collections.Concurrent;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging.Abstractions;
+using TianWen.Lib.Astrometry.Catalogs;
+using TianWen.Lib.Astrometry.PlateSolve;
+using TianWen.Lib.Imaging;
+using Shouldly;
+using Xunit;
+
+namespace TianWen.Lib.Tests
+{
+    /// <summary>
+    /// Pre-detection binning is PROPOSED by the declared plate scale and vetoed by the sampling the
+    /// detector measures. These pin the veto, because the alternative -- a scale gate deciding alone
+    /// -- is wrong in a way no output reveals: the solve still answers, from aliased centroids.
+    /// </summary>
+    [Collection("Astrometry")]
+    public class SolverSamplingFloorTests(ITestOutputHelper output)
+    {
+        /// <summary>
+        /// A real frame, told it is finely sampled. Every committed fixture is 2.9-6.0"/px, so none
+        /// is a binning candidate on its own header and the veto would never be reached; handing the
+        /// solver a fabricated fine <see cref="ImageDim"/> over the SAME pixels is what puts a real
+        /// star profile behind a proposal to bin it. The stars then measure what they measure, and
+        /// what they measure is a frame that cannot afford it.
+        /// </summary>
+        [Fact(Timeout = 600_000)]
+        public async Task ABinTheStarsCannotAffordIsUndoneBeforeItReachesMatching()
+        {
+            var ct = TestContext.Current.CancellationToken;
+            var image = await SharedTestData.ExtractGZippedFitsImageAsync(
+                "Vela_SNR_Panel_8_1-Multi-NB-mono-Hydrogen-alpha-Oxygen_III-crop", isReadOnly: false, cancellationToken: ct);
+
+            var db = new CelestialObjectDB();
+            await db.InitDBAsync(waitForTycho2BulkLoad: true, cancellationToken: ct);
+            var solver = new CatalogPlateSolver(db, NullLogger<CatalogPlateSolver>.Instance);
+
+            // 0.6"/px asks for a 3x bin (ceil(1.5 / 0.6)). The pixels are unchanged, so the stars are
+            // still the ~1.75 px they were, and 3x would leave them at ~1.2 px -- aliased.
+            var pretendFine = new ImageDim(0.6, image.Width, image.Height);
+            var hint = new Astrometry.WCS(image.ImageMeta.TargetRA, image.ImageMeta.TargetDec);
+            _ = await solver.SolveImageAsync(image, pretendFine, searchOrigin: hint, cancellationToken: ct);
+
+            var binning = solver.LastDetectionBinning;
+            output.WriteLine($"proposed {binning.Proposed}x, used {binning.Used}x");
+
+            binning.Proposed.ShouldBe(3, "the fabricated 0.6\"/px scale must actually reach the gate -- "
+                + "if this is 1 the test is asserting the veto on a frame that was never a candidate");
+            binning.Used.ShouldBe(1, "a 3x bin puts this frame's stars under two pixels per FWHM, so the "
+                + "sampling floor must undo it and re-detect at full resolution");
+
+            image.Release();
+        }
+
+        /// <summary>
+        /// The other half, and the reason the change is safe to ship without an oversampled fixture:
+        /// on a frame at its OWN declared scale nothing is proposed, so nothing is vetoed and the
+        /// path is byte-identical to the one that shipped.
+        /// </summary>
+        [Fact(Timeout = 600_000)]
+        public async Task AFrameAtItsOwnScaleIsNeverABinningCandidate()
+        {
+            var ct = TestContext.Current.CancellationToken;
+            var image = await SharedTestData.ExtractGZippedFitsImageAsync(
+                "Vela_SNR_Panel_8_1-Multi-NB-mono-Hydrogen-alpha-Oxygen_III-crop", isReadOnly: false, cancellationToken: ct);
+            var dim = image.GetImageDim();
+            Assert.NotNull(dim);
+
+            var db = new CelestialObjectDB();
+            await db.InitDBAsync(waitForTycho2BulkLoad: true, cancellationToken: ct);
+            var solver = new CatalogPlateSolver(db, NullLogger<CatalogPlateSolver>.Instance);
+
+            var hint = new Astrometry.WCS(image.ImageMeta.TargetRA, image.ImageMeta.TargetDec);
+            var result = await solver.SolveImageAsync(image, dim.Value, searchOrigin: hint, cancellationToken: ct);
+
+            solver.LastDetectionBinning.ShouldBe(new CatalogPlateSolver.DetectionBinning(1, 1));
+            result.Solution.ShouldNotBeNull("the frame still solves, unbinned, exactly as before");
+
+            image.Release();
+        }
+
+        [Theory]
+        [InlineData(new float[] { }, null)]
+        [InlineData(new[] { 0f, -1f }, null)]
+        [InlineData(new[] { 3f, 1f, 2f }, 2f)]
+        [InlineData(new[] { 0f, 3f, 1f }, 3f)]
+        public void TheMedianWidthCountsOnlyTheStarsThatCarryOne(float[] widths, float? expected)
+        {
+            var bag = new ConcurrentBag<ImagedStar>();
+            foreach (var w in widths)
+            {
+                bag.Add(new ImagedStar { StarFWHM = w, HFD = 1f, XCentroid = 1, YCentroid = 1, SNR = 10, Flux = 1 });
+            }
+
+            // An unmeasured width is absent, not narrow: counting it would drag the median down and
+            // undo a bin that was fine. {0, 3, 1} therefore medians the pair {1, 3} to 3, not 1.
+            CatalogPlateSolver.MedianStarFwhm(new StarList(bag)).ShouldBe(expected);
+        }
+    }
+}

--- a/src/TianWen.Lib.Tests/VelaMosaicFieldTests.cs
+++ b/src/TianWen.Lib.Tests/VelaMosaicFieldTests.cs
@@ -136,7 +136,14 @@ namespace TianWen.Lib.Tests
 
             foreach (var frame in panel.Frames)
             {
-                var det = frame.DetectedPoints();
+                // Capped the way the solver caps, for the same reason the scale window below is the
+                // shipped one: these frames carry 1,394-1,755 detections and the solver carries only
+                // the brightest 500 of them into matching, so an uncapped seed here would be guarding
+                // a path production no longer takes. Measured both ways over all 96 frames when the
+                // cap landed -- 96 of 96 seed either way, and the capped seed keeps 100% of the
+                // uncapped hits at every frame, because the anchors are the brightest catalog stars
+                // and the detections a true hypothesis lands on are the bright ones the cap keeps.
+                var det = frame.DetectedPoints(CatalogPlateSolver.MaxStarsCarriedIntoMatching);
 
                 // Seed the way the SHIPPED path seeds, not through a window of the test's own
                 // choosing: recover the plate scale from the quads and search inside
@@ -357,6 +364,11 @@ namespace TianWen.Lib.Tests
                 footprints[panel.Id] = InFrameIndices(panel, panel.Frames[0]);
                 // B's field at full in-frame density, as B's own camera saw it.
                 fields[panel.Id] = VelaProjection.ProjectInFrame(Manifest.Catalog, panel.Frames[0].Wcs, panel.Width, panel.Height);
+                // UNCAPPED, deliberately, and unlike the positive test above. The solver carries only
+                // its brightest 500 into matching, but this is the adversarial case: more detections
+                // is more freedom to pile up a spurious consensus, so the uncapped list is the harder
+                // question and the one worth asking. Measured with the cap too when it landed -- 0
+                // false locks either way across all 272 pairs.
                 detected[panel.Id] = panel.Frames[0].DetectedPoints();
             }
 

--- a/src/TianWen.Lib/Astrometry/PlateSolve/CatalogPlateSolver.cs
+++ b/src/TianWen.Lib/Astrometry/PlateSolve/CatalogPlateSolver.cs
@@ -60,6 +60,40 @@ internal sealed class CatalogPlateSolver(ICelestialObjectDB db, ILogger logger) 
     const int MinStarsForMatch = 6;
 
     /// <summary>
+    /// Brightest detections carried into matching. 500 is what the detection call has always asked
+    /// for; <see cref="Image.FindStarsAsync"/>'s <c>maxStars</c> simply never enforced it.
+    /// </summary>
+    /// <remarks>
+    /// <para>The faint tail costs accuracy nothing -- a fit is anchored on bright stars, and ASTAP
+    /// solves the NGC 3576 frame from 527 where we detect 8,103 -- but it is NOT inert. It is the
+    /// verification census the seed scores every hypothesis against, and the population the proximity
+    /// loop re-matches on each iteration.</para>
+    /// <para><b>It also moves the chance model, which is the part that needed measuring rather than
+    /// asserting.</b> <see cref="PairRansacLock"/> derives its Poisson rate from the detected DENSITY,
+    /// so truncating the list lowers the expected chance hits and with them the accept threshold,
+    /// which is a LOOSER bar on exactly the fields where the dense-field false-lock failure mode
+    /// lives. Measured over the frozen Vela set, capped against uncapped on the same frames (1,394 to
+    /// 1,755 detections each, so the cap discards about two thirds of every list):</para>
+    /// <list type="bullet">
+    /// <item>seeds 96 of 96 either way, none lost to the cap;</item>
+    /// <item>the capped seed keeps <b>100% of the uncapped hits</b> -- minimum, median and maximum --
+    /// because the anchors are the brightest CATALOG stars, so the detections a true hypothesis lands
+    /// on are the bright ones this keeps;</item>
+    /// <item>0 false locks across the 272 disjoint panel pairs, unchanged.</item>
+    /// </list>
+    /// <para>The negative case is untouched there for a reason worth knowing: at these densities the
+    /// accept bar is the <c>0.15 x census</c> floor (24, from the 160 anchors) and not the chance
+    /// term, and the cap does not move the floor. <b>The bar can only fall on a frame dense enough for
+    /// the chance term to exceed that floor</b> -- 8,103 detections on the NGC 3576 frame against the
+    /// Vela panels' ~1,500 -- and in that regime the noise hits fall with it, since they are drawn
+    /// from the same thinned population. The guard for it is
+    /// <c>GivenDenseFieldAndWrongSearchOriginWhenCatalogPlateSolvingThenItFailsInsteadOfReturningGarbage</c>,
+    /// which seeds at 22 hits against a threshold of 24 on 3,250 detections -- a two-hit margin, so
+    /// it is the test that would go red first if this ever loosened the gate.</para>
+    /// </remarks>
+    internal const int MaxStarsCarriedIntoMatching = 500;
+
+    /// <summary>
     /// Acceptance-gate probe radius in native pixels (scaled up by the detection binning
     /// factor, whose centroid quantisation it must dominate). A genuine solve puts its true
     /// matches within ~1px of the catalog projection; the dense-field failure mode puts them
@@ -414,6 +448,37 @@ internal sealed class CatalogPlateSolver(ICelestialObjectDB db, ILogger logger) 
         if (detectedStars.Count < MinStarsForMatch)
         {
             return Result(empty);
+        }
+
+        // Carry only the brightest into matching. The detection call has asked for this all along --
+        // it passes maxStars: 500 -- but that parameter caps NOTHING (its only effect is to supply
+        // the default for minStars), so a dense frame has been handing the solver everything it
+        // found: 8,103 stars on the NGC 3576 frame, where ASTAP solves the same field from 527.
+        //
+        // The faint tail is not what a fit is anchored on, and it is not free: it is the verification
+        // census every hypothesis is scored against, the population the proximity loop re-matches on
+        // each of its iterations, and -- see MaxStarsCarriedIntoMatching -- the density the chance
+        // model is derived from.
+        //
+        // _detectedStars above keeps the TRUE count, because that is a property of the frame and the
+        // number a diagnostic wants; what is capped is what matching sees.
+        if (detectedStars.Count > MaxStarsCarriedIntoMatching)
+        {
+            var brightest = new List<ImagedStar>(detectedStars);
+            brightest.Sort(static (a, b) => b.Flux.CompareTo(a.Flux));
+            var kept = new System.Collections.Concurrent.ConcurrentBag<ImagedStar>();
+            for (var i = 0; i < MaxStarsCarriedIntoMatching; i++)
+            {
+                kept.Add(brightest[i]);
+            }
+
+            _logger.LogDebug("CatalogPlateSolver: carrying the brightest {Kept} of {Detected} detections into matching",
+                MaxStarsCarriedIntoMatching, detectedStars.Count);
+
+            // The star MASK is deliberately dropped with the tail: it indexes the pixels the full
+            // detection ran on, so a mask kept beside a truncated list would describe stars the list
+            // no longer contains. Nothing downstream of here reads it.
+            detectedStars = new StarList(kept);
         }
 
         // Sort catalog stars by brightness (lowest mag = brightest first).

--- a/src/TianWen.Lib/Astrometry/PlateSolve/CatalogPlateSolver.cs
+++ b/src/TianWen.Lib/Astrometry/PlateSolve/CatalogPlateSolver.cs
@@ -94,6 +94,31 @@ internal sealed class CatalogPlateSolver(ICelestialObjectDB db, ILogger logger) 
     internal const int MaxStarsCarriedIntoMatching = 500;
 
     /// <summary>
+    /// The narrowest median star, in DETECTION pixels, a binned frame may present before the binning
+    /// is undone. Nyquist: a profile sampled below two pixels per FWHM is aliased, and its centroid
+    /// stops being recoverable.
+    /// </summary>
+    /// <remarks>
+    /// <para>This exists because sampling is what pre-detection binning SPENDS, and no gate on the
+    /// declared plate scale can see it. Sampling is the star's width in pixels -- seeing divided by
+    /// scale -- so a 1.5"/px target lands the binned width at <c>FWHM_arcsec / 1.5</c>, under two
+    /// pixels for any seeing better than 3". That is most usable nights, not a corner case, and the
+    /// gate had no way to know: two rigs at the same scale on nights an arcsecond apart want opposite
+    /// answers. ASTAP gates on image HEIGHT instead, the same shape of proxy one step further from
+    /// the physics.</para>
+    /// <para><b>It is a veto, never a trigger.</b> A frame is only ever un-binned by this, so the
+    /// worst case is one wasted detection pass on the CHEAP (binned) image, and a stale or absent
+    /// measurement leaves the proposal standing. Binning up on a frame that measures wide would be
+    /// the opposite trade -- speculative, and paid in the aliasing this is here to prevent.</para>
+    /// <para><b>Measured FWHM floors near 1.2 px</b>, so a binned reading cannot be multiplied back
+    /// to recover the unbinned width (on the NGC 3576 frame, 2.15 px at bin 1 reads 1.85 px at bin 2,
+    /// not 1.08): an undersampled star cannot measure narrower than the grid it is sampled on. Only
+    /// the comparison against this floor is sound, which is why the fallback goes to full resolution
+    /// and re-measures rather than solving for a better factor.</para>
+    /// </remarks>
+    internal const float MinSampledFwhmPx = 2.0f;
+
+    /// <summary>
     /// Acceptance-gate probe radius in native pixels (scaled up by the detection binning
     /// factor, whose centroid quantisation it must dominate). A genuine solve puts its true
     /// matches within ~1px of the catalog projection; the dense-field failure mode puts them
@@ -182,6 +207,22 @@ internal sealed class CatalogPlateSolver(ICelestialObjectDB db, ILogger logger) 
     /// path. The two are kept apart deliberately, since one measures THIS frame's stars.</para>
     /// </summary>
     internal QuadScaleRecovery.Recovery? LastScalePrior { get; private set; }
+
+    /// <summary>
+    /// What the plate scale PROPOSED for detection binning on the last solve, and what detection
+    /// actually ran at once the sampling floor had its say.
+    /// </summary>
+    /// <remarks>
+    /// Both halves, because <c>Used == 1</c> alone cannot tell a frame that was never a binning
+    /// candidate from one whose bin was vetoed -- and those are the two outcomes worth separating.
+    /// Invisible from the outside otherwise: the solve answers in original-image pixels either way.
+    /// </remarks>
+    internal DetectionBinning LastDetectionBinning { get; private set; }
+
+    /// <param name="Proposed">The factor the declared plate scale asked for; 1 for no bin.</param>
+    /// <param name="Used">The factor detection ran at; below <paramref name="Proposed"/> only where
+    /// <see cref="MinSampledFwhmPx"/> vetoed it.</param>
+    internal readonly record struct DetectionBinning(int Proposed, int Used);
 
     /// <param name="AbandonedAParity">One parity was stopped because the other seeded clear of chance.</param>
     /// <param name="ReRanAbandonedParity">The gate needed the abandoned half after all, so it was re-run.</param>
@@ -372,28 +413,29 @@ internal sealed class CatalogPlateSolver(ICelestialObjectDB db, ILogger logger) 
             return Result(empty);
         }
 
-        // Downsample heavily oversampled frames to ~1.5"/px before star
-        // detection. Plate solving doesn't need sub-arcsec centroid accuracy --
-        // catalog projections are already arcsec-scale via the WCS fit -- but
-        // FindStarsAsync's per-pass cost scales with pixel count. A 0.97"/px
-        // 9576x6388 polar preview binned 2x drops to 4788x3194 and runs ~4x
-        // faster per pass. Centroid coords come back in binned pixel space, so
-        // we scale them back to original-image pixels before matching.
+        // Bin heavily oversampled frames before star detection: FindStarsAsync's per-pass cost scales
+        // with pixel count, and a 0.97"/px 9576x6388 polar preview binned 2x drops to 4788x3194 and
+        // runs ~4x faster per pass. Centroid coords come back in binned pixel space, so we scale them
+        // back to original-image pixels before matching.
+        //
+        // The declared plate scale PROPOSES the factor; it does not decide it. See
+        // MinSampledFwhmPx for why scale cannot decide it -- what binning spends is sampling, which
+        // is seeing over scale, and a scale gate cannot see seeing. The proposal is verified below
+        // against the width the detector actually measures, and may only ever be undone.
         var detectionImage = image;
         var detectionScale = 1;
+        var proposedDetectionScale = 1;
         // Integer-tenths comparison: pixelScale * 10 vs 15 dodges the
         // floating-point edge where round(1.5 / 1.293) collapses to 1 and
         // leaves the 600mm/3.76um polar preview running FindStars on the
         // full 9576x6388 frame -- ~5 s wall-clock, which blows the polar
-        // ramp's 5.5 s rung-1 budget. With this gate, anything finer than
-        // 1.5"/px gets binned to ~1.5-3.0"/px (still well above seeing,
-        // still plenty for plate-solving centroid accuracy).
+        // ramp's 5.5 s rung-1 budget.
         const int TargetPixelScaleX10 = 15;
         var pixelScaleX10 = (int)Math.Round(dim.PixelScale * 10);
         if (pixelScaleX10 > 0 && pixelScaleX10 < TargetPixelScaleX10)
         {
             // Ceiling so finer-than-target inputs always get at least 2x bin.
-            detectionScale = (TargetPixelScaleX10 + pixelScaleX10 - 1) / pixelScaleX10;
+            proposedDetectionScale = detectionScale = (TargetPixelScaleX10 + pixelScaleX10 - 1) / pixelScaleX10;
             if (detectionScale > 1)
             {
                 stageSw.Restart();
@@ -423,9 +465,28 @@ internal sealed class CatalogPlateSolver(ICelestialObjectDB db, ILogger logger) 
         // positions in aggregate, so the faint end it admits is worth having -- which is not true of the
         // detector's other callers (see Image.MaxFirstPassNoiseSigma for what capping them cost).
         stageSw.Restart();
-        var detectedStars = await detectionImage.FindStarsAsync(detectionImage.ReferenceStarChannel, snrMin: 5f, maxStars: 500, minStars: 50, maxRetries: 0, maxFirstPassNoiseSigma: Image.MaxFirstPassNoiseSigma, logger: _logger, cancellationToken: cancellationToken);
+        var detectedStars = await DetectStarsAsync(detectionImage, cancellationToken);
         _logger.LogDebug("CatalogPlateSolver: FindStarsAsync detected {Count} stars in {Ms}ms ({W}x{H})",
             detectedStars.Count, stageSw.Elapsed.TotalMilliseconds, detectionImage.Width, detectionImage.Height);
+
+        // The proposal, judged against what the detector just measured. A binned frame that comes
+        // back under Nyquist was binned past what its stars could carry, and every centroid in it is
+        // aliased -- so throw that pass away and re-detect at full resolution, where the widths are
+        // whatever the optics and the night actually delivered. Costs one pass on the binned (cheap)
+        // image in exactly the case where the alternative is a fit built on aliased positions.
+        if (detectionScale > 1 && MedianStarFwhm(detectedStars) is { } binnedFwhm && binnedFwhm < MinSampledFwhmPx)
+        {
+            _logger.LogDebug("CatalogPlateSolver: bin {Factor} left median FWHM {Fwhm:F2} px below the {Floor:F2} px sampling floor; re-detecting unbinned",
+                detectionScale, binnedFwhm, MinSampledFwhmPx);
+            detectionImage = image;
+            detectionScale = 1;
+            stageSw.Restart();
+            detectedStars = await DetectStarsAsync(image, cancellationToken);
+            _logger.LogDebug("CatalogPlateSolver: FindStarsAsync detected {Count} stars in {Ms}ms ({W}x{H}) after undoing the bin",
+                detectedStars.Count, stageSw.Elapsed.TotalMilliseconds, image.Width, image.Height);
+        }
+
+        LastDetectionBinning = new DetectionBinning(proposedDetectionScale, detectionScale);
 
         // Scale centroids back to original-image pixel space if we downsampled.
         // (factor*x + factor/2 - 0.5) puts the binned-pixel centre back to
@@ -704,6 +765,45 @@ internal sealed class CatalogPlateSolver(ICelestialObjectDB db, ILogger logger) 
         }
 
         return Result(winner);
+    }
+
+    /// <summary>
+    /// The solver's detection call, in one place so the binned pass and the un-binned re-run cannot
+    /// drift apart -- they must ask the same question of two rasters for their star counts and widths
+    /// to be comparable at all.
+    /// </summary>
+    private Task<StarList> DetectStarsAsync(Image img, CancellationToken cancellationToken)
+        => img.FindStarsAsync(img.ReferenceStarChannel, snrMin: 5f, maxStars: MaxStarsCarriedIntoMatching, minStars: 50, maxRetries: 0, maxFirstPassNoiseSigma: Image.MaxFirstPassNoiseSigma, logger: _logger, cancellationToken: cancellationToken);
+
+    /// <summary>
+    /// Median fitted star width, or null when nothing in the list carries one.
+    /// </summary>
+    /// <remarks>
+    /// The MEDIAN rather than the mean because the tail this has to survive is one-sided and large:
+    /// a nebula knot, a pair the deblender declined and a satellite streak all read wide, and none of
+    /// them says anything about how the frame is sampled. <c>StarFWHM &lt;= 0</c> is "not measured"
+    /// rather than "zero wide" -- see <see cref="Image.MaxFirstPassNoiseSigma"/>'s neighbours in
+    /// <c>Image.StarDeblend</c> -- so those are excluded rather than counted as narrow, which would
+    /// drag the median toward undoing a bin that was fine.
+    /// </remarks>
+    internal static float? MedianStarFwhm(StarList stars)
+    {
+        var widths = new List<float>(stars.Count);
+        foreach (var s in stars)
+        {
+            if (s.StarFWHM > 0f)
+            {
+                widths.Add(s.StarFWHM);
+            }
+        }
+
+        if (widths.Count == 0)
+        {
+            return null;
+        }
+
+        widths.Sort();
+        return widths[widths.Count / 2];
     }
 
     /// <summary>


### PR DESCRIPTION
Phase D of [plate-solver-performance.md](docs/plans/plate-solver-performance.md), both halves, plus what measuring it against ASTAP turned up.

## Cap the star list carried into matching

`MaxStarsCarriedIntoMatching = 500`. The number is not new -- the detection call has passed `maxStars: 500` all along, and `FindStarsAsync` documents that parameter as "Caps nothing", so a dense frame has been handing the solver everything it found (8,103 stars on the NGC 3576 frame, where ASTAP solves the same field from 527).

The risk needed measuring rather than asserting, because truncating the list **lowers** the accept threshold (`max(max(10, 5 x chance), 0.15 x census)`) -- a looser bar on exactly the dense fields where the false-lock failure mode lives. Capped against uncapped over the 96 frozen Vela frames:

| | uncapped | capped |
|---|---|---|
| frames that seed | 96 / 96 | **96 / 96** |
| hits kept vs the uncapped seed | -- | **100%** at min, median and max |
| false locks over 272 disjoint pairs | 0 | **0** |

Not one hit is lost, for a reason rather than by luck: the anchors are the brightest *catalog* stars, so the detections a true hypothesis lands on are the bright ones the cap keeps.

Wall clock (Release AOT, whole process, median of 5 interleaved runs):

| frame | uncapped | capped | |
|---|---|---|---|
| NGC 3576, 8,103 detections, good hint | 839 ms | **711 ms** | 1.18x |
| Vela panel 10 crop, hint 93 arcmin off | 6,931 ms | **3,170 ms** | **2.19x, -3.8 s** |

The cap pays in proportion to **hypotheses tried**, not detections discarded, which is why the densest frame barely moves and the relocating one saves 3.8 s.

## Let the stars veto a bin

The solver downsampled to ~1.5"/px whenever the declared scale was finer, on the stated grounds that 1.5"/px is "still well above seeing" -- a claim about a quantity the gate never looked at. Binned `FWHM_px = FWHM_arcsec / 1.5`, so it lands under two pixels per FWHM for any seeing better than 3", i.e. most usable nights.

The scale now **proposes** and the measurement **decides**: `MinSampledFwhmPx = 2.0` re-detects at full resolution when the binned median `StarFWHM` falls under it. It is a veto and never a trigger, so the worst case is one wasted pass on the cheap raster.

Measured over the committed fixtures (`SolverBinningSamplingProbe`):

- binning's real cost is the star **count** -- 8103 -> 3123, 4003 -> 2240 -- and `PlateSolveTestFile` falls 11 -> 7 -> **3** at bin 3, under `MinStarsForMatch = 6`. A bin can turn a solvable frame into a failure.
- measured FWHM floors near 1.2 px, so a binned width cannot be multiplied back (2.15 px at bin 1 reads 1.85 at bin 2, not 1.08).
- **every committed fixture is 2.87-5.97"/px**, so the gate proposes 1 on all of them and always did. That is what makes this safe to land, and it also means the oversampled class of frame is unrepresented -- the polar-preview consequence is reasoned, not measured, and is filed as hardware-validation item 25 rather than dressed up as coverage.

## What the ASTAP comparison turned up

ASTAP's search recomputes only the **catalogue** side -- the image quads are built once, outside the spiral -- so a trial centre is nearly free, while ours re-runs the seed per candidate. With a full-FOV step against our 0.35, one parity against our two, and ~110k `abs` compares against a RANSAC seed, it takes ~9 cheap steps where we take ~40 expensive ones.

More consequentially: **ASTAP solves both Vela crops from quads**, in 0.66 s and 1.54 s, agreeing with us to 3.2 arcsec -- while phase C's probe reports 2.6% shared quads under ideal conditions. Both are real, so that verdict is about *our quad construction*, not about quad matching, and the doc now says so. The likely mechanism is in ASTAP's source (a quad is a star plus its three nearest neighbours, so it only reproduces between comparably dense lists, and it matches the densities explicitly); the rerun that would settle it is written down and flagged as **not yet run**.

## Testing

- Unit suite green: 5,327 passed, 0 failed, 79 skipped (from 5,321 -- the six are the new tests).
- `SolverSamplingFloorTests`: a real raster handed a fabricated 0.6"/px `ImageDim` asserts `(Proposed 3, Used 1)`, so it cannot pass on a frame that was never a binning candidate; the same frame at its own scale asserts `(1, 1)` and still solves. Seen red first -- with the veto disabled it reports `proposed 3x, used 3x`.
- `RealFrameSolveTests` gains a second solve asserting the light-path cache makes it materially cheaper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)