### PR TITLE
refactor(skymap): VkSkyMapTab belongs beside its pipeline, not in the GUI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,7 +75,7 @@ src/
 ├── TianWen.RemoteClient/          # Client for a remote node (TianWenNodeClient / EventStream / SessionMirror)
 ├── TianWen.AscomHost/             # Windows-only out-of-proc host for in-proc COM ASCOM drivers
 ├── TianWen.UI.Abstractions/       # Widget system, layout, state, shared types
-├── TianWen.UI.Shared/             # SDL→InputKey mapping, Vulkan FITS pipeline, VkSkyMapPipeline
+├── TianWen.UI.Shared/             # SDL→InputKey mapping, Vulkan FITS pipeline, VkSkyMap pipeline + tab
 ├── TianWen.UI.Gui/                # N.I.N.A.-style integrated GUI (AOT-published → `tianwen-gui`)
 ├── TianWen.UI.FitsViewer/         # Standalone FITS viewer (AOT-published → `tianwen-fits`)
 ├── TianWen.UI.Web/                # WebAssembly showcase build (WebGl renderer)

--- a/src/TianWen.UI.Shared/VkSkyMapTab.cs
+++ b/src/TianWen.UI.Shared/VkSkyMapTab.cs
@@ -12,9 +12,8 @@ using TianWen.Lib.Devices;
 using TianWen.Lib.Sequencing;
 using TianWen.UI.Abstractions;
 using TianWen.UI.Abstractions.Overlays;
-using TianWen.UI.Shared;
 
-namespace TianWen.UI.Gui;
+namespace TianWen.UI.Shared;
 
 /// <summary>
 /// Vulkan-pinned Sky Map tab. Renders stars, constellation lines, grid, and horizon


### PR DESCRIPTION
A pure move, and the whole change is a rename plus three lines.

`VkSkyMapTab` has always been the Vulkan concretion of `SkyMapTab<TSurface>` — the same relationship `VkImageRenderer` has to `ImageRendererBase<TSurface>`. `VkImageRenderer`, `VkFitsImagePipeline` and `VkSkyMapPipeline` all live in `TianWen.UI.Shared` already; only this one sat in `TianWen.UI.Gui`, which made the sky map reachable from exactly one host for no reason anyone had chosen.

Nothing had to be untangled:

| | |
|---|---|
| Usings | already DIR.Lib, SdlVulkan.Renderer, `TianWen.Lib.*`, UI.Abstractions, UI.Shared — **no GUI type at all** |
| csproj | **no change** — UI.Shared reaches `TianWen.Lib` transitively via UI.Abstractions, and already sets `AllowUnsafeBlocks` |
| Consumers | **no change** — `VkGuiRenderer` is the only one and already had `using TianWen.UI.Shared;` |

So: the file rename, the namespace line, and dropping a `using` that is now its own namespace.

## Verification

Full solution builds 0/0; 168 sky-map tests pass. `TianWen.UI.Web` was built explicitly — it consumes UI.Abstractions from `.razor`, which no `.cs` grep sees, and is the documented trap for exactly this kind of rename.

No behaviour change. This is a prerequisite for hosting the atlas in `tianwen-fits`, but stands on its own and lands independently of that work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G5fZYZcrZnm3qCJUjeDDad