### PR TITLE
feat(viewer): the ? panel can open a tip jar, and it may never give anything back

### DIFF
--- a/src/TianWen.Lib.Tests/ViewerHelpPanelTests.cs
+++ b/src/TianWen.Lib.Tests/ViewerHelpPanelTests.cs
@@ -1,0 +1,140 @@
+using System;
+using System.Collections.Generic;
+using DIR.Lib;
+using Shouldly;
+using TianWen.Lib.Astrometry;
+using TianWen.Lib.Imaging;
+using TianWen.UI.Abstractions;
+using Xunit;
+
+namespace TianWen.Lib.Tests
+{
+    /// <summary>
+    /// The "?" panel's action rows are addressed by INDEX, and this pins which index does what.
+    /// </summary>
+    /// <remarks>
+    /// <para>The panel is a dropdown of mostly inert facts with a few live rows in it, and
+    /// <c>HandleHelpSelection</c> keys on the row index rather than the label because the labels are
+    /// ellipsized to fit the window. That is the right call -- comparing trimmed strings would work
+    /// until the day someone runs a narrow window -- but it means <b>inserting a row silently
+    /// renumbers every row after it</b>, and a misrouted row is not a crash: it is the wrong link
+    /// opening, which nothing else would catch.</para>
+    /// <para>So this drives EVERY index rather than the three it knows about, and asserts the complete
+    /// set of rows that do anything. A row added without a case here fails the count.</para>
+    /// </remarks>
+    [Collection("UI")]
+    public class ViewerHelpPanelTests
+    {
+        private sealed class HelpViewer : ImageRendererBase<RgbaImage>
+        {
+            public HelpViewer(RgbaImageRenderer renderer)
+                : base(renderer)
+            {
+                Width = renderer.Width;
+                Height = renderer.Height;
+                DpiScale = 1f;
+                FontPath = FontResolver.ResolveSystemFont();
+            }
+
+            protected override void RenderImageQuad(IPreviewSource? source, ViewerState state,
+                in DisplayRendition rendition, WCS? wcs,
+                float left, float top, float right, float bottom, uint projW, uint projH,
+                RenditionSlot slot, bool sampleBeforeChannels) { }
+
+            protected override void RenderHistogramQuad(StretchUniforms stretch, HistogramDisplay histogram,
+                ViewerState state, float left, float top, float right, float bottom, uint projW, uint projH) { }
+
+            protected override void DrawEllipseOverlay(float cx, float cy, float semiMajor, float semiMinor,
+                float rotationRad, RGBAColor32 color, float thickness) { }
+
+            protected override void DrawCrossOverlay(float cx, float cy, float armLength, RGBAColor32 color) { }
+
+            protected override void DrawLineOverlay(float x0, float y0, float x1, float y1,
+                RGBAColor32 color, float thickness) { }
+
+            protected override void OnResize(uint width, uint height) { }
+
+            public override void UploadImageTexture(ReadOnlySpan<float> data, int channel,
+                int width, int height) { }
+
+            public override void UploadHistogramData(IPreviewSource source) { }
+
+            protected override HistogramDisplay? GetHistogramDisplay() => null;
+        }
+
+        /// <summary>Drives every row of the panel and reports the ones that opened a URL.</summary>
+        private static List<(int Index, string Url)> OpenedLinksPerRow()
+        {
+            var bus = new SignalBus();
+            var urls = new List<string>();
+            bus.Subscribe<OpenUrlSignal>(sig => urls.Add(sig.Url));
+
+            using var renderer = new RgbaImageRenderer(900, 700);
+            var viewer = new HelpViewer(renderer) { Bus = bus };
+
+            var lines = viewer.BuildHelpLines();
+            lines.Length.ShouldBeGreaterThan(0);
+
+            var opened = new List<(int, string)>();
+            for (var i = 0; i < lines.Length; i++)
+            {
+                urls.Clear();
+                viewer.HandleHelpSelection(i);
+                bus.ProcessPending(); // Post enqueues; delivery is the frame's job
+                foreach (var url in urls)
+                {
+                    opened.Add((i, url));
+                }
+            }
+
+            return opened;
+        }
+
+        [Fact]
+        public void ExactlyThreeRowsOpenALinkAndEachOpensItsOwn()
+        {
+            var opened = OpenedLinksPerRow();
+
+            opened.Count.ShouldBe(3, "the ? panel has three action rows; a new one needs a case here");
+
+            // In panel order: guide, report, tip jar.
+            opened[0].Url.ShouldBe(BugReportLink.DocumentationUrl);
+            opened[1].Url.ShouldStartWith("https://github.com/SharpAstro/tianwen/issues/new");
+            opened[2].Url.ShouldBe(BugReportLink.SupportUrl);
+
+            // Distinct rows: the whole failure mode this guards is two rows sharing an index.
+            opened[0].Index.ShouldBeLessThan(opened[1].Index);
+            opened[1].Index.ShouldBeLessThan(opened[2].Index);
+        }
+
+        /// <summary>
+        /// The tip jar is last. Not cosmetic: the panel is what someone opens when the viewer has just
+        /// misbehaved, and an ask placed above "report a problem" would meet them at the worst moment.
+        /// </summary>
+        [Fact]
+        public void TheTipJarIsTheLastActionRow()
+        {
+            var opened = OpenedLinksPerRow();
+
+            opened[^1].Url.ShouldBe(BugReportLink.SupportUrl);
+        }
+
+        /// <summary>
+        /// A row index nothing claims must do nothing at all -- the panel is mostly inert facts, and a
+        /// stray click on the build string or a shortcut line must not open anything.
+        /// </summary>
+        [Fact]
+        public void AnInertRowOpensNothing()
+        {
+            var opened = OpenedLinksPerRow();
+            var live = new HashSet<int>();
+            foreach (var (index, _) in opened)
+            {
+                live.Add(index);
+            }
+
+            // Row 0 is the build string, which is a fact and not a link.
+            live.ShouldNotContain(0);
+        }
+    }
+}

--- a/src/TianWen.UI.Abstractions/BugReportLink.cs
+++ b/src/TianWen.UI.Abstractions/BugReportLink.cs
@@ -28,6 +28,26 @@ namespace TianWen.UI.Abstractions
         /// <summary>The viewer's user guide (P13), on the org site rather than restated in the panel.</summary>
         public const string DocumentationUrl = "https://sharpastro.github.io/guide/viewer.html";
 
+        /// <summary>
+        /// The optional tip jar, opened from the "?" panel.
+        /// </summary>
+        /// <remarks>
+        /// <para><b>Nothing may ever be given in return for this, and that is a shipping constraint
+        /// rather than a preference.</b> Microsoft Store Policy 10.8.2 permits a non-game PC product to
+        /// take voluntary donations through a secure third-party provider, but only while the user
+        /// receives no digital goods or services back -- "including but not limited to additional
+        /// features or removal of advertising". The moment a supporter gets anything the viewer
+        /// withholds from everyone else, §10.8.1 requires Microsoft's own in-product purchase API and
+        /// this link stops being allowed at all. So: no supporter-only features, no unlocks, no
+        /// nag removal (there is no nag), no priority anything.</para>
+        /// <para>Naming the provider on the row that opens it is deliberate -- §10.8.2 asks that a
+        /// product identify the commerce transaction provider, and a link that says where it is about
+        /// to send you is the honest shape regardless of policy.</para>
+        /// <para>It lives beside <see cref="DocumentationUrl"/> because this type is already the set of
+        /// links the "?" panel can open, not only the issue builder its name describes.</para>
+        /// </remarks>
+        public const string SupportUrl = "https://buymeacoffee.com/sharpastro";
+
         private const string NewIssueUrl = "https://github.com/SharpAstro/tianwen/issues/new";
 
         /// <summary>

--- a/src/TianWen.UI.Abstractions/ImageRendererBase.Toolbar.cs
+++ b/src/TianWen.UI.Abstractions/ImageRendererBase.Toolbar.cs
@@ -1478,7 +1478,7 @@ namespace TianWen.UI.Abstractions
         /// could not tell them which version they were running.
         /// </para>
         /// </summary>
-        private ImmutableArray<string> BuildHelpLines()
+        internal ImmutableArray<string> BuildHelpLines()
         {
             var lines = ImmutableArray.CreateBuilder<string>(ShortcutLines.Length + _aiLines.Length + 6);
             lines.Add($"TianWen {TianWen.Lib.BuildInfo.Describe()}");
@@ -1503,13 +1503,17 @@ namespace TianWen.UI.Abstractions
             }
             lines.Add("");
 
-            // The two things this panel can DO, above the reference material: it is the screen
-            // someone opens when the viewer has just misbehaved, so the way to report that belongs
-            // where they already are rather than in a menu they would have to go looking for.
+            // The things this panel can DO, above the reference material: it is the screen someone
+            // opens when the viewer has just misbehaved, so the way to report that belongs where they
+            // already are rather than in a menu they would have to go looking for. The tip jar goes
+            // last of the three deliberately -- it is the only row nobody came here for, and putting
+            // it above "report a problem" would meet a frustrated user with an ask.
             _helpDocsLine = lines.Count;
             lines.Add("Open the user guide in a browser");
             _helpReportLine = lines.Count;
             lines.Add("Report a problem (prepares an issue, sends nothing)");
+            _helpSupportLine = lines.Count;
+            lines.Add("\u2615 Support development (opens Buy Me a Coffee)");
             lines.Add("");
 
             lines.AddRange(ShortcutLines);
@@ -1525,6 +1529,8 @@ namespace TianWen.UI.Abstractions
 
         private int _helpReportLine = -1;
 
+        private int _helpSupportLine = -1;
+
         /// <summary>
         /// A click on one of the "?" panel's action rows. Every other row is a fact and does nothing,
         /// which is why this keys on the index and not on "did anything get clicked".
@@ -1534,7 +1540,7 @@ namespace TianWen.UI.Abstractions
         /// URL is a shell call, and this assembly is shared with the WebAssembly build, where there is
         /// no shell. The host decides, as it already does for the planner's Wikipedia links.
         /// </remarks>
-        private void HandleHelpSelection(int index)
+        internal void HandleHelpSelection(int index)
         {
             if (index == _helpDocsLine)
             {
@@ -1546,6 +1552,10 @@ namespace TianWen.UI.Abstractions
                     TianWen.Lib.BuildInfo.Describe(),
                     System.Runtime.InteropServices.RuntimeInformation.OSDescription,
                     _aiLines)));
+            }
+            else if (index == _helpSupportLine)
+            {
+                PostSignal(new OpenUrlSignal(BugReportLink.SupportUrl));
             }
         }
 


### PR DESCRIPTION
A third action row in the `?` panel, beside the user guide and the problem report, opening `buymeacoffee.com/sharpastro` via `OpenUrlSignal` like the other two — this assembly is shared with the WebAssembly build, where there is no shell.

```
Open the user guide in a browser
Report a problem (prepares an issue, sends nothing)
☕ Support development (opens Buy Me a Coffee)
```

It goes **last of the three deliberately**. The panel is what someone opens when the viewer has just misbehaved, and an ask placed above "report a problem" would meet a frustrated user at the worst possible moment.

## Nothing may ever be given in return

That is a shipping requirement, not a preference. [Store Policy 10.8.2](https://learn.microsoft.com/en-us/windows/apps/publish/store-policies) lets a non-game PC product take voluntary donations through a third-party provider — but only while the user receives no digital goods or services back, *"including but not limited to additional features or removal of advertising"*. The moment a supporter gets something the viewer withholds from everyone else, §10.8.1 requires Microsoft's own in-product purchase API and this link stops being permitted at all.

That reasoning lives on `SupportUrl`, because the next person with a nice idea about supporter perks will be reading the constant, not this description. The row names the provider for the same reason §10.8.2 asks a product to identify its commerce provider.

**Still outstanding, and not something the repo can do:** §10.8.2 requires noting the third-party purchase provider in Partner Center at the next Store submission.

## No vendored artwork

The mark is a bare `U+2615`, no variation selector, written as an escape — the sidebar glyph convention. No baking needed: `ResolveFontPath` already resolves the emoji face *and* the coverage chain for this viewer. Buy Me a Coffee's own logo is their trademark, which an AGPL repo has no grant to redistribute and their brand page does not give one in writing; their button belongs on the website, served from their CDN, which is the use it exists for. (That half is [already live](https://sharpastro.github.io/).)

## The test earns its keep

`BuildHelpLines` and `HandleHelpSelection` become `internal`. The rows are addressed by **index** — correct, because the labels are ellipsized and comparing trimmed strings would work until someone runs a narrow window — but that means inserting a row silently renumbers the ones after it, and a misrouted row is not a crash, it is the wrong link opening.

So the test drives **every** index and asserts the complete set that does anything, rather than the three it knows about. With the new dispatch branch removed, two of its three cases fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G5fZYZcrZnm3qCJUjeDDad