### PR TITLE
feat(viewer): a demosaic the frame chooses, since the frame is what knows

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1358,8 +1358,15 @@ matrix, the two full-scale numbers and the header parse:
 - **A demosaic the viewer OFFERS must have its own branch in `image.frag`** -- the screen shows the
   shader's output while a Save CPU-debayers the same frame, so an algorithm without one silently
   writes a different picture from the one on screen. That is why `ViewerActions.DebayerAlgorithms`
-  drops AHD (no GPU branch, and 1258 ms per save) and defaults to VNG (no ring at a star core,
-  measured), while `DebayerAlgorithm` keeps AHD for the batch paths. `debayerVng` / `debayerMhc`
+  drops AHD (no GPU branch, and 1258 ms per save), while `DebayerAlgorithm` keeps AHD for the batch
+  paths. **`DebayerAlgorithm.Auto` is the one offered entry with no branch, and only because it is
+  never asked for one**: it is a UI intent resolved by `ResolveAuto` at every consumer (GPU upload,
+  both save paths, document load, enhance) before `GpuDebayerMode`, which **throws** on an
+  unresolved Auto rather than falling through to MHC. It is the default, and resolves a still CFA
+  mosaic to VNG (no ring at a star core, measured), a SER to MHC (**parity with `PlanetaryMaster`,
+  not speed**: VNG's advantage was measured AT STARS and a planetary disk has none), a mono frame to
+  `BilinearMono` and an already-colour frame to `None`. The container is only a PROXY for a
+  planetary subject, so a lunar still resolves to VNG and wants a manual MHC. `debayerVng` / `debayerMhc`
   mirror `Image.DebayerVNGAsync` / `DebayerMHCAsync` down to the epsilons, and **VNG's thresholds are
   ABSOLUTE, so both sides must be fed a `[0, 1]` mosaic**. Pinned by `GpuVngDebayerParityTests`
   (which also carries why a mean byte diff cannot see a demosaic bug);

--- a/docs/architecture/image-pipeline.md
+++ b/docs/architecture/image-pipeline.md
@@ -127,7 +127,7 @@ edges.
 | 5D Mark IV | 6888x4546 | 6720x4480 at (156, 58) |
 | EOS M50 | 6288x4056 | 6000x4000 at (276, 48) |
 | EOS R5 | 5248x3510 | 5088x3392 at (144, 108) |
-| CR2 (5D Mk III) | 5568x3708 | 5472x3648 at (84, 50) |
+| CR2 (6D) | 5568x3708 | 5472x3648 at (84, 50) |
 
 Uncropped, that margin was a flat black L on any stretched render and ~3% of the frame sitting at the
 black level inside every statistic computed over it -- including the subsampled median/MAD the stretch

--- a/docs/plans/sensor-active-area.md
+++ b/docs/plans/sensor-active-area.md
@@ -25,7 +25,7 @@ Canon raw is cropped to its active area on import".
 | 5D Mark IV | 6888x4546 | (156, 58) 6720x4480 |
 | EOS M50 | 6288x4056 | (276, 48) 6000x4000 |
 | EOS R5 | 5248x3510 | (144, 108) 5088x3392 |
-| CR2 (5D Mk III) | 5568x3708 | (84, 50) 5472x3648 |
+| CR2 (6D) | 5568x3708 | (84, 50) 5472x3648 |
 
 **QHY has the bindings and calls none of them.** `QHYCCD.SDK/include/QHYCamera.cs` declares
 `GetQHYCCDEffectiveArea` (821), `GetQHYCCDOverScanArea` (825) and

--- a/src/TianWen.Lib.Tests/ViewerDebayerSelectionTests.cs
+++ b/src/TianWen.Lib.Tests/ViewerDebayerSelectionTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Linq;
 using Shouldly;
 using TianWen.Lib.Imaging;
@@ -25,7 +25,11 @@ public class ViewerDebayerSelectionTests
     [Fact]
     public void EveryOfferedAlgorithmHasItsOwnShaderBranch()
     {
+        // Auto is excluded because it is not a demosaic: it is resolved to one of the others before
+        // the shader mode is asked, and GpuDebayerMode throws if it ever is not (see
+        // AnUnresolvedAutoIsRefusedAtTheShaderBoundary). Every OTHER entry is a real branch.
         var modes = ViewerActions.DebayerAlgorithms
+            .Where(a => a is not DebayerAlgorithm.Auto)
             .Select(a => (Algorithm: a, Mode: ImageRendererBase<object>.GpuDebayerMode(a)))
             .ToArray();
 
@@ -66,7 +70,7 @@ public class ViewerDebayerSelectionTests
     [Fact]
     public void AFreshViewerStartsOnTheDefaultAndTheDefaultIsOffered()
     {
-        ViewerActions.DefaultDebayerAlgorithm.ShouldBe(DebayerAlgorithm.VNG);
+        ViewerActions.DefaultDebayerAlgorithm.ShouldBe(DebayerAlgorithm.Auto);
         ViewerActions.DebayerAlgorithms.ShouldContain(ViewerActions.DefaultDebayerAlgorithm);
         new ViewerState().DebayerAlgorithm.ShouldBe(ViewerActions.DefaultDebayerAlgorithm);
     }
@@ -103,4 +107,69 @@ public class ViewerDebayerSelectionTests
     [InlineData(DebayerAlgorithm.VNG, 4)]
     public void TheShaderModeNumbersAreTheOnesImageFragSwitchesOn(DebayerAlgorithm algorithm, int mode)
         => ImageRendererBase<object>.GpuDebayerMode(algorithm).ShouldBe(mode);
+
+    /// <summary>
+    /// The four rules of <see cref="DebayerAlgorithm.Auto"/>. A CFA mosaic is the only input a
+    /// demosaic acts on at all; the other two answers exist so the selector never SHOWS an algorithm
+    /// that is doing nothing.
+    /// </summary>
+    [Theory]
+    // isBayerMosaic, isColour, isVideoStream, expected
+    [InlineData(true, false, false, DebayerAlgorithm.VNG)]          // still CFA frame: VNG, measured at stars
+    [InlineData(true, false, true, DebayerAlgorithm.MHC)]           // SER: parity with PlanetaryMaster
+    [InlineData(false, true, false, DebayerAlgorithm.None)]         // already colour: nothing to demosaic
+    [InlineData(false, false, false, DebayerAlgorithm.BilinearMono)] // mono sensor
+    public void AutoResolvesFromTheFrame(bool isBayerMosaic, bool isColour, bool isVideoStream, DebayerAlgorithm expected)
+        => DebayerAlgorithm.Auto.ResolveAuto(isBayerMosaic, isColour, isVideoStream).ShouldBe(expected);
+
+    /// <summary>
+    /// A still CFA frame and a SER carrying the SAME pixels must resolve differently. Stated as its own
+    /// test because it is the only rule whose inputs are otherwise identical, so a resolver that ignored
+    /// <c>isVideoStream</c> would still pass every other case above.
+    /// </summary>
+    [Fact]
+    public void OnlyTheStreamKindSeparatesTheTwoCfaAnswers()
+    {
+        var still = DebayerAlgorithm.Auto.ResolveAuto(isBayerMosaic: true, isColour: false, isVideoStream: false);
+        var video = DebayerAlgorithm.Auto.ResolveAuto(isBayerMosaic: true, isColour: false, isVideoStream: true);
+
+        still.ShouldBe(DebayerAlgorithm.VNG);
+        video.ShouldBe(DebayerAlgorithm.MHC);
+        still.ShouldNotBe(video);
+    }
+
+    /// <summary>Anything that is not Auto passes through untouched, whatever the frame looks like.</summary>
+    [Theory]
+    [InlineData(DebayerAlgorithm.None)]
+    [InlineData(DebayerAlgorithm.BilinearMono)]
+    [InlineData(DebayerAlgorithm.VNG)]
+    [InlineData(DebayerAlgorithm.MHC)]
+    [InlineData(DebayerAlgorithm.AHD)]
+    public void AnExplicitChoiceIsNeverOverridden(DebayerAlgorithm chosen)
+    {
+        chosen.ResolveAuto(isBayerMosaic: true, isColour: false, isVideoStream: true).ShouldBe(chosen);
+        chosen.ResolveAuto(isBayerMosaic: false, isColour: true, isVideoStream: false).ShouldBe(chosen);
+    }
+
+    /// <summary>
+    /// Auto has no shader branch, so a producer that forgets to resolve it must fail loudly. It used to
+    /// be that an unknown algorithm fell through to MHC, which is how AHD displayed as something else
+    /// for months without anything going red.
+    /// </summary>
+    [Fact]
+    public void AnUnresolvedAutoIsRefusedAtTheShaderBoundary()
+        => Should.Throw<ArgumentOutOfRangeException>(
+            () => ImageRendererBase<object>.GpuDebayerMode(DebayerAlgorithm.Auto));
+
+    /// <summary>Auto is last in the enum, so values already written into serialized viewer state stay put.</summary>
+    [Fact]
+    public void AddingAutoDidNotRenumberTheExistingAlgorithms()
+    {
+        ((int)DebayerAlgorithm.None).ShouldBe(0);
+        ((int)DebayerAlgorithm.BilinearMono).ShouldBe(1);
+        ((int)DebayerAlgorithm.VNG).ShouldBe(2);
+        ((int)DebayerAlgorithm.AHD).ShouldBe(3);
+        ((int)DebayerAlgorithm.MHC).ShouldBe(4);
+        ((int)DebayerAlgorithm.Auto).ShouldBe(5);
+    }
 }

--- a/src/TianWen.Lib/Imaging/DebayerAlgorithm.cs
+++ b/src/TianWen.Lib/Imaging/DebayerAlgorithm.cs
@@ -13,4 +13,14 @@ public enum DebayerAlgorithm
     // Appended last so the existing numeric values stay stable for any serialized profile state.
     [Description("Malvar-He-Cutler gradient-corrected linear")]
     MHC,
+
+    /// <summary>
+    /// Let the viewer pick from the frame itself. A UI-level intent, NOT a GPU mode: it is resolved to
+    /// a concrete algorithm before the viewer's <c>GpuDebayerMode</c> is asked,
+    /// so it never reaches the shader (which only ever sees None/BilinearMono/MHC/VNG). Deliberately
+    /// LAST, like <see cref="StretchMode.Auto"/> and for the same reason: the numeric values already
+    /// written into serialized viewer state stay put.
+    /// Resolution: <see cref="DebayerAlgorithmExtensions.ResolveAuto"/>.
+    /// </summary>
+    Auto,
 }

--- a/src/TianWen.Lib/Imaging/DebayerAlgorithmExtensions.cs
+++ b/src/TianWen.Lib/Imaging/DebayerAlgorithmExtensions.cs
@@ -9,5 +9,42 @@ public static class DebayerAlgorithmExtensions
             DebayerAlgorithm.BilinearMono => "Mono",
             _ => algorithm.ToString(),
         };
+
+        /// <summary>
+        /// Resolves <see cref="DebayerAlgorithm.Auto"/> to a concrete algorithm; returns any other
+        /// algorithm unchanged.
+        ///
+        /// <para>A CFA mosaic is the only case where the choice does anything at all, since every other
+        /// input takes a different shader path entirely. It still answers for them, because the selector
+        /// SHOWS the resolved value and "VNG" on a mono frame claims work nobody is doing.</para>
+        ///
+        /// <para><b>Why a video stream gets MHC and a still gets VNG.</b> VNG is the default on a
+        /// measurement taken AT STARS: over four stars of a real CR3 the halo rim sits 0.36% below the
+        /// local sky for VNG against 2.86% above for MHC, which is a dark ring around every bright core.
+        /// A planetary capture has no stars, so that measurement does not transfer, while
+        /// <c>PlanetaryMaster</c> demosaics its own output with MHC. Matching it means the frame being
+        /// scrubbed looks like the master the stacker will build. Parity, NOT speed: if this is ever
+        /// re-argued as a performance choice it will be optimised into the wrong answer.</para>
+        /// </summary>
+        /// <param name="isBayerMosaic">One channel carrying a CFA pattern, the only input a demosaic acts on.</param>
+        /// <param name="isColour">Three or more channels, i.e. already demosaiced or natively colour.</param>
+        /// <param name="isVideoStream">A planetary/lunar video source (SER) rather than a still frame.</param>
+        public DebayerAlgorithm ResolveAuto(bool isBayerMosaic, bool isColour, bool isVideoStream)
+            => algorithm is not DebayerAlgorithm.Auto ? algorithm
+                : isBayerMosaic ? (isVideoStream ? DebayerAlgorithm.MHC : DebayerAlgorithm.VNG)
+                : isColour ? DebayerAlgorithm.None
+                : DebayerAlgorithm.BilinearMono;
+
+        /// <summary>
+        /// The same resolution, reading the two frame facts off the image so the
+        /// "one channel carrying a CFA" predicate is written once rather than at every call site.
+        /// </summary>
+        /// <param name="image">The frame as it will be displayed or saved.</param>
+        /// <param name="isVideoStream">See the overload above; a still document is never one.</param>
+        public DebayerAlgorithm ResolveAuto(Image image, bool isVideoStream = false)
+            => algorithm.ResolveAuto(
+                isBayerMosaic: image.ImageMeta.SensorType is SensorType.RGGB && image.ChannelCount == 1,
+                isColour: image.ChannelCount >= 3,
+                isVideoStream: isVideoStream);
     }
 }

--- a/src/TianWen.UI.Abstractions/AnnotatedRasterExport.cs
+++ b/src/TianWen.UI.Abstractions/AnnotatedRasterExport.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -143,7 +143,11 @@ namespace TianWen.UI.Abstractions
             // image's own channels do not, because the shader debayers from the mosaic. Mirrors
             // DisplayRasterExport, which mirrors what UploadDocumentTextures decides between.
             var pixels = image.ImageMeta.SensorType is SensorType.RGGB && image.Shape.ChannelCount == 1 && isComposite
-                ? await image.DebayerAsync(state.DebayerAlgorithm, cancellationToken: cancellationToken).ConfigureAwait(false)
+                // Same resolution the GPU upload does, or a saved Auto frame is demosaiced by a
+                // different algorithm from the one on screen. A document is a still, never a stream.
+                ? await image.DebayerAsync(
+                    state.DebayerAlgorithm.ResolveAuto(isBayerMosaic: true, isColour: false, isVideoStream: false),
+                    cancellationToken: cancellationToken).ConfigureAwait(false)
                 : image;
 
             var (_, width, height) = pixels.Shape;

--- a/src/TianWen.UI.Abstractions/AstroImageDocument.cs
+++ b/src/TianWen.UI.Abstractions/AstroImageDocument.cs
@@ -1,4 +1,4 @@
-using CommunityToolkit.HighPerformance;
+﻿using CommunityToolkit.HighPerformance;
 using System;
 using System.Collections.Immutable;
 using System.Diagnostics;
@@ -322,6 +322,11 @@ public sealed class AstroImageDocument : IPreviewSource
         // match the existing histogram-based computation, and because the shader's VNG thresholds
         // are absolute. The GPU shader demosaics, in whichever branch `algorithm` selects.
         Image viewImage;
+        // Auto is resolved HERE, the first point that has the frame to resolve against: the caller is
+        // a file load, which cannot know the sensor type before opening it. A document is a still, so
+        // the SER answer is not reachable from this path.
+        algorithm = algorithm.ResolveAuto(image);
+
         DebayerAlgorithm actualAlgorithm;
         if (image.ImageMeta.SensorType is SensorType.RGGB && algorithm is not DebayerAlgorithm.None)
         {

--- a/src/TianWen.UI.Abstractions/IPreviewSource.cs
+++ b/src/TianWen.UI.Abstractions/IPreviewSource.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using TianWen.Lib.Imaging;
 
 namespace TianWen.UI.Abstractions;
@@ -73,6 +73,18 @@ public interface IPreviewSource
 
     /// <summary>Number of frames (1 for a still image).</summary>
     int FrameCount { get; }
+
+    /// <summary>
+    /// A planetary/lunar VIDEO source, as opposed to a still frame or a sequence of stills. Read by
+    /// <see cref="DebayerAlgorithmExtensions.ResolveAuto"/> to pick MHC over VNG, for the reason given
+    /// there.
+    ///
+    /// <para>Stated explicitly, and defaulted to <c>false</c>, rather than derived from
+    /// <see cref="FrameCount"/>: a live session preview accumulates frames too, so a frame count above
+    /// one is true of an ordinary deep-sky run and would flip it to the planetary answer partway
+    /// through.</para>
+    /// </summary>
+    bool IsVideoStream => false;
 
     /// <summary>Index of the currently selected frame (0 for a still image).</summary>
     int FrameIndex { get; }

--- a/src/TianWen.UI.Abstractions/ImageRendererBase.Toolbar.cs
+++ b/src/TianWen.UI.Abstractions/ImageRendererBase.Toolbar.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
@@ -1512,6 +1512,20 @@ namespace TianWen.UI.Abstractions
             };
         }
 
+        /// <summary>
+        /// What <see cref="DebayerAlgorithm.Auto"/> resolves to for the frame on screen, so the button
+        /// can name it. Reads <c>_source</c> rather than the document, because a SER has no
+        /// <see cref="AstroImageDocument"/> and is exactly the case whose answer differs.
+        /// </summary>
+        private string ResolvedDebayerLabel()
+        {
+            var isBayerMosaic = _source?.SensorType is SensorType.RGGB && _source.ChannelCount == 1;
+            var isColour = _source is { ChannelCount: >= 3 };
+            return DebayerAlgorithm.Auto
+                .ResolveAuto(isBayerMosaic, isColour, _source?.IsVideoStream ?? false)
+                .DisplayName;
+        }
+
         private string GetToolbarButtonLabel(string baseLabel, ToolbarAction action, AstroImageDocument? document, ViewerState state)
         {
             return action switch
@@ -1533,7 +1547,10 @@ namespace TianWen.UI.Abstractions
                     : $"{state.ChannelView}",
                 // No label at all: the folder and the tray say it, and the tooltip carries the rest.
                 ToolbarAction.Open or ToolbarAction.Save => string.Empty,
-                ToolbarAction.Debayer => state.DebayerAlgorithm.DisplayName,
+                // Auto names what it resolved to, exactly as StretchLink above does.
+                ToolbarAction.Debayer => state.DebayerAlgorithm is DebayerAlgorithm.Auto
+                    ? $"Auto ({ResolvedDebayerLabel()})"
+                    : state.DebayerAlgorithm.DisplayName,
                 ToolbarAction.CurvesBoost => state.CurvesBoost > 0f ? $"Boost {UiFormat.Percent0(state.CurvesBoost)}" : "Boost",
                 ToolbarAction.Hdr => state.HdrAmount > 0f ? $"HDR: {state.HdrAmount:F1}" : "HDR",
                 // Tri-state, and the third state is the point: at any zoom that is neither fit nor 1:1

--- a/src/TianWen.UI.Abstractions/ImageRendererBase.cs
+++ b/src/TianWen.UI.Abstractions/ImageRendererBase.cs
@@ -1,4 +1,4 @@
-// TODO high priority: cached offscreen framebuffer for partial UI redraws
+﻿// TODO high priority: cached offscreen framebuffer for partial UI redraws
 //
 // Problem: every mouse move that changes the status bar pixel readout triggers a full
 // Vulkan render pass (image quad + stretch shader + histogram + stars + toolbar + status bar).
@@ -130,10 +130,18 @@ namespace TianWen.UI.Abstractions
 
         /// <summary>In-shader Bayer demosaic for the RawBayer path (see <see cref="GpuDebayerMode"/> for
         /// the full mode list). Derived from <see cref="ViewerState.DebayerAlgorithm"/> and refreshed in
-        /// <see cref="UploadDocumentTextures"/>; the initial value matches
-        /// <see cref="ViewerActions.DefaultDebayerAlgorithm"/> so the first frame after an upload is not a
-        /// different demosaic from every frame after it.</summary>
-        public int RawBayerDebayerMode { get; set; } = GpuDebayerMode(ViewerActions.DefaultDebayerAlgorithm);
+        /// <see cref="UploadDocumentTextures"/>; the initial value is what the default resolves to for a
+        /// still CFA frame, so the first frame after an upload is not a different demosaic from every
+        /// frame after it.
+        ///
+        /// <para>Resolved rather than taken raw: the default is
+        /// <see cref="DebayerAlgorithm.Auto"/>, which has no shader mode, and this is a field
+        /// initialiser -- it runs in the constructor of every viewer, before any frame exists to resolve
+        /// against. A still CFA mosaic is the right assumption because it is the only shape this value
+        /// is ever read for, and an upload overwrites it before anything is drawn.</para></summary>
+        public int RawBayerDebayerMode { get; set; } = GpuDebayerMode(
+            ViewerActions.DefaultDebayerAlgorithm.ResolveAuto(
+                isBayerMosaic: true, isColour: false, isVideoStream: false));
 
         /// <summary>Maps a <see cref="DebayerAlgorithm"/> to the GPU live-demosaic mode written into
         /// <c>stretchBlend.z</c> for the RawBayer shader path: <c>0</c> = bilinear colour, <c>1</c> = MHC colour,
@@ -152,6 +160,12 @@ namespace TianWen.UI.Abstractions
             DebayerAlgorithm.None => 2,         // raw mosaic, no demosaic
             DebayerAlgorithm.BilinearMono => 3, // monochrome
             DebayerAlgorithm.VNG => 4,          // VNG colour
+            // Auto is a UI intent with no shader branch, and reaching here means a producer forgot to
+            // call ResolveAuto. Throwing rather than falling through to MHC on purpose: silently
+            // rendering as MHC is the exact failure this whole area exists to prevent, and it would
+            // look like a working viewer that ignores three quarters of the rule.
+            DebayerAlgorithm.Auto => throw new ArgumentOutOfRangeException(nameof(algorithm), algorithm,
+                "DebayerAlgorithm.Auto must be resolved via ResolveAuto before the shader mode is asked."),
             _ => 1,                             // MHC colour (AHD, no longer selectable, falls back to MHC)
         };
 
@@ -609,7 +623,11 @@ namespace TianWen.UI.Abstractions
                 uploadedSlots = 1;     // ... from ONE mosaic texture; see ReleaseUnusedChannelTextures
                 BayerOffsetX = source.BayerOffsetX;
                 BayerOffsetY = source.BayerOffsetY;
-                RawBayerDebayerMode = GpuDebayerMode(state.DebayerAlgorithm);
+                // Resolved HERE rather than passed through: Auto is a UI intent and the shader has no
+                // branch for it, exactly as StretchMode.Auto never reaches the stretch. isBayerMosaic is
+                // true by the branch condition above.
+                RawBayerDebayerMode = GpuDebayerMode(state.DebayerAlgorithm.ResolveAuto(
+                    isBayerMosaic: true, isColour: false, isVideoStream: source.IsVideoStream));
                 if (!TryUploadRetainedRaster(source, 0, 0, pixelWidth, pixelHeight))
                 {
                     UploadChannelTexture(source.GetChannelData(0), 0, pixelWidth, pixelHeight);

--- a/src/TianWen.UI.Abstractions/SerPreviewSource.cs
+++ b/src/TianWen.UI.Abstractions/SerPreviewSource.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
@@ -133,6 +133,9 @@ public sealed class SerPreviewSource : IPreviewSource, ISequencePlaybackSource, 
             applyColorCalibration);
 
     public int FrameCount => _reader.FrameCount;
+
+    /// <summary>SER is a planetary/lunar capture stream; see <see cref="IPreviewSource.IsVideoStream"/>.</summary>
+    public bool IsVideoStream => true;
     public int FrameIndex => _frameIndex;
 
     /// <summary>

--- a/src/TianWen.UI.Abstractions/ViewerActions.cs
+++ b/src/TianWen.UI.Abstractions/ViewerActions.cs
@@ -1,4 +1,4 @@
-using DIR.Lib;
+﻿using DIR.Lib;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
@@ -110,11 +110,19 @@ public static class ViewerActions
     // DebayerAlgorithm still has it, the batch paths (stacking, dataset export) still ask for it by
     // name, GpuDebayerMode still answers for it, and a state that has AHD in it keeps rendering
     // exactly as it did.
+    //
+    // Auto leads, because it is the default and the only entry that is right for every input rather
+    // than for one. It is a UI intent, not a GPU mode: the upload path and the save path both resolve
+    // it through DebayerAlgorithmExtensions.ResolveAuto before anything acts on it.
     internal static readonly DebayerAlgorithm[] DebayerAlgorithms =
-        [DebayerAlgorithm.None, DebayerAlgorithm.BilinearMono, DebayerAlgorithm.MHC, DebayerAlgorithm.VNG];
+        [DebayerAlgorithm.Auto, DebayerAlgorithm.None, DebayerAlgorithm.BilinearMono, DebayerAlgorithm.MHC, DebayerAlgorithm.VNG];
 
     /// <summary>
-    /// What a viewer demosaics a raw CFA frame with when nobody has chosen: <see cref="DebayerAlgorithm.VNG"/>.
+    /// What a viewer demosaics with when nobody has chosen: <see cref="DebayerAlgorithm.Auto"/>, which
+    /// resolves a still CFA mosaic to <see cref="DebayerAlgorithm.VNG"/>, a SER stream to
+    /// <see cref="DebayerAlgorithm.MHC"/>, a mono frame to <see cref="DebayerAlgorithm.BilinearMono"/>
+    /// and an already-colour frame to <see cref="DebayerAlgorithm.None"/>. The measurement below is why
+    /// VNG is the answer for the still-CFA case specifically.
     ///
     /// <para>VNG because of what it does at a star, which is the thing this application is looking at.
     /// Measured on a real CR3 over four stars, the rim of the halo sits 0.36% BELOW the local sky for
@@ -129,7 +137,7 @@ public static class ViewerActions
     /// <para>Named once here so the places that need a default -- ViewerState's initialiser, the
     /// document open/cache entry points, the CLI view command -- cannot drift apart.</para>
     /// </summary>
-    public const DebayerAlgorithm DefaultDebayerAlgorithm = DebayerAlgorithm.VNG;
+    public const DebayerAlgorithm DefaultDebayerAlgorithm = DebayerAlgorithm.Auto;
 
     public static void CycleDebayerAlgorithm(ViewerState state, bool reverse = false)
     {

--- a/src/TianWen.UI.Abstractions/ViewerController.cs
+++ b/src/TianWen.UI.Abstractions/ViewerController.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -474,7 +474,7 @@ public sealed class ViewerController(
                 state.CurvesBoost, state.CurvesMode, state.CurveData, background,
                 state.HdrAmount, state.HdrKnee,
                 displayedChannel: state.ChannelView.DisplayedSourceChannel(image.ChannelCount),
-                debayerAlgorithm: state.DebayerAlgorithm,
+                debayerAlgorithm: state.DebayerAlgorithm.ResolveAuto(image),
                 cancellationToken: token).ConfigureAwait(false);
 
             LogSaved(target, format.DisplayName(), saveStarted);
@@ -659,7 +659,7 @@ public sealed class ViewerController(
                     state.NeedsRedraw = true;
                     // Snapshot the backend preference into immutable options per click (no global).
                     var options = new EnhanceOptions(state.PreferredEnhanceBackend);
-                    var debayer = state.DebayerAlgorithm;
+                    var debayer = state.DebayerAlgorithm.ResolveAuto(enhanceDoc.UnstretchedImage);
                     // Off the render thread: ProcessAsync's sync prefix (sanitise + noise estimate) and the
                     // AI work all run on the pool, so the render loop never hitches (important on integrated
                     // GPUs where the AI work itself contends for the GPU -- we do NOT spin-render meanwhile).


### PR DESCRIPTION
The selector asked the user to answer a question the file already answers. VNG on a mono frame claims
work nobody is doing, `None` on a CFA mosaic shows the grey lattice, and a SER got whatever the last
still happened to be left on.

## The rule

`DebayerAlgorithm.Auto` is a **UI intent, not a GPU mode**, exactly as `StretchMode.Auto` is:
appended last so serialized viewer state keeps its numbers, resolved by `ResolveAuto` beside the enum
in `TianWen.Lib` rather than in the viewer, so a headless producer reaches the same answer.

| frame | resolves to |
|---|---|
| one channel + CFA, still | **VNG** |
| one channel + CFA, SER | **MHC** |
| three or more channels | **None** (nothing to demosaic) |
| one channel, no pattern | **Mono** |

It is the default now, leads the dropdown, and the button reads `Auto (VNG)` the way the stretch
button already reads `Auto (Unlinked)`.

## Why a SER gets MHC is parity, not speed

VNG is the default on a measurement taken **at stars**: over four stars of a real CR3 the halo rim
sits 0.36% below local sky for VNG against 2.86% above for MHC, which is a dark ring at every bright
core. A planetary capture has no stars, so that measurement does not transfer, while
`PlanetaryMaster` demosaics its own output with MHC. Matching it means the frame being scrubbed looks
like the master the stacker will build.

That reasoning is written into the resolver, because re-argued as a performance choice it would be
optimised into the wrong answer.

## The video signal is explicit, and deliberately not `FrameCount`

`IPreviewSource.IsVideoStream` defaults to `false` and only `SerPreviewSource` overrides it.
`FrameCount` looks like the free answer and is a trap: `LiveFramePreviewSource` accumulates frames
during an ordinary deep-sky session, so a count above one is true of a normal run and would have
flipped it to the planetary answer partway through the night.

## The throw caught its own bug

`GpuDebayerMode` **throws** on an unresolved `Auto` rather than falling through to MHC. Within a
minute of adding it, 86 tests went red at once, all one root cause: `RawBayerDebayerMode` seeds
itself in a **field initialiser**, which runs in every viewer constructor before any frame exists to
resolve against.

The old `_ => 1` wildcard would have seeded MHC silently and nothing would have failed. That is the
same shape as the AHD bug this area already exists to prevent, so the throw stays. The seed now
resolves against a still CFA frame, the only shape it is ever read for, and an upload overwrites it
before anything is drawn.

Resolution happens at all five consumers: GPU upload, annotated save, display-raster save, document
load and enhance. `Image.DebayerAsync` already refused an unknown algorithm, so a leak was a crash
rather than a wrong picture, but a crash in the viewer is not a plan.

## Known limitation, deliberate

**The container is a proxy for a planetary subject, and a lunar still slips through it.** A moon shot
with a DSLR resolves to VNG, and MHC visibly looks better on it. Closing that needs a content test
(a large *contiguous* near-saturated region means an extended bright subject, where scattered
saturated pixels mean star cores), which is the kind of inference this codebase has been burned by
before, so it is not guessed at here. One click to MHC in the meantime.

## Testing

5603 passed, 0 failed, 83 skipped.

| sabotage | result |
|---|---|
| `ResolveAuto` ignores `isVideoStream` | 2 red (`OnlyTheStreamKindSeparatesTheTwoCfaAnswers` + a Theory case) |
| the seed left unresolved | 86 red, every viewer constructor |

`OnlyTheStreamKindSeparatesTheTwoCfaAnswers` exists because that is the only rule whose inputs are
otherwise identical: a resolver that dropped the parameter still passes every other case.
`AddingAutoDidNotRenumberTheExistingAlgorithms` pins the enum values a persisted viewer state holds.

## Also here

One doc fix found by running the viewer against the fixtures: `_MG_7578.CR2` is a **Canon EOS 6D**,
which two tables called a 5D Mark III. The geometry was never wrong and is what proves the name is,
since 5568x3708 is the 6D's raster while a 5D Mk III is 5796x3870 carrying 5760x3840. FC.SDK's own
`CanonSliceUnscramblerTests` has said 6D about the same file all along; its half is
[FC.SDK#9](https://github.com/SharpAstro/FC.SDK/pull/9).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019zPjosBKnRXChG5AEccE4F
