### PR TITLE
feat(viewer): A/B is two comparisons where a crop is involved

### DIFF
--- a/docs/plans/viewer-prerelease-fixes.md
+++ b/docs/plans/viewer-prerelease-fixes.md
@@ -1147,6 +1147,35 @@ what makes the two frames comparable at all; zero means "same frame as live", wh
 comparison was until now. Pinned by
 `ViewerAutoCropTests.TheBeforeHalfIsPlacedByItsOwnFrameWhenAnEnhanceBakedACropIn`.
 
+### A/B is TWO comparisons where a crop is involved, and they want opposite things  (2026-09-09)
+
+Stated by the user after driving the aligned split: *"there's two behaviours. open frame, press crop,
+A|B should compare crop vs uncrop. open frame, crop, run enhance, A|B should compare before=crop vs
+after=cropped + enhanced."* Both are right, and the rules are opposites -- which is why one clip could
+never serve both, and why the first attempt at this section argued for keeping the extents different
+and the second for clipping them the same.
+
+- **Crop, no enhance -> `SplitCompare.CropExtent`,** labelled "Uncropped | Cropped". The halves
+  deliberately cover DIFFERENT areas: same pixels, same dials, one side showing the band and ring the
+  crop took off. It answers the question a crop actually raises, and nothing else in the app can --
+  comparing pixels needs an enhance to have retained some, and comparing settings puts two
+  identically-framed halves on screen, which is what a crop used to light up. The implementation is one
+  clip: the quad already covers the whole frame at the right place (the placement backs its origin off
+  by the crop), so the comparison half is simply NOT narrowed.
+- **Crop then enhance -> `BeforePixels`, bounded to the live quad.** Here the retained texture is the
+  uncropped original and the live frame is the crop, so an unbounded half changes the FRAME as well as
+  the pixels and the comparison answers two questions at once. Both halves show the same region and
+  differ only by the enhancement.
+
+**Retained pixels still win** (`Toggle`, and `AdoptBeforePixels` for an enhance that lands while the
+split is already up, which now also switches out of `CropExtent`): a user who just enhanced is asking
+about the enhance. **Both press dispatchers pass the crop state** -- the keyboard through
+`Split.Toggle`, the button through `ViewerActions.HandleToolbarAction` -- because those two have
+silently disagreed before (P17's single-click) and a mode chosen one way and not the other is exactly
+the shape that survives review. Pinned by `ACropWithNoEnhanceComparesCroppedAgainstUncropped`,
+`AnEnhancedCropComparesTheSameRegionOnBothHalves` and `TheCompareButtonPicksTheCropComparisonToo`, each
+red with only its own rule removed.
+
 **One real race fell out of the full suite, in the status line rather than the pixels.**
 `EnhanceActions` built its progress sink with `Progress<T>`, which posts each report to the captured
 context -- and inside `Task.Run` there is none, so reports go to the pool and one queued during the run

--- a/src/TianWen.Lib.Tests/SynchronousProgressTests.cs
+++ b/src/TianWen.Lib.Tests/SynchronousProgressTests.cs
@@ -46,7 +46,7 @@ namespace TianWen.Lib.Tests
             {
                 progress.Report("step 1");
                 progress.Report("step 2");
-            });
+            }, TestContext.Current.CancellationToken);
             status = "done";
 
             status.ShouldBe("done");

--- a/src/TianWen.Lib.Tests/ViewerAutoCropTests.cs
+++ b/src/TianWen.Lib.Tests/ViewerAutoCropTests.cs
@@ -139,6 +139,10 @@ namespace TianWen.Lib.Tests
 
             public RectF32 Shown => ShownImageRect;
 
+            public RectF32 LastComparisonHalfClipForTest => LastComparisonHalfClip;
+
+            public RectF32 LastLiveHalfClipForTest => LastLiveHalfClip;
+
             public RectF32 ImageArea => ImageAreaRect;
         }
 
@@ -424,6 +428,98 @@ namespace TianWen.Lib.Tests
             // ...and offset so the crop's own origin lands on the live half's origin.
             (compare.X + (crop.X * scale)).ShouldBe(viewer.QuadLeft, 0.01f);
             (compare.Y + (crop.Y * scale)).ShouldBe(viewer.QuadTop, 0.01f);
+        }
+
+        /// <summary>
+        /// Crop, then A/B, with nothing enhanced: the halves compare CROPPED against UNCROPPED, which is
+        /// the question a crop raises and which no other mode can answer.
+        /// </summary>
+        /// <remarks>
+        /// Comparing pixels needs an enhance to have retained some, and comparing settings puts two
+        /// identically-framed halves on screen. So a crop with nothing enhanced used to light up the
+        /// settings comparison, i.e. the least informative of the three. The implementation is one
+        /// clip: the quad already covers the whole frame at the right place, so the comparison half
+        /// simply is not narrowed to the crop.
+        /// </remarks>
+        [Fact]
+        public void ACropWithNoEnhanceComparesCroppedAgainstUncropped()
+        {
+            var (viewer, state) = NewViewer();
+            state.DisplayCrop = new Rectangle(40, 30, 200, 150);
+            viewer.Render(null, state);
+
+            viewer.Split.Toggle(hasBeforePixels: false, hasCrop: true);
+            viewer.Split.Mode.ShouldBe(SplitCompare.CropExtent);
+            viewer.Split.HalfLabels(DisplayControls.Defaults).ShouldBe(("Uncropped", "Cropped"));
+
+            viewer.Render(null, state);
+
+            // Both halves must actually have been drawn: an empty clip would satisfy every bound below
+            // by drawing nothing, which is how a split that never engaged reads as a passing test.
+            viewer.LastComparisonHalfClipForTest.Width.ShouldBeGreaterThan(1f);
+            viewer.LastLiveHalfClipForTest.Width.ShouldBeGreaterThan(1f);
+
+            // The live half is bounded by the crop; the comparison half is not, which is what lets it
+            // show the band the crop took off.
+            var shown = viewer.Shown;
+            const float Tolerance = 0.01f;
+            viewer.LastLiveHalfClipForTest.Width.ShouldBeLessThanOrEqualTo(shown.Width + Tolerance);
+            viewer.LastComparisonHalfClipForTest.X.ShouldBeLessThan(shown.X - Tolerance);
+        }
+
+        /// <summary>
+        /// The BUTTON picks the same comparison as the key. The viewer has two press dispatchers and
+        /// they have silently disagreed before (P17's single-click), so the toolbar path is asserted
+        /// separately rather than assumed to share the keyboard's.
+        /// </summary>
+        [Fact]
+        public void TheCompareButtonPicksTheCropComparisonToo()
+        {
+            var (viewer, state) = NewViewer();
+            state.DisplayCrop = new Rectangle(40, 30, 200, 150);
+            viewer.Render(null, state);
+
+            ViewerActions.HandleToolbarAction(state, document: null, ToolbarAction.Compare,
+                split: viewer.Split, hasBeforePixels: false, hasCrop: viewer.HasDisplayCrop);
+
+            viewer.HasDisplayCrop.ShouldBeTrue("the renderer is what knows a crop is in force");
+            viewer.Split.Mode.ShouldBe(SplitCompare.CropExtent);
+            viewer.Split.IsOn.ShouldBeTrue();
+        }
+
+        /// <summary>
+        /// After an enhance BAKED a crop in, the two halves show the SAME region and differ only by the
+        /// enhancement -- the opposite rule to the one above, and deliberately so.
+        /// </summary>
+        /// <remarks>
+        /// The retained texture is the uncropped original, so without this the left half also changes
+        /// the FRAME and the comparison answers two questions at once. The placement already aligns the
+        /// two; this bounds the before half to the live quad so it stops there.
+        /// </remarks>
+        [Fact]
+        public async Task AnEnhancedCropComparesTheSameRegionOnBothHalves()
+        {
+            var ct = TestContext.Current.CancellationToken;
+            var (viewer, state) = NewViewer();
+            var crop = new Rectangle(8, 6, ImageW - 16, ImageH - 18);
+
+            var baked = await AstroImageDocument.AdoptImageAsync(SyntheticFrame(crop.Width, crop.Height),
+                DebayerAlgorithm.None, filePath: "master.fits", sourceCrop: crop, cancellationToken: ct);
+            viewer.UploadChannelTexture(ReadOnlySpan<float>.Empty, 0, crop.Width, crop.Height);
+            viewer.BeforeSize = (ImageW, ImageH);
+            viewer.Split.Mode = SplitCompare.BeforePixels;
+            viewer.Split.Toggle(hasBeforePixels: true);
+
+            viewer.Render(baked, state);
+
+            // The comparison half stops at the live quad: no part of it shows frame the After half lacks.
+            var compare = viewer.LastComparisonHalfClipForTest;
+            compare.Width.ShouldBeGreaterThan(1f, "an empty clip would pass every bound below");
+            const float Tolerance = 0.01f;
+            compare.X.ShouldBeGreaterThanOrEqualTo(viewer.QuadLeft - Tolerance);
+            compare.Y.ShouldBeGreaterThanOrEqualTo(viewer.QuadTop - Tolerance);
+            (compare.X + compare.Width).ShouldBeLessThanOrEqualTo(viewer.QuadLeft + viewer.QuadWidth + Tolerance);
+            (compare.Y + compare.Height).ShouldBeLessThanOrEqualTo(viewer.QuadTop + viewer.QuadHeight + Tolerance);
         }
 
         private static Image SyntheticFrame(int width = ImageW, int height = ImageH)

--- a/src/TianWen.UI.Abstractions/DisplayRendition.cs
+++ b/src/TianWen.UI.Abstractions/DisplayRendition.cs
@@ -62,6 +62,20 @@ namespace TianWen.UI.Abstractions
         PinnedSettings,
 
         /// <summary>
+        /// The same pixels and the same settings, with and without the display CROP: the left half
+        /// shows the whole frame, the right the crop. Needs a crop to be in force and nothing else --
+        /// no retained texture, no pinned snapshot, because neither half is a different rendition.
+        /// </summary>
+        /// <remarks>
+        /// It answers the question a crop actually raises -- what did that take off? -- which no other
+        /// mode can: comparing pixels needs an enhance to have retained some, and comparing settings
+        /// shows two identically-framed halves. Distinct from the enhance comparison on purpose: once a
+        /// crop has been baked into an enhance, the two halves must show the SAME region and differ only
+        /// by the enhancement, or the comparison is answering two questions at once.
+        /// </remarks>
+        CropExtent,
+
+        /// <summary>
         /// The retained pre-enhance pixels, rendered with the CURRENT display settings (so moving a
         /// slider moves both halves together and only the pixels differ). Needs the backend to be
         /// holding a before texture set; unavailable otherwise.

--- a/src/TianWen.UI.Abstractions/ImageRendererBase.CachedLayer.cs
+++ b/src/TianWen.UI.Abstractions/ImageRendererBase.CachedLayer.cs
@@ -335,7 +335,7 @@ namespace TianWen.UI.Abstractions
             // The split draws two renditions into complementary clips of one pane. Caching it would need
             // a layer per rendition, and the split is a deliberate, transient comparison gesture -- not
             // the state a viewer sits in while the user reads the status bar. So it renders directly.
-            if (Split.ResolveDividerX(HasBeforeImageTextures, DpiScale) is not null)
+            if (Split.ResolveDividerX(HasBeforeImageTextures, DpiScale, _cropActive) is not null)
             {
                 _cachedLayerLastMiss = "before/after split is open";
                 return false;

--- a/src/TianWen.UI.Abstractions/ImageRendererBase.Input.cs
+++ b/src/TianWen.UI.Abstractions/ImageRendererBase.Input.cs
@@ -228,7 +228,7 @@ namespace TianWen.UI.Abstractions
                     }
                     else
                     {
-                        Split.Toggle(HasBeforeImageTextures);
+                        Split.Toggle(HasBeforeImageTextures, _cropActive);
                     }
                     state.NeedsRedraw = true;
                     return true;
@@ -611,7 +611,7 @@ namespace TianWen.UI.Abstractions
             if (hit is HitResult.ButtonHit { Action: var action } && Enum.TryParse<ToolbarAction>(action, out var toolbarAction))
             {
                 ViewerActions.HandleToolbarAction(state, _document, toolbarAction,
-                    split: Split, hasBeforePixels: HasBeforeImageTextures);
+                    split: Split, hasBeforePixels: HasBeforeImageTextures, hasCrop: HasDisplayCrop);
                 if (toolbarAction is ToolbarAction.ColorCalibrate or ToolbarAction.SpccCalibrate)
                 {
                     TryStartColorCalibration(state);

--- a/src/TianWen.UI.Abstractions/ImageRendererBase.Layout.cs
+++ b/src/TianWen.UI.Abstractions/ImageRendererBase.Layout.cs
@@ -186,6 +186,10 @@ namespace TianWen.UI.Abstractions
 
         private bool _cropActive;
 
+        /// <summary>Whether a display crop is narrowing what the viewer shows, as of the last arranged
+        /// frame. The split asks, because a crop is something to compare against.</summary>
+        public bool HasDisplayCrop => _cropActive;
+
         /// <summary>
         /// Narrows a clip rect to the region actually being shown, so a crop discards the border by never
         /// rasterising it. With no crop this is the quad's own rect, which is a no-op against the pane:
@@ -201,10 +205,16 @@ namespace TianWen.UI.Abstractions
                 return rect;
             }
 
-            var x0 = MathF.Max(rect.X, _shownRect.X);
-            var y0 = MathF.Max(rect.Y, _shownRect.Y);
-            var x1 = MathF.Min(rect.X + rect.Width, _shownRect.X + _shownRect.Width);
-            var y1 = MathF.Min(rect.Y + rect.Height, _shownRect.Y + _shownRect.Height);
+            return Intersect(rect, _shownRect);
+        }
+
+        /// <summary>The overlap of two rectangles, zero-sized when they do not meet.</summary>
+        protected static RectF32 Intersect(in RectF32 a, in RectF32 b)
+        {
+            var x0 = MathF.Max(a.X, b.X);
+            var y0 = MathF.Max(a.Y, b.Y);
+            var x1 = MathF.Min(a.X + a.Width, b.X + b.Width);
+            var y1 = MathF.Min(a.Y + a.Height, b.Y + b.Height);
             return new RectF32(x0, y0, MathF.Max(0f, x1 - x0), MathF.Max(0f, y1 - y0));
         }
 

--- a/src/TianWen.UI.Abstractions/ImageRendererBase.cs
+++ b/src/TianWen.UI.Abstractions/ImageRendererBase.cs
@@ -438,6 +438,15 @@ namespace TianWen.UI.Abstractions
         /// </remarks>
         public virtual bool HasBeforeImageTextures => false;
 
+        /// <summary>The clip the A/B comparison (left) half was last drawn under. A read-back for tests:
+        /// the clip is where each split mode's rule actually lands, and it cannot be observed from the
+        /// pixels of a stub renderer.</summary>
+        internal RectF32 LastComparisonHalfClip { get; private set; }
+
+        /// <summary>The clip the A/B live (right) half was last drawn under. See
+        /// <see cref="LastComparisonHalfClip"/>.</summary>
+        internal RectF32 LastLiveHalfClip { get; private set; }
+
         /// <summary>
         /// Size of the retained "before" textures, or (0, 0) when the backend has none. Zero means "the
         /// same frame as the live image", which is what every comparison was until an enhance could bake
@@ -1163,7 +1172,7 @@ namespace TianWen.UI.Abstractions
             // bar behind everywhere the picture does not reach (P24).
             FillRect(area.X, area.Y, area.Width, area.Height, CanvasBackground);
 
-            if (Split.ResolveDividerX(HasBeforeImageTextures, DpiScale) is not { } splitX)
+            if (Split.ResolveDividerX(HasBeforeImageTextures, DpiScale, _cropActive) is not { } splitX)
             {
                 // Clipped to the pane, for the same reason the split halves below are: the quad is
                 // sized to the ZOOMED image, so once it exceeds the pane it reaches under the file
@@ -1223,7 +1232,25 @@ namespace TianWen.UI.Abstractions
             // BEYOND the image area when zoomed in (ConfineToViewport lets it cover the pane rather than
             // sit inside it), and a scissor set here would REPLACE an enclosing clip instead of narrowing
             // it, with nothing to put it back.
-            var leftHalf = ClipToShown(new RectF32(area.X, area.Y, splitX - area.X, area.Height));
+            // Each mode wants a different left half, and the difference is the whole point of it:
+            //
+            //  - CropExtent shows what the crop TOOK OFF, so its half must NOT be narrowed to the crop.
+            //    The quad already covers the whole frame at the right place (the placement backs its
+            //    origin off by the crop), so simply not narrowing is the entire implementation.
+            //  - BeforePixels after a crop was baked into an enhance is the opposite: the retained
+            //    texture is the uncropped original, and a comparison that also changed the FRAME would
+            //    be answering two questions at once. Bounded to the live quad, so both halves show the
+            //    same region and only the enhancement differs.
+            //  - Anything else is the same frame on both sides and takes the ordinary narrowing.
+            var leftRect = new RectF32(area.X, area.Y, splitX - area.X, area.Height);
+            var leftHalf = Split.ComparesCropExtent
+                ? leftRect
+                : ClipToShown(leftRect);
+            if (comparesPixels && (compareLeft != p.OffsetX || compareTop != p.OffsetY))
+            {
+                leftHalf = Intersect(leftHalf, new RectF32(p.OffsetX, p.OffsetY, p.DrawW, p.DrawH));
+            }
+            LastComparisonHalfClip = leftHalf;
             PushClip(leftHalf.X, leftHalf.Y, leftHalf.Width, leftHalf.Height);
             RenderImageQuad(source, state, comparison, gridWcs,
                 compareLeft, compareTop, compareLeft + compareW, compareTop + compareH, Width, Height,
@@ -1231,6 +1258,7 @@ namespace TianWen.UI.Abstractions
             PopClip();
 
             var rightHalf = ClipToShown(new RectF32(splitX, area.Y, area.Right - splitX, area.Height));
+            LastLiveHalfClip = rightHalf;
             PushClip(rightHalf.X, rightHalf.Y, rightHalf.Width, rightHalf.Height);
             RenderImageQuad(source, state, live, gridWcs,
                 p.OffsetX, p.OffsetY, p.OffsetX + p.DrawW, p.OffsetY + p.DrawH, Width, Height,

--- a/src/TianWen.UI.Abstractions/SplitCompareController.cs
+++ b/src/TianWen.UI.Abstractions/SplitCompareController.cs
@@ -173,7 +173,7 @@ namespace TianWen.UI.Abstractions
         /// to compare PIXELS -- which also makes the mode a consequence of what exists rather than a
         /// setting to learn.
         /// </remarks>
-        public void Toggle(bool hasBeforePixels)
+        public void Toggle(bool hasBeforePixels, bool hasCrop = false)
         {
             if (IsOn)
             {
@@ -185,6 +185,13 @@ namespace TianWen.UI.Abstractions
             if (hasBeforePixels)
             {
                 Mode = SplitCompare.BeforePixels;
+            }
+            else if (hasCrop)
+            {
+                // A crop with nothing enhanced yet: what the user just did IS the difference, and the
+                // question it raises -- what did that take off? -- has no other answer in the app.
+                // Pinning the settings here would put two identically-framed halves on screen instead.
+                Mode = SplitCompare.CropExtent;
             }
             else
             {
@@ -212,7 +219,7 @@ namespace TianWen.UI.Abstractions
         /// </remarks>
         public void AdoptBeforePixels()
         {
-            if (IsOn && Mode is SplitCompare.PinnedSettings)
+            if (IsOn && Mode is SplitCompare.PinnedSettings or SplitCompare.CropExtent)
             {
                 Mode = SplitCompare.BeforePixels;
             }
@@ -285,7 +292,7 @@ namespace TianWen.UI.Abstractions
         /// </summary>
         /// <param name="hasBeforePixels">Whether the backend is holding pre-enhance pixels.</param>
         /// <param name="dpiScale">Scales <see cref="MinHalfWidth"/> into surface pixels.</param>
-        public float? ResolveDividerX(bool hasBeforePixels, float dpiScale)
+        public float? ResolveDividerX(bool hasBeforePixels, float dpiScale, bool hasCrop = false)
         {
             if (Fraction is not { } fraction)
             {
@@ -297,6 +304,7 @@ namespace TianWen.UI.Abstractions
             var available = Mode switch
             {
                 SplitCompare.BeforePixels => hasBeforePixels,
+                SplitCompare.CropExtent => hasCrop,
                 _ => Pinned is not null,
             };
             if (!available)
@@ -316,10 +324,17 @@ namespace TianWen.UI.Abstractions
 
         /// <summary>The rendition the left half draws with, given the one being displayed live.</summary>
         public DisplayRendition ComparisonRendition(in DisplayRendition live)
-            => Mode is SplitCompare.BeforePixels ? live : Pinned ?? live;
+            => Mode is SplitCompare.BeforePixels or SplitCompare.CropExtent ? live : Pinned ?? live;
 
         /// <summary>Whether the left half samples the retained pixels rather than the live ones.</summary>
         public bool ComparesPixels => Mode is SplitCompare.BeforePixels;
+
+        /// <summary>
+        /// Whether the left half is the same pixels WITHOUT the display crop. The one mode whose halves
+        /// deliberately cover different areas of the frame; every other one differs in what is drawn,
+        /// not in how much.
+        /// </summary>
+        public bool ComparesCropExtent => Mode is SplitCompare.CropExtent;
 
         /// <summary>What each half is, named for the user.</summary>
         /// <remarks>
@@ -342,6 +357,13 @@ namespace TianWen.UI.Abstractions
         /// </param>
         public (string Left, string Right) HalfLabels(in DisplayControls live, bool pixelsEnhanced = false)
         {
+            if (Mode is SplitCompare.CropExtent)
+            {
+                // Names the axis, which here is the FRAME rather than the pixels: same data, same dials,
+                // one side showing what the crop took off.
+                return ("Uncropped", "Cropped");
+            }
+
             if (Mode is SplitCompare.BeforePixels)
             {
                 // Pixel comparison: the display settings are IDENTICAL on both halves by construction

--- a/src/TianWen.UI.Abstractions/ViewerActions.cs
+++ b/src/TianWen.UI.Abstractions/ViewerActions.cs
@@ -519,6 +519,10 @@ public static class ViewerActions
     /// <param name="hasBeforePixels">Whether the backend is holding pre-enhance pixels, which decides
     /// which comparison <see cref="ToolbarAction.Compare"/> turns on. Passed in rather than read from
     /// state because it is a property of the GPU backend, not of the view state.</param>
+    /// <param name="hasCrop">Whether a display crop is in force, which is the next comparison
+    /// <see cref="ToolbarAction.Compare"/> reaches for when no pixels were retained. Both of the
+    /// viewer's press dispatchers pass it: the keyboard and the button must choose the same mode, and
+    /// this is the pair that has silently disagreed before.</param>
     /// <summary>
     /// The largest denominator the zoom ladder reaches, i.e. 1:9. This is the shared vocabulary of the
     /// zoom control -- the keyboard's Ctrl+1..Ctrl+9, the dropdown's rows, and the wheel all speak it,
@@ -671,7 +675,7 @@ public static class ViewerActions
     }
 
     public static bool HandleToolbarAction(ViewerState state, AstroImageDocument? document, ToolbarAction action, bool reverse = false,
-        SplitCompareController? split = null, bool hasBeforePixels = false)
+        SplitCompareController? split = null, bool hasBeforePixels = false, bool hasCrop = false)
     {
         switch (action)
         {
@@ -741,7 +745,7 @@ public static class ViewerActions
                 }
                 else
                 {
-                    split?.Toggle(hasBeforePixels);
+                    split?.Toggle(hasBeforePixels, hasCrop);
                 }
                 state.NeedsRedraw = true;
                 return true;

--- a/src/TianWen.UI.FitsViewer/Program.cs
+++ b/src/TianWen.UI.FitsViewer/Program.cs
@@ -756,7 +756,8 @@ bool HandleMouseDown(InputEvent.MouseDown down)
             // Base handles pure state; controller handles DI-dependent actions
             var reverse = down.Button == MouseButton.Right;
             if (!ViewerActions.HandleToolbarAction(state, controller.Document, toolbarAction, reverse,
-                    split: imageRenderer.Split, hasBeforePixels: imageRenderer.HasBeforeImageTextures))
+                    split: imageRenderer.Split, hasBeforePixels: imageRenderer.HasBeforeImageTextures,
+                    hasCrop: imageRenderer.HasDisplayCrop))
             {
                 controller.HandleToolbarAction(toolbarAction, reverse, cts.Token);
             }


### PR DESCRIPTION
**Where a crop is involved, A|B is TWO comparisons, and they want opposite things.** Stated after
driving the aligned split from #231:

> there's two behaviours. open frame, press crop, A|B should compare crop vs uncrop.
> open frame, crop, run enhance, A|B should compare before=crop vs after=cropped + enhanced

Both are right, and the rules are opposites -- which is why no single clip could serve both. My first
reading of the same screen argued for keeping the extents different, my second for clipping them the
same; each was one of these two cases mistaken for the whole rule.

## Crop, nothing enhanced -> a comparison that did not exist

`SplitCompare.CropExtent`, labelled **"Uncropped | Cropped"**. The halves deliberately cover DIFFERENT
areas: same pixels, same dials, one side showing the band and ring the crop took off.

It answers the question a crop actually raises, and nothing else in the app can -- comparing pixels
needs an enhance to have retained some, and comparing settings puts two identically-framed halves on
screen. **That is what a crop used to light up**, i.e. the least informative of the three, so this is
not routing work: the comparison did not exist.

The implementation is one clip. The quad already covers the whole frame at the right place (the
placement backs its origin off by the crop), so the comparison half is simply not narrowed.

## Crop then enhance -> the same region on both halves

The retained texture is the uncropped original while the live frame is the crop (#231 cut the crop
before the pipeline). Unbounded, the left half changes the FRAME as well as the pixels and the
comparison answers two questions at once. Bounded to the live quad, both halves show the same region
and differ only by the enhancement.

## The rules around them

- **Retained pixels still win** -- in `Toggle`, and in `AdoptBeforePixels` for an enhance that lands
  while the split is already up, which now also switches out of `CropExtent`. Someone who just
  enhanced is asking about the enhance.
- **Both press dispatchers pass the crop state**: the keyboard through `Split.Toggle`, the button
  through `ViewerActions.HandleToolbarAction`. That pair has silently disagreed before (P17's
  single-click), and a mode chosen one way but not the other is exactly the shape that survives
  review, so the button path has its own test.
- `Intersect` is factored out of `ClipToShown` rather than written a second time.

## Verified on the real thing

Driven on the reported 3073 x 3085 master: the crop-only split shows "Uncropped | Cropped" with the sky
continuous across the divider and the right half stopping at the crop; the enhanced split shows Before
and After over the same region. Screenshots in the session.

## Tests

`TianWen.Lib.Tests`: **5705 passed**, 0 failed, 83 skipped. Solution builds clean.

Each of the three rules is red with only its own rule removed. Two of the new tests also assert the
clip is non-empty FIRST: an empty clip satisfies every bound below it, so a split that never engaged
would otherwise read as a pass -- which is the same class of mistake as the test #231 replaced, one
that modelled the rule instead of observing it.

Also fixes an xUnit1051 warning I left in `SynchronousProgressTests` in #231.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G5fZYZcrZnm3qCJUjeDDad
