### PR TITLE
test(solve): pin the winning parity's hypotheses exactly; the abandoned half is quantised

### DIFF
--- a/docs/plans/plate-solver-performance.md
+++ b/docs/plans/plate-solver-performance.md
@@ -272,8 +272,8 @@ never `ReferenceEquals` on a record struct.
 Guarded by `SolveHintCacheTests` (learning, light-path separation, and that an unidentified frame or a
 non-positive ratio teaches nothing) plus the second solve in
 `RealFrameSolveTests.TheCropWhoseHeaderPointsElsewhereStillSolves`, which asserts on
-`CatalogPlateSolver.LastSeedHypotheses` -- deterministic, unlike wall clock -- and was seen to FAIL
-with the cap disabled.
+`CatalogPlateSolver.LastSeedHypothesesByParity` (the winning half is deterministic, unlike wall clock;
+the abandoned half is not, see the 2026-09-01 note under C3) and was seen to FAIL with the cap disabled.
 
 ### B. Tycho-2 pre-baked region index -- **OBSOLETE, the work is already done**
 
@@ -903,10 +903,23 @@ Two consequences worth recording:
 
 - **The cache's end-to-end pin on this frame is gone, and that is correct.** The second solve used to
   spend 1.6x fewer hypotheses because the remembered parity capped the doubted half; the seed now tells
-  the FIRST solve the parity and the scale, so both solves spend the same 8,381, and `RealFrameSolveTests`
-  pins that no material saving is left (+/-25%, since the abandoned half's count depends on when its
-  sibling cancelled it). The cache still earns its keep wherever the quad seed declines; no committed
-  fixture reproduces that.
+  the FIRST solve the parity and the scale, so both solves spend the same on the half that answers, and
+  `RealFrameSolveTests` pins that no material saving is left. The cache still earns its keep wherever
+  the quad seed declines; no committed fixture reproduces that.
+  **The abandoned half is not deterministic, and a band on the total cannot hold (2026-09-01).** The
+  first CI run after this landed read 8,381 hypotheses on the first solve and 8,381 on the second on
+  every leg but one; the ubuntu x64 leg read 12,477 then 8,381 and failed the +/-25% band, and the
+  next run's x64 leg read 13,031 then 8,935 on the hint-cache test's easy field. Both differences are
+  exactly 4,096: the losing parity reads its cancellation token every 4,096 hypotheses, so whether
+  the winner's claim catches it just before or just after a check boundary costs one whole quantum,
+  which on an 8,381 total is 49% and no band under that is safe. The counter is now split by parity
+  (`LastSeedHypothesesByParity`); the tests pin the winning half EXACTLY (it is the deterministic
+  part, and the part a cache could change) and bound the abandoned half by the doubted-parity budget,
+  which is what "nothing material left to add" means operationally. The 8,381 quoted above is 189
+  hypotheses for the half that answered plus 8,192 (two quanta) for the loser, and the 12,477 was the
+  same 189 plus three; the easy hint-cache field splits 743 plus 8,192. The winning half is the figure
+  to compare across machines, and it says the relocated solve costs 48,000x fewer hypotheses than it
+  did, not 1,094x: the total was always mostly the loser waiting to notice it had been cancelled.
 - **The frozen-panel pins all hold** -- 24 of 24 seed from the header hint and agree with the frozen
   solution, and the unrelated-field, triple-overlap and anchor-pool tests are unchanged -- so a
   near-perfect hint loses nothing: the seed relocates by ~0 and hands the race the scale and parity it

--- a/src/TianWen.Lib.Tests/RealFrameSolveTests.cs
+++ b/src/TianWen.Lib.Tests/RealFrameSolveTests.cs
@@ -166,19 +166,27 @@ public class RealFrameSolveTests(ITestOutputHelper output)
         // Before the quad seed this was the cache's end-to-end pin: the second solve spent 1.6x fewer
         // hypotheses (9,165,717 -> 5,813,171) because the remembered PARITY capped the doubted half.
         // The quad seed measures parity and scale on the frame itself, ahead of the race, so the first
-        // solve already knows everything the cache could tell the second and the two spend the same
-        // 8,381 hypotheses -- 1,094x fewer than the first solve used to. What is pinned now is that no
-        // material saving is LEFT: a second solve markedly cheaper than the first would mean the seed
-        // had stopped supplying parity or scale and the cache was covering for it. The cache's own
+        // solve already knows everything the cache could tell the second. What is pinned now is that no
+        // material saving is LEFT, and it is pinned on the half that ANSWERS: that scan is deterministic
+        // for a given input, so the two solves must spend exactly the same on it, and a second solve
+        // markedly cheaper there would mean the seed had stopped supplying parity or scale and the cache
+        // was covering for it. The abandoned half is NOT compared between solves: its count is quantised
+        // to the 4,096-hypothesis cancellation check and lands one quantum either way depending on
+        // where the winner's claim caught it, which is how the total read 8,381 on one CI run and 12,477
+        // on the next for this very frame (2026-09-01) and broke a +/-25% band on the total. What it
+        // must show instead is that the claim stopped it long before the per-pool budget the cache
+        // would cap it at, which is the operational meaning of "nothing left to add". The cache's own
         // behaviour is pinned in SolveHintCacheTests; its end-to-end win survives only on a frame where
         // the quad seed declines, which no committed fixture reproduces.
-        var firstHypotheses = solver.LastSeedHypotheses;
+        var firstTotal = solver.LastSeedHypotheses;
+        var (firstWinner, firstAbandoned) = solver.LastSeedHypothesesByOutcome;
         var swSecond = Stopwatch.StartNew();
         var again = await solver.SolveImageAsync(image, dim.Value, searchOrigin: hint, cancellationToken: ct);
         swSecond.Stop();
-        var secondHypotheses = solver.LastSeedHypotheses;
-        output.WriteLine($"second solve {swSecond.ElapsedMilliseconds} ms, seed hypotheses {firstHypotheses:N0} -> {secondHypotheses:N0} "
-            + $"({(firstHypotheses > 0 ? (double)firstHypotheses / Math.Max(1, secondHypotheses) : 0):F1}x fewer)");
+        var secondTotal = solver.LastSeedHypotheses;
+        var (secondWinner, secondAbandoned) = solver.LastSeedHypothesesByOutcome;
+        output.WriteLine($"second solve {swSecond.ElapsedMilliseconds} ms, seed hypotheses {firstTotal:N0} -> {secondTotal:N0}; "
+            + $"winning parity {firstWinner:N0} -> {secondWinner:N0}, abandoned parity {firstAbandoned:N0} -> {secondAbandoned:N0}");
 
         Assert.NotNull(again.Solution);
         var solvedAgain = again.Solution.Value;
@@ -189,10 +197,14 @@ public class RealFrameSolveTests(ITestOutputHelper output)
             "a remembered scale and parity may make the solve cheaper, never different");
         Shouldly.ShouldBeTestExtensions.ShouldBe(solver.LastOriginSource, CatalogPlateSolver.OriginSource.QuadSeed,
             "the second solve must relocate through the quad seed as the first did");
-        Shouldly.ShouldBeTestExtensions.ShouldBeInRange(secondHypotheses, (int)(firstHypotheses * 0.75), (int)(firstHypotheses * 1.25),
-            $"with the quad seed supplying parity and scale on the FIRST solve the cache has nothing material left to add "
-            + $"({firstHypotheses:N0} -> {secondHypotheses:N0} hypotheses; measured equal, and the band is +/-25% because the "
-            + "abandoned parity's count depends on when its sibling cancelled it)");
+        Shouldly.ShouldBeTestExtensions.ShouldBe(secondWinner, firstWinner,
+            "the winning parity's scan is deterministic for a given input, and the quad seed already told the FIRST solve "
+            + "its parity and scale, so a remembered light path has nothing to change on the half that answers");
+        Shouldly.ShouldBeTestExtensions.ShouldBeLessThan(firstAbandoned, CatalogPlateSolver.DoubtedParityHypothesisBudget,
+            "the winner's claim must stop the abandoned half within a few 4,096-hypothesis cancellation quanta on the FIRST "
+            + "solve, long before the per-pool budget a remembered parity would cap it at; otherwise the cache had a saving left");
+        Shouldly.ShouldBeTestExtensions.ShouldBeLessThan(secondAbandoned, CatalogPlateSolver.DoubtedParityHypothesisBudget,
+            "and on the second solve, where the cache does cap it, the claim must still come first");
 
         image.Release();
     }

--- a/src/TianWen.Lib.Tests/SolveHintCacheTests.cs
+++ b/src/TianWen.Lib.Tests/SolveHintCacheTests.cs
@@ -19,10 +19,13 @@ namespace TianWen.Lib.Tests;
 /// and that a wrong answer is never the price.
 /// </summary>
 /// <remarks>
-/// Asserted on <see cref="CatalogPlateSolver.LastSeedHypotheses"/>, because the cache's entire effect
-/// is work that does not happen: the emitted WCS is identical with it and without it, so nothing an
-/// ordinary assertion can reach would move if it were deleted. Hypotheses rather than milliseconds --
-/// they are deterministic for a given input, so the same numbers hold on CI and in Debug.
+/// Asserted on <see cref="CatalogPlateSolver.LastSeedHypothesesByOutcome"/>, because the cache's entire
+/// effect is work that does not happen: the emitted WCS is identical with it and without it, so nothing
+/// an ordinary assertion can reach would move if it were deleted. Hypotheses rather than milliseconds,
+/// and the WINNING half's rather than the total: that scan is deterministic for a given input, so the
+/// same number holds on CI and in Debug, while the abandoned half's count is quantised to its
+/// 4,096-hypothesis cancellation check and lands a quantum either way with the scheduler (13,031
+/// against 8,935 on two CI runs of the same easy field, 2026-09-01).
 /// </remarks>
 [Collection("Astrometry")]
 public class SolveHintCacheTests(ITestOutputHelper output)
@@ -68,13 +71,13 @@ public class SolveHintCacheTests(ITestOutputHelper output)
     /// </summary>
     /// <remarks>
     /// It deliberately does NOT assert a saving, because on this frame there is none to assert and a
-    /// test that claimed one would be measuring noise: an easy field seeds in 8,937 hypotheses across
-    /// the whole race, phase A's cancellation has already stopped the loser, and the quad recovery
-    /// answers from the frame's own stars so the remembered scale is never consulted. The saving
-    /// lands where the seed is expensive, and is measured there --
-    /// <see cref="RealFrameSolveTests.TheCropWhoseHeaderPointsElsewhereStillSolves"/>, 1.6x.
-    /// What matters here is the other half of the contract: the hints are HINTS, so the answer must
-    /// not move.
+    /// test that claimed one would be measuring noise: an easy field seeds in a few thousand hypotheses
+    /// across the whole race, phase A's cancellation has already stopped the loser, and the quad seed
+    /// answers scale and parity from the frame's own stars so the remembered ones are never consulted.
+    /// Since the quad seed runs ahead of the race no committed fixture shows the cache a saving at all
+    /// (<see cref="RealFrameSolveTests.TheCropWhoseHeaderPointsElsewhereStillSolves"/> pins that
+    /// nothing material is left). What matters here is the other half of the contract: the hints are
+    /// HINTS, so the answer must not move, and neither may the cost of the half that answers.
     /// </remarks>
     [Fact(Timeout = 300_000)]
     public async Task AnAcceptedSolveTeachesTheLightPathAndTheNextAnswerIsIdentical()
@@ -87,16 +90,18 @@ public class SolveHintCacheTests(ITestOutputHelper output)
         var hint = new WCS(TargetRA, TargetDec);
 
         var first = await solver.SolveImageAsync(image, dim, searchOrigin: hint, searchRadius: 3d, cancellationToken: ct);
-        var firstHypotheses = solver.LastSeedHypotheses;
+        var firstTotal = solver.LastSeedHypotheses;
+        var (firstWinner, firstAbandoned) = solver.LastSeedHypothesesByOutcome;
         first.Solution.ShouldNotBeNull("the premise is a frame that solves");
         solver.Hints.Count.ShouldBe(1, "an accepted solve teaches the light path it came from");
 
         var second = await solver.SolveImageAsync(image, dim, searchOrigin: hint, searchRadius: 3d, cancellationToken: ct);
-        var secondHypotheses = solver.LastSeedHypotheses;
+        var secondTotal = solver.LastSeedHypotheses;
+        var (secondWinner, secondAbandoned) = solver.LastSeedHypothesesByOutcome;
         second.Solution.ShouldNotBeNull();
 
-        output.WriteLine($"seed hypotheses: first {firstHypotheses:N0}, second {secondHypotheses:N0} "
-            + $"({(firstHypotheses > 0 ? (double)secondHypotheses / firstHypotheses : 0):P1} of the first)");
+        output.WriteLine($"seed hypotheses: first {firstTotal:N0}, second {secondTotal:N0}; "
+            + $"winning parity {firstWinner:N0} -> {secondWinner:N0}, abandoned {firstAbandoned:N0} -> {secondAbandoned:N0}");
 
         // The answer must not move -- the whole design rests on the hints being hints.
         var a = first.Solution.Value;
@@ -104,9 +109,9 @@ public class SolveHintCacheTests(ITestOutputHelper output)
         CoordinateUtils.AngularSeparationDeg(a.CenterRA, a.CenterDec, b.CenterRA, b.CenterDec)
             .ShouldBeLessThan(1.0 / 3600.0, "a remembered scale and parity may make the solve cheaper, never different");
 
-        secondHypotheses.ShouldBeLessThanOrEqualTo(firstHypotheses,
-            "a light path's remembered scale and parity may never make its own field COSTLIER to "
-            + "solve than it was with no history at all");
+        secondWinner.ShouldBe(firstWinner,
+            "a light path's remembered scale and parity may never change what the half that answers spends "
+            + "on its own field: that scan is deterministic, and the cache only ever caps the OTHER half");
     }
 
     [Fact(Timeout = 300_000)]

--- a/src/TianWen.Lib/Astrometry/PlateSolve/CatalogPlateSolver.cs
+++ b/src/TianWen.Lib/Astrometry/PlateSolve/CatalogPlateSolver.cs
@@ -293,19 +293,57 @@ internal sealed class CatalogPlateSolver(ICelestialObjectDB db, ILogger logger) 
     /// <summary>Test seam: what the solver has learned about the rigs it has solved for.</summary>
     internal SolveHintCache Hints => _hints;
 
-    private int _seedHypotheses;
+    private int _seedHypothesesStd;
+    private int _seedHypothesesMirror;
 
     /// <summary>
     /// Test seam: hypotheses the pair-lock seed spent on the most recent solve, summed over both
     /// parities, every anchor pool and the relocation retry.
     /// </summary>
     /// <remarks>
-    /// The measure the cache has to be judged on, for the same reason phase A was: its entire effect
-    /// is work that DOES NOT HAPPEN, so the emitted WCS is identical with it and without it and only
-    /// the cost moves. Hypotheses rather than milliseconds because they are deterministic for a given
-    /// input, so they compare across machines, across builds and between a Debug and a Release run.
+    /// <para>The measure the cache has to be judged on, for the same reason phase A was: its entire
+    /// effect is work that DOES NOT HAPPEN, so the emitted WCS is identical with it and without it and
+    /// only the cost moves. Hypotheses rather than milliseconds because they compare across machines,
+    /// across builds and between a Debug and a Release run.</para>
+    /// <para><b>Only the half that answers is deterministic for a given input.</b> The abandoned half
+    /// reads its cancellation token every 4,096 hypotheses (<see cref="PairRansacLock"/>'s innermost
+    /// loop, deliberately), so its count is quantised to that check and lands one quantum either side
+    /// depending on where its sibling's claim caught it: the same solve on the same bytes read 8,381
+    /// on one CI run and 12,477 on the next (ubuntu x64, 2026-09-01), the difference exactly 4,096. A
+    /// test that compares two solves therefore reads <see cref="LastSeedHypothesesByParity"/> and pins
+    /// the winning half exactly; this total is for logging and for a doomed scan, where the abandoned
+    /// half's 1.4M is the whole story and a quantum is noise.</para>
     /// </remarks>
-    internal int LastSeedHypotheses => _seedHypotheses;
+    internal int LastSeedHypotheses => _seedHypothesesStd + _seedHypothesesMirror;
+
+    /// <summary>
+    /// <see cref="LastSeedHypotheses"/> split by parity: the standard (<c>xSign = +1</c>) and the
+    /// mirror (<c>xSign = -1</c>) attempt's spend, each summed over its tiers and any re-run. Which of
+    /// the two answered is <see cref="ParityRaceOutcome.WinnerIsStd"/>.
+    /// </summary>
+    internal (int Std, int Mirror) LastSeedHypothesesByParity => (_seedHypothesesStd, _seedHypothesesMirror);
+
+    /// <summary>
+    /// <see cref="LastSeedHypothesesByParity"/> divided by <see cref="ParityRaceOutcome.WinnerIsStd"/>:
+    /// what the half that answered spent, and what the abandoned half spent before its sibling's claim
+    /// (or its budget) stopped it. The first is the deterministic figure to compare between solves.
+    /// </summary>
+    internal (int Winner, int Abandoned) LastSeedHypothesesByOutcome => LastParityRace.WinnerIsStd
+        ? (_seedHypothesesStd, _seedHypothesesMirror)
+        : (_seedHypothesesMirror, _seedHypothesesStd);
+
+    /// <summary>Books one seed tier's spend against the parity that made it.</summary>
+    private void CountSeedHypotheses(double xSign, int hypotheses)
+    {
+        if (xSign > 0)
+        {
+            Interlocked.Add(ref _seedHypothesesStd, hypotheses);
+        }
+        else
+        {
+            Interlocked.Add(ref _seedHypothesesMirror, hypotheses);
+        }
+    }
 
     /// <summary>
     /// Hypotheses per anchor pool allowed to the parity a remembered solve says is the WRONG one.
@@ -398,7 +436,8 @@ internal sealed class CatalogPlateSolver(ICelestialObjectDB db, ILogger logger) 
         {
             // Per SOLVE, not per call: the relocation retry re-enters here and its seed is part of
             // what this solve cost.
-            _seedHypotheses = 0;
+            _seedHypothesesStd = 0;
+            _seedHypothesesMirror = 0;
             LastQuadSeed = null;
             LastOriginSource = OriginSource.Hint;
         }
@@ -1429,7 +1468,7 @@ internal sealed class CatalogPlateSolver(ICelestialObjectDB db, ILogger logger) 
                 var recoveredPixelScaleRad = hintPixelScaleRad / recovery.Ratio;
                 seedLock = TrySeedPairLock(catalogCoords, detPts, currentOrigin, recoveredPixelScaleRad,
                     cx, cy, dim, xSign, RecoveredScaleTolerance, out var recoveredCost, _logger, cancellationToken, maxHypotheses: seedHypothesisBudget);
-                Interlocked.Add(ref _seedHypotheses, recoveredCost.Hypotheses);
+                CountSeedHypotheses(xSign, recoveredCost.Hypotheses);
                 if (seedLock is not null)
                 {
                     pixelScaleRad = recoveredPixelScaleRad;
@@ -1450,7 +1489,7 @@ internal sealed class CatalogPlateSolver(ICelestialObjectDB db, ILogger logger) 
             {
                 seedLock = TrySeedPairLock(catalogCoords, detPts, currentOrigin, pixelScaleRad, cx, cy,
                     dim, xSign, Math.Max(scaleRange, MinPairLockScaleTolerance), out var headerCost, _logger, cancellationToken, maxHypotheses: seedHypothesisBudget);
-                Interlocked.Add(ref _seedHypotheses, headerCost.Hypotheses);
+                CountSeedHypotheses(xSign, headerCost.Hypotheses);
             }
 
             // A seed this far clear of chance settles the parity, so tell the sibling to stop --


### PR DESCRIPTION
Run 33570118409 failed `RealFrameSolveTests.TheCropWhoseHeaderPointsElsewhereStillSolves` on the ubuntu x64 leg only: seed hypotheses read 12,477 on the first solve and 8,381 on the second, outside a +/-25% band on the total. Every other leg read 8,381 twice, the next push passed everywhere, and that push's x64 leg read 13,031 then 8,935 on the hint-cache test's easy field, which only passed because its one-sided bound faced the right way. Both differences are exactly 4,096.

**Cause.** The losing parity reads its cancellation token every 4,096 hypotheses (`PairRansacLock`'s innermost loop, deliberately), so whether the winner's claim catches it just before or just after a check boundary costs one whole quantum. The winning half is deterministic for a given input; the total never was. Split by parity the crop is 189 hypotheses for the half that answers plus 8,192 for the loser, the easy field 743 plus 8,192: the 8,381 quoted as the quad seed's result was mostly a scan waiting to notice it had been cancelled, and the relocating crop's real improvement is ~48,000x in hypotheses, not 1,094x.

**Fix.**
- `CatalogPlateSolver` books the seed spend per parity and exposes `LastSeedHypothesesByParity` and `LastSeedHypothesesByOutcome`; the total stays for logging, its doc now says which half is deterministic and why.
- Both tests pin the winning half EXACTLY between the two solves (the cache may only ever cap the other half) and bound the abandoned half by `DoubtedParityHypothesisBudget`, the operational meaning of "nothing material left to add".
- `docs/plans/plate-solver-performance.md` records the incident, the quantum and the corrected split.

**Verified.** The two tests three times with identical 189 -> 189 / 8,192 -> 8,192 splits, then 14 of 14 across `RealFrameSolveTests`, `SolveHintCacheTests`, `PairRansacLockTests` and `QuadCatalogMatchTests`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013LYFTZV2sJtXeFfyRLn374
