### PR TITLE
LAN.Lib 2.0, whose discovery port can actually be bound

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -19,7 +19,7 @@
 
     <PackageVersion Include="Lzip.Lib" Version="1.1.*" />
 
-    <PackageVersion Include="LAN.Lib" Version="1.2.*" />
+    <PackageVersion Include="LAN.Lib" Version="2.0.*" />
     <PackageVersion Include="SharpAstro.AppShell" Version="1.1.*" />
     <PackageVersion Include="GeoTimeZone" Version="6.1.0" />
 


### PR DESCRIPTION
@
Repins `LAN.Lib` from `1.2.*` to `2.0.*`. Pin-only — no code change.

## Why 2.0 exists, and why it matters here specifically

1.2 announced on UDP `52821`, inside the Windows **dynamic** port range (49152-65535) — exactly where Hyper-V, WSL and Docker carve their port exclusions (`netsh int ipv4 show excludedportrange protocol=udp`). That is not hypothetical for this repo: on a box where it landed inside one, `bind` failed with `WSAEACCES` 10013 and, because `UdpLanTransport`'s constructor runs at DI resolution, **tianwen-gui died before its first frame** over an optional "rigs nearby" feature.

2.0 fixes it twice over — the port moves to `38821` (registered range, unassigned, never dynamically reserved), and a bind failure now degrades to announce-only instead of throwing, reporting itself via the new `ILanTransport.Degradation` (which `LanDiscoveryHostedService` logs once).

No code change is needed: the new surface is purely additive (`Degradation` as a default interface member, `LanDiscoveryOptions.DiscoveryPort`, an optional logger parameter). **The incompatibility is on the wire, not in the API** — a 1.x node and a 2.0 node never see each other — so this pin and chess's move together or not at all. Chess is repinned in sebgod/chess#47.

## Verification

Against the published package, not the local sibling (`-p:UseLocalSiblings=false`):

- restore resolves `LAN.Lib 2.0.121` across all 11 projects
- the three LAN.Lib consumers — `TianWen.UI.Abstractions`, `TianWen.Server`, `TianWen.UI.Gui` — compile clean

Two notes on how, both worth recording:

- **Release, not Debug.** `Debug` + `UseLocalSiblings=false` cannot compile here at all: the debug-inspector surface is `#if DEBUG` upstream, so it exists only in a DEBUG-built sibling and never in the Release package. Release is also what CI builds.
- **The full suite was not run.** A `dotnet test TianWen.Lib.Tests.Functional` was in flight and holding the Release output tree (`MSB4018` on a locked `deps.json` — a lock, not a compile error). Killing someone's test run is not a verification step, so the three consumers were compiled with `BaseOutputPath` redirected elsewhere instead. CI covers the suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019pcRRqq7vczNdsSNgkq83G
@