### PR TITLE
fix(viewer): the crop was drawn, not enforced -- and it never reached the enhance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1548,7 +1548,16 @@ visible inside 5% of the span is refused, not trimmed to the bound**; and the co
 16x16 BLOCK, since per-pixel drizzle weight scatters ~10% in a fully covered interior and a per-pixel
 threshold collapses the answer to 0.7% of the frame. Measurements, the corpus and the three refuted
 rules: [docs/plans/viewer-prerelease-fixes.md](docs/plans/viewer-prerelease-fixes.md) P25; harness in
-`tools/coverage-edge-walk/`.
+`tools/coverage-edge-walk/`. **A crop is a CLIP, so every draw path owes it one** -- the cached image
+layer returns before `ClipToShown` and needs its own narrowing (destination AND source UVs), or the
+border is blitted back at any zoom that brings it inside the pane while the status bar still says
+cropped. It reaches the renderer, the status bar, the toolbar state, both exports and **the enhance
+INPUT** -- the enhancers are spatial models and the ring is exact zero, which a CNN reads as structure
+and smears inward (NaN is no escape: `SharpenPipeline` fills non-finite with the channel mean by
+design). So an enhance on a cropped view is CUT first: the result is the crop, `WCS.CroppedTo`
+translates the solution, `AstroImageDocument.SourceCrop` records it, and the crop button gates on that.
+A crop also **cannot be re-derived after an enhance** (both tiers need evidence the enhancers destroy),
+so it is REMEMBERED across the toggle rather than re-scanned, and a revert restores frame and crop.
 
 **One viewer, no mini viewer.** Live Session preview, polar-align and guide-cam host this viewer
 chromeless (`ViewerState.HideChrome`), fed by `LiveFramePreviewSource : IPreviewSource` (normalises to

--- a/docs/plans/viewer-prerelease-fixes.md
+++ b/docs/plans/viewer-prerelease-fixes.md
@@ -1134,6 +1134,19 @@ before the pipeline sees anything, and four things follow:
 Pinned by `EnhanceActionsTests.ACropIsCutBeforeThePipelineAndTravelsWithTheResult` (+ its no-crop
 twin) and `ViewerAutoCropTests.TheCropButtonIsDisabledOnceAnEnhanceHasBakedACropIn`.
 
+**The A/B split then showed two different frames, which is the one thing it must never do** (reported
+2026-09-09 the moment the cropped enhance was first driven: *"A|B is warping, before is showing me the
+uncropped"*). The retained "before" textures are the pre-enhance pixels -- kept by moving three GPU
+handles aside, at no copy -- and after a cropped enhance those are the UNCROPPED original while the live
+half is the crop. Drawn on the live quad they stretch by the crop's ratio and bring the canvas ring back
+with them. The fix is pure geometry and costs nothing: the comparison half gets its OWN quad, same
+scale, origin backed off by `SourceCrop`'s offset, so the crop's pixel (0, 0) lands where the live half
+draws it. Only when that half samples the retained pixels (`SplitCompareController.ComparesPixels`) -- a
+pinned-settings comparison is the same frame and must not move. `BeforeImageSize` on the renderer is
+what makes the two frames comparable at all; zero means "same frame as live", which is what every
+comparison was until now. Pinned by
+`ViewerAutoCropTests.TheBeforeHalfIsPlacedByItsOwnFrameWhenAnEnhanceBakedACropIn`.
+
 **The measurement that decided it, and what is still unmeasured:** `DisplayCrop` reaches the
 renderer, the status bar, the toolbar state, `DisplayRasterExport` and `AnnotatedRasterExport`, and
 nothing else -- so GraXpert, BlurX and NoiseX all see the canvas ring and the under-exposed band. That

--- a/docs/plans/viewer-prerelease-fixes.md
+++ b/docs/plans/viewer-prerelease-fixes.md
@@ -1147,6 +1147,18 @@ what makes the two frames comparable at all; zero means "same frame as live", wh
 comparison was until now. Pinned by
 `ViewerAutoCropTests.TheBeforeHalfIsPlacedByItsOwnFrameWhenAnEnhanceBakedACropIn`.
 
+**One real race fell out of the full suite, in the status line rather than the pixels.**
+`EnhanceActions` built its progress sink with `Progress<T>`, which posts each report to the captured
+context -- and inside `Task.Run` there is none, so reports go to the pool and one queued during the run
+can execute AFTER the terminal `Enhanced (...)` message, leaving a finished enhance reading
+`Enhancing: gradient-correction (0%)` for good. It surfaced as one failure in 5,782 tests, never as
+something anyone saw on screen (the upload path clears the line a frame later, most of the time).
+`SynchronousProgress<T>` (TianWen.Lib) reports inline, so the caller's final write always wins; the
+private `SyncProgress` the HOSTING side had already grown for the same reason folds into it, since two
+copies of one rule is how they drift. Pinned by `SynchronousProgressTests`, on the MECHANISM -- an
+ordering bug cannot be pinned by the code that suffers it, which is exactly why this one was a
+one-in-a-suite flake rather than a test.
+
 **The measurement that decided it, and what is still unmeasured:** `DisplayCrop` reaches the
 renderer, the status bar, the toolbar state, `DisplayRasterExport` and `AnnotatedRasterExport`, and
 nothing else -- so GraXpert, BlurX and NoiseX all see the canvas ring and the under-exposed band. That

--- a/docs/plans/viewer-prerelease-fixes.md
+++ b/docs/plans/viewer-prerelease-fixes.md
@@ -1061,6 +1061,96 @@ against 0.001). So the answer to that ring is to CROP it, which is now available
 for a caller that wants the model itself independent of the border. Pinned, with both pairs of numbers
 printed, by `ClassicalBackgroundExtractorTests.ANoisierBorderIsKeptOutOfTheFit`.
 
+### The crop was drawn, not enforced: the cached layer blitted the border back  (found and FIXED 2026-09-09)
+
+Reported the day after the crop shipped: with a crop applied, zooming out brings the ragged corner
+back, while the status bar still says `Cropped to 2915x2877 (88.5% of the frame)` and the toolbar
+toggle is still lit. The state was never lost -- the border was being painted.
+
+**`TryDrawImageFromCachedLayer` returns before the uncached path's `ClipToShown`.** The direct path
+clips the quad to the pane narrowed by the crop; the cached path clipped to the PANE alone. At fit
+the discarded border falls outside the pane, so the pane clip hid it, and every zoom anyone had
+looked at was at or above fit. Zoom out and the whole frame fits inside the pane, so the blit paints
+what the crop had removed. The session that found it had **1309 blits against 253 renders**: the
+cached path is not an optimisation the user sees occasionally, it is the one they look at.
+
+**The blit is narrowed, not merely scissored.** The destination rectangle is the intersection of the
+pane and the shown region, and the source UVs shrink with it -- narrowing the destination alone
+samples the whole pane into the crop's rectangle, which squashes the picture instead of cropping it
+and still looks plausible.
+
+**The test that existed re-derived the clip instead of observing it.**
+`NothingOutsideTheCropReachesTheScreenWhenZoomedIn` recomputes `ClipToShown` in its own body from the
+placement, so it models the rule rather than asserting what the renderer declared, and it stays green
+with the bug present (verified: back the fix out and exactly one test fails, the new one).
+`TheCachedLayerBlitIsNarrowedToTheCrop` asserts the rectangle handed to `TryDrawCachedLayer`, driving
+the cached-layer seam through its `protected virtual` hooks -- which is also the first test coverage
+that path has had.
+
+**A crop no longer re-fits the view** (raised in the same breath: *"it shouldn't actually refit the
+frame on crop, just cropping it"*). Setting `ZoomToFit` alongside the rectangle made the picture jump
+and grow at the moment the user was studying its edge -- a second change nobody asked for on top of
+the one they did. Fit stays one keypress away and, with a crop in force, fits the CROP. Pinned by
+`ViewerControllerTests.ApplyingACropLeavesTheZoomAndPanAlone`.
+
+**The crop SURVIVES an enhance; what does not survive is switching it off.** Reported as "the crop is
+removed once auto-enhance finishes", and the code says otherwise -- neither `TryApplyPendingEnhance`
+nor `RevertEnhance` touches `DisplayCrop`, and driving the running viewer confirmed it: after a
+93-second BlurX + GraXpert + StarXTerminator + denoise program the status bar still read
+`Crop 2915x2877` and the ring was still gone. What the report caught is the TOGGLE. Switching the crop
+off and pressing again re-SCANS, and on enhanced pixels both tiers are blind -- the coverage sidecar
+belongs to the file on disk, the absent-pixel test needs exact zeros, and the edge walk needs a noise
+step, and a deblur, a gradient correction and a denoise leave none of the three. The second press
+therefore answered `Nothing to crop: the frame is covered edge to edge` and the crop could never come
+back. `ViewerController._rememberedCrop` keeps the rectangle, so switching it back on restores it in
+the same press rather than scanning; the restore is synchronous, which is what
+`SwitchingTheCropOffAndOnAgainRestoresItWithoutScanning` asserts (a scan would leave it null until its
+task landed). Un-cropping no longer re-fits either, for the same reason cropping does not.
+
+**Enhance is fed the CROP (decided 2026-09-09, on the evidence below).** `DisplayCrop` used to reach
+the renderer, the status bar, the toolbar state and both exports, and nothing else, so GraXpert, BlurX
+and NoiseX all saw the canvas ring. They are spatial models and the ring is exact ZERO -- a cliff a CNN
+reads as structure and smears inward, which is what a border still visible after a gradient correction
+IS. Masking it was not available either: `SharpenPipeline` fills non-finite samples with the CHANNEL
+MEAN at its boundary, deliberately ("the enhancers ... compute non-NaN-aware global normalisation, so a
+single NaN poisons the whole output"), and exact zeros pass through untouched. So the crop is cut
+before the pipeline sees anything, and four things follow:
+
+- **The result IS the crop.** `EnhanceActions.EnhanceAsync` takes the rectangle, `Image.Crop`s the
+  input, and the enhanced document is that size.
+- **`WCS.CroppedTo` translates the solution**, because a crop is a pure translation of the pixel grid:
+  only CRPIX moves, the CD matrix is a derivative and SIP is relative to CRPIX. It exists so no caller
+  hand-edits CRPIX -- these are the 0-based in-memory values and a stray -1 here is exactly the
+  off-by-one `WcsPixelOriginTests` exists to prevent. Star detection re-runs on the cropped pixels, so
+  the object and star overlays land without further work; a sign error would put every marker off by
+  the crop origin and still look plausible, which is why the test asserts the SKY position of the
+  crop's own corner rather than the CRPIX numbers.
+- **`AstroImageDocument.SourceCrop` records where the pixels came from**, and the crop button gates on
+  it: there is nothing left to take off, and nothing to put back either, since both scan tiers are
+  blind on enhanced pixels. The document owning that rather than the viewer holding a flag is what
+  keeps it true -- a flag would need clearing on every path that replaces the document.
+- **Reverting restores both** the full frame and the crop that was on it.
+
+Pinned by `EnhanceActionsTests.ACropIsCutBeforeThePipelineAndTravelsWithTheResult` (+ its no-crop
+twin) and `ViewerAutoCropTests.TheCropButtonIsDisabledOnceAnEnhanceHasBakedACropIn`.
+
+**The measurement that decided it, and what is still unmeasured:** `DisplayCrop` reaches the
+renderer, the status bar, the toolbar state, `DisplayRasterExport` and `AnnotatedRasterExport`, and
+nothing else -- so GraXpert, BlurX and NoiseX all see the canvas ring and the under-exposed band. That
+is defensible for a VIEW crop -- the viewer must not quietly destroy data an enhance then works from --
+and questionable for the gradient corrector, which masks the canvas ring as absent anyway
+([background-extraction.md](background-extraction.md), 0.3 percent of a frame at the median) but has
+no such protection against the under-exposed BAND inside it. The live run is evidence for changing it:
+enhanced with the ring in, the frame comes back with a soft bright band right around its edge and the
+ragged corner intact, while the interior improves (stars 5887 -> 12905, HFR 2.49 -> 1.65). And note
+`SharpenPipeline` sanitises non-finite samples to the CHANNEL MEAN at its boundary -- deliberately,
+since "the enhancers ... compute non-NaN-aware global normalisation, so a single NaN poisons the whole
+output" -- so **NaN is a fill here, not a mask**, and exact zeros pass through untouched. Of the three candidates -- crop the input, fill
+outside-crop with the channel mean, mirror-pad and discard -- the first shipped: it is the only one
+that hands the models no fabricated pixels at all. **Not measured: how far inside the frame the smear
+actually reaches**, i.e. whether the 56/92/16/92 px this crop removes is deep enough to contain it.
+Cropping first makes the question moot for a cropped view and leaves it open for an uncropped one.
+
 ## P26. The `?` panel cannot report a bug  (FIXED 2026-09-08)
 
 From the user's notes 2026-09-07: *"in the help menu allow to auto-create an issue, with attaching logs

--- a/src/TianWen.Hosting/HostedImageEnhancer.cs
+++ b/src/TianWen.Hosting/HostedImageEnhancer.cs
@@ -4,6 +4,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using TianWen.Hosting.Dto;
+using TianWen.Lib;
 using TianWen.Lib.Imaging;
 using TianWen.Lib.Imaging.Enhancement;
 
@@ -105,7 +106,7 @@ internal sealed class HostedImageEnhancer(
 
                 // Synchronous relay (NOT Progress<T>): runs inline on this task thread so the status
                 // snapshot updates in order and never overwrites the terminal status set in finally.
-                var progress = new SyncProgress(p =>
+                var progress = new SynchronousProgress<EnhanceProgress>(p =>
                 {
                     _status = new EnhanceStatusDto
                     {
@@ -188,12 +189,6 @@ internal sealed class HostedImageEnhancer(
         return Path.Combine(dir, $"{name}_enhanced.fits");
     }
 
-    /// <summary>Inline <see cref="IProgress{T}"/> that reports synchronously on the caller's thread
-    /// (unlike <see cref="Progress{T}"/>, which posts to the captured context out of order).</summary>
-    private sealed class SyncProgress(Action<EnhanceProgress> sink) : IProgress<EnhanceProgress>
-    {
-        public void Report(EnhanceProgress value) => sink(value);
-    }
 }
 
 /// <summary>Payload for <see cref="HostedImageEnhancer.Completed"/>.</summary>

--- a/src/TianWen.Lib.Tests/DisplayCarryTests.cs
+++ b/src/TianWen.Lib.Tests/DisplayCarryTests.cs
@@ -69,7 +69,7 @@ public class DisplayCarryTests
 
     private static Task<AstroImageDocument> DocumentAsync(Image image, string fileName)
         => AstroImageDocument.AdoptImageAsync(image, DebayerAlgorithm.None, wcs: null, filePath: fileName,
-            TestContext.Current.CancellationToken);
+            cancellationToken: TestContext.Current.CancellationToken);
 
     private static StretchUniforms Uniforms(AstroImageDocument document)
         => document.ComputeStretchUniforms(StretchMode.Unlinked, StretchParameters.Default);

--- a/src/TianWen.Lib.Tests/EnhanceActionsTests.cs
+++ b/src/TianWen.Lib.Tests/EnhanceActionsTests.cs
@@ -1,6 +1,8 @@
+using System.Drawing;
 using System.Threading;
 using System.Threading.Tasks;
 using Shouldly;
+using TianWen.Lib.Astrometry;
 using TianWen.Lib.Imaging;
 using TianWen.Lib.Imaging.Enhancement;
 using TianWen.UI.Abstractions;
@@ -56,8 +58,70 @@ public class EnhanceActionsTests
             new ImageMeta { SensorType = SensorType.Color });
     }
 
+    /// <summary>
+    /// A crop reaches the PIPELINE, not just the display, and the result carries where it came from.
+    /// </summary>
+    /// <remarks>
+    /// The enhancers are spatial models and the canvas ring is exact zero -- a cliff a CNN reads as
+    /// structure and smears inward, which is what a border still visible after a gradient correction
+    /// is. Masking it is not available either: <c>SharpenPipeline</c> fills non-finite samples with the
+    /// channel mean at its boundary, deliberately, because SAS ONNX and RC-Astro both normalise without
+    /// NaN awareness. So the crop is cut before the pipeline sees anything.
+    /// <para>The WCS assertion is the one that would fail silently: a sign error there puts every
+    /// overlay marker off by the crop's origin, twice over, and the picture still looks right.</para>
+    /// </remarks>
+    [Fact]
+    public async Task ACropIsCutBeforeThePipelineAndTravelsWithTheResult()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var clone = new CloneEnhancer();
+        var pipeline = new SharpenPipeline(
+            starRemover: clone, stellarSharpener: clone, nonStellarDeconvolver: clone,
+            denoiser: clone, gradientCorrector: clone);
+
+        const double Scale = 0.0005;
+        var wcs = new WCS(5.5, -12.25) { CRPix1 = 8, CRPix2 = 8, CD1_1 = -Scale, CD1_2 = 0, CD2_1 = 0, CD2_2 = Scale };
+        var source = await AstroImageDocument.AdoptImageAsync(SyntheticRgb(16, 16, 0.4f),
+            DebayerAlgorithm.None, wcs, filePath: "test.fits", cancellationToken: ct);
+        var crop = new Rectangle(4, 3, 8, 9);
+        var state = new ViewerState();
+
+        var result = await EnhanceActions.EnhanceAsync(
+            source, state, pipeline, EnhanceOptions.Default, DebayerAlgorithm.None, crop, ct);
+
+        var enhanced = result.ShouldNotBeNull();
+        enhanced.UnstretchedImage.Width.ShouldBe(8, "the pipeline is handed the crop, not the frame");
+        enhanced.UnstretchedImage.Height.ShouldBe(9);
+        enhanced.SourceCrop.ShouldBe(crop);
+
+        // The sky did not move: the crop's origin names the same place it named in the full frame.
+        var before = source.Wcs!.Value.PixelToSky(crop.X, crop.Y).ShouldNotBeNull();
+        var after = enhanced.Wcs!.Value.PixelToSky(0, 0).ShouldNotBeNull();
+        after.RA.ShouldBe(before.RA, 1e-9);
+        after.Dec.ShouldBe(before.Dec, 1e-9);
+    }
+
+    /// <summary>With no crop the whole frame goes in and nothing claims a provenance it does not have.</summary>
+    [Fact]
+    public async Task WithoutACropTheWholeFrameIsEnhanced()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var clone = new CloneEnhancer();
+        var pipeline = new SharpenPipeline(
+            starRemover: clone, stellarSharpener: clone, nonStellarDeconvolver: clone,
+            denoiser: clone, gradientCorrector: clone);
+        var source = await BuildDocAsync(ct);
+
+        var result = await EnhanceActions.EnhanceAsync(
+            source, new ViewerState(), pipeline, EnhanceOptions.Default, DebayerAlgorithm.None, crop: null, ct);
+
+        var enhanced = result.ShouldNotBeNull();
+        enhanced.UnstretchedImage.Width.ShouldBe(16);
+        enhanced.SourceCrop.ShouldBeNull();
+    }
+
     private static async Task<AstroImageDocument> BuildDocAsync(CancellationToken ct)
-        => await AstroImageDocument.AdoptImageAsync(SyntheticRgb(16, 16, 0.4f), DebayerAlgorithm.None, wcs: null, filePath: "test.fits", ct);
+        => await AstroImageDocument.AdoptImageAsync(SyntheticRgb(16, 16, 0.4f), DebayerAlgorithm.None, wcs: null, filePath: "test.fits", cancellationToken: ct);
 
     [Fact]
     public async Task EnhanceAsync_NoDeblurrer_RunsCanonicalAndReturnsAdoptedDocument()
@@ -72,7 +136,7 @@ public class EnhanceActionsTests
         var state = new ViewerState();
 
         var result = await EnhanceActions.EnhanceAsync(
-            source, state, pipeline, EnhanceOptions.Default, DebayerAlgorithm.None, ct);
+            source, state, pipeline, EnhanceOptions.Default, DebayerAlgorithm.None, cancellationToken: ct);
 
         result.ShouldNotBeNull();
         result.UnstretchedImage.Width.ShouldBe(16);
@@ -93,7 +157,7 @@ public class EnhanceActionsTests
         var state = new ViewerState();
 
         var result = await EnhanceActions.EnhanceAsync(
-            source, state, pipeline, EnhanceOptions.Default, DebayerAlgorithm.None, ct);
+            source, state, pipeline, EnhanceOptions.Default, DebayerAlgorithm.None, cancellationToken: ct);
 
         result.ShouldBeNull();
         var msg = state.StatusMessage.ShouldNotBeNull();

--- a/src/TianWen.Lib.Tests/GpuStretchPipelineTests.cs
+++ b/src/TianWen.Lib.Tests/GpuStretchPipelineTests.cs
@@ -210,7 +210,7 @@ public sealed class GpuStretchPipelineTests : IClassFixture<OffscreenGpuFixture>
             CD2_2 = -pixelScaleDeg,
         };
 
-        var doc = await AstroImageDocument.AdoptImageAsync(bayerImage, DebayerAlgorithm.AHD, wcs, filePath: "synthetic.fits", ct);
+        var doc = await AstroImageDocument.AdoptImageAsync(bayerImage, DebayerAlgorithm.AHD, wcs, filePath: "synthetic.fits", cancellationToken: ct);
         await doc.DetectStarsAsync(ct);
         await doc.ComputeSpccColorCalibrationAsync(db, ct);
         doc.ColorCalibration.ShouldNotBeNull();

--- a/src/TianWen.Lib.Tests/NarrowbandStretchModeTests.cs
+++ b/src/TianWen.Lib.Tests/NarrowbandStretchModeTests.cs
@@ -107,7 +107,7 @@ namespace TianWen.Lib.Tests
         public async Task ADocumentCalibratedThroughANarrowbandFilterRendersUnlinked()
         {
             var document = await AstroImageDocument.AdoptImageAsync(ColourFrame(), DebayerAlgorithm.None,
-                wcs: null, filePath: "hoo.fits", TestContext.Current.CancellationToken);
+                wcs: null, filePath: "hoo.fits", cancellationToken: TestContext.Current.CancellationToken);
             var summary = new ColorCalibrationSummary("SPCC", 1.4f, 1f, 0.7f, StarCount: 120, WhiteReference: "G2V");
 
             document.InheritColorCalibration((1.4f, 1f, 0.7f), summary, isNarrowband: true);
@@ -127,7 +127,7 @@ namespace TianWen.Lib.Tests
         public async Task ADocumentCalibratedThroughABroadbandFilterStillRendersLinked()
         {
             var document = await AstroImageDocument.AdoptImageAsync(ColourFrame(), DebayerAlgorithm.None,
-                wcs: null, filePath: "rgb.fits", TestContext.Current.CancellationToken);
+                wcs: null, filePath: "rgb.fits", cancellationToken: TestContext.Current.CancellationToken);
             var summary = new ColorCalibrationSummary("SPCC", 1.4f, 1f, 0.7f, StarCount: 120, WhiteReference: "G2V");
 
             document.InheritColorCalibration((1.4f, 1f, 0.7f), summary, isNarrowband: false);
@@ -142,9 +142,9 @@ namespace TianWen.Lib.Tests
         public async Task AnEnhancedPlateInheritsHowTheCalibrationWasArrivedAt()
         {
             var original = await AstroImageDocument.AdoptImageAsync(ColourFrame(), DebayerAlgorithm.None,
-                wcs: null, filePath: "hoo.fits", TestContext.Current.CancellationToken);
+                wcs: null, filePath: "hoo.fits", cancellationToken: TestContext.Current.CancellationToken);
             var enhanced = await AstroImageDocument.AdoptImageAsync(ColourFrame(), DebayerAlgorithm.None,
-                wcs: null, filePath: "hoo_enhanced.fits", TestContext.Current.CancellationToken);
+                wcs: null, filePath: "hoo_enhanced.fits", cancellationToken: TestContext.Current.CancellationToken);
             original.InheritColorCalibration((1.4f, 1f, 0.7f), summary: null, isNarrowband: true);
 
             enhanced.InheritColorCalibration(original);
@@ -167,7 +167,7 @@ namespace TianWen.Lib.Tests
         public async Task AnHooCompositeRendersUnlinkedEvenWithNoFilterHeader()
         {
             var document = await AstroImageDocument.AdoptImageAsync(HooComposite(), DebayerAlgorithm.None,
-                wcs: null, filePath: "Sag_Triplet_OIII-HOO_1.fits", TestContext.Current.CancellationToken);
+                wcs: null, filePath: "Sag_Triplet_OIII-HOO_1.fits", cancellationToken: TestContext.Current.CancellationToken);
 
             // The sky-background path, which is what a file with no filter or sensor header gets.
             document.InheritColorCalibration((1.4f, 1f, 0.7f), summary: null, isNarrowband: false);
@@ -200,7 +200,7 @@ namespace TianWen.Lib.Tests
         public async Task ANearlyGreyFrameIsStillPhotometric()
         {
             var document = await AstroImageDocument.AdoptImageAsync(NearlyGreyFrame(), DebayerAlgorithm.None,
-                wcs: null, filePath: "grey.fits", TestContext.Current.CancellationToken);
+                wcs: null, filePath: "grey.fits", cancellationToken: TestContext.Current.CancellationToken);
             document.InheritColorCalibration((1.02f, 1f, 0.99f), summary: null, isNarrowband: false);
 
             document.ColourIsNotPhotometric.ShouldBeFalse();

--- a/src/TianWen.Lib.Tests/PreStretchDetectionTests.cs
+++ b/src/TianWen.Lib.Tests/PreStretchDetectionTests.cs
@@ -39,7 +39,7 @@ public class PreStretchDetectionTests
         var image = Flat(64, 64, level);
 
         var doc = await AstroImageDocument.AdoptImageAsync(
-            image, DebayerAlgorithm.None, wcs: null, filePath: "synthetic.fits", CancellationToken.None);
+            image, DebayerAlgorithm.None, wcs: null, filePath: "synthetic.fits", cancellationToken: CancellationToken.None);
 
         doc.IsPreStretched.ShouldBe(expected);
     }
@@ -66,7 +66,7 @@ public class PreStretchDetectionTests
     {
         var doc = await AstroImageDocument.AdoptImageAsync(
             Flat(64, 64, level, depth), DebayerAlgorithm.None, wcs: null, filePath: "synthetic.fits",
-            CancellationToken.None);
+            cancellationToken: CancellationToken.None);
 
         doc.IsPreStretched.ShouldBe(expected);
     }

--- a/src/TianWen.Lib.Tests/StretchTests_NewPipeline.cs
+++ b/src/TianWen.Lib.Tests/StretchTests_NewPipeline.cs
@@ -392,7 +392,7 @@ public class StretchTests_NewPipeline(ITestOutputHelper output)
         wcs.HasCDMatrix.ShouldBeTrue();
         output.WriteLine($"Synthetic WCS: center=({wcs.CenterRA:F4}h, {wcs.CenterDec:F3}°)  scale={pixelScaleArcsec:F3}\"/px");
 
-        var doc = await AstroImageDocument.AdoptImageAsync(bayerImage, DebayerAlgorithm.AHD, wcs, filePath: "synthetic.fits", ct);
+        var doc = await AstroImageDocument.AdoptImageAsync(bayerImage, DebayerAlgorithm.AHD, wcs, filePath: "synthetic.fits", cancellationToken: ct);
         doc.IsPlateSolved.ShouldBeTrue();
 
         var sw = Stopwatch.StartNew();

--- a/src/TianWen.Lib.Tests/SynchronousProgressTests.cs
+++ b/src/TianWen.Lib.Tests/SynchronousProgressTests.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Shouldly;
+using TianWen.Lib;
+using Xunit;
+
+namespace TianWen.Lib.Tests
+{
+    /// <summary>
+    /// Why this type exists rather than <see cref="Progress{T}"/>, pinned deterministically.
+    /// </summary>
+    /// <remarks>
+    /// The bug it fixes is an ORDERING one, and ordering bugs cannot be pinned by the code that suffers
+    /// them: the full suite caught the viewer's enhance leaving "Enhancing: gradient-correction (0%)" on
+    /// the status line of a finished run exactly once in 5,782 tests, because a queued report landed
+    /// after the terminal message. So the assertion is on the mechanism -- a report has already run by
+    /// the time Report returns -- which is true or false on every run, on any machine.
+    /// </remarks>
+    public class SynchronousProgressTests
+    {
+        [Fact]
+        public void AReportHasAlreadyRunByTheTimeReportReturns()
+        {
+            var seen = new List<int>();
+            IProgress<int> progress = new SynchronousProgress<int>(seen.Add);
+
+            progress.Report(1);
+            seen.ShouldBe([1], "inline, on the calling thread -- no queue to drain");
+
+            progress.Report(2);
+            seen.ShouldBe([1, 2]);
+        }
+
+        /// <summary>
+        /// The property the viewer depends on: a report issued during a run cannot overtake the state
+        /// written after it. With <see cref="Progress{T}"/> this is a race; here it is arithmetic.
+        /// </summary>
+        [Fact]
+        public async Task TheCallersFinalWriteWins()
+        {
+            var status = "";
+            IProgress<string> progress = new SynchronousProgress<string>(s => status = $"running: {s}");
+
+            await Task.Run(() =>
+            {
+                progress.Report("step 1");
+                progress.Report("step 2");
+            });
+            status = "done";
+
+            status.ShouldBe("done");
+        }
+
+        [Fact]
+        public void ASinkIsRequired()
+            => Should.Throw<ArgumentNullException>(() => new SynchronousProgress<int>(null!));
+    }
+}

--- a/src/TianWen.Lib.Tests/ViewerAutoCropTests.cs
+++ b/src/TianWen.Lib.Tests/ViewerAutoCropTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Drawing;
+using System.Threading.Tasks;
 using DIR.Lib;
 using Shouldly;
 using TianWen.Lib.Astrometry;
@@ -65,6 +66,49 @@ namespace TianWen.Lib.Tests
             public override void UploadHistogramData(IPreviewSource source) { }
 
             protected override HistogramDisplay? GetHistogramDisplay() => null;
+
+            // ---- the cached-layer seam, so a test can drive the path the GPU hosts take ----
+            //
+            // Every hook defaults to "unsupported", so the tests that do not opt in
+            // (UseCachedImageLayer stays false) render exactly as they did.
+
+            protected override int CachedLayerSlotCount => 1;
+
+            protected override bool TryEnsureCachedLayerTargets(int width, int height,
+                out int capacityWidth, out int capacityHeight)
+            {
+                capacityWidth = width;
+                capacityHeight = height;
+                CapacityW = width;
+                CapacityH = height;
+                return true;
+            }
+
+            protected override bool TryBeginCachedLayerPass(int width, int height) => true;
+
+            protected override void EndCachedLayerPass() { }
+
+            protected override bool TryDrawCachedLayer(int slot, float x, float y, float w, float h,
+                float u0, float v0, float u1, float v1)
+            {
+                Blit = new RectF32(x, y, w, h);
+                BlitU = (u0, u1);
+                BlitV = (v0, v1);
+                Blits++;
+                return true;
+            }
+
+            public RectF32 Blit { get; private set; }
+
+            public (float Lo, float Hi) BlitU { get; private set; }
+
+            public (float Lo, float Hi) BlitV { get; private set; }
+
+            public int Blits { get; private set; }
+
+            public int CapacityW { get; private set; }
+
+            public int CapacityH { get; private set; }
 
             public float QuadLeft { get; private set; }
 
@@ -237,6 +281,128 @@ namespace TianWen.Lib.Tests
             imgY0.ShouldBeGreaterThanOrEqualTo(crop.Y - Tolerance);
             imgX1.ShouldBeLessThanOrEqualTo(crop.Right + Tolerance);
             imgY1.ShouldBeLessThanOrEqualTo(crop.Bottom + Tolerance);
+        }
+
+        /// <summary>
+        /// The CACHED-LAYER blit is narrowed to the crop too. Reported 2026-09-09: zoom out and the
+        /// discarded border comes back, while the status bar still says the frame is cropped.
+        /// </summary>
+        /// <remarks>
+        /// <para>The uncached path clips the quad to the shown region; the cached path returned before
+        /// ever reaching that, clipping to the PANE alone. At fit the border falls outside the pane, so
+        /// the pane clip hid it -- zoom out and the whole frame fits inside the pane, and the blit
+        /// painted the border back. With 1309 blits against 253 renders in the reported session, the
+        /// cached path is the one a user actually looks at.</para>
+        /// <para><b>This asserts what the renderer DECLARED, which is the point.</b> Its sibling above
+        /// re-derives the clip from the placement inside the test body, so it models ClipToShown rather
+        /// than observing it and stayed green through the whole bug. Delete the narrowing in
+        /// TryDrawImageFromCachedLayer and this fails; that one still passes.</para>
+        /// </remarks>
+        [Fact]
+        public void TheCachedLayerBlitIsNarrowedToTheCrop()
+        {
+            var (viewer, state) = NewViewer();
+            var crop = new Rectangle(40, 30, 200, 150);
+            viewer.UseCachedImageLayer = true;
+            state.DisplayCrop = crop;
+
+            // Zoomed OUT far enough that the whole frame, border included, fits inside the pane. That is
+            // the regime the pane clip cannot help with.
+            state.ZoomToFit = false;
+            state.Zoom = 0.5f;
+
+            // PrepareCachedImageLayer renders the layer, Render then blits out of it -- both in the
+            // same frame, which is how the hosts drive it.
+            viewer.PrepareFrame(null, state);
+            viewer.PrepareCachedImageLayer();
+            viewer.Render(null, state);
+
+            viewer.Blits.ShouldBe(1, "the frame must come from the layer, or this proves nothing");
+
+            var shown = viewer.Shown;
+            var blit = viewer.Blit;
+            const float Tolerance = 0.01f;
+            blit.X.ShouldBeGreaterThanOrEqualTo(shown.X - Tolerance);
+            blit.Y.ShouldBeGreaterThanOrEqualTo(shown.Y - Tolerance);
+            (blit.X + blit.Width).ShouldBeLessThanOrEqualTo(shown.X + shown.Width + Tolerance);
+            (blit.Y + blit.Height).ShouldBeLessThanOrEqualTo(shown.Y + shown.Height + Tolerance);
+
+            // Not degenerate: the crop itself is what is drawn, at this zoom entirely inside the pane.
+            blit.Width.ShouldBe(crop.Width * state.Zoom, Tolerance);
+            blit.Height.ShouldBe(crop.Height * state.Zoom, Tolerance);
+
+            // The SOURCE rectangle has to shrink with the destination. Narrowing the destination alone
+            // would sample the whole pane into the crop's rectangle, which squashes the picture rather
+            // than cropping it -- and it would still look plausible at a glance.
+            ((viewer.BlitU.Hi - viewer.BlitU.Lo) * viewer.CapacityW).ShouldBe(blit.Width, Tolerance);
+            ((viewer.BlitV.Hi - viewer.BlitV.Lo) * viewer.CapacityH).ShouldBe(blit.Height, Tolerance);
+        }
+
+        /// <summary>
+        /// Once an enhance has BAKED a crop in, the crop button is disabled: the pixels are the crop, so
+        /// there is nothing left to take off -- and nothing to put back either, since both scan tiers are
+        /// blind on enhanced pixels. Reverting the enhance is what restores the full frame and its crop.
+        /// </summary>
+        /// <remarks>
+        /// Asserted through <c>TryGetPaintedToolbarRect</c>, which answers only for REGISTERED buttons,
+        /// i.e. the clickable ones. <c>PaintedToolbarButtons</c> would not do: a disabled button is still
+        /// laid out, so it stays in that list by design.
+        /// </remarks>
+        [Fact]
+        public async Task TheCropButtonIsDisabledOnceAnEnhanceHasBakedACropIn()
+        {
+            var ct = TestContext.Current.CancellationToken;
+            var (viewer, state) = NewViewer();
+
+            var whole = await AstroImageDocument.AdoptImageAsync(SyntheticFrame(), DebayerAlgorithm.None,
+                filePath: "master.fits", cancellationToken: ct);
+            viewer.Render(whole, state);
+            viewer.TryGetPaintedToolbarRect(ToolbarAction.AutoCrop, out _)
+                .ShouldBeTrue("a whole frame is exactly what the crop button is for");
+
+            var baked = await AstroImageDocument.AdoptImageAsync(SyntheticFrame(), DebayerAlgorithm.None,
+                filePath: "master.fits", sourceCrop: new Rectangle(8, 6, ImageW, ImageH), cancellationToken: ct);
+            viewer.Render(baked, state);
+            viewer.TryGetPaintedToolbarRect(ToolbarAction.AutoCrop, out _)
+                .ShouldBeFalse("these pixels ARE the crop");
+        }
+
+        private static Image SyntheticFrame()
+        {
+            var plane = new float[ImageH, ImageW];
+            for (var y = 0; y < ImageH; y++)
+            {
+                for (var x = 0; x < ImageW; x++)
+                {
+                    plane[y, x] = 0.25f;
+                }
+            }
+
+            return new Image([plane], BitDepth.Float32, maxValue: 1f, minValue: 0f, pedestal: 0f,
+                imageMeta: new ImageMeta { Instrument = "synth", SensorType = SensorType.Monochrome });
+        }
+
+        /// <summary>With no crop the blit is the whole pane, unchanged: the ordinary path must not pay
+        /// for the crop's narrowing.</summary>
+        [Fact]
+        public void WithoutACropTheCachedLayerBlitIsTheWholePane()
+        {
+            var (viewer, state) = NewViewer();
+            viewer.UseCachedImageLayer = true;
+            state.ZoomToFit = false;
+            state.Zoom = 0.5f;
+
+            viewer.PrepareFrame(null, state);
+            viewer.PrepareCachedImageLayer();
+            viewer.Render(null, state);
+
+            viewer.Blits.ShouldBe(1);
+            var area = viewer.ImageArea;
+            const float Tolerance = 0.01f;
+            viewer.Blit.X.ShouldBe(area.X, Tolerance);
+            viewer.Blit.Y.ShouldBe(area.Y, Tolerance);
+            viewer.Blit.Width.ShouldBe(area.Width, Tolerance);
+            viewer.Blit.Height.ShouldBe(area.Height, Tolerance);
         }
     }
 }

--- a/src/TianWen.Lib.Tests/ViewerAutoCropTests.cs
+++ b/src/TianWen.Lib.Tests/ViewerAutoCropTests.cs
@@ -45,7 +45,24 @@ namespace TianWen.Lib.Tests
                 QuadWidth = right - left;
                 QuadHeight = bottom - top;
                 Quads++;
+                if (slot == RenditionSlot.Comparison)
+                {
+                    ComparisonQuad = new RectF32(left, top, right - left, bottom - top);
+                    ComparisonSampledBefore = sampleBeforeChannels;
+                }
             }
+
+            /// <summary>Where the A/B comparison half's quad was placed, and whether it sampled the
+            /// retained pixels rather than the live ones.</summary>
+            public RectF32 ComparisonQuad { get; private set; }
+
+            public bool ComparisonSampledBefore { get; private set; }
+
+            public override bool HasBeforeImageTextures => BeforeSize is { Width: > 0 };
+
+            public override (int Width, int Height) BeforeImageSize => BeforeSize;
+
+            public (int Width, int Height) BeforeSize { get; set; }
 
             protected override void RenderHistogramQuad(StretchUniforms stretch, HistogramDisplay histogram,
                 ViewerState state, float left, float top, float right, float bottom, uint projW, uint projH) { }
@@ -367,12 +384,54 @@ namespace TianWen.Lib.Tests
                 .ShouldBeFalse("these pixels ARE the crop");
         }
 
-        private static Image SyntheticFrame()
+        /// <summary>
+        /// The A/B "before" half is placed by ITS OWN frame. Reported 2026-09-09 as "A|B is warping",
+        /// with the before half showing the uncropped image.
+        /// </summary>
+        /// <remarks>
+        /// An enhance on a cropped view is cut before the pipeline sees it, so the live frame is the crop
+        /// while the retained textures are the uncropped original -- two different frames in one
+        /// comparison. Drawn on the live quad the before half stretches by the crop's ratio (here
+        /// 400/384 across and 300/282 down) and brings the canvas ring back with it. The fix is pure
+        /// geometry: same scale, origin backed off by the crop's offset, so the crop's pixel (0,0) lands
+        /// where the live half draws it.
+        /// </remarks>
+        [Fact]
+        public async Task TheBeforeHalfIsPlacedByItsOwnFrameWhenAnEnhanceBakedACropIn()
         {
-            var plane = new float[ImageH, ImageW];
-            for (var y = 0; y < ImageH; y++)
+            var ct = TestContext.Current.CancellationToken;
+            var (viewer, state) = NewViewer();
+            var crop = new Rectangle(8, 6, ImageW - 16, ImageH - 18);
+
+            // The live document is the crop; the retained textures are the frame it came from.
+            var baked = await AstroImageDocument.AdoptImageAsync(SyntheticFrame(crop.Width, crop.Height),
+                DebayerAlgorithm.None, filePath: "master.fits", sourceCrop: crop, cancellationToken: ct);
+            viewer.UploadChannelTexture(ReadOnlySpan<float>.Empty, 0, crop.Width, crop.Height);
+            viewer.BeforeSize = (ImageW, ImageH);
+            viewer.Split.Mode = SplitCompare.BeforePixels;
+            viewer.Split.Toggle(hasBeforePixels: true);
+
+            viewer.Render(baked, state);
+
+            viewer.ComparisonSampledBefore.ShouldBeTrue("the left half is the retained pixels");
+            var scale = state.Zoom;
+            var compare = viewer.ComparisonQuad;
+
+            // Same scale as the live half, sized to the ORIGINAL frame...
+            compare.Width.ShouldBe(ImageW * scale, 0.01f);
+            compare.Height.ShouldBe(ImageH * scale, 0.01f);
+
+            // ...and offset so the crop's own origin lands on the live half's origin.
+            (compare.X + (crop.X * scale)).ShouldBe(viewer.QuadLeft, 0.01f);
+            (compare.Y + (crop.Y * scale)).ShouldBe(viewer.QuadTop, 0.01f);
+        }
+
+        private static Image SyntheticFrame(int width = ImageW, int height = ImageH)
+        {
+            var plane = new float[height, width];
+            for (var y = 0; y < height; y++)
             {
-                for (var x = 0; x < ImageW; x++)
+                for (var x = 0; x < width; x++)
                 {
                     plane[y, x] = 0.25f;
                 }

--- a/src/TianWen.Lib.Tests/ViewerControllerTests.cs
+++ b/src/TianWen.Lib.Tests/ViewerControllerTests.cs
@@ -318,6 +318,116 @@ public class ViewerControllerTests
         state.IsBlinking.ShouldBeFalse();
     }
 
+    // --- auto-crop ---
+
+    /// <summary>
+    /// A crop takes a border away and changes NOTHING else about the view. Raised by the user
+    /// 2026-09-09: "it shouldn't actually refit the frame on crop, just cropping it".
+    /// </summary>
+    /// <remarks>
+    /// It used to set <c>ZoomToFit</c> alongside the rectangle, so the picture jumped and grew at the
+    /// exact moment the user was studying its edge -- a second change nobody asked for, on top of the
+    /// one they did. Fit stays one keypress away, and with a crop in force it fits the CROP
+    /// (<c>ViewerAutoCropTests.FitScalesToTheCropRatherThanTheFrame</c>), which is what makes leaving
+    /// the view alone here safe rather than merely quieter.
+    /// </remarks>
+    [Fact]
+    public async Task ApplyingACropLeavesTheZoomAndPanAlone()
+    {
+        var (controller, state, cache, _, _) = CreateSut();
+        cache.GetOrLoadAsync(Arg.Any<string>(), Arg.Any<DebayerAlgorithm>(), Arg.Any<CancellationToken>())
+            .Returns(_ => RingDocumentAsync(TestContext.Current.CancellationToken));
+
+        state.RequestedFilePath = "ring.fits";
+        controller.HandleFileRequest(TestContext.Current.CancellationToken);
+        await WaitForLoadAsync(controller);
+        controller.Document.ShouldNotBeNull();
+
+        state.ZoomToFit = false;
+        state.Zoom = 2f;
+        state.PanOffset = (17f, -23f);
+
+        controller.HandleToolbarAction(ToolbarAction.AutoCrop, reverse: false, TestContext.Current.CancellationToken);
+        await WaitForCropAsync(controller, state);
+
+        state.DisplayCrop.ShouldNotBeNull("the ring is what the crop is for");
+        state.ZoomToFit.ShouldBeFalse("cropping is not a request to re-frame what is left");
+        state.Zoom.ShouldBe(2f);
+        state.PanOffset.ShouldBe((17f, -23f));
+    }
+
+    /// <summary>
+    /// Switching the crop off and on again restores the SAME rectangle, without scanning. Raised by the
+    /// user 2026-09-09 as "the crop is removed once auto-enhance finishes".
+    /// </summary>
+    /// <remarks>
+    /// The crop turned out to survive an enhance untouched (verified in the running viewer); what the
+    /// report had actually caught is that the toggle is one-way afterwards. Both scan tiers look for
+    /// evidence a deblur, a gradient correction and a denoise destroy -- exact zeros, a noise step at the
+    /// edge, a coverage sidecar belonging to the file on disk -- so a fresh scan on an enhanced frame
+    /// answers "covered edge to edge" and the crop can never come back. The restore is SYNCHRONOUS,
+    /// which is what this asserts: a scan would leave DisplayCrop null until its task completed.
+    /// </remarks>
+    [Fact]
+    public async Task SwitchingTheCropOffAndOnAgainRestoresItWithoutScanning()
+    {
+        var (controller, state, cache, _, _) = CreateSut();
+        cache.GetOrLoadAsync(Arg.Any<string>(), Arg.Any<DebayerAlgorithm>(), Arg.Any<CancellationToken>())
+            .Returns(_ => RingDocumentAsync(TestContext.Current.CancellationToken));
+
+        state.RequestedFilePath = "ring.fits";
+        controller.HandleFileRequest(TestContext.Current.CancellationToken);
+        await WaitForLoadAsync(controller);
+
+        controller.HandleToolbarAction(ToolbarAction.AutoCrop, reverse: false, TestContext.Current.CancellationToken);
+        await WaitForCropAsync(controller, state);
+        var cropped = state.DisplayCrop.ShouldNotBeNull();
+
+        controller.HandleToolbarAction(ToolbarAction.AutoCrop, reverse: false, TestContext.Current.CancellationToken);
+        state.DisplayCrop.ShouldBeNull("the first press switches it off");
+
+        controller.HandleToolbarAction(ToolbarAction.AutoCrop, reverse: false, TestContext.Current.CancellationToken);
+        state.DisplayCrop.ShouldBe(cropped, "restored from memory, in the same press rather than a scan later");
+        state.StatusMessage.ShouldEndWith("remembered)");
+    }
+
+    /// <summary>The ring frame as a loaded document. Declared nullable to match what the cache
+    /// returns; AdoptImageAsync's own task is not, and handing that over warns (CS8620).</summary>
+    private static async Task<AstroImageDocument?> RingDocumentAsync(CancellationToken cancellationToken)
+        => await AstroImageDocument.AdoptImageAsync(FrameWithAZeroRing(), DebayerAlgorithm.None,
+            filePath: "ring.fits", cancellationToken: cancellationToken).ConfigureAwait(false);
+
+    /// <summary>A 64 x 64 frame with an 8 px border of exact zero: the canvas ring of a stacked
+    /// master, in miniature, so the crop actually lands.</summary>
+    private static Image FrameWithAZeroRing(int size = 64, int border = 8)
+    {
+        var plane = new float[size, size];
+        for (var y = border; y < size - border; y++)
+        {
+            for (var x = border; x < size - border; x++)
+            {
+                plane[y, x] = 0.25f;
+            }
+        }
+
+        return new Image([plane], BitDepth.Float32, maxValue: 1f, minValue: 0f, pedestal: 0f,
+            imageMeta: new ImageMeta { Instrument = "synth", SensorType = SensorType.Monochrome });
+    }
+
+    /// <summary>
+    /// Polls until the crop scan has been applied, up to a timeout. TryApplyPendingCrop returns at once
+    /// while the scan is still running, so calling it in the loop is how the host drives it too.
+    /// </summary>
+    private static async Task WaitForCropAsync(ViewerController controller, ViewerState state, int timeoutMs = 5000)
+    {
+        var deadline = Environment.TickCount64 + timeoutMs;
+        while (state.DisplayCrop is null && Environment.TickCount64 < deadline)
+        {
+            controller.TryApplyPendingCrop();
+            await Task.Delay(10);
+        }
+    }
+
     /// <summary>
     /// Polls until the controller's load task completes, up to a timeout.
     /// </summary>

--- a/src/TianWen.Lib/Astrometry/WCS.cs
+++ b/src/TianWen.Lib/Astrometry/WCS.cs
@@ -63,6 +63,21 @@ public record struct WCS(double CenterRA, double CenterDec)
     /// <summary>The FITS standard's coordinate of the first pixel's centre: the offset between header and memory.</summary>
     private const double FitsPixelOrigin = 1.0;
 
+    /// <summary>
+    /// The same solution read against a CROPPED frame: the sky is untouched, the pixel grid's origin
+    /// moves to <paramref name="cropX"/>, <paramref name="cropY"/>.
+    /// </summary>
+    /// <remarks>
+    /// A crop is a pure TRANSLATION of the pixel grid, so only the reference pixel moves -- the CD
+    /// matrix is a derivative and the SIP coefficients are relative to CRPIX, both unchanged. Exists so
+    /// no caller hand-edits CRPIX: these are the 0-BASED in-memory values (see the type remarks), the
+    /// header's plus-one is applied on write, and a caller subtracting one here would inject the very
+    /// off-by-one <c>WcsPixelOriginTests</c> exists to prevent. NaN in means NaN out, which is what an
+    /// unsolved frame carries.
+    /// </remarks>
+    public readonly WCS CroppedTo(int cropX, int cropY)
+        => this with { CRPix1 = CRPix1 - cropX, CRPix2 = CRPix2 - cropY };
+
     /// <summary>Partial derivative ∂RA/∂x in degrees per pixel.</summary>
     public double CD1_1 { get; init; } = double.NaN;
 

--- a/src/TianWen.Lib/SynchronousProgress.cs
+++ b/src/TianWen.Lib/SynchronousProgress.cs
@@ -1,0 +1,32 @@
+using System;
+
+namespace TianWen.Lib
+{
+    /// <summary>
+    /// An <see cref="IProgress{T}"/> that runs its sink INLINE, on whatever thread called
+    /// <see cref="Report"/>.
+    /// </summary>
+    /// <remarks>
+    /// <para><b><see cref="Progress{T}"/> is asynchronous, and that loses the last word.</b> It posts
+    /// each report to the captured synchronization context, or to the thread pool when there is none --
+    /// which is the case for anything started with <c>Task.Run</c>. A report queued during a run can
+    /// therefore execute AFTER the caller has written its final state, overwriting it: the viewer's
+    /// enhance finished and left the status line reading "Enhancing: gradient-correction (0%)" forever,
+    /// caught by <c>EnhanceActionsTests</c> as a one-in-many-runs failure rather than by anyone looking
+    /// at the screen. Reporting inline makes the ordering a fact rather than a race -- the last report
+    /// happens before the awaited call returns, so the caller's final assignment always wins.</para>
+    /// <para><b>The sink must be safe to run on the reporting thread</b>, which is the producer's, not
+    /// the UI's. Both callers here write a handful of scalars to state a render loop reads as a
+    /// snapshot, the pattern that is documented on those fields; a sink that needed the UI thread would
+    /// have to marshal for itself, exactly as it would with any other callback.</para>
+    /// </remarks>
+    /// <typeparam name="T">The progress payload.</typeparam>
+    /// <param name="sink">Invoked on every <see cref="Report"/>, synchronously.</param>
+    public sealed class SynchronousProgress<T>(Action<T> sink) : IProgress<T>
+    {
+        private readonly Action<T> _sink = sink ?? throw new ArgumentNullException(nameof(sink));
+
+        /// <inheritdoc />
+        public void Report(T value) => _sink(value);
+    }
+}

--- a/src/TianWen.UI.Abstractions/AstroImageDocument.cs
+++ b/src/TianWen.UI.Abstractions/AstroImageDocument.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using System.Drawing;
 using System.IO;
 using System.Linq;
 using System.Threading;
@@ -49,6 +50,20 @@ public sealed class AstroImageDocument : IPreviewSource
 
     /// <summary>WCS solution, available after plate solving.</summary>
     public WCS? Wcs { get; private set; }
+
+    /// <summary>
+    /// Where this document's pixels came from in a LARGER frame, or null when they are the whole frame.
+    /// Set when an enhance is run on a cropped view: the pipeline is handed the crop, so the result IS
+    /// the crop and there is no border left to hide.
+    /// </summary>
+    /// <remarks>
+    /// The document owning this rather than the viewer holding a flag is what keeps the rules in one
+    /// place: the crop button gates on it (there is nothing left to crop), <see cref="Wcs"/> has already
+    /// been translated by it, and anything wanting the original frame's pixel coordinates adds its
+    /// origin. A UI flag would have to be cleared on every path that replaces the document, and the one
+    /// that was missed would be a document claiming a crop it does not have.
+    /// </remarks>
+    public Rectangle? SourceCrop { get; private init; }
 
     /// <summary>Per-channel statistics computed from the raw image.</summary>
     public ImageHistogram[] ChannelStatistics { get; }
@@ -357,7 +372,7 @@ public sealed class AstroImageDocument : IPreviewSource
     /// <c>Adopt</c> in the name states, per the rule that ownership transfer is visible in the name.
     /// See the frame-ownership notes on <see cref="Image"/>.</para>
     /// </remarks>
-    public static async Task<AstroImageDocument> AdoptImageAsync(Image image, DebayerAlgorithm algorithm = DebayerAlgorithm.VNG, WCS? wcs = null, string filePath = "", CancellationToken cancellationToken = default)
+    public static async Task<AstroImageDocument> AdoptImageAsync(Image image, DebayerAlgorithm algorithm = DebayerAlgorithm.VNG, WCS? wcs = null, string filePath = "", Rectangle? sourceCrop = null, CancellationToken cancellationToken = default)
     {
         // For Bayer images: skip CPU debayer but normalize to [0,1] so stretch stats
         // match the existing histogram-based computation, and because the shader's VNG thresholds
@@ -399,7 +414,10 @@ public sealed class AstroImageDocument : IPreviewSource
             perChannelBg,
             lumaBg,
             wcs,
-            DetectPreStretched(viewImage, perChannelStats));
+            DetectPreStretched(viewImage, perChannelStats))
+        {
+            SourceCrop = sourceCrop,
+        };
     }
 
     /// <summary>
@@ -440,7 +458,7 @@ public sealed class AstroImageDocument : IPreviewSource
             }
         }
 
-        return await AdoptImageAsync(rawImage, algorithm, fileWcs, filePath, cancellationToken);
+        return await AdoptImageAsync(rawImage, algorithm, fileWcs, filePath, cancellationToken: cancellationToken);
     }
 
     private static async Task<AstroImageDocument?> OpenImageFileAsync(string filePath, CancellationToken cancellationToken)

--- a/src/TianWen.UI.Abstractions/EnhanceActions.cs
+++ b/src/TianWen.UI.Abstractions/EnhanceActions.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Drawing;
 using System.Threading;
 using System.Threading.Tasks;
 using TianWen.Lib.Imaging;
@@ -31,15 +32,35 @@ public static class EnhanceActions
         SharpenPipeline pipeline,
         EnhanceOptions options,
         DebayerAlgorithm debayerAlgorithm,
+        Rectangle? crop = null,
         CancellationToken cancellationToken = default)
     {
+        // A crop is applied to the INPUT, not left for the display to hide afterwards. Every enhancer
+        // here is a spatial model, and the canvas ring is exact zero -- a hard cliff a CNN reads as
+        // structure and smears inward, which is what a border still visible after a gradient correction
+        // actually is. Note the pipeline cannot be told to ignore it instead: SharpenPipeline fills
+        // non-finite samples with the channel mean at its boundary (SAS ONNX and RC-Astro both
+        // normalise without NaN awareness), so masking is not available, and exact zeros pass through
+        // untouched.
+        //
+        // The result IS the crop: smaller pixels, a WCS translated to match, and SourceCrop recording
+        // where it came from. Costs one full-size copy of the kept region, against a pipeline that runs
+        // for a minute and a half.
+        var input = source.UnstretchedImage;
+        var wcs = source.Wcs;
+        if (crop is { } region)
+        {
+            input = input.Crop(region);
+            wcs = wcs?.CroppedTo(region.X, region.Y);
+        }
+
         // BlurX-first program when a deblurrer is registered (RC-Astro), else the SAS-shaped
         // canonical -- the same selection MasterPostProcessor makes, via the shared factories
         // (single source of truth for the step program). Linear in / linear out: the viewer
         // applies its own stretch, so no final stretch step is included.
         var request = pipeline.SupportsDeblur
-            ? SharpenRequest.DeblurFirst(source.UnstretchedImage)
-            : SharpenRequest.Canonical(source.UnstretchedImage);
+            ? SharpenRequest.DeblurFirst(input)
+            : SharpenRequest.Canonical(input);
 
         // Per-step progress -> viewer status line. Runs on the background thread; these scalar
         // writes to ViewerState are the only writers during the run and the render thread reads
@@ -81,7 +102,7 @@ public static class EnhanceActions
         // output, never the caller's buffer). WCS + provenance path carry over so overlays/coords
         // still resolve on the enhanced view.
         var doc = await AstroImageDocument.AdoptImageAsync(
-            enhanced, debayerAlgorithm, source.Wcs, source.FilePath, cancellationToken).ConfigureAwait(false);
+            enhanced, debayerAlgorithm, wcs, source.FilePath, crop, cancellationToken).ConfigureAwait(false);
         state.StatusMessage = $"Enhanced ({(pipeline.SupportsDeblur ? "BlurX-first" : "SAS")})";
         return doc;
     }

--- a/src/TianWen.UI.Abstractions/EnhanceActions.cs
+++ b/src/TianWen.UI.Abstractions/EnhanceActions.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Drawing;
+using TianWen.Lib;
 using System.Threading;
 using System.Threading.Tasks;
 using TianWen.Lib.Imaging;
@@ -65,7 +66,10 @@ public static class EnhanceActions
         // Per-step progress -> viewer status line. Runs on the background thread; these scalar
         // writes to ViewerState are the only writers during the run and the render thread reads
         // snapshots (a stale read just shows a slightly old %), matching the load-task pattern.
-        var progress = new Progress<EnhanceProgress>(p =>
+        // SYNCHRONOUS on purpose: Progress<T> posts each report to the pool (there is no context inside
+        // Task.Run), so one queued during the run can land after the final status below and leave the
+        // line reading "Enhancing: ..." on a finished enhance. See SynchronousProgress.
+        var progress = new SynchronousProgress<EnhanceProgress>(p =>
         {
             var overall = p.StepCount > 0
                 ? (p.StepIndex + Math.Clamp(p.StepPercent, 0f, 1f)) / p.StepCount * 100f

--- a/src/TianWen.UI.Abstractions/ImageRendererBase.CachedLayer.cs
+++ b/src/TianWen.UI.Abstractions/ImageRendererBase.CachedLayer.cs
@@ -248,11 +248,26 @@ namespace TianWen.UI.Abstractions
                 return false;
             }
 
-            // The pane's position inside the layer: one margin in, less however far the image has been
-            // panned since the layer was rendered.
+            // What a crop leaves showing, which is the pane itself when there is no crop. This path
+            // RETURNS before the uncached one reaches its ClipToShown, so the narrowing has to happen
+            // here as well -- and it is the blit that is narrowed, not merely the scissor, because the
+            // destination rectangle is the one thing a backend cannot get wrong. Without it the border
+            // a crop discards is painted back from the layer as soon as the view is zoomed out far
+            // enough to bring it inside the pane, while the status bar still says the frame is cropped
+            // (reported 2026-09-09; at fit the border falls outside the pane, so the pane clip hid the
+            // bug for every zoom anyone had looked at).
+            var visible = ClipToShown(pane);
+            if (visible.Width <= 0f || visible.Height <= 0f)
+            {
+                _cachedLayerLastMiss = "the crop leaves nothing of the pane showing";
+                return false;
+            }
+
+            // The visible rectangle's position inside the layer: one margin in, less however far the
+            // image has been panned since the layer was rendered.
             var (originX, originY) = CachedLayerOrigin(pane);
-            var srcX = pane.X - originX - dx;
-            var srcY = pane.Y - originY - dy;
+            var srcX = visible.X - originX - dx;
+            var srcY = visible.Y - originY - dy;
 
             // Texture coordinates, so normalised by the texture's size: the CAPACITY the backend
             // allocated, of which this layer occupies the top-left layerW x layerH. Dividing by the
@@ -260,11 +275,11 @@ namespace TianWen.UI.Abstractions
             // pane shrinks (see TryEnsureCachedLayerTargets).
             var u0 = srcX / _cachedLayerCapacityW;
             var v0 = srcY / _cachedLayerCapacityH;
-            var u1 = (srcX + pane.Width) / _cachedLayerCapacityW;
-            var v1 = (srcY + pane.Height) / _cachedLayerCapacityH;
+            var u1 = (srcX + visible.Width) / _cachedLayerCapacityW;
+            var v1 = (srcY + visible.Height) / _cachedLayerCapacityH;
 
-            PushClip((int)pane.X, (int)pane.Y, (int)pane.Width, (int)pane.Height);
-            var drawn = TryDrawCachedLayer(slot, pane.X, pane.Y, pane.Width, pane.Height, u0, v0, u1, v1);
+            PushClip((int)visible.X, (int)visible.Y, (int)visible.Width, (int)visible.Height);
+            var drawn = TryDrawCachedLayer(slot, visible.X, visible.Y, visible.Width, visible.Height, u0, v0, u1, v1);
             PopClip();
 
             if (drawn)

--- a/src/TianWen.UI.Abstractions/ImageRendererBase.Toolbar.cs
+++ b/src/TianWen.UI.Abstractions/ImageRendererBase.Toolbar.cs
@@ -834,7 +834,10 @@ namespace TianWen.UI.Abstractions
                 && (document.UnstretchedImage.ChannelCount >= 3
                     || document.UnstretchedImage.ImageMeta.SensorType is SensorType.RGGB),
             ToolbarAction.PlateSolve => document is not null && !document.IsPlateSolved,
-            ToolbarAction.AutoCrop => document is not null,
+            // Disabled once an enhance has BAKED a crop in: the pixels are the crop, so there is no
+            // border left to take off and no way to put one back. Reverting the enhance restores both
+            // the full frame and the crop that was on it.
+            ToolbarAction.AutoCrop => document is { SourceCrop: null },
             ToolbarAction.ZoomFit or ToolbarAction.ZoomActual or ToolbarAction.Zoom => document is not null,
             // Only in the button set when EnhanceAvailable, so the gate here is just "have an image".
             // Re-click while a pass runs is harmless -- the controller guards on IsEnhancing.

--- a/src/TianWen.UI.Abstractions/ImageRendererBase.cs
+++ b/src/TianWen.UI.Abstractions/ImageRendererBase.cs
@@ -438,6 +438,13 @@ namespace TianWen.UI.Abstractions
         /// </remarks>
         public virtual bool HasBeforeImageTextures => false;
 
+        /// <summary>
+        /// Size of the retained "before" textures, or (0, 0) when the backend has none. Zero means "the
+        /// same frame as the live image", which is what every comparison was until an enhance could bake
+        /// a crop in and leave the two halves showing different frames.
+        /// </summary>
+        public virtual (int Width, int Height) BeforeImageSize => (0, 0);
+
         /// <summary>Device memory held by the retained before pixels, in bytes; 0 when none.</summary>
         public virtual long BeforeImageTextureBytes => 0;
 
@@ -1190,6 +1197,24 @@ namespace TianWen.UI.Abstractions
             var comparesPixels = Split.ComparesPixels;
             var comparison = Split.ComparisonRendition(live);
 
+            // The BEFORE pixels can be a different frame from the live ones: an enhance run on a cropped
+            // view is cut before the pipeline sees it, so the retained textures are the uncropped
+            // original. Drawn on the live quad they stretch by the crop's ratio and bring the canvas
+            // ring back with them, and the two halves stop being a comparison at all -- reported
+            // 2026-09-09 as "A|B is warping". Same scale, origin backed off by the crop's own offset, so
+            // a pixel of the crop lands exactly where the live half draws it.
+            var (compareLeft, compareTop, compareW, compareH) = (p.OffsetX, p.OffsetY, p.DrawW, p.DrawH);
+            if (comparesPixels
+                && _document?.SourceCrop is { } sourceCrop
+                && BeforeImageSize is { Width: > 0, Height: > 0 } beforeSize
+                && (beforeSize.Width != ImageWidth || beforeSize.Height != ImageHeight))
+            {
+                compareLeft = p.OffsetX - (sourceCrop.X * p.Scale);
+                compareTop = p.OffsetY - (sourceCrop.Y * p.Scale);
+                compareW = beforeSize.Width * p.Scale;
+                compareH = beforeSize.Height * p.Scale;
+            }
+
             // Both halves draw the WHOLE quad and are cut down by the clip, so the two renditions stay
             // in identical pan/zoom/projection space and features line up across the divider.
             //
@@ -1201,7 +1226,7 @@ namespace TianWen.UI.Abstractions
             var leftHalf = ClipToShown(new RectF32(area.X, area.Y, splitX - area.X, area.Height));
             PushClip(leftHalf.X, leftHalf.Y, leftHalf.Width, leftHalf.Height);
             RenderImageQuad(source, state, comparison, gridWcs,
-                p.OffsetX, p.OffsetY, p.OffsetX + p.DrawW, p.OffsetY + p.DrawH, Width, Height,
+                compareLeft, compareTop, compareLeft + compareW, compareTop + compareH, Width, Height,
                 RenditionSlot.Comparison, sampleBeforeChannels: comparesPixels);
             PopClip();
 

--- a/src/TianWen.UI.Abstractions/ViewerController.cs
+++ b/src/TianWen.UI.Abstractions/ViewerController.cs
@@ -38,6 +38,22 @@ public sealed class ViewerController(
     /// and the Task IS the synchronisation primitive (see the concurrency rules in CLAUDE.md).
     /// </summary>
     private Task<ViewerActions.CropScan>? _cropTask;
+
+    /// <summary>
+    /// The last rectangle a crop settled on, kept after the crop is switched off so switching it back
+    /// on restores it instead of scanning again.
+    /// </summary>
+    /// <remarks>
+    /// <b>Re-scanning is not equivalent, and on an ENHANCED frame it cannot work at all.</b> Both tiers
+    /// look for evidence the enhancers destroy: the coverage plane belongs to the file on disk, the
+    /// absent-pixel test needs exact zeros, and the edge walk needs a noise step -- and a deblur,
+    /// gradient correction and denoise leave none of the three. A fresh scan there answers "covered edge
+    /// to edge", so without this the toggle is one-way: switch the crop off after an enhance and it can
+    /// never come back. Verified live 2026-09-09 on the Sagittarius Triplet master, which is also the
+    /// session that showed the crop itself survives an enhance untouched.
+    /// </remarks>
+    private Rectangle? _rememberedCrop;
+
     private CancellationTokenSource? _starDetectionCts;
 
     // Per-RUN enhance cancellation, so pressing the button while it computes stops THAT run. It used
@@ -593,10 +609,23 @@ public sealed class ViewerController(
                 if (state.DisplayCrop is not null)
                 {
                     // Off is immediate and needs no scan: the crop only ever hid pixels that were there
-                    // the whole time.
+                    // the whole time. The rectangle is REMEMBERED on the way out -- see _rememberedCrop
+                    // for why switching it back on must not mean scanning again.
+                    _rememberedCrop = state.DisplayCrop;
                     state.DisplayCrop = null;
-                    state.ZoomToFit = true;
                     state.StatusMessage = "Showing the whole frame";
+                    state.NeedsRedraw = true;
+                }
+                else if (Document is { } rememberedDoc
+                    && ViewerState.ResolveDisplayCrop(_rememberedCrop,
+                        rememberedDoc.UnstretchedImage.Width, rememberedDoc.UnstretchedImage.Height) is { } remembered)
+                {
+                    state.DisplayCrop = remembered;
+                    var rememberedImage = rememberedDoc.UnstretchedImage;
+                    var rememberedKept = 100.0 * remembered.Width * remembered.Height
+                        / (rememberedImage.Width * (double)rememberedImage.Height);
+                    state.StatusMessage =
+                        $"Cropped to {remembered.Width}x{remembered.Height} ({rememberedKept:F1}% of the frame, remembered)";
                     state.NeedsRedraw = true;
                 }
                 else if (Document is { } cropDoc && _cropTask is null)
@@ -710,8 +739,12 @@ public sealed class ViewerController(
                     _enhanceCts?.Dispose();
                     _enhanceCts = CancellationTokenSource.CreateLinkedTokenSource(appToken);
                     var enhanceToken = _enhanceCts.Token;
+                    // The crop goes to the PIPELINE, not just the display: see EnhanceActions for why a
+                    // spatial model must not be shown the canvas ring at all.
+                    var enhanceCrop = ViewerState.ResolveDisplayCrop(state.DisplayCrop,
+                        enhanceDoc.UnstretchedImage.Width, enhanceDoc.UnstretchedImage.Height);
                     _enhanceTask = Task.Run(
-                        () => EnhanceActions.EnhanceAsync(enhanceDoc, state, pipeline, options, debayer, enhanceToken),
+                        () => EnhanceActions.EnhanceAsync(enhanceDoc, state, pipeline, options, debayer, enhanceCrop, enhanceToken),
                         enhanceToken);
                     _ = _enhanceTask.ContinueWith(_ => state.NeedsRedraw = true, TaskScheduler.Default);
                 }
@@ -737,6 +770,12 @@ public sealed class ViewerController(
             _rawSource = retained;
             _liveSource = null;
             state.IsSequence = false;
+            // The full frame is back, so the crop that was taken off when the enhance baked it in goes
+            // back on: reverting means returning to the view the enhance was launched from, and the
+            // border is once again there to hide. Nothing happens when there was no crop, and a
+            // rectangle that does not fit the restored frame resolves to null rather than being obeyed.
+            state.DisplayCrop = ViewerState.ResolveDisplayCrop(_rememberedCrop,
+                retained.UnstretchedImage.Width, retained.UnstretchedImage.Height);
             state.NotifySourceReplaced();
             state.NeedsTextureUpdate = true;
             // Deliberately no status message. The upload path clears StatusMessage once the pixels
@@ -877,8 +916,12 @@ public sealed class ViewerController(
         }
         else
         {
+            // The zoom and the pan are left exactly as they were: a crop takes a border away, and
+            // re-fitting on top of that is a second, unasked-for change to the view -- the picture
+            // jumps and grows at the moment the user was looking at its edge. Fit remains one keypress
+            // away (F), and with a crop in force it fits the CROP, which is the whole point of it.
             state.DisplayCrop = rect;
-            state.ZoomToFit = true;
+            _rememberedCrop = rect;
             var kept = 100.0 * rect.Width * rect.Height / (image.Width * (double)image.Height);
             // Which tier answered is worth a word: one is the master's own record of what it covered, the
             // other is measured off the noise and can be short of the mark. "Edge held" names the case
@@ -919,6 +962,12 @@ public sealed class ViewerController(
             if (Document is { } original)
             {
                 enhancedDoc.InheritColorCalibration(original);
+            }
+            // The enhanced pixels ARE the crop, so the display crop has to come off -- left on, it would
+            // crop the crop. It is remembered (as every crop is), which is what puts it back on revert.
+            if (enhancedDoc.SourceCrop is not null)
+            {
+                state.DisplayCrop = null;
             }
             Document = enhancedDoc;
             _rawSource = enhancedDoc;

--- a/src/TianWen.UI.Shared/VkFitsImagePipeline.cs
+++ b/src/TianWen.UI.Shared/VkFitsImagePipeline.cs
@@ -428,6 +428,16 @@ public sealed unsafe class VkFitsImagePipeline : IDisposable
     /// </summary>
     public bool HasBeforeChannels { get; private set; }
 
+    /// <summary>Width of the retained "before" channel textures, or 0 when there are none.</summary>
+    /// <remarks>
+    /// Not always the live frame's width: an enhance run on a cropped view bakes the crop in, so the
+    /// retained textures are the UNCROPPED original and the split has to place them accordingly.
+    /// </remarks>
+    public int BeforeChannelWidth => HasBeforeChannels ? _beforeWidth[0] : 0;
+
+    /// <summary>Height of the retained "before" channel textures, or 0 when there are none.</summary>
+    public int BeforeChannelHeight => HasBeforeChannels ? _beforeHeight[0] : 0;
+
     /// <summary>
     /// Device memory currently held by the retained before textures, in bytes. Reported so the host
     /// can declare it to the GC (<c>GC.AddMemoryPressure</c>): a <c>VkImage</c> is invisible to

--- a/src/TianWen.UI.Shared/VkImageRenderer.cs
+++ b/src/TianWen.UI.Shared/VkImageRenderer.cs
@@ -319,6 +319,10 @@ public class VkImageRenderer : ImageRendererBase<VulkanContext>, IDisposable
     /// <inheritdoc/>
     public override bool HasBeforeImageTextures => _fitsPipeline.HasBeforeChannels;
 
+    /// <inheritdoc />
+    public override (int Width, int Height) BeforeImageSize
+        => (_fitsPipeline.BeforeChannelWidth, _fitsPipeline.BeforeChannelHeight);
+
     /// <inheritdoc/>
     public override long BeforeImageTextureBytes => _fitsPipeline.BeforeChannelBytes;
 


### PR DESCRIPTION
**A crop was only ever a way of DRAWING, and everything here follows from that.** Reported the day
after the auto-crop shipped: *"zooming out somehow does show the full thing again"*, with the status
bar still saying the frame was cropped. The state was never lost -- the border was being painted -- and
pulling that thread turned up four more, one of them found by the full suite rather than by anyone
looking.

## The crop is now enforced, not drawn

**The cached-layer blit ignored it.** `TryDrawImageFromCachedLayer` returns BEFORE the uncached path's
`ClipToShown`, so it clipped to the pane alone. At fit the discarded border falls outside the pane and
the pane clip hid it -- which is every zoom anyone had looked at. Zoom out, the whole frame fits inside
the pane, and the blit paints back exactly what the crop removed. The reporting session had **1309
blits against 253 renders**: the cached path is the one a user actually looks at.

The blit is narrowed now, **destination AND source UVs** -- narrowing the destination alone samples the
whole pane into the crop's rectangle, which squashes the picture rather than cropping it and still
looks plausible.

**Why the suite missed it:** `NothingOutsideTheCropReachesTheScreenWhenZoomedIn` re-derives
`ClipToShown` inside its own test body, so it models the rule instead of observing it, and stays green
with the bug present (verified: back the fix out and exactly one test fails, the new one). The
replacement asserts the rectangle handed to `TryDrawCachedLayer`, driving the cached-layer seam through
its `protected virtual` hooks -- the first coverage that path has ever had.

**A crop no longer re-fits the view**, nor does un-cropping ("*it shouldn't actually refit the frame on
crop, just cropping it*"). Fit stays one keypress away and, with a crop in force, fits the CROP.

**A crop cannot be re-derived after an enhance, so it is remembered.** The crop SURVIVES an enhance
(verified in the running viewer: after a 93 s BlurX + GraXpert + SXT + denoise program the status bar
still read `Crop 2915x2877`). What did not survive was switching it OFF: the next press re-scanned, and
both tiers are blind on enhanced pixels -- the sidecar belongs to the file on disk, the absent-pixel
test needs exact zeros, the edge walk needs a noise step, and a deblur/gradient-correction/denoise
leave none of the three. So it answered "covered edge to edge" and the crop could never come back.

## The enhance is fed the crop

Decided on evidence: enhanced with the ring in, the frame comes back with a bright band around its edge
and the ragged corner intact, while the interior improves (stars 5887 -> 12905, HFR 2.49 -> 1.65). Every
enhancer is a spatial model and the canvas ring is **exact zero** -- a cliff a CNN reads as structure and
smears inward, which is what a border still visible after a gradient correction IS.

**Masking is not available, and that is deliberate upstream:** `SharpenPipeline` fills non-finite
samples with the CHANNEL MEAN at its boundary, because "the enhancers ... compute non-NaN-aware global
normalisation, so a single NaN poisons the whole output". Exact zeros pass through untouched. So the
crop is CUT before the pipeline sees anything:

- `WCS.CroppedTo` translates the solution -- a crop is a pure translation, so only CRPIX moves. It
  exists so no caller hand-edits CRPIX, where a stray -1 is the off-by-one `WcsPixelOriginTests` exists
  to prevent. **The test asserts the SKY position of the crop's own corner**, not the CRPIX numbers: a
  sign error there puts every overlay marker off by the crop origin and still looks plausible.
- `AstroImageDocument.SourceCrop` records where the pixels came from, and the crop button gates on it.
  On the document rather than a viewer flag, because a flag needs clearing on every path that swaps the
  document and the one that gets missed is a document claiming a crop it does not have.
- Reverting restores the full frame **and** the crop that was on it.

## Two more, found by driving it and by the suite

**The A/B split showed two different frames**, which is the one thing it must never do (*"A|B is
warping, before is showing me the uncropped"*). Both halves were true -- the live one is the crop, the
retained one is the frame it was cut from -- but drawn on the same quad the before half stretches by the
crop's ratio and brings the ring back with it. The comparison half gets its own quad now: same scale,
origin backed off by `SourceCrop`. Pure geometry, no copy, no upload. Applied only when that half
samples the retained pixels; a pinned-settings comparison is the same frame and must not move.

**A finished enhance could leave the status line reading `Enhancing: gradient-correction (0%)`** -- one
failure in 5,782 tests. `Progress<T>` posts each report to the captured context, and inside `Task.Run`
there is none, so a report queued during the run can execute after the terminal message and overwrite
it. `SynchronousProgress<T>` reports inline, which makes the ordering arithmetic rather than a race.
The **hosting** side had already grown a private `SyncProgress` for the same reason; it folds into the
shared type. Pinned on the MECHANISM, since an ordering bug cannot be pinned by the code that suffers
it -- which is exactly why it was a one-in-a-suite flake instead of a test.

## Tests

| suite | result |
|---|---|
| `TianWen.Lib.Tests` | 5702 passed, 0 failed, 83 skipped (7m28s) |
| `TianWen.Lib.Tests.Functional` | 368 passed, 0 failed (48s) |
| solution build | 0 warnings, 0 errors |

**Every fix here was seen RED with itself backed out** -- the cached-layer blit, the refit, the
remembered crop, the WCS sign, the button gate, the A/B placement.

One incidental: adding `sourceCrop` ahead of the token broke thirteen positional callers; the token is
named at each rather than moved, since CancellationToken stays last.

**Not measured:** how far inside the frame the enhancers' smear actually reaches on an UNCROPPED
enhance. Cropping first makes it moot for a cropped view and leaves it open otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G5fZYZcrZnm3qCJUjeDDad
